### PR TITLE
test: reach 100% coverage across all packages

### DIFF
--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -1,0 +1,909 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	engramsrv "github.com/alanbuscaglia/engram/internal/server"
+	"github.com/alanbuscaglia/engram/internal/setup"
+	"github.com/alanbuscaglia/engram/internal/store"
+	engramsync "github.com/alanbuscaglia/engram/internal/sync"
+	"github.com/alanbuscaglia/engram/internal/tui"
+
+	tea "github.com/charmbracelet/bubbletea"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+type exitCode int
+
+func captureOutputAndRecover(t *testing.T, fn func()) (stdout string, stderr string, recovered any) {
+	t.Helper()
+
+	oldOut := os.Stdout
+	oldErr := os.Stderr
+
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+
+	os.Stdout = outW
+	os.Stderr = errW
+
+	func() {
+		defer func() {
+			recovered = recover()
+		}()
+		fn()
+	}()
+
+	_ = outW.Close()
+	_ = errW.Close()
+	os.Stdout = oldOut
+	os.Stderr = oldErr
+
+	outBytes, err := io.ReadAll(outR)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	errBytes, err := io.ReadAll(errR)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+
+	return string(outBytes), string(errBytes), recovered
+}
+
+func stubExitWithPanic(t *testing.T) {
+	t.Helper()
+	old := exitFunc
+	exitFunc = func(code int) { panic(exitCode(code)) }
+	t.Cleanup(func() { exitFunc = old })
+}
+
+func stubRuntimeHooks(t *testing.T) {
+	t.Helper()
+	oldStoreNew := storeNew
+	oldNewHTTPServer := newHTTPServer
+	oldStartHTTP := startHTTP
+	oldNewMCPServer := newMCPServer
+	oldServeMCP := serveMCP
+	oldNewTUIModel := newTUIModel
+	oldNewTeaProgram := newTeaProgram
+	oldRunTeaProgram := runTeaProgram
+	oldSetupSupportedAgents := setupSupportedAgents
+	oldSetupInstallAgent := setupInstallAgent
+	oldScanInputLine := scanInputLine
+	oldStoreSearch := storeSearch
+	oldStoreAddObservation := storeAddObservation
+	oldStoreTimeline := storeTimeline
+	oldStoreFormatContext := storeFormatContext
+	oldStoreStats := storeStats
+	oldStoreExport := storeExport
+	oldJSONMarshalIndent := jsonMarshalIndent
+	oldSyncStatus := syncStatus
+	oldSyncImport := syncImport
+	oldSyncExport := syncExport
+
+	storeNew = store.New
+	newHTTPServer = func(s *store.Store, _ int) *engramsrv.Server { return engramsrv.New(s, 0) }
+	startHTTP = func(_ *engramsrv.Server) error { return nil }
+	newMCPServer = func(s *store.Store) *mcpserver.MCPServer {
+		return mcpserver.NewMCPServer("test", "0", mcpserver.WithRecovery())
+	}
+	serveMCP = func(_ *mcpserver.MCPServer, _ ...mcpserver.StdioOption) error { return nil }
+	newTUIModel = func(_ *store.Store) tui.Model { return tui.New(nil) }
+	newTeaProgram = func(tea.Model, ...tea.ProgramOption) *tea.Program { return &tea.Program{} }
+	runTeaProgram = func(*tea.Program) (tea.Model, error) { return nil, nil }
+	setupSupportedAgents = setup.SupportedAgents
+	setupInstallAgent = setup.Install
+	scanInputLine = fmt.Scanln
+	storeSearch = func(s *store.Store, query string, opts store.SearchOptions) ([]store.SearchResult, error) {
+		return s.Search(query, opts)
+	}
+	storeAddObservation = func(s *store.Store, p store.AddObservationParams) (int64, error) {
+		return s.AddObservation(p)
+	}
+	storeTimeline = func(s *store.Store, observationID int64, before, after int) (*store.TimelineResult, error) {
+		return s.Timeline(observationID, before, after)
+	}
+	storeFormatContext = func(s *store.Store, project, scope string) (string, error) {
+		return s.FormatContext(project, scope)
+	}
+	storeStats = func(s *store.Store) (*store.Stats, error) { return s.Stats() }
+	storeExport = func(s *store.Store) (*store.ExportData, error) { return s.Export() }
+	jsonMarshalIndent = json.MarshalIndent
+	syncStatus = func(sy *engramsync.Syncer) (localChunks int, remoteChunks int, pendingImport int, err error) {
+		return sy.Status()
+	}
+	syncImport = func(sy *engramsync.Syncer) (*engramsync.ImportResult, error) { return sy.Import() }
+	syncExport = func(sy *engramsync.Syncer, createdBy, project string) (*engramsync.SyncResult, error) {
+		return sy.Export(createdBy, project)
+	}
+
+	t.Cleanup(func() {
+		storeNew = oldStoreNew
+		newHTTPServer = oldNewHTTPServer
+		startHTTP = oldStartHTTP
+		newMCPServer = oldNewMCPServer
+		serveMCP = oldServeMCP
+		newTUIModel = oldNewTUIModel
+		newTeaProgram = oldNewTeaProgram
+		runTeaProgram = oldRunTeaProgram
+		setupSupportedAgents = oldSetupSupportedAgents
+		setupInstallAgent = oldSetupInstallAgent
+		scanInputLine = oldScanInputLine
+		storeSearch = oldStoreSearch
+		storeAddObservation = oldStoreAddObservation
+		storeTimeline = oldStoreTimeline
+		storeFormatContext = oldStoreFormatContext
+		storeStats = oldStoreStats
+		storeExport = oldStoreExport
+		jsonMarshalIndent = oldJSONMarshalIndent
+		syncStatus = oldSyncStatus
+		syncImport = oldSyncImport
+		syncExport = oldSyncExport
+	})
+}
+
+func TestFatal(t *testing.T) {
+	stubExitWithPanic(t)
+	_, stderr, recovered := captureOutputAndRecover(t, func() {
+		fatal(errors.New("boom"))
+	})
+
+	code, ok := recovered.(exitCode)
+	if !ok || int(code) != 1 {
+		t.Fatalf("expected exit code 1 panic, got %v", recovered)
+	}
+	if !strings.Contains(stderr, "engram: boom") {
+		t.Fatalf("fatal stderr mismatch: %q", stderr)
+	}
+}
+
+func TestCmdServeParsesPortAndErrors(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+
+	tests := []struct {
+		name      string
+		envPort   string
+		argPort   string
+		wantPort  int
+		startErr  error
+		wantFatal bool
+	}{
+		{name: "default port", wantPort: 7437},
+		{name: "env port", envPort: "8123", wantPort: 8123},
+		{name: "arg overrides env", envPort: "8123", argPort: "9001", wantPort: 9001},
+		{name: "invalid env keeps default", envPort: "nope", wantPort: 7437},
+		{name: "invalid arg keeps env", envPort: "8123", argPort: "bad", wantPort: 8123},
+		{name: "start failure", wantPort: 7437, startErr: errors.New("listen failed"), wantFatal: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stubExitWithPanic(t)
+			if tc.envPort != "" {
+				t.Setenv("ENGRAM_PORT", tc.envPort)
+			} else {
+				t.Setenv("ENGRAM_PORT", "")
+			}
+
+			args := []string{"engram", "serve"}
+			if tc.argPort != "" {
+				args = append(args, tc.argPort)
+			}
+			withArgs(t, args...)
+
+			seenPort := -1
+			newHTTPServer = func(s *store.Store, port int) *engramsrv.Server {
+				seenPort = port
+				return engramsrv.New(s, 0)
+			}
+			startHTTP = func(_ *engramsrv.Server) error {
+				return tc.startErr
+			}
+
+			_, stderr, recovered := captureOutputAndRecover(t, func() {
+				cmdServe(cfg)
+			})
+
+			if seenPort != tc.wantPort {
+				t.Fatalf("port=%d want=%d", seenPort, tc.wantPort)
+			}
+			if tc.wantFatal {
+				if _, ok := recovered.(exitCode); !ok {
+					t.Fatalf("expected fatal exit, got %v", recovered)
+				}
+				if !strings.Contains(stderr, "listen failed") {
+					t.Fatalf("stderr missing start error: %q", stderr)
+				}
+			} else if recovered != nil {
+				t.Fatalf("expected no panic, got %v", recovered)
+			}
+		})
+	}
+}
+
+func TestCmdMCPAndTUIBranches(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+
+	serveMCP = func(_ *mcpserver.MCPServer, _ ...mcpserver.StdioOption) error { return errors.New("mcp failed") }
+	_, mcpErr, recovered := captureOutputAndRecover(t, func() { cmdMCP(cfg) })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(mcpErr, "mcp failed") {
+		t.Fatalf("expected mcp fatal, got panic=%v stderr=%q", recovered, mcpErr)
+	}
+
+	serveMCP = func(_ *mcpserver.MCPServer, _ ...mcpserver.StdioOption) error { return nil }
+	_, _, recovered = captureOutputAndRecover(t, func() { cmdMCP(cfg) })
+	if recovered != nil {
+		t.Fatalf("unexpected panic on successful mcp: %v", recovered)
+	}
+
+	runTeaProgram = func(*tea.Program) (tea.Model, error) { return nil, errors.New("tui failed") }
+	_, tuiErr, recovered := captureOutputAndRecover(t, func() { cmdTUI(cfg) })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(tuiErr, "tui failed") {
+		t.Fatalf("expected tui fatal, got panic=%v stderr=%q", recovered, tuiErr)
+	}
+
+	runTeaProgram = func(*tea.Program) (tea.Model, error) { return nil, nil }
+	_, _, recovered = captureOutputAndRecover(t, func() { cmdTUI(cfg) })
+	if recovered != nil {
+		t.Fatalf("unexpected panic on successful tui: %v", recovered)
+	}
+}
+
+func TestCmdSetupDirectAndInteractive(t *testing.T) {
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+
+	setupInstallAgent = func(agent string) (*setup.Result, error) {
+		if agent == "broken" {
+			return nil, errors.New("install failed")
+		}
+		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
+	}
+
+	withArgs(t, "engram", "setup", "codex")
+	out, errOut, recovered := captureOutputAndRecover(t, func() { cmdSetup() })
+	if recovered != nil || errOut != "" {
+		t.Fatalf("direct setup should succeed, panic=%v stderr=%q", recovered, errOut)
+	}
+	if !strings.Contains(out, "Installed codex plugin") {
+		t.Fatalf("unexpected direct setup output: %q", out)
+	}
+
+	withArgs(t, "engram", "setup", "broken")
+	_, errOut, recovered = captureOutputAndRecover(t, func() { cmdSetup() })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(errOut, "install failed") {
+		t.Fatalf("expected direct setup fatal, panic=%v stderr=%q", recovered, errOut)
+	}
+
+	setupSupportedAgents = func() []setup.Agent {
+		return []setup.Agent{{Name: "opencode", Description: "OpenCode", InstallDir: "/tmp/opencode"}}
+	}
+	scanInputLine = func(a ...any) (int, error) {
+		p := a[0].(*string)
+		*p = "1"
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "setup")
+	out, errOut, recovered = captureOutputAndRecover(t, func() { cmdSetup() })
+	if recovered != nil || errOut != "" {
+		t.Fatalf("interactive setup should succeed, panic=%v stderr=%q", recovered, errOut)
+	}
+	if !strings.Contains(out, "Installing opencode plugin") {
+		t.Fatalf("unexpected interactive setup output: %q", out)
+	}
+
+	scanInputLine = func(a ...any) (int, error) {
+		p := a[0].(*string)
+		*p = "99"
+		return 1, nil
+	}
+	withArgs(t, "engram", "setup")
+	_, errOut, recovered = captureOutputAndRecover(t, func() { cmdSetup() })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(errOut, "Invalid choice") {
+		t.Fatalf("expected invalid choice exit, panic=%v stderr=%q", recovered, errOut)
+	}
+}
+
+func TestCmdExportDefaultAndCmdImportErrors(t *testing.T) {
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+
+	cfg := testConfig(t)
+	stubExitWithPanic(t)
+
+	mustSeedObservation(t, cfg, "s-exp-default", "proj", "note", "title", "content", "project")
+
+	withArgs(t, "engram", "export")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdExport(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("export default should succeed, panic=%v stderr=%q", recovered, stderr)
+	}
+	if !strings.Contains(stdout, "Exported to engram-export.json") {
+		t.Fatalf("unexpected default export output: %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "engram-export.json")); err != nil {
+		t.Fatalf("expected default export file: %v", err)
+	}
+
+	badPath := filepath.Join(workDir, "missing", "out.json")
+	withArgs(t, "engram", "export", badPath)
+	_, stderr, recovered = captureOutputAndRecover(t, func() { cmdExport(cfg) })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(stderr, "no such file or directory") {
+		t.Fatalf("expected export write fatal, panic=%v stderr=%q", recovered, stderr)
+	}
+
+	withArgs(t, "engram", "import")
+	_, stderr, recovered = captureOutputAndRecover(t, func() { cmdImport(cfg) })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(stderr, "usage: engram import") {
+		t.Fatalf("expected import usage exit, panic=%v stderr=%q", recovered, stderr)
+	}
+
+	withArgs(t, "engram", "import", filepath.Join(workDir, "nope.json"))
+	_, stderr, recovered = captureOutputAndRecover(t, func() { cmdImport(cfg) })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(stderr, "read") {
+		t.Fatalf("expected import read fatal, panic=%v stderr=%q", recovered, stderr)
+	}
+
+	invalidJSON := filepath.Join(workDir, "invalid.json")
+	if err := os.WriteFile(invalidJSON, []byte("{invalid"), 0644); err != nil {
+		t.Fatalf("write invalid json: %v", err)
+	}
+	withArgs(t, "engram", "import", invalidJSON)
+	_, stderr, recovered = captureOutputAndRecover(t, func() { cmdImport(cfg) })
+	if _, ok := recovered.(exitCode); !ok || !strings.Contains(stderr, "parse") {
+		t.Fatalf("expected import parse fatal, panic=%v stderr=%q", recovered, stderr)
+	}
+}
+
+func TestMainDispatchServeMCPAndTUI(t *testing.T) {
+	stubRuntimeHooks(t)
+
+	t.Setenv("ENGRAM_DATA_DIR", t.TempDir())
+	withArgs(t, "engram", "serve", "8088")
+	_, stderr, recovered := captureOutputAndRecover(t, func() { main() })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("serve dispatch failed: panic=%v stderr=%q", recovered, stderr)
+	}
+
+	withArgs(t, "engram", "mcp")
+	_, stderr, recovered = captureOutputAndRecover(t, func() { main() })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("mcp dispatch failed: panic=%v stderr=%q", recovered, stderr)
+	}
+
+	withArgs(t, "engram", "tui")
+	_, stderr, recovered = captureOutputAndRecover(t, func() { main() })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("tui dispatch failed: panic=%v stderr=%q", recovered, stderr)
+	}
+}
+
+func TestStoreInitFailurePaths(t *testing.T) {
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+	cfg := testConfig(t)
+	importFile := filepath.Join(t.TempDir(), "import.json")
+	if err := os.WriteFile(importFile, []byte(`{"version":"0.1.0","exported_at":"2026-01-01T00:00:00Z","sessions":[],"observations":[],"prompts":[]}`), 0644); err != nil {
+		t.Fatalf("write import file: %v", err)
+	}
+
+	storeNew = func(store.Config) (*store.Store, error) {
+		return nil, errors.New("store init failed")
+	}
+
+	cmds := []func(store.Config){
+		cmdServe,
+		cmdMCP,
+		cmdTUI,
+		cmdSearch,
+		cmdSave,
+		cmdTimeline,
+		cmdContext,
+		cmdStats,
+		cmdExport,
+		cmdImport,
+		cmdSync,
+	}
+
+	argsByCmd := [][]string{
+		{"engram", "serve"},
+		{"engram", "mcp"},
+		{"engram", "tui"},
+		{"engram", "search", "q"},
+		{"engram", "save", "t", "c"},
+		{"engram", "timeline", "1"},
+		{"engram", "context"},
+		{"engram", "stats"},
+		{"engram", "export"},
+		{"engram", "import", importFile},
+		{"engram", "sync"},
+	}
+
+	for i, fn := range cmds {
+		withArgs(t, argsByCmd[i]...)
+		_, stderr, recovered := captureOutputAndRecover(t, func() { fn(cfg) })
+		if _, ok := recovered.(exitCode); !ok {
+			t.Fatalf("command %d: expected exit panic, got %v", i, recovered)
+		}
+		if !strings.Contains(stderr, "store init failed") {
+			t.Fatalf("command %d: expected store failure stderr, got %q", i, stderr)
+		}
+	}
+}
+
+func TestUsageAndValidationExits(t *testing.T) {
+	cfg := testConfig(t)
+	stubExitWithPanic(t)
+
+	tests := []struct {
+		name       string
+		args       []string
+		run        func(store.Config)
+		errSubstr  string
+		stderrOnly bool
+	}{
+		{name: "search usage", args: []string{"engram", "search"}, run: cmdSearch, errSubstr: "usage: engram search"},
+		{name: "search missing query", args: []string{"engram", "search", "--limit", "3"}, run: cmdSearch, errSubstr: "search query is required"},
+		{name: "save usage", args: []string{"engram", "save", "title"}, run: cmdSave, errSubstr: "usage: engram save"},
+		{name: "timeline usage", args: []string{"engram", "timeline"}, run: cmdTimeline, errSubstr: "usage: engram timeline"},
+		{name: "timeline invalid id", args: []string{"engram", "timeline", "abc"}, run: cmdTimeline, errSubstr: "invalid observation id"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withArgs(t, tc.args...)
+			_, stderr, recovered := captureOutputAndRecover(t, func() { tc.run(cfg) })
+			if _, ok := recovered.(exitCode); !ok {
+				t.Fatalf("expected exit panic, got %v", recovered)
+			}
+			if !strings.Contains(stderr, tc.errSubstr) {
+				t.Fatalf("stderr missing %q: %q", tc.errSubstr, stderr)
+			}
+		})
+	}
+}
+
+func TestMainDispatchRemainingCommands(t *testing.T) {
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+	withCwd(t, t.TempDir())
+
+	dataDir := t.TempDir()
+	t.Setenv("ENGRAM_DATA_DIR", dataDir)
+
+	seedCfg := store.DefaultConfig()
+	seedCfg.DataDir = dataDir
+	focusID := mustSeedObservation(t, seedCfg, "s-main", "main-proj", "note", "focus", "focus content", "project")
+
+	importFile := filepath.Join(t.TempDir(), "import.json")
+	if err := os.WriteFile(importFile, []byte(`{"version":"0.1.0","exported_at":"2026-01-01T00:00:00Z","sessions":[],"observations":[],"prompts":[]}`), 0644); err != nil {
+		t.Fatalf("write import file: %v", err)
+	}
+
+	setupInstallAgent = func(agent string) (*setup.Result, error) {
+		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 1}, nil
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "search", args: []string{"engram", "search", "focus"}},
+		{name: "save", args: []string{"engram", "save", "t", "c"}},
+		{name: "timeline", args: []string{"engram", "timeline", fmt.Sprintf("%d", focusID)}},
+		{name: "context", args: []string{"engram", "context", "main-proj"}},
+		{name: "stats", args: []string{"engram", "stats"}},
+		{name: "export", args: []string{"engram", "export", filepath.Join(t.TempDir(), "exp.json")}},
+		{name: "import", args: []string{"engram", "import", importFile}},
+		{name: "sync", args: []string{"engram", "sync", "--all"}},
+		{name: "setup", args: []string{"engram", "setup", "codex"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withArgs(t, tc.args...)
+			_, stderr, recovered := captureOutputAndRecover(t, func() { main() })
+			if recovered != nil {
+				t.Fatalf("main panic for %s: %v stderr=%q", tc.name, recovered, stderr)
+			}
+		})
+	}
+}
+
+func TestCmdSyncAdditionalBranches(t *testing.T) {
+	stubExitWithPanic(t)
+
+	t.Run("all projects empty export message", func(t *testing.T) {
+		workDir := t.TempDir()
+		withCwd(t, workDir)
+		cfg := testConfig(t)
+
+		withArgs(t, "engram", "sync", "--all")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("expected clean run, panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "Exporting ALL memories") || !strings.Contains(stdout, "Nothing new to sync") {
+			t.Fatalf("unexpected output: %q", stdout)
+		}
+	})
+
+	t.Run("status parse error", func(t *testing.T) {
+		workDir := t.TempDir()
+		withCwd(t, workDir)
+		cfg := testConfig(t)
+
+		if err := os.MkdirAll(filepath.Join(workDir, ".engram"), 0755); err != nil {
+			t.Fatalf("mkdir .engram: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, ".engram", "manifest.json"), []byte("{bad json"), 0644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		withArgs(t, "engram", "sync", "--status")
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+		if _, ok := recovered.(exitCode); !ok {
+			t.Fatalf("expected fatal exit, got %v", recovered)
+		}
+		if !strings.Contains(stderr, "parse manifest") {
+			t.Fatalf("unexpected stderr: %q", stderr)
+		}
+	})
+
+	t.Run("import parse error", func(t *testing.T) {
+		workDir := t.TempDir()
+		withCwd(t, workDir)
+		cfg := testConfig(t)
+
+		if err := os.MkdirAll(filepath.Join(workDir, ".engram"), 0755); err != nil {
+			t.Fatalf("mkdir .engram: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, ".engram", "manifest.json"), []byte("{bad json"), 0644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		withArgs(t, "engram", "sync", "--import")
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+		if _, ok := recovered.(exitCode); !ok {
+			t.Fatalf("expected fatal exit, got %v", recovered)
+		}
+		if !strings.Contains(stderr, "parse manifest") {
+			t.Fatalf("unexpected stderr: %q", stderr)
+		}
+	})
+
+	t.Run("export parse error", func(t *testing.T) {
+		workDir := t.TempDir()
+		withCwd(t, workDir)
+		cfg := testConfig(t)
+
+		if err := os.MkdirAll(filepath.Join(workDir, ".engram"), 0755); err != nil {
+			t.Fatalf("mkdir .engram: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, ".engram", "manifest.json"), []byte("{bad json"), 0644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		withArgs(t, "engram", "sync")
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+		if _, ok := recovered.(exitCode); !ok {
+			t.Fatalf("expected fatal exit, got %v", recovered)
+		}
+		if !strings.Contains(stderr, "parse manifest") {
+			t.Fatalf("unexpected stderr: %q", stderr)
+		}
+	})
+}
+
+func TestCmdImportStoreImportFailure(t *testing.T) {
+	stubExitWithPanic(t)
+	cfg := testConfig(t)
+
+	badImport := filepath.Join(t.TempDir(), "bad-import.json")
+	badJSON := `{
+		"version":"0.1.0",
+		"exported_at":"2026-01-01T00:00:00Z",
+		"sessions":[],
+		"observations":[{"id":1,"session_id":"missing-session","type":"note","title":"x","content":"y","scope":"project","revision_count":1,"duplicate_count":1,"created_at":"2026-01-01 00:00:00","updated_at":"2026-01-01 00:00:00"}],
+		"prompts":[]
+	}`
+	if err := os.WriteFile(badImport, []byte(badJSON), 0644); err != nil {
+		t.Fatalf("write bad import: %v", err)
+	}
+
+	withArgs(t, "engram", "import", badImport)
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdImport(cfg) })
+	if _, ok := recovered.(exitCode); !ok {
+		t.Fatalf("expected fatal exit, got %v", recovered)
+	}
+	if !strings.Contains(stderr, "import observation") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestCmdSearchAndSaveDanglingFlags(t *testing.T) {
+	cfg := testConfig(t)
+
+	withArgs(t, "engram", "save", "dangling-title", "dangling-content", "--type")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSave(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("save with dangling flag failed, panic=%v stderr=%q", recovered, stderr)
+	}
+	if !strings.Contains(stdout, "Memory saved:") {
+		t.Fatalf("unexpected save output: %q", stdout)
+	}
+
+	withArgs(t, "engram", "search", "dangling-content", "--limit", "not-a-number", "--project")
+	stdout, stderr, recovered = captureOutputAndRecover(t, func() { cmdSearch(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("search with dangling flags failed, panic=%v stderr=%q", recovered, stderr)
+	}
+	if !strings.Contains(stdout, "Found") {
+		t.Fatalf("unexpected search output: %q", stdout)
+	}
+}
+
+func TestCmdSetupHyphenArgFallsBackToInteractive(t *testing.T) {
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+
+	setupSupportedAgents = func() []setup.Agent {
+		return []setup.Agent{{Name: "codex", Description: "Codex", InstallDir: "/tmp/codex"}}
+	}
+	setupInstallAgent = func(agent string) (*setup.Result, error) {
+		return &setup.Result{Agent: agent, Destination: "/tmp/codex", Files: 1}, nil
+	}
+	scanInputLine = func(a ...any) (int, error) {
+		p := a[0].(*string)
+		*p = "1"
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "setup", "--not-an-agent")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSetup() })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("setup interactive fallback failed: panic=%v stderr=%q", recovered, stderr)
+	}
+	if !strings.Contains(stdout, "Which agent do you want to set up?") || !strings.Contains(stdout, "Installing codex plugin") {
+		t.Fatalf("unexpected setup output: %q", stdout)
+	}
+}
+
+func TestCmdTimelineNoBeforeAfterSections(t *testing.T) {
+	cfg := testConfig(t)
+	focusID := mustSeedObservation(t, cfg, "solo-session", "solo", "note", "focus", "only content", "project")
+
+	withArgs(t, "engram", "timeline", fmt.Sprintf("%d", focusID), "--before", "0", "--after", "0")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdTimeline(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("timeline failed: panic=%v stderr=%q", recovered, stderr)
+	}
+	if strings.Contains(stdout, "─── Before ───") || strings.Contains(stdout, "─── After ───") {
+		t.Fatalf("unexpected before/after sections in output: %q", stdout)
+	}
+}
+
+func TestCmdStatsNoProjectsYet(t *testing.T) {
+	cfg := testConfig(t)
+	withArgs(t, "engram", "stats")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdStats(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("stats failed: panic=%v stderr=%q", recovered, stderr)
+	}
+	if !strings.Contains(stdout, "Projects:     none yet") {
+		t.Fatalf("expected empty projects output, got: %q", stdout)
+	}
+}
+
+func TestCmdSyncImportEmptyAndMixedChunks(t *testing.T) {
+	stubExitWithPanic(t)
+
+	t.Run("import with empty manifest", func(t *testing.T) {
+		workDir := t.TempDir()
+		withCwd(t, workDir)
+		cfg := testConfig(t)
+
+		if err := os.MkdirAll(filepath.Join(workDir, ".engram"), 0755); err != nil {
+			t.Fatalf("mkdir .engram: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, ".engram", "manifest.json"), []byte(`{"version":1,"chunks":[]}`), 0644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		withArgs(t, "engram", "sync", "--import")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("empty import failed: panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "Already up to date") || strings.Contains(stdout, "already imported") {
+			t.Fatalf("unexpected empty import output: %q", stdout)
+		}
+	})
+
+	t.Run("import new plus skipped chunk", func(t *testing.T) {
+		workDir := t.TempDir()
+		withCwd(t, workDir)
+
+		exportCfg := testConfig(t)
+		importCfg := testConfig(t)
+
+		mustSeedObservation(t, exportCfg, "mix-1", "mix", "note", "one", "content-one", "project")
+		withArgs(t, "engram", "sync", "--all")
+		_, _, _ = captureOutputAndRecover(t, func() { cmdSync(exportCfg) })
+
+		withArgs(t, "engram", "sync", "--import")
+		_, _, _ = captureOutputAndRecover(t, func() { cmdSync(importCfg) })
+
+		time.Sleep(1100 * time.Millisecond)
+		mustSeedObservation(t, exportCfg, "mix-2", "mix", "note", "two", "content-two", "project")
+		withArgs(t, "engram", "sync", "--all")
+		_, _, _ = captureOutputAndRecover(t, func() { cmdSync(exportCfg) })
+
+		withArgs(t, "engram", "sync", "--import")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(importCfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("mixed import failed: panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "Imported 1 new chunk(s)") || !strings.Contains(stdout, "Skipped:") {
+			t.Fatalf("unexpected mixed import output: %q", stdout)
+		}
+	})
+}
+
+func TestCommandErrorSeamsAndUncoveredBranches(t *testing.T) {
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+	cfg := testConfig(t)
+
+	assertFatal := func(t *testing.T, stderr string, recovered any, want string) {
+		t.Helper()
+		if _, ok := recovered.(exitCode); !ok {
+			t.Fatalf("expected fatal exit, got %v", recovered)
+		}
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr missing %q: %q", want, stderr)
+		}
+	}
+
+	t.Run("search seam error", func(t *testing.T) {
+		withArgs(t, "engram", "search", "needle")
+		storeSearch = func(*store.Store, string, store.SearchOptions) ([]store.SearchResult, error) {
+			return nil, errors.New("forced search error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSearch(cfg) })
+		assertFatal(t, stderr, recovered, "forced search error")
+	})
+
+	t.Run("save seam error", func(t *testing.T) {
+		withArgs(t, "engram", "save", "title", "content")
+		storeAddObservation = func(*store.Store, store.AddObservationParams) (int64, error) {
+			return 0, errors.New("forced save error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSave(cfg) })
+		assertFatal(t, stderr, recovered, "forced save error")
+	})
+
+	t.Run("timeline seam error", func(t *testing.T) {
+		withArgs(t, "engram", "timeline", "1")
+		storeTimeline = func(*store.Store, int64, int, int) (*store.TimelineResult, error) {
+			return nil, errors.New("forced timeline error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdTimeline(cfg) })
+		assertFatal(t, stderr, recovered, "forced timeline error")
+	})
+
+	t.Run("timeline prints session summary", func(t *testing.T) {
+		summary := "this session has a non-empty summary"
+		withArgs(t, "engram", "timeline", "1")
+		storeTimeline = func(*store.Store, int64, int, int) (*store.TimelineResult, error) {
+			return &store.TimelineResult{
+				Focus:        store.Observation{ID: 1, Type: "note", Title: "focus", Content: "content", CreatedAt: "2026-01-01"},
+				SessionInfo:  &store.Session{Project: "proj", StartedAt: "2026-01-01", Summary: &summary},
+				TotalInRange: 1,
+			}, nil
+		}
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdTimeline(cfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("expected successful timeline render, panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "Session: proj") || !strings.Contains(stdout, "non-empty summary") {
+			t.Fatalf("expected summary in timeline output, got: %q", stdout)
+		}
+	})
+
+	t.Run("context seam error", func(t *testing.T) {
+		withArgs(t, "engram", "context")
+		storeFormatContext = func(*store.Store, string, string) (string, error) {
+			return "", errors.New("forced context error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdContext(cfg) })
+		assertFatal(t, stderr, recovered, "forced context error")
+	})
+
+	t.Run("stats seam error", func(t *testing.T) {
+		withArgs(t, "engram", "stats")
+		storeStats = func(*store.Store) (*store.Stats, error) {
+			return nil, errors.New("forced stats error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdStats(cfg) })
+		assertFatal(t, stderr, recovered, "forced stats error")
+	})
+
+	t.Run("export seam error", func(t *testing.T) {
+		withArgs(t, "engram", "export")
+		storeExport = func(*store.Store) (*store.ExportData, error) {
+			return nil, errors.New("forced export error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdExport(cfg) })
+		assertFatal(t, stderr, recovered, "forced export error")
+	})
+
+	t.Run("export marshal seam error", func(t *testing.T) {
+		withArgs(t, "engram", "export")
+		storeExport = func(s *store.Store) (*store.ExportData, error) { return s.Export() }
+		jsonMarshalIndent = func(any, string, string) ([]byte, error) {
+			return nil, errors.New("forced marshal error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdExport(cfg) })
+		assertFatal(t, stderr, recovered, "forced marshal error")
+	})
+
+	t.Run("sync seam status error", func(t *testing.T) {
+		withCwd(t, t.TempDir())
+		withArgs(t, "engram", "sync", "--status")
+		syncStatus = func(*engramsync.Syncer) (int, int, int, error) {
+			return 0, 0, 0, errors.New("forced status error")
+		}
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+		assertFatal(t, stderr, recovered, "forced status error")
+	})
+
+	t.Run("sync uses explicit project flag", func(t *testing.T) {
+		withCwd(t, t.TempDir())
+		withArgs(t, "engram", "sync", "--project", "explicit-proj")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("sync with --project should succeed, panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, `Exporting memories for project "explicit-proj"`) {
+			t.Fatalf("expected explicit project output, got: %q", stdout)
+		}
+	})
+
+	t.Run("setup interactive install error", func(t *testing.T) {
+		setupSupportedAgents = func() []setup.Agent {
+			return []setup.Agent{{Name: "codex", Description: "Codex", InstallDir: "/tmp/codex"}}
+		}
+		scanInputLine = func(a ...any) (int, error) {
+			p := a[0].(*string)
+			*p = "1"
+			return 1, nil
+		}
+		setupInstallAgent = func(string) (*setup.Result, error) {
+			return nil, errors.New("forced setup error")
+		}
+
+		withArgs(t, "engram", "setup")
+		_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSetup() })
+		assertFatal(t, stderr, recovered, "forced setup error")
+	})
+}

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/alanbuscaglia/engram/internal/store"
+)
+
+func testConfig(t *testing.T) store.Config {
+	t.Helper()
+	cfg := store.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	return cfg
+}
+
+func withArgs(t *testing.T, args ...string) {
+	t.Helper()
+	old := os.Args
+	os.Args = args
+	t.Cleanup(func() {
+		os.Args = old
+	})
+}
+
+func withCwd(t *testing.T, dir string) {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir to %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(old)
+	})
+}
+
+func captureOutput(t *testing.T, fn func()) (stdout string, stderr string) {
+	t.Helper()
+
+	oldOut := os.Stdout
+	oldErr := os.Stderr
+
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+
+	os.Stdout = outW
+	os.Stderr = errW
+
+	fn()
+
+	_ = outW.Close()
+	_ = errW.Close()
+	os.Stdout = oldOut
+	os.Stderr = oldErr
+
+	outBytes, err := io.ReadAll(outR)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	errBytes, err := io.ReadAll(errR)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+
+	return string(outBytes), string(errBytes)
+}
+
+func mustSeedObservation(t *testing.T, cfg store.Config, sessionID, project, typ, title, content, scope string) int64 {
+	t.Helper()
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	if err := s.CreateSession(sessionID, project, "/tmp"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	id, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      typ,
+		Title:     title,
+		Content:   content,
+		Project:   project,
+		Scope:     scope,
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	return id
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{name: "short string", in: "abc", max: 10, want: "abc"},
+		{name: "exact length", in: "hello", max: 5, want: "hello"},
+		{name: "long string", in: "abcdef", max: 3, want: "abc..."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncate(tc.in, tc.max)
+			if got != tc.want {
+				t.Fatalf("truncate(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintUsage(t *testing.T) {
+	oldVersion := version
+	version = "test-version"
+	t.Cleanup(func() {
+		version = oldVersion
+	})
+
+	stdout, stderr := captureOutput(t, func() { printUsage() })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, "engram vtest-version") {
+		t.Fatalf("usage missing version: %q", stdout)
+	}
+	if !strings.Contains(stdout, "search <query>") || !strings.Contains(stdout, "setup [agent]") {
+		t.Fatalf("usage missing expected commands: %q", stdout)
+	}
+}
+
+func TestPrintPostInstall(t *testing.T) {
+	tests := []struct {
+		agent   string
+		expects []string
+	}{
+		{agent: "opencode", expects: []string{"Restart OpenCode", "engram serve &"}},
+		{agent: "claude-code", expects: []string{"Restart Claude Code", "claude plugin list"}},
+		{agent: "gemini-cli", expects: []string{"Restart Gemini CLI", "~/.gemini/settings.json"}},
+		{agent: "codex", expects: []string{"Restart Codex", "~/.codex/config.toml"}},
+		{agent: "unknown", expects: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.agent, func(t *testing.T) {
+			stdout, stderr := captureOutput(t, func() { printPostInstall(tc.agent) })
+			if stderr != "" {
+				t.Fatalf("expected no stderr, got: %q", stderr)
+			}
+			for _, expected := range tc.expects {
+				if !strings.Contains(stdout, expected) {
+					t.Fatalf("output missing %q: %q", expected, stdout)
+				}
+			}
+			if len(tc.expects) == 0 && stdout != "" {
+				t.Fatalf("expected empty output for unknown agent, got: %q", stdout)
+			}
+		})
+	}
+}
+
+func TestCmdSaveAndSearch(t *testing.T) {
+	cfg := testConfig(t)
+
+	withArgs(t,
+		"engram", "save", "my-title", "my-content",
+		"--type", "bugfix",
+		"--project", "alpha",
+		"--scope", "personal",
+		"--topic", "auth/token",
+	)
+
+	stdout, stderr := captureOutput(t, func() { cmdSave(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, "Memory saved:") || !strings.Contains(stdout, "my-title") {
+		t.Fatalf("unexpected save output: %q", stdout)
+	}
+
+	withArgs(t, "engram", "search", "my-content", "--type", "bugfix", "--project", "alpha", "--scope", "personal", "--limit", "1")
+	searchOut, searchErr := captureOutput(t, func() { cmdSearch(cfg) })
+	if searchErr != "" {
+		t.Fatalf("expected no stderr from search, got: %q", searchErr)
+	}
+	if !strings.Contains(searchOut, "Found 1 memories") || !strings.Contains(searchOut, "my-title") {
+		t.Fatalf("unexpected search output: %q", searchOut)
+	}
+
+	withArgs(t, "engram", "search", "definitely-not-found")
+	noneOut, noneErr := captureOutput(t, func() { cmdSearch(cfg) })
+	if noneErr != "" {
+		t.Fatalf("expected no stderr from empty search, got: %q", noneErr)
+	}
+	if !strings.Contains(noneOut, "No memories found") {
+		t.Fatalf("expected empty search message, got: %q", noneOut)
+	}
+}
+
+func TestCmdTimeline(t *testing.T) {
+	cfg := testConfig(t)
+	mustSeedObservation(t, cfg, "s-1", "proj", "note", "first", "first content", "project")
+	focusID := mustSeedObservation(t, cfg, "s-1", "proj", "note", "focus", "focus content", "project")
+	mustSeedObservation(t, cfg, "s-1", "proj", "note", "third", "third content", "project")
+
+	withArgs(t, "engram", "timeline", strconv.FormatInt(focusID, 10), "--before", "1", "--after", "1")
+	stdout, stderr := captureOutput(t, func() { cmdTimeline(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, "Session:") || !strings.Contains(stdout, ">>> #"+strconv.FormatInt(focusID, 10)) {
+		t.Fatalf("timeline output missing expected focus/session info: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Before") || !strings.Contains(stdout, "After") {
+		t.Fatalf("timeline output missing before/after sections: %q", stdout)
+	}
+}
+
+func TestCmdContextAndStats(t *testing.T) {
+	cfg := testConfig(t)
+
+	withArgs(t, "engram", "context")
+	emptyCtxOut, emptyCtxErr := captureOutput(t, func() { cmdContext(cfg) })
+	if emptyCtxErr != "" {
+		t.Fatalf("expected no stderr for empty context, got: %q", emptyCtxErr)
+	}
+	if !strings.Contains(emptyCtxOut, "No previous session memories found") {
+		t.Fatalf("unexpected empty context output: %q", emptyCtxOut)
+	}
+
+	mustSeedObservation(t, cfg, "s-ctx", "project-x", "decision", "title", "content", "project")
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	_, err = s.AddPrompt(store.AddPromptParams{SessionID: "s-ctx", Content: "user asked about context", Project: "project-x"})
+	if err != nil {
+		t.Fatalf("AddPrompt: %v", err)
+	}
+	_ = s.Close()
+
+	withArgs(t, "engram", "context", "project-x")
+	ctxOut, ctxErr := captureOutput(t, func() { cmdContext(cfg) })
+	if ctxErr != "" {
+		t.Fatalf("expected no stderr for populated context, got: %q", ctxErr)
+	}
+	if !strings.Contains(ctxOut, "## Memory from Previous Sessions") || !strings.Contains(ctxOut, "Recent Observations") {
+		t.Fatalf("unexpected populated context output: %q", ctxOut)
+	}
+
+	withArgs(t, "engram", "stats")
+	statsOut, statsErr := captureOutput(t, func() { cmdStats(cfg) })
+	if statsErr != "" {
+		t.Fatalf("expected no stderr from stats, got: %q", statsErr)
+	}
+	if !strings.Contains(statsOut, "Engram Memory Stats") || !strings.Contains(statsOut, "project-x") {
+		t.Fatalf("unexpected stats output: %q", statsOut)
+	}
+}
+
+func TestCmdExportAndImport(t *testing.T) {
+	sourceCfg := testConfig(t)
+	targetCfg := testConfig(t)
+
+	mustSeedObservation(t, sourceCfg, "s-exp", "proj-exp", "pattern", "exported", "export me", "project")
+
+	exportPath := filepath.Join(t.TempDir(), "memories.json")
+
+	withArgs(t, "engram", "export", exportPath)
+	exportOut, exportErr := captureOutput(t, func() { cmdExport(sourceCfg) })
+	if exportErr != "" {
+		t.Fatalf("expected no stderr from export, got: %q", exportErr)
+	}
+	if !strings.Contains(exportOut, "Exported to "+exportPath) {
+		t.Fatalf("unexpected export output: %q", exportOut)
+	}
+
+	withArgs(t, "engram", "import", exportPath)
+	importOut, importErr := captureOutput(t, func() { cmdImport(targetCfg) })
+	if importErr != "" {
+		t.Fatalf("expected no stderr from import, got: %q", importErr)
+	}
+	if !strings.Contains(importOut, "Imported from "+exportPath) {
+		t.Fatalf("unexpected import output: %q", importOut)
+	}
+
+	s, err := store.New(targetCfg)
+	if err != nil {
+		t.Fatalf("store.New target: %v", err)
+	}
+	defer s.Close()
+
+	results, err := s.Search("export", store.SearchOptions{Limit: 10, Project: "proj-exp"})
+	if err != nil {
+		t.Fatalf("Search after import: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("expected imported data to be searchable")
+	}
+}
+
+func TestCmdSyncStatusExportAndImport(t *testing.T) {
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+
+	exportCfg := testConfig(t)
+	importCfg := testConfig(t)
+
+	mustSeedObservation(t, exportCfg, "s-sync", "sync-project", "note", "sync title", "sync content", "project")
+
+	withArgs(t, "engram", "sync", "--status")
+	statusOut, statusErr := captureOutput(t, func() { cmdSync(exportCfg) })
+	if statusErr != "" {
+		t.Fatalf("expected no stderr from status, got: %q", statusErr)
+	}
+	if !strings.Contains(statusOut, "Sync status:") {
+		t.Fatalf("unexpected status output: %q", statusOut)
+	}
+
+	withArgs(t, "engram", "sync", "--all")
+	exportOut, exportErr := captureOutput(t, func() { cmdSync(exportCfg) })
+	if exportErr != "" {
+		t.Fatalf("expected no stderr from sync export, got: %q", exportErr)
+	}
+	if !strings.Contains(exportOut, "Created chunk") {
+		t.Fatalf("unexpected sync export output: %q", exportOut)
+	}
+
+	withArgs(t, "engram", "sync", "--import")
+	importOut, importErr := captureOutput(t, func() { cmdSync(importCfg) })
+	if importErr != "" {
+		t.Fatalf("expected no stderr from sync import, got: %q", importErr)
+	}
+	if !strings.Contains(importOut, "Imported 1 new chunk(s)") {
+		t.Fatalf("unexpected sync import output: %q", importOut)
+	}
+
+	withArgs(t, "engram", "sync", "--import")
+	noopOut, noopErr := captureOutput(t, func() { cmdSync(importCfg) })
+	if noopErr != "" {
+		t.Fatalf("expected no stderr from second sync import, got: %q", noopErr)
+	}
+	if !strings.Contains(noopOut, "Already up to date") {
+		t.Fatalf("unexpected second sync import output: %q", noopOut)
+	}
+}
+
+func TestCmdSyncDefaultProjectNoData(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "repo-name")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+	withCwd(t, workDir)
+
+	cfg := testConfig(t)
+	withArgs(t, "engram", "sync")
+	stdout, stderr := captureOutput(t, func() { cmdSync(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, `Exporting memories for project "repo-name"`) {
+		t.Fatalf("expected default project message, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, `Nothing new to sync for project "repo-name"`) {
+		t.Fatalf("expected no-data sync message, got: %q", stdout)
+	}
+}
+
+func TestMainVersionAndHelpAliases(t *testing.T) {
+	oldVersion := version
+	version = "9.9.9-test"
+	t.Cleanup(func() { version = oldVersion })
+
+	tests := []struct {
+		name      string
+		arg       string
+		contains  string
+		notStderr bool
+	}{
+		{name: "version", arg: "version", contains: "engram 9.9.9-test", notStderr: true},
+		{name: "version short", arg: "-v", contains: "engram 9.9.9-test", notStderr: true},
+		{name: "version long", arg: "--version", contains: "engram 9.9.9-test", notStderr: true},
+		{name: "help", arg: "help", contains: "Usage:", notStderr: true},
+		{name: "help short", arg: "-h", contains: "Commands:", notStderr: true},
+		{name: "help long", arg: "--help", contains: "Environment:", notStderr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withArgs(t, "engram", tc.arg)
+			stdout, stderr := captureOutput(t, func() { main() })
+			if tc.notStderr && stderr != "" {
+				t.Fatalf("expected no stderr, got: %q", stderr)
+			}
+			if !strings.Contains(stdout, tc.contains) {
+				t.Fatalf("stdout %q does not include %q", stdout, tc.contains)
+			}
+		})
+	}
+}
+
+func TestMainExitPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		helperCase      string
+		expectedOutput  string
+		expectedStderr  string
+		expectedExitOne bool
+	}{
+		{name: "no args", helperCase: "no-args", expectedOutput: "Usage:", expectedExitOne: true},
+		{name: "unknown command", helperCase: "unknown", expectedOutput: "Usage:", expectedStderr: "unknown command:", expectedExitOne: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestMainExitHelper")
+			cmd.Env = append(os.Environ(),
+				"GO_WANT_HELPER_PROCESS=1",
+				"HELPER_CASE="+tc.helperCase,
+			)
+
+			out, err := cmd.CombinedOutput()
+			if tc.expectedExitOne {
+				exitErr, ok := err.(*exec.ExitError)
+				if !ok {
+					t.Fatalf("expected exit error, got %T (%v)", err, err)
+				}
+				if exitErr.ExitCode() != 1 {
+					t.Fatalf("expected exit code 1, got %d; output=%q", exitErr.ExitCode(), string(out))
+				}
+			}
+
+			if !strings.Contains(string(out), tc.expectedOutput) {
+				t.Fatalf("output missing %q: %q", tc.expectedOutput, string(out))
+			}
+			if tc.expectedStderr != "" && !strings.Contains(string(out), tc.expectedStderr) {
+				t.Fatalf("output missing stderr text %q: %q", tc.expectedStderr, string(out))
+			}
+		})
+	}
+}
+
+func TestMainExitHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	switch os.Getenv("HELPER_CASE") {
+	case "no-args":
+		os.Args = []string{"engram"}
+	case "unknown":
+		os.Args = []string{"engram", "definitely-unknown-command"}
+	default:
+		os.Args = []string{"engram", "--help"}
+	}
+
+	main()
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -15,6 +15,12 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+var suggestTopicKey = store.SuggestTopicKey
+
+var loadMCPStats = func(s *store.Store) (*store.Stats, error) {
+	return s.Stats()
+}
+
 func NewServer(s *store.Store) *server.MCPServer {
 	srv := server.NewMCPServer(
 		"engram",
@@ -407,7 +413,7 @@ func handleSave(s *store.Store) server.ToolHandlerFunc {
 		if sessionID == "" {
 			sessionID = "manual-save"
 		}
-		suggestedTopicKey := store.SuggestTopicKey(typ, title, content)
+		suggestedTopicKey := suggestTopicKey(typ, title, content)
 
 		// Ensure the session exists
 		s.CreateSession(sessionID, project, "")
@@ -443,7 +449,7 @@ func handleSuggestTopicKey() server.ToolHandlerFunc {
 			return mcp.NewToolResultError("provide title or content to suggest a topic_key"), nil
 		}
 
-		topicKey := store.SuggestTopicKey(typ, title, content)
+		topicKey := suggestTopicKey(typ, title, content)
 		if topicKey == "" {
 			return mcp.NewToolResultError("could not suggest topic_key from input"), nil
 		}
@@ -569,7 +575,7 @@ func handleContext(s *store.Store) server.ToolHandlerFunc {
 
 func handleStats(s *store.Store) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		stats, err := s.Stats()
+		stats, err := loadMCPStats(s)
 		if err != nil {
 			return mcp.NewToolResultError("Failed to get stats: " + err.Error()), nil
 		}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -241,5 +242,649 @@ func TestHandleCapturePassiveReturnsToolErrorOnStoreFailure(t *testing.T) {
 	}
 	if !res.IsError {
 		t.Fatalf("expected tool error when store returns failure")
+	}
+}
+
+func TestHelperArgsAndTruncate(t *testing.T) {
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"limit": 7.0,
+		"flag":  true,
+	}}}
+
+	if got := intArg(req, "limit", 10); got != 7 {
+		t.Fatalf("expected intArg=7, got %d", got)
+	}
+	if got := intArg(req, "missing", 10); got != 10 {
+		t.Fatalf("expected default intArg=10, got %d", got)
+	}
+	if got := boolArg(req, "flag", false); !got {
+		t.Fatalf("expected boolArg true")
+	}
+	if got := boolArg(req, "missing", true); !got {
+		t.Fatalf("expected default boolArg=true")
+	}
+
+	if got := truncate("short", 10); got != "short" {
+		t.Fatalf("unexpected truncate for short input: %q", got)
+	}
+	if got := truncate("this is long", 4); got != "this..." {
+		t.Fatalf("unexpected truncate for long input: %q", got)
+	}
+}
+
+func TestHandleSearchAndCRUDHandlers(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-mcp", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	obsID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-mcp",
+		Type:      "bugfix",
+		Title:     "Fix panic",
+		Content:   "Fix panic in parser branch when args are missing",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	search := handleSearch(s)
+	searchReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"query":   "panic",
+		"project": "engram",
+		"scope":   "project",
+		"limit":   5.0,
+	}}}
+	searchRes, err := search(context.Background(), searchReq)
+	if err != nil {
+		t.Fatalf("search handler error: %v", err)
+	}
+	if searchRes.IsError {
+		t.Fatalf("unexpected search error: %s", callResultText(t, searchRes))
+	}
+	if !strings.Contains(callResultText(t, searchRes), "Found 1 memories") {
+		t.Fatalf("expected non-empty search result")
+	}
+
+	update := handleUpdate(s)
+	updateReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":    float64(obsID),
+		"title": "Fix parser panic",
+	}}}
+	updateRes, err := update(context.Background(), updateReq)
+	if err != nil {
+		t.Fatalf("update handler error: %v", err)
+	}
+	if updateRes.IsError {
+		t.Fatalf("unexpected update error: %s", callResultText(t, updateRes))
+	}
+
+	getObs := handleGetObservation(s)
+	getReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id": float64(obsID),
+	}}}
+	getRes, err := getObs(context.Background(), getReq)
+	if err != nil {
+		t.Fatalf("get handler error: %v", err)
+	}
+	if getRes.IsError {
+		t.Fatalf("unexpected get error: %s", callResultText(t, getRes))
+	}
+
+	deleteHandler := handleDelete(s)
+	delReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":          float64(obsID),
+		"hard_delete": true,
+	}}}
+	delRes, err := deleteHandler(context.Background(), delReq)
+	if err != nil {
+		t.Fatalf("delete handler error: %v", err)
+	}
+	if delRes.IsError {
+		t.Fatalf("unexpected delete error: %s", callResultText(t, delRes))
+	}
+	if !strings.Contains(callResultText(t, delRes), "permanently deleted") {
+		t.Fatalf("expected hard delete message")
+	}
+}
+
+func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-flow", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-flow",
+		Type:      "decision",
+		Title:     "Auth decision",
+		Content:   "Keep auth in middleware",
+		Project:   "engram",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	savePrompt := handleSavePrompt(s)
+	savePromptReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "how do we fix auth race conditions?",
+		"project": "engram",
+	}}}
+	savePromptRes, err := savePrompt(context.Background(), savePromptReq)
+	if err != nil {
+		t.Fatalf("save prompt handler error: %v", err)
+	}
+	if savePromptRes.IsError {
+		t.Fatalf("unexpected save prompt error: %s", callResultText(t, savePromptRes))
+	}
+
+	contextHandler := handleContext(s)
+	contextReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"project": "engram",
+		"scope":   "project",
+	}}}
+	contextRes, err := contextHandler(context.Background(), contextReq)
+	if err != nil {
+		t.Fatalf("context handler error: %v", err)
+	}
+	if contextRes.IsError {
+		t.Fatalf("unexpected context error: %s", callResultText(t, contextRes))
+	}
+	if !strings.Contains(callResultText(t, contextRes), "Memory stats") {
+		t.Fatalf("expected context output with memory stats")
+	}
+
+	statsHandler := handleStats(s)
+	statsRes, err := statsHandler(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("stats handler error: %v", err)
+	}
+	if statsRes.IsError {
+		t.Fatalf("unexpected stats error: %s", callResultText(t, statsRes))
+	}
+
+	recent, err := s.RecentObservations("engram", "project", 1)
+	if err != nil || len(recent) == 0 {
+		t.Fatalf("recent observations for timeline: %v len=%d", err, len(recent))
+	}
+
+	timelineHandler := handleTimeline(s)
+	timelineReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"observation_id": float64(recent[0].ID),
+		"before":         2.0,
+		"after":          2.0,
+	}}}
+	timelineRes, err := timelineHandler(context.Background(), timelineReq)
+	if err != nil {
+		t.Fatalf("timeline handler error: %v", err)
+	}
+	if timelineRes.IsError {
+		t.Fatalf("unexpected timeline error: %s", callResultText(t, timelineRes))
+	}
+
+	sessionSummary := handleSessionSummary(s)
+	summaryReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"project": "engram",
+		"content": "## Goal\nImprove tests",
+	}}}
+	summaryRes, err := sessionSummary(context.Background(), summaryReq)
+	if err != nil {
+		t.Fatalf("session summary handler error: %v", err)
+	}
+	if summaryRes.IsError {
+		t.Fatalf("unexpected session summary error: %s", callResultText(t, summaryRes))
+	}
+
+	sessionStart := handleSessionStart(s)
+	startReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":        "s-new",
+		"project":   "engram",
+		"directory": "/tmp/engram",
+	}}}
+	startRes, err := sessionStart(context.Background(), startReq)
+	if err != nil {
+		t.Fatalf("session start handler error: %v", err)
+	}
+	if startRes.IsError {
+		t.Fatalf("unexpected session start error: %s", callResultText(t, startRes))
+	}
+
+	sessionEnd := handleSessionEnd(s)
+	endReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":      "s-new",
+		"summary": "done",
+	}}}
+	endRes, err := sessionEnd(context.Background(), endReq)
+	if err != nil {
+		t.Fatalf("session end handler error: %v", err)
+	}
+	if endRes.IsError {
+		t.Fatalf("unexpected session end error: %s", callResultText(t, endRes))
+	}
+}
+
+func TestMCPHandlersErrorBranches(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	search := handleSearch(s)
+	noResultsReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"query": "definitely-no-hit"}}}
+	noResultsRes, err := search(context.Background(), noResultsReq)
+	if err != nil {
+		t.Fatalf("search handler error: %v", err)
+	}
+	if noResultsRes.IsError {
+		t.Fatalf("expected non-error no-results response")
+	}
+	if !strings.Contains(callResultText(t, noResultsRes), "No memories found") {
+		t.Fatalf("expected no memories response")
+	}
+
+	update := handleUpdate(s)
+	missingIDRes, err := update(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{}}})
+	if err != nil {
+		t.Fatalf("update missing id error: %v", err)
+	}
+	if !missingIDRes.IsError {
+		t.Fatalf("expected update missing id to return tool error")
+	}
+
+	noFieldsReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": 1.0}}}
+	noFieldsRes, err := update(context.Background(), noFieldsReq)
+	if err != nil {
+		t.Fatalf("update no fields error: %v", err)
+	}
+	if !noFieldsRes.IsError {
+		t.Fatalf("expected update no fields to return tool error")
+	}
+
+	deleteHandler := handleDelete(s)
+	delMissingIDRes, err := deleteHandler(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{}}})
+	if err != nil {
+		t.Fatalf("delete missing id error: %v", err)
+	}
+	if !delMissingIDRes.IsError {
+		t.Fatalf("expected delete missing id to return tool error")
+	}
+
+	timeline := handleTimeline(s)
+	timelineMissingIDRes, err := timeline(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{}}})
+	if err != nil {
+		t.Fatalf("timeline missing id error: %v", err)
+	}
+	if !timelineMissingIDRes.IsError {
+		t.Fatalf("expected timeline missing id to return tool error")
+	}
+
+	getObs := handleGetObservation(s)
+	getMissingIDRes, err := getObs(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{}}})
+	if err != nil {
+		t.Fatalf("get observation missing id error: %v", err)
+	}
+	if !getMissingIDRes.IsError {
+		t.Fatalf("expected get observation missing id to return tool error")
+	}
+
+	getNotFoundReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": 9999.0}}}
+	getNotFoundRes, err := getObs(context.Background(), getNotFoundReq)
+	if err != nil {
+		t.Fatalf("get observation not found error: %v", err)
+	}
+	if !getNotFoundRes.IsError {
+		t.Fatalf("expected get observation not found to return tool error")
+	}
+}
+
+func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-closed", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-closed",
+		Type:      "decision",
+		Title:     "Title",
+		Content:   "Content",
+		Project:   "engram",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	searchRes, err := handleSearch(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"query": "title"}}})
+	if err != nil {
+		t.Fatalf("closed store search call: %v", err)
+	}
+	if !searchRes.IsError {
+		t.Fatalf("expected search to return tool error when store is closed")
+	}
+
+	updateRes, err := handleUpdate(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": 1.0, "title": "new"}}})
+	if err != nil {
+		t.Fatalf("closed store update call: %v", err)
+	}
+	if !updateRes.IsError {
+		t.Fatalf("expected update to return tool error when store is closed")
+	}
+
+	deleteRes, err := handleDelete(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": 1.0}}})
+	if err != nil {
+		t.Fatalf("closed store delete call: %v", err)
+	}
+	if !deleteRes.IsError {
+		t.Fatalf("expected delete to return tool error when store is closed")
+	}
+
+	promptRes, err := handleSavePrompt(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"content": "prompt", "project": "engram"}}})
+	if err != nil {
+		t.Fatalf("closed store save prompt call: %v", err)
+	}
+	if !promptRes.IsError {
+		t.Fatalf("expected save prompt to return tool error when store is closed")
+	}
+
+	contextRes, err := handleContext(s)(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("closed store context call: %v", err)
+	}
+	if !contextRes.IsError {
+		t.Fatalf("expected context to return tool error when store is closed")
+	}
+
+	statsRes, err := handleStats(s)(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("closed store stats call: %v", err)
+	}
+	if statsRes.IsError {
+		t.Fatalf("expected stats fallback result even when store is closed")
+	}
+
+	timelineRes, err := handleTimeline(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"observation_id": 1.0}}})
+	if err != nil {
+		t.Fatalf("closed store timeline call: %v", err)
+	}
+	if !timelineRes.IsError {
+		t.Fatalf("expected timeline to return tool error when store is closed")
+	}
+
+	getObsRes, err := handleGetObservation(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": 1.0}}})
+	if err != nil {
+		t.Fatalf("closed store get observation call: %v", err)
+	}
+	if !getObsRes.IsError {
+		t.Fatalf("expected get observation to return tool error when store is closed")
+	}
+
+	sessionSummaryRes, err := handleSessionSummary(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "engram", "content": "summary"}}})
+	if err != nil {
+		t.Fatalf("closed store session summary call: %v", err)
+	}
+	if !sessionSummaryRes.IsError {
+		t.Fatalf("expected session summary to return tool error when store is closed")
+	}
+
+	sessionStartRes, err := handleSessionStart(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": "s1", "project": "engram"}}})
+	if err != nil {
+		t.Fatalf("closed store session start call: %v", err)
+	}
+	if !sessionStartRes.IsError {
+		t.Fatalf("expected session start to return tool error when store is closed")
+	}
+
+	sessionEndRes, err := handleSessionEnd(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": "s1"}}})
+	if err != nil {
+		t.Fatalf("closed store session end call: %v", err)
+	}
+	if !sessionEndRes.IsError {
+		t.Fatalf("expected session end to return tool error when store is closed")
+	}
+}
+
+func TestMCPAdditionalCoverageBranches(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	contextRes, err := handleContext(s)(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("context empty store: %v", err)
+	}
+	if contextRes.IsError {
+		t.Fatalf("expected non-error context for empty store")
+	}
+	if !strings.Contains(callResultText(t, contextRes), "No previous session memories found") {
+		t.Fatalf("expected empty context message")
+	}
+
+	statsRes, err := handleStats(s)(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("stats empty store: %v", err)
+	}
+	if statsRes.IsError {
+		t.Fatalf("expected non-error stats for empty store")
+	}
+	if !strings.Contains(callResultText(t, statsRes), "Projects: none yet") {
+		t.Fatalf("expected none yet projects in stats output")
+	}
+
+	if err := s.CreateSession("s-extra", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	firstID, err := s.AddObservation(store.AddObservationParams{SessionID: "s-extra", Type: "note", Title: "first", Content: "first content", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add first: %v", err)
+	}
+	_, err = s.AddObservation(store.AddObservationParams{SessionID: "s-extra", Type: "note", Title: "second", Content: "second content", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add second: %v", err)
+	}
+
+	timelineReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"observation_id": float64(firstID), "before": 1.0, "after": 2.0}}}
+	timelineRes, err := handleTimeline(s)(context.Background(), timelineReq)
+	if err != nil {
+		t.Fatalf("timeline with header branches: %v", err)
+	}
+	if timelineRes.IsError {
+		t.Fatalf("expected non-error timeline with data")
+	}
+	text := callResultText(t, timelineRes)
+	if !strings.Contains(text, "Session:") || !strings.Contains(text, "After") {
+		t.Fatalf("expected timeline session/after sections, got %q", text)
+	}
+
+	save := handleSave(s)
+	saveReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Default values",
+		"content": "Ensure defaults for type and session are used",
+		"project": "engram",
+	}}}
+	saveRes, err := save(context.Background(), saveReq)
+	if err != nil {
+		t.Fatalf("save defaults: %v", err)
+	}
+	if saveRes.IsError {
+		t.Fatalf("expected save defaults to succeed: %s", callResultText(t, saveRes))
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	saveClosedRes, err := save(context.Background(), saveReq)
+	if err != nil {
+		t.Fatalf("save closed store call: %v", err)
+	}
+	if !saveClosedRes.IsError {
+		t.Fatalf("expected save to fail when store is closed")
+	}
+}
+
+func TestHandleSuggestTopicKeyReturnsErrorWhenSuggestionEmpty(t *testing.T) {
+	prev := suggestTopicKey
+	suggestTopicKey = func(typ, title, content string) string {
+		return ""
+	}
+	t.Cleanup(func() {
+		suggestTopicKey = prev
+	})
+
+	h := handleSuggestTopicKey()
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title": "valid title",
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected tool error when suggestion is empty")
+	}
+}
+
+func TestHandleUpdateAcceptsAllOptionalFields(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-all-fields", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-all-fields",
+		Type:      "decision",
+		Title:     "Original",
+		Content:   "Original content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	res, err := handleUpdate(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":        float64(id),
+		"title":     "Updated",
+		"content":   "Updated content",
+		"type":      "architecture",
+		"project":   "engram",
+		"scope":     "personal",
+		"topic_key": "architecture/auth-model",
+	}}})
+	if err != nil {
+		t.Fatalf("update handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected update error: %s", callResultText(t, res))
+	}
+}
+
+func TestHandleContextWithSessionOnlyUsesNoneProjects(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-context-none", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	res, err := handleContext(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"project": "engram",
+	}}})
+	if err != nil {
+		t.Fatalf("context handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected context error: %s", callResultText(t, res))
+	}
+	if !strings.Contains(callResultText(t, res), "projects: none") {
+		t.Fatalf("expected context output with projects: none")
+	}
+}
+
+func TestHandleStatsReturnsErrorWhenLoaderFails(t *testing.T) {
+	prev := loadMCPStats
+	loadMCPStats = func(s *store.Store) (*store.Stats, error) {
+		return nil, errors.New("stats unavailable")
+	}
+	t.Cleanup(func() {
+		loadMCPStats = prev
+	})
+
+	s := newMCPTestStore(t)
+	res, err := handleStats(s)(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("stats handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected tool error when stats loader fails")
+	}
+}
+
+func TestHandleTimelineBeforeSectionAndSummaryBranches(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-timeline", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	_, err := s.AddObservation(store.AddObservationParams{SessionID: "s-timeline", Type: "note", Title: "first", Content: "first", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add first observation: %v", err)
+	}
+	focusID, err := s.AddObservation(store.AddObservationParams{SessionID: "s-timeline", Type: "note", Title: "second", Content: "second", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add second observation: %v", err)
+	}
+	_, err = s.AddObservation(store.AddObservationParams{SessionID: "s-timeline", Type: "note", Title: "third", Content: "third", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add third observation: %v", err)
+	}
+	if err := s.EndSession("s-timeline", "timeline summary"); err != nil {
+		t.Fatalf("end session: %v", err)
+	}
+
+	res, err := handleTimeline(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"observation_id": float64(focusID),
+		"before":         2.0,
+		"after":          1.0,
+	}}})
+	if err != nil {
+		t.Fatalf("timeline handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected timeline error: %s", callResultText(t, res))
+	}
+	text := callResultText(t, res)
+	if !strings.Contains(text, "timeline summary") || !strings.Contains(text, "Before") {
+		t.Fatalf("expected timeline output with summary and before section, got %q", text)
+	}
+}
+
+func TestHandleGetObservationIncludesTopicAndToolMetadata(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-get-meta", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-get-meta",
+		Type:      "architecture",
+		Title:     "Auth model",
+		Content:   "Details",
+		Project:   "engram",
+		ToolName:  "mcp-passive",
+		TopicKey:  "architecture/auth-model",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	res, err := handleGetObservation(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id": float64(id),
+	}}})
+	if err != nil {
+		t.Fatalf("get observation handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected get observation error: %s", callResultText(t, res))
+	}
+	text := callResultText(t, res)
+	if !strings.Contains(text, "Topic: architecture/auth-model") || !strings.Contains(text, "Tool: mcp-passive") {
+		t.Fatalf("expected topic and tool metadata in output, got %q", text)
 	}
 }

--- a/internal/server/server_e2e_test.go
+++ b/internal/server/server_e2e_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -288,4 +289,581 @@ func TestPassiveCaptureEndpointReturnsServerErrorWhenSessionMissing(t *testing.T
 	if captureResp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("expected 500 when session does not exist, got %d", captureResp.StatusCode)
 	}
+}
+
+func TestCoreReadHandlersAndHelpersE2E(t *testing.T) {
+	_, ts := newE2EServer(t)
+	client := ts.Client()
+
+	healthResp, err := client.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	if healthResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 health, got %d", healthResp.StatusCode)
+	}
+	health := decodeJSON[map[string]any](t, healthResp)
+	if health["status"] != "ok" {
+		t.Fatalf("expected health status ok, got %v", health["status"])
+	}
+
+	create := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+		"id":      "s-core",
+		"project": "engram",
+	})
+	if create.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating session, got %d", create.StatusCode)
+	}
+	create.Body.Close()
+
+	obs := postJSON(t, client, ts.URL+"/observations", map[string]any{
+		"session_id": "s-core",
+		"type":       "decision",
+		"title":      "Core test",
+		"content":    "exercise handlers",
+		"project":    "engram",
+	})
+	if obs.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating observation, got %d", obs.StatusCode)
+	}
+	obsData := decodeJSON[map[string]any](t, obs)
+	obsID := int64(obsData["id"].(float64))
+
+	recentSessionsResp, err := client.Get(ts.URL + "/sessions/recent?project=engram&limit=oops")
+	if err != nil {
+		t.Fatalf("recent sessions: %v", err)
+	}
+	if recentSessionsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 recent sessions, got %d", recentSessionsResp.StatusCode)
+	}
+	recentSessions := decodeJSON[[]map[string]any](t, recentSessionsResp)
+	if len(recentSessions) == 0 {
+		t.Fatalf("expected at least one recent session")
+	}
+
+	recentObsResp, err := client.Get(ts.URL + "/observations/recent?project=engram&scope=project&limit=bad")
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if recentObsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 recent observations, got %d", recentObsResp.StatusCode)
+	}
+	recentObs := decodeJSON[[]map[string]any](t, recentObsResp)
+	if len(recentObs) == 0 {
+		t.Fatalf("expected recent observations")
+	}
+
+	timelineResp, err := client.Get(ts.URL + "/timeline?observation_id=" + strconv.FormatInt(obsID, 10) + "&before=bad&after=bad")
+	if err != nil {
+		t.Fatalf("timeline: %v", err)
+	}
+	if timelineResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 timeline, got %d", timelineResp.StatusCode)
+	}
+	timeline := decodeJSON[map[string]any](t, timelineResp)
+	if timeline["focus"] == nil {
+		t.Fatalf("expected focus observation in timeline")
+	}
+
+	contextResp, err := client.Get(ts.URL + "/context?project=engram&scope=project")
+	if err != nil {
+		t.Fatalf("context: %v", err)
+	}
+	if contextResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 context, got %d", contextResp.StatusCode)
+	}
+	contextData := decodeJSON[map[string]string](t, contextResp)
+	if !strings.Contains(contextData["context"], "Memory from Previous Sessions") {
+		t.Fatalf("expected formatted context output")
+	}
+
+	statsResp, err := client.Get(ts.URL + "/stats")
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 stats, got %d", statsResp.StatusCode)
+	}
+	stats := decodeJSON[map[string]any](t, statsResp)
+	if stats["total_sessions"].(float64) < 1 {
+		t.Fatalf("expected at least one session in stats")
+	}
+
+	endResp := postJSON(t, client, ts.URL+"/sessions/s-core/end", map[string]any{"summary": "done"})
+	if endResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 ending session, got %d", endResp.StatusCode)
+	}
+	endResp.Body.Close()
+}
+
+func TestValidationAndImportExportErrorsE2E(t *testing.T) {
+	_, ts := newE2EServer(t)
+	client := ts.Client()
+
+	invalidSessionResp, err := client.Post(ts.URL+"/sessions", "application/json", strings.NewReader("{"))
+	if err != nil {
+		t.Fatalf("post invalid session json: %v", err)
+	}
+	if invalidSessionResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 invalid session json, got %d", invalidSessionResp.StatusCode)
+	}
+	invalidSessionResp.Body.Close()
+
+	missingFieldsResp := postJSON(t, client, ts.URL+"/sessions", map[string]any{"id": "only-id"})
+	if missingFieldsResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 missing required fields, got %d", missingFieldsResp.StatusCode)
+	}
+	missingFieldsResp.Body.Close()
+
+	create := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+		"id":      "s-validate",
+		"project": "engram",
+	})
+	if create.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating session, got %d", create.StatusCode)
+	}
+	create.Body.Close()
+
+	updateBadIDReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/observations/not-a-number", strings.NewReader(`{"title":"x"}`))
+	updateBadIDReq.Header.Set("Content-Type", "application/json")
+	updateBadIDResp, err := client.Do(updateBadIDReq)
+	if err != nil {
+		t.Fatalf("patch bad id: %v", err)
+	}
+	if updateBadIDResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 update bad id, got %d", updateBadIDResp.StatusCode)
+	}
+	updateBadIDResp.Body.Close()
+
+	searchMissingQResp, err := client.Get(ts.URL + "/search")
+	if err != nil {
+		t.Fatalf("search without q: %v", err)
+	}
+	if searchMissingQResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 search missing q, got %d", searchMissingQResp.StatusCode)
+	}
+	searchMissingQResp.Body.Close()
+
+	promptsMissingQResp, err := client.Get(ts.URL + "/prompts/search")
+	if err != nil {
+		t.Fatalf("search prompts without q: %v", err)
+	}
+	if promptsMissingQResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 prompts search missing q, got %d", promptsMissingQResp.StatusCode)
+	}
+	promptsMissingQResp.Body.Close()
+
+	invalidImportResp, err := client.Post(ts.URL+"/import", "application/json", strings.NewReader("{"))
+	if err != nil {
+		t.Fatalf("import invalid json: %v", err)
+	}
+	if invalidImportResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 import invalid json, got %d", invalidImportResp.StatusCode)
+	}
+	invalidImportResp.Body.Close()
+
+	exportResp, err := client.Get(ts.URL + "/export")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if exportResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 export, got %d", exportResp.StatusCode)
+	}
+	exportedBody, err := io.ReadAll(exportResp.Body)
+	if err != nil {
+		t.Fatalf("read export body: %v", err)
+	}
+	exportResp.Body.Close()
+
+	reimportResp, err := client.Post(ts.URL+"/import", "application/json", bytes.NewReader(exportedBody))
+	if err != nil {
+		t.Fatalf("reimport: %v", err)
+	}
+	if reimportResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 import after export, got %d", reimportResp.StatusCode)
+	}
+	reimportResp.Body.Close()
+
+	recentPromptsResp, err := client.Get(ts.URL + "/prompts/recent?project=engram&limit=bad")
+	if err != nil {
+		t.Fatalf("recent prompts: %v", err)
+	}
+	if recentPromptsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 recent prompts, got %d", recentPromptsResp.StatusCode)
+	}
+	recentPromptsResp.Body.Close()
+}
+
+func TestPromptAndObservationMutationHandlersE2E(t *testing.T) {
+	_, ts := newE2EServer(t)
+	client := ts.Client()
+
+	create := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+		"id":      "s-mutate",
+		"project": "engram",
+	})
+	if create.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating session, got %d", create.StatusCode)
+	}
+	create.Body.Close()
+
+	addPrompt := postJSON(t, client, ts.URL+"/prompts", map[string]any{
+		"session_id": "s-mutate",
+		"content":    "How to fix auth panic?",
+		"project":    "engram",
+	})
+	if addPrompt.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 adding prompt, got %d", addPrompt.StatusCode)
+	}
+	addPrompt.Body.Close()
+
+	addPromptMissing := postJSON(t, client, ts.URL+"/prompts", map[string]any{
+		"session_id": "s-mutate",
+	})
+	if addPromptMissing.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for prompt missing content, got %d", addPromptMissing.StatusCode)
+	}
+	addPromptMissing.Body.Close()
+
+	searchPromptResp, err := client.Get(ts.URL + "/prompts/search?q=auth&project=engram&limit=5")
+	if err != nil {
+		t.Fatalf("search prompts: %v", err)
+	}
+	if searchPromptResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 searching prompts, got %d", searchPromptResp.StatusCode)
+	}
+	prompts := decodeJSON[[]map[string]any](t, searchPromptResp)
+	if len(prompts) == 0 {
+		t.Fatalf("expected prompt search results")
+	}
+
+	obs := postJSON(t, client, ts.URL+"/observations", map[string]any{
+		"session_id": "s-mutate",
+		"type":       "decision",
+		"title":      "Auth handling",
+		"content":    "Use middleware",
+		"project":    "engram",
+	})
+	if obs.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 adding observation, got %d", obs.StatusCode)
+	}
+	obsBody := decodeJSON[map[string]any](t, obs)
+	obsID := int64(obsBody["id"].(float64))
+
+	updateReq, err := http.NewRequest(http.MethodPatch, ts.URL+"/observations/"+strconv.FormatInt(obsID, 10), strings.NewReader(`{"title":"Auth handling updated","topic_key":"architecture/auth"}`))
+	if err != nil {
+		t.Fatalf("new patch request: %v", err)
+	}
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateResp, err := client.Do(updateReq)
+	if err != nil {
+		t.Fatalf("patch observation: %v", err)
+	}
+	if updateResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 updating observation, got %d", updateResp.StatusCode)
+	}
+	updated := decodeJSON[map[string]any](t, updateResp)
+	if updated["title"] != "Auth handling updated" {
+		t.Fatalf("expected updated title, got %v", updated["title"])
+	}
+
+	emptyUpdateReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/observations/"+strconv.FormatInt(obsID, 10), strings.NewReader(`{}`))
+	emptyUpdateReq.Header.Set("Content-Type", "application/json")
+	emptyUpdateResp, err := client.Do(emptyUpdateReq)
+	if err != nil {
+		t.Fatalf("patch empty update: %v", err)
+	}
+	if emptyUpdateResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty update payload, got %d", emptyUpdateResp.StatusCode)
+	}
+	emptyUpdateResp.Body.Close()
+
+	badUpdateReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/observations/"+strconv.FormatInt(obsID, 10), strings.NewReader("{"))
+	badUpdateReq.Header.Set("Content-Type", "application/json")
+	badUpdateResp, err := client.Do(badUpdateReq)
+	if err != nil {
+		t.Fatalf("patch invalid json: %v", err)
+	}
+	if badUpdateResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid update json, got %d", badUpdateResp.StatusCode)
+	}
+	badUpdateResp.Body.Close()
+
+	deleteHardReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/observations/"+strconv.FormatInt(obsID, 10)+"?hard=true", nil)
+	deleteHardResp, err := client.Do(deleteHardReq)
+	if err != nil {
+		t.Fatalf("delete hard observation: %v", err)
+	}
+	if deleteHardResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 hard delete, got %d", deleteHardResp.StatusCode)
+	}
+	deleteHardResp.Body.Close()
+
+	deleteInvalidBoolReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/observations/"+strconv.FormatInt(obsID, 10)+"?hard=not-bool", nil)
+	deleteInvalidBoolResp, err := client.Do(deleteInvalidBoolReq)
+	if err != nil {
+		t.Fatalf("delete with invalid bool: %v", err)
+	}
+	if deleteInvalidBoolResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 delete with invalid bool fallback, got %d", deleteInvalidBoolResp.StatusCode)
+	}
+	deleteInvalidBoolResp.Body.Close()
+
+	timelineMissingIDResp, err := client.Get(ts.URL + "/timeline")
+	if err != nil {
+		t.Fatalf("timeline missing id: %v", err)
+	}
+	if timelineMissingIDResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 timeline missing observation_id, got %d", timelineMissingIDResp.StatusCode)
+	}
+	timelineMissingIDResp.Body.Close()
+
+	timelineBadIDResp, err := client.Get(ts.URL + "/timeline?observation_id=abc")
+	if err != nil {
+		t.Fatalf("timeline bad id: %v", err)
+	}
+	if timelineBadIDResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 invalid timeline id, got %d", timelineBadIDResp.StatusCode)
+	}
+	timelineBadIDResp.Body.Close()
+}
+
+func TestServerHandlersReturn500WhenStoreClosed(t *testing.T) {
+	s, ts := newE2EServer(t)
+	client := ts.Client()
+
+	create := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+		"id":      "s-closed",
+		"project": "engram",
+	})
+	if create.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating session, got %d", create.StatusCode)
+	}
+	create.Body.Close()
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	addPrompt := postJSON(t, client, ts.URL+"/prompts", map[string]any{
+		"session_id": "s-closed",
+		"content":    "prompt",
+		"project":    "engram",
+	})
+	if addPrompt.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 add prompt with closed store, got %d", addPrompt.StatusCode)
+	}
+	addPrompt.Body.Close()
+
+	recentPromptsResp, err := client.Get(ts.URL + "/prompts/recent")
+	if err != nil {
+		t.Fatalf("recent prompts closed store: %v", err)
+	}
+	if recentPromptsResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 recent prompts with closed store, got %d", recentPromptsResp.StatusCode)
+	}
+	recentPromptsResp.Body.Close()
+
+	searchPromptsResp, err := client.Get(ts.URL + "/prompts/search?q=test")
+	if err != nil {
+		t.Fatalf("search prompts closed store: %v", err)
+	}
+	if searchPromptsResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 search prompts with closed store, got %d", searchPromptsResp.StatusCode)
+	}
+	searchPromptsResp.Body.Close()
+
+	contextResp, err := client.Get(ts.URL + "/context")
+	if err != nil {
+		t.Fatalf("context closed store: %v", err)
+	}
+	if contextResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 context with closed store, got %d", contextResp.StatusCode)
+	}
+	contextResp.Body.Close()
+
+	statsResp, err := client.Get(ts.URL + "/stats")
+	if err != nil {
+		t.Fatalf("stats closed store: %v", err)
+	}
+	if statsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 stats with closed store fallback, got %d", statsResp.StatusCode)
+	}
+	statsResp.Body.Close()
+}
+
+func TestObservationAndSessionErrorBranchesE2E(t *testing.T) {
+	_, ts := newE2EServer(t)
+	client := ts.Client()
+
+	addObsBadJSONResp, err := client.Post(ts.URL+"/observations", "application/json", strings.NewReader("{"))
+	if err != nil {
+		t.Fatalf("post bad observation json: %v", err)
+	}
+	if addObsBadJSONResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 invalid observation json, got %d", addObsBadJSONResp.StatusCode)
+	}
+	addObsBadJSONResp.Body.Close()
+
+	addObsMissingFieldsResp := postJSON(t, client, ts.URL+"/observations", map[string]any{"session_id": "s-x"})
+	if addObsMissingFieldsResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 observation missing fields, got %d", addObsMissingFieldsResp.StatusCode)
+	}
+	addObsMissingFieldsResp.Body.Close()
+
+	create := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+		"id":      "s-errors",
+		"project": "engram",
+	})
+	if create.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating session, got %d", create.StatusCode)
+	}
+	create.Body.Close()
+
+	obs := postJSON(t, client, ts.URL+"/observations", map[string]any{
+		"session_id": "s-errors",
+		"type":       "decision",
+		"title":      "Delete me",
+		"content":    "content",
+		"project":    "engram",
+	})
+	if obs.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 adding observation, got %d", obs.StatusCode)
+	}
+	obsData := decodeJSON[map[string]any](t, obs)
+	obsID := int64(obsData["id"].(float64))
+
+	deleteBadIDReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/observations/not-number", nil)
+	deleteBadIDResp, err := client.Do(deleteBadIDReq)
+	if err != nil {
+		t.Fatalf("delete bad id: %v", err)
+	}
+	if deleteBadIDResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 delete bad id, got %d", deleteBadIDResp.StatusCode)
+	}
+	deleteBadIDResp.Body.Close()
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/observations/"+strconv.FormatInt(obsID, 10), nil)
+	deleteResp, err := client.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete observation: %v", err)
+	}
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 deleting observation, got %d", deleteResp.StatusCode)
+	}
+	deleteResp.Body.Close()
+
+	timelineNotFoundResp, err := client.Get(ts.URL + "/timeline?observation_id=" + strconv.FormatInt(obsID, 10))
+	if err != nil {
+		t.Fatalf("timeline for deleted obs: %v", err)
+	}
+	if timelineNotFoundResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 timeline for deleted observation, got %d", timelineNotFoundResp.StatusCode)
+	}
+	timelineNotFoundResp.Body.Close()
+
+	searchBadFTSResp, err := client.Get(ts.URL + "/search?q=%22%22%22")
+	if err != nil {
+		t.Fatalf("search malformed fts input: %v", err)
+	}
+	if searchBadFTSResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected handled malformed query response, got %d", searchBadFTSResp.StatusCode)
+	}
+	searchBadFTSResp.Body.Close()
+}
+
+func TestStoreClosedExtraServerBranchesE2E(t *testing.T) {
+	s, ts := newE2EServer(t)
+	client := ts.Client()
+
+	create := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+		"id":      "s-closed-2",
+		"project": "engram",
+	})
+	if create.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating session, got %d", create.StatusCode)
+	}
+	create.Body.Close()
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	createSessionResp := postJSON(t, client, ts.URL+"/sessions", map[string]any{"id": "s2", "project": "engram"})
+	if createSessionResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 creating session on closed store, got %d", createSessionResp.StatusCode)
+	}
+	createSessionResp.Body.Close()
+
+	endResp := postJSON(t, client, ts.URL+"/sessions/s-closed-2/end", map[string]any{"summary": "done"})
+	if endResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 ending session on closed store, got %d", endResp.StatusCode)
+	}
+	endResp.Body.Close()
+
+	recentSessionsResp, err := client.Get(ts.URL + "/sessions/recent")
+	if err != nil {
+		t.Fatalf("recent sessions closed store: %v", err)
+	}
+	if recentSessionsResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 recent sessions on closed store, got %d", recentSessionsResp.StatusCode)
+	}
+	recentSessionsResp.Body.Close()
+
+	addObsResp := postJSON(t, client, ts.URL+"/observations", map[string]any{
+		"session_id": "s-closed-2",
+		"type":       "decision",
+		"title":      "t",
+		"content":    "c",
+	})
+	if addObsResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 add observation on closed store, got %d", addObsResp.StatusCode)
+	}
+	addObsResp.Body.Close()
+
+	recentObsResp, err := client.Get(ts.URL + "/observations/recent")
+	if err != nil {
+		t.Fatalf("recent observations closed store: %v", err)
+	}
+	if recentObsResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 recent observations on closed store, got %d", recentObsResp.StatusCode)
+	}
+	recentObsResp.Body.Close()
+
+	searchResp, err := client.Get(ts.URL + "/search?q=test")
+	if err != nil {
+		t.Fatalf("search closed store: %v", err)
+	}
+	if searchResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 search on closed store, got %d", searchResp.StatusCode)
+	}
+	searchResp.Body.Close()
+
+	getResp, err := client.Get(ts.URL + "/observations/1")
+	if err != nil {
+		t.Fatalf("get observation closed store: %v", err)
+	}
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 get observation on closed store, got %d", getResp.StatusCode)
+	}
+	getResp.Body.Close()
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/observations/1", nil)
+	deleteResp, err := client.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete observation closed store: %v", err)
+	}
+	if deleteResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 delete observation on closed store, got %d", deleteResp.StatusCode)
+	}
+	deleteResp.Body.Close()
+
+	exportResp, err := client.Get(ts.URL + "/export")
+	if err != nil {
+		t.Fatalf("export closed store: %v", err)
+	}
+	if exportResp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 export on closed store, got %d", exportResp.StatusCode)
+	}
+	exportResp.Body.Close()
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alanbuscaglia/engram/internal/store"
+)
+
+type stubListener struct{}
+
+func (stubListener) Accept() (net.Conn, error) { return nil, errors.New("not used") }
+func (stubListener) Close() error              { return nil }
+func (stubListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
+func TestStartReturnsListenError(t *testing.T) {
+	s := New(nil, 7777)
+	s.listen = func(network, address string) (net.Listener, error) {
+		return nil, errors.New("listen failed")
+	}
+
+	err := s.Start()
+	if err == nil {
+		t.Fatalf("expected start to fail on listen error")
+	}
+}
+
+func TestStartUsesInjectedServe(t *testing.T) {
+	s := New(&store.Store{}, 7777)
+	s.listen = func(network, address string) (net.Listener, error) {
+		return stubListener{}, nil
+	}
+	s.serve = func(ln net.Listener, h http.Handler) error {
+		if ln == nil || h == nil {
+			t.Fatalf("expected listener and handler to be provided")
+		}
+		return errors.New("serve stopped")
+	}
+
+	err := s.Start()
+	if err == nil || err.Error() != "serve stopped" {
+		t.Fatalf("expected propagated serve error, got %v", err)
+	}
+}
+
+func newServerTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	cfg := store.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+	return s
+}
+
+func TestStartUsesDefaultListenWhenListenNil(t *testing.T) {
+	s := New(newServerTestStore(t), 0)
+	s.listen = nil
+	s.serve = func(ln net.Listener, h http.Handler) error {
+		if ln == nil || h == nil {
+			t.Fatalf("expected non-nil listener and handler")
+		}
+		_ = ln.Close()
+		return errors.New("serve stopped")
+	}
+
+	err := s.Start()
+	if err == nil || err.Error() != "serve stopped" {
+		t.Fatalf("expected propagated serve error, got %v", err)
+	}
+}
+
+func TestStartUsesDefaultServeWhenServeNil(t *testing.T) {
+	s := New(newServerTestStore(t), 7777)
+	s.listen = func(network, address string) (net.Listener, error) {
+		return stubListener{}, nil
+	}
+	s.serve = nil
+
+	err := s.Start()
+	if err == nil {
+		t.Fatalf("expected start to fail when default http.Serve receives failing listener")
+	}
+}
+
+func TestAdditionalServerErrorBranches(t *testing.T) {
+	st := newServerTestStore(t)
+	srv := New(st, 0)
+	h := srv.Handler()
+
+	createReq := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(`{"id":"s-test","project":"engram"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	h.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("expected session create 201, got %d", createRec.Code)
+	}
+
+	getBadIDReq := httptest.NewRequest(http.MethodGet, "/observations/not-a-number", nil)
+	getBadIDRec := httptest.NewRecorder()
+	h.ServeHTTP(getBadIDRec, getBadIDReq)
+	if getBadIDRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid observation id, got %d", getBadIDRec.Code)
+	}
+
+	updateNotFoundReq := httptest.NewRequest(http.MethodPatch, "/observations/99999", strings.NewReader(`{"title":"updated"}`))
+	updateNotFoundReq.Header.Set("Content-Type", "application/json")
+	updateNotFoundRec := httptest.NewRecorder()
+	h.ServeHTTP(updateNotFoundRec, updateNotFoundReq)
+	if updateNotFoundRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 updating missing observation, got %d", updateNotFoundRec.Code)
+	}
+
+	promptBadJSONReq := httptest.NewRequest(http.MethodPost, "/prompts", strings.NewReader("{"))
+	promptBadJSONReq.Header.Set("Content-Type", "application/json")
+	promptBadJSONRec := httptest.NewRecorder()
+	h.ServeHTTP(promptBadJSONRec, promptBadJSONReq)
+	if promptBadJSONRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid prompt json, got %d", promptBadJSONRec.Code)
+	}
+
+	oversizeBody := bytes.Repeat([]byte("a"), 50<<20+1)
+	importTooLargeReq := httptest.NewRequest(http.MethodPost, "/import", bytes.NewReader(oversizeBody))
+	importTooLargeReq.Header.Set("Content-Type", "application/json")
+	importTooLargeRec := httptest.NewRecorder()
+	h.ServeHTTP(importTooLargeRec, importTooLargeReq)
+	if importTooLargeRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversize import body, got %d", importTooLargeRec.Code)
+	}
+
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	validImport, err := json.Marshal(store.ExportData{Version: "0.1.0", ExportedAt: "now"})
+	if err != nil {
+		t.Fatalf("marshal import payload: %v", err)
+	}
+	importClosedReq := httptest.NewRequest(http.MethodPost, "/import", bytes.NewReader(validImport))
+	importClosedReq.Header.Set("Content-Type", "application/json")
+	importClosedRec := httptest.NewRecorder()
+	h.ServeHTTP(importClosedRec, importClosedReq)
+	if importClosedRec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 importing on closed store, got %d", importClosedRec.Code)
+	}
+}
+
+func TestHandleStatsReturnsInternalServerErrorOnLoaderError(t *testing.T) {
+	prev := loadServerStats
+	loadServerStats = func(s *store.Store) (*store.Stats, error) {
+		return nil, errors.New("stats unavailable")
+	}
+	t.Cleanup(func() {
+		loadServerStats = prev
+	})
+
+	s := New(newServerTestStore(t), 0)
+	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	rec := httptest.NewRecorder()
+
+	s.handleStats(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 stats response, got %d", rec.Code)
+	}
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2,11 +2,60 @@ package setup
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func resetSetupSeams(t *testing.T) {
+	t.Helper()
+	oldRuntimeGOOS := runtimeGOOS
+	oldUserHomeDir := userHomeDir
+	oldLookPathFn := lookPathFn
+	oldRunCommand := runCommand
+	oldOpenCodeReadFile := openCodeReadFile
+	oldOpenCodeWriteFileFn := openCodeWriteFileFn
+	oldReadFileFn := readFileFn
+	oldWriteFileFn := writeFileFn
+	oldJSONMarshalFn := jsonMarshalFn
+	oldJSONMarshalIndentFn := jsonMarshalIndentFn
+	oldInjectOpenCodeMCPFn := injectOpenCodeMCPFn
+	oldInjectGeminiMCPFn := injectGeminiMCPFn
+	oldWriteGeminiSystemPromptFn := writeGeminiSystemPromptFn
+	oldEnsureGeminiEnvOverrideFn := ensureGeminiEnvOverrideFn
+	oldWriteCodexMemoryInstructionFilesFn := writeCodexMemoryInstructionFilesFn
+	oldInjectCodexMCPFn := injectCodexMCPFn
+	oldInjectCodexMemoryConfigFn := injectCodexMemoryConfigFn
+
+	t.Cleanup(func() {
+		runtimeGOOS = oldRuntimeGOOS
+		userHomeDir = oldUserHomeDir
+		lookPathFn = oldLookPathFn
+		runCommand = oldRunCommand
+		openCodeReadFile = oldOpenCodeReadFile
+		openCodeWriteFileFn = oldOpenCodeWriteFileFn
+		readFileFn = oldReadFileFn
+		writeFileFn = oldWriteFileFn
+		jsonMarshalFn = oldJSONMarshalFn
+		jsonMarshalIndentFn = oldJSONMarshalIndentFn
+		injectOpenCodeMCPFn = oldInjectOpenCodeMCPFn
+		injectGeminiMCPFn = oldInjectGeminiMCPFn
+		writeGeminiSystemPromptFn = oldWriteGeminiSystemPromptFn
+		ensureGeminiEnvOverrideFn = oldEnsureGeminiEnvOverrideFn
+		writeCodexMemoryInstructionFilesFn = oldWriteCodexMemoryInstructionFilesFn
+		injectCodexMCPFn = oldInjectCodexMCPFn
+		injectCodexMemoryConfigFn = oldInjectCodexMemoryConfigFn
+	})
+}
+
+func useTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	userHomeDir = func() (string, error) { return home, nil }
+	return home
+}
 
 func TestSupportedAgentsIncludesGeminiAndCodex(t *testing.T) {
 	agents := SupportedAgents()
@@ -126,6 +175,7 @@ func TestInstallGeminiCLIInjectsMCPConfig(t *testing.T) {
 }
 
 func TestInstallCodexInjectsTOMLAndIsIdempotent(t *testing.T) {
+	resetSetupSeams(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -233,4 +283,1056 @@ func TestInstallCodexInjectsTOMLAndIsIdempotent(t *testing.T) {
 	if !strings.Contains(string(compactRaw), "FIRST ACTION REQUIRED") {
 		t.Fatalf("expected FIRST ACTION REQUIRED text in compact prompt")
 	}
+}
+
+func TestInstallUnknownAgent(t *testing.T) {
+	resetSetupSeams(t)
+	_, err := Install("unknown")
+	if err == nil || !strings.Contains(err.Error(), "unknown agent") {
+		t.Fatalf("expected unknown agent error, got %v", err)
+	}
+}
+
+func TestInstallOpenCodeSuccessAndMCPRegistered(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	runtimeGOOS = "linux"
+	xdg := filepath.Join(home, "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	result, err := installOpenCode()
+	if err != nil {
+		t.Fatalf("installOpenCode failed: %v", err)
+	}
+	if result.Files != 2 {
+		t.Fatalf("expected 2 files after MCP registration, got %d", result.Files)
+	}
+
+	pluginPath := filepath.Join(xdg, "opencode", "plugins", "engram.ts")
+	if _, err := os.Stat(pluginPath); err != nil {
+		t.Fatalf("expected plugin file to exist: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(xdg, "opencode", "opencode.json"))
+	if err != nil {
+		t.Fatalf("read opencode config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse opencode config: %v", err)
+	}
+	mcp, ok := cfg["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mcp object in opencode.json")
+	}
+	if _, ok := mcp["engram"]; !ok {
+		t.Fatalf("expected mcp.engram registration")
+	}
+}
+
+func TestInstallOpenCodeReadEmbeddedError(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	runtimeGOOS = "linux"
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	openCodeReadFile = func(string) ([]byte, error) {
+		return nil, errors.New("boom")
+	}
+
+	_, err := installOpenCode()
+	if err == nil || !strings.Contains(err.Error(), "read embedded engram.ts") {
+		t.Fatalf("expected read embedded error, got %v", err)
+	}
+}
+
+func TestInstallOpenCodeWriteError(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	runtimeGOOS = "linux"
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	openCodeWriteFileFn = func(string, []byte, os.FileMode) error {
+		return errors.New("write boom")
+	}
+
+	_, err := installOpenCode()
+	if err == nil || !strings.Contains(err.Error(), "write ") {
+		t.Fatalf("expected write error, got %v", err)
+	}
+}
+
+func TestInstallOpenCodeMCPInjectionFailureIsNonFatal(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	runtimeGOOS = "linux"
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	injectOpenCodeMCPFn = func() error {
+		return errors.New("cannot write config")
+	}
+
+	result, err := installOpenCode()
+	if err != nil {
+		t.Fatalf("expected non-fatal MCP injection failure, got %v", err)
+	}
+	if result.Files != 1 {
+		t.Fatalf("expected only plugin file counted when MCP injection fails, got %d", result.Files)
+	}
+}
+
+func TestInjectOpenCodeMCPPreservesExistingAndIsIdempotent(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	runtimeGOOS = "linux"
+	xdg := filepath.Join(home, "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	configPath := filepath.Join(xdg, "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	initial := `{"theme":"kanagawa","mcp":{"other":{"type":"local","command":["foo"]}}}`
+	if err := os.WriteFile(configPath, []byte(initial), 0644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	if err := injectOpenCodeMCP(); err != nil {
+		t.Fatalf("injectOpenCodeMCP failed: %v", err)
+	}
+	if err := injectOpenCodeMCP(); err != nil {
+		t.Fatalf("injectOpenCodeMCP should be idempotent: %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read updated config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse updated config: %v", err)
+	}
+	mcp, ok := cfg["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mcp object")
+	}
+	if _, ok := mcp["other"]; !ok {
+		t.Fatalf("expected existing mcp entry to be preserved")
+	}
+	engram, ok := mcp["engram"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected engram object")
+	}
+	if engram["enabled"] != true {
+		t.Fatalf("expected engram.enabled=true")
+	}
+}
+
+func TestInjectOpenCodeMCPConfigErrors(t *testing.T) {
+	t.Run("invalid root json", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		xdg := filepath.Join(home, "xdg")
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		configPath := filepath.Join(xdg, "opencode", "opencode.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			t.Fatalf("mkdir config dir: %v", err)
+		}
+		if err := os.WriteFile(configPath, []byte("{"), 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		err := injectOpenCodeMCP()
+		if err == nil || !strings.Contains(err.Error(), "parse config") {
+			t.Fatalf("expected parse config error, got %v", err)
+		}
+	})
+
+	t.Run("invalid mcp block", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		xdg := filepath.Join(home, "xdg")
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		configPath := filepath.Join(xdg, "opencode", "opencode.json")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			t.Fatalf("mkdir config dir: %v", err)
+		}
+		if err := os.WriteFile(configPath, []byte(`{"mcp":"nope"}`), 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		err := injectOpenCodeMCP()
+		if err == nil || !strings.Contains(err.Error(), "parse mcp block") {
+			t.Fatalf("expected parse mcp block error, got %v", err)
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		xdg := filepath.Join(home, "xdg")
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		configPath := filepath.Join(xdg, "opencode", "opencode.json")
+		if err := os.MkdirAll(configPath, 0755); err != nil {
+			t.Fatalf("create directory at config path: %v", err)
+		}
+
+		err := injectOpenCodeMCP()
+		if err == nil || !strings.Contains(err.Error(), "read config") {
+			t.Fatalf("expected read config error, got %v", err)
+		}
+	})
+
+	t.Run("marshal engram entry error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		xdg := filepath.Join(home, "xdg")
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		jsonMarshalFn = func(any) ([]byte, error) {
+			return nil, errors.New("marshal entry boom")
+		}
+
+		err := injectOpenCodeMCP()
+		if err == nil || !strings.Contains(err.Error(), "marshal engram entry") {
+			t.Fatalf("expected marshal engram entry error, got %v", err)
+		}
+	})
+
+	t.Run("marshal mcp block error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		xdg := filepath.Join(home, "xdg")
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		calls := 0
+		jsonMarshalFn = func(v any) ([]byte, error) {
+			calls++
+			if calls == 2 {
+				return nil, errors.New("marshal mcp boom")
+			}
+			return json.Marshal(v)
+		}
+
+		err := injectOpenCodeMCP()
+		if err == nil || !strings.Contains(err.Error(), "marshal mcp block") {
+			t.Fatalf("expected marshal mcp block error, got %v", err)
+		}
+	})
+
+	t.Run("marshal config error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		xdg := filepath.Join(home, "xdg")
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		jsonMarshalIndentFn = func(any, string, string) ([]byte, error) {
+			return nil, errors.New("marshal config boom")
+		}
+
+		err := injectOpenCodeMCP()
+		if err == nil || !strings.Contains(err.Error(), "marshal config") {
+			t.Fatalf("expected marshal config error, got %v", err)
+		}
+	})
+}
+
+func TestDefaultRunCommandExecutes(t *testing.T) {
+	resetSetupSeams(t)
+	out, err := runCommand("sh", "-c", "printf ok")
+	if err != nil {
+		t.Fatalf("expected default runCommand to execute, got %v", err)
+	}
+	if string(out) != "ok" {
+		t.Fatalf("unexpected output: %q", string(out))
+	}
+}
+
+func TestInstallClaudeCodeBranches(t *testing.T) {
+	t.Run("cli missing", func(t *testing.T) {
+		resetSetupSeams(t)
+		lookPathFn = func(string) (string, error) {
+			return "", errors.New("not found")
+		}
+
+		_, err := installClaudeCode()
+		if err == nil || !strings.Contains(err.Error(), "claude CLI not found") {
+			t.Fatalf("expected not found error, got %v", err)
+		}
+	})
+
+	t.Run("marketplace add hard failure", func(t *testing.T) {
+		resetSetupSeams(t)
+		lookPathFn = func(string) (string, error) { return "claude", nil }
+		runCommand = func(string, ...string) ([]byte, error) {
+			return []byte("permission denied"), errors.New("exit 1")
+		}
+
+		_, err := installClaudeCode()
+		if err == nil || !strings.Contains(err.Error(), "marketplace add failed") {
+			t.Fatalf("expected marketplace add failure, got %v", err)
+		}
+	})
+
+	t.Run("marketplace already then install success", func(t *testing.T) {
+		resetSetupSeams(t)
+		lookPathFn = func(string) (string, error) { return "claude", nil }
+		calls := 0
+		runCommand = func(_ string, args ...string) ([]byte, error) {
+			calls++
+			if calls == 1 {
+				if strings.Join(args, " ") != "plugin marketplace add "+claudeCodeMarketplace {
+					t.Fatalf("unexpected first command args: %q", strings.Join(args, " "))
+				}
+				return []byte("already added"), errors.New("exit 1")
+			}
+			if strings.Join(args, " ") != "plugin install engram" {
+				t.Fatalf("unexpected second command args: %q", strings.Join(args, " "))
+			}
+			return []byte("installed"), nil
+		}
+
+		result, err := installClaudeCode()
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if result.Agent != "claude-code" || result.Files != 0 {
+			t.Fatalf("unexpected result: %#v", result)
+		}
+	})
+
+	t.Run("install hard failure", func(t *testing.T) {
+		resetSetupSeams(t)
+		lookPathFn = func(string) (string, error) { return "claude", nil }
+		calls := 0
+		runCommand = func(string, ...string) ([]byte, error) {
+			calls++
+			if calls == 1 {
+				return []byte("ok"), nil
+			}
+			return []byte("network failure"), errors.New("exit 1")
+		}
+
+		_, err := installClaudeCode()
+		if err == nil || !strings.Contains(err.Error(), "plugin install failed") {
+			t.Fatalf("expected plugin install failure, got %v", err)
+		}
+	})
+
+	t.Run("install already is success", func(t *testing.T) {
+		resetSetupSeams(t)
+		lookPathFn = func(string) (string, error) { return "claude", nil }
+		calls := 0
+		runCommand = func(string, ...string) ([]byte, error) {
+			calls++
+			if calls == 1 {
+				return []byte("ok"), nil
+			}
+			return []byte("already installed"), errors.New("exit 1")
+		}
+
+		if _, err := installClaudeCode(); err != nil {
+			t.Fatalf("expected already-installed branch to succeed, got %v", err)
+		}
+	})
+}
+
+func TestPathHelpersAcrossOSVariants(t *testing.T) {
+	resetSetupSeams(t)
+	userHomeDir = func() (string, error) { return "/home/tester", nil }
+
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("APPDATA", "")
+
+	runtimeGOOS = "linux"
+	if got := openCodeConfigPath(); got != filepath.Join("/home/tester", ".config", "opencode", "opencode.json") {
+		t.Fatalf("unexpected linux openCodeConfigPath: %s", got)
+	}
+	if got := openCodePluginDir(); got != filepath.Join("/home/tester", ".config", "opencode", "plugins") {
+		t.Fatalf("unexpected linux openCodePluginDir: %s", got)
+	}
+	if got := geminiConfigPath(); got != filepath.Join("/home/tester", ".gemini", "settings.json") {
+		t.Fatalf("unexpected linux geminiConfigPath: %s", got)
+	}
+	if got := codexConfigPath(); got != filepath.Join("/home/tester", ".codex", "config.toml") {
+		t.Fatalf("unexpected linux codexConfigPath: %s", got)
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", "/xdg")
+	if got := openCodeConfigPath(); got != filepath.Join("/xdg", "opencode", "opencode.json") {
+		t.Fatalf("unexpected linux xdg openCodeConfigPath: %s", got)
+	}
+	if got := openCodePluginDir(); got != filepath.Join("/xdg", "opencode", "plugins") {
+		t.Fatalf("unexpected linux xdg openCodePluginDir: %s", got)
+	}
+
+	runtimeGOOS = "windows"
+	t.Setenv("APPDATA", "C:/AppData/Roaming")
+	if got := openCodeConfigPath(); got != filepath.Join("C:/AppData/Roaming", "opencode", "opencode.json") {
+		t.Fatalf("unexpected windows openCodeConfigPath: %s", got)
+	}
+	if got := openCodePluginDir(); got != filepath.Join("C:/AppData/Roaming", "opencode", "plugins") {
+		t.Fatalf("unexpected windows openCodePluginDir: %s", got)
+	}
+	if got := geminiConfigPath(); got != filepath.Join("C:/AppData/Roaming", "gemini", "settings.json") {
+		t.Fatalf("unexpected windows geminiConfigPath: %s", got)
+	}
+	if got := codexConfigPath(); got != filepath.Join("C:/AppData/Roaming", "codex", "config.toml") {
+		t.Fatalf("unexpected windows codexConfigPath: %s", got)
+	}
+
+	t.Setenv("APPDATA", "")
+	if got := openCodeConfigPath(); got != filepath.Join("/home/tester", "AppData", "Roaming", "opencode", "opencode.json") {
+		t.Fatalf("unexpected windows fallback openCodeConfigPath: %s", got)
+	}
+	if got := openCodePluginDir(); got != filepath.Join("/home/tester", "AppData", "Roaming", "opencode", "plugins") {
+		t.Fatalf("unexpected windows fallback openCodePluginDir: %s", got)
+	}
+	if got := geminiConfigPath(); got != filepath.Join("/home/tester", "AppData", "Roaming", "gemini", "settings.json") {
+		t.Fatalf("unexpected windows fallback geminiConfigPath: %s", got)
+	}
+	if got := codexConfigPath(); got != filepath.Join("/home/tester", "AppData", "Roaming", "codex", "config.toml") {
+		t.Fatalf("unexpected windows fallback codexConfigPath: %s", got)
+	}
+
+	runtimeGOOS = "plan9"
+	if got := openCodeConfigPath(); got != filepath.Join("/home/tester", ".config", "opencode", "opencode.json") {
+		t.Fatalf("unexpected default openCodeConfigPath: %s", got)
+	}
+	if got := openCodePluginDir(); got != filepath.Join("/home/tester", ".config", "opencode", "plugins") {
+		t.Fatalf("unexpected default openCodePluginDir: %s", got)
+	}
+
+	if got := geminiSystemPromptPath(); got != filepath.Join(filepath.Dir(geminiConfigPath()), "system.md") {
+		t.Fatalf("unexpected gemini system prompt path: %s", got)
+	}
+	if got := geminiEnvPath(); got != filepath.Join(filepath.Dir(geminiConfigPath()), ".env") {
+		t.Fatalf("unexpected gemini env path: %s", got)
+	}
+	if got := codexInstructionsPath(); got != filepath.Join(filepath.Dir(codexConfigPath()), "engram-instructions.md") {
+		t.Fatalf("unexpected codex instructions path: %s", got)
+	}
+	if got := codexCompactPromptPath(); got != filepath.Join(filepath.Dir(codexConfigPath()), "engram-compact-prompt.md") {
+		t.Fatalf("unexpected codex compact prompt path: %s", got)
+	}
+}
+
+func TestInstallGeminiCLIErrorPropagation(t *testing.T) {
+	t.Run("inject mcp fails", func(t *testing.T) {
+		resetSetupSeams(t)
+		injectGeminiMCPFn = func(string) error { return errors.New("inject failed") }
+
+		_, err := installGeminiCLI()
+		if err == nil || !strings.Contains(err.Error(), "inject failed") {
+			t.Fatalf("expected inject failure, got %v", err)
+		}
+	})
+
+	t.Run("write system prompt fails", func(t *testing.T) {
+		resetSetupSeams(t)
+		injectGeminiMCPFn = func(string) error { return nil }
+		writeGeminiSystemPromptFn = func() error { return errors.New("prompt failed") }
+
+		_, err := installGeminiCLI()
+		if err == nil || !strings.Contains(err.Error(), "prompt failed") {
+			t.Fatalf("expected system prompt failure, got %v", err)
+		}
+	})
+
+	t.Run("ensure env fails", func(t *testing.T) {
+		resetSetupSeams(t)
+		injectGeminiMCPFn = func(string) error { return nil }
+		writeGeminiSystemPromptFn = func() error { return nil }
+		ensureGeminiEnvOverrideFn = func() error { return errors.New("env failed") }
+
+		_, err := installGeminiCLI()
+		if err == nil || !strings.Contains(err.Error(), "env failed") {
+			t.Fatalf("expected env failure, got %v", err)
+		}
+	})
+}
+
+func TestInstallCodexErrorPropagation(t *testing.T) {
+	t.Run("write instruction files fails", func(t *testing.T) {
+		resetSetupSeams(t)
+		writeCodexMemoryInstructionFilesFn = func() (string, error) {
+			return "", errors.New("instructions failed")
+		}
+
+		_, err := installCodex()
+		if err == nil || !strings.Contains(err.Error(), "instructions failed") {
+			t.Fatalf("expected instructions failure, got %v", err)
+		}
+	})
+
+	t.Run("inject mcp fails", func(t *testing.T) {
+		resetSetupSeams(t)
+		writeCodexMemoryInstructionFilesFn = func() (string, error) { return "/tmp/instructions", nil }
+		injectCodexMCPFn = func(string) error { return errors.New("mcp failed") }
+
+		_, err := installCodex()
+		if err == nil || !strings.Contains(err.Error(), "mcp failed") {
+			t.Fatalf("expected mcp failure, got %v", err)
+		}
+	})
+
+	t.Run("inject memory config fails", func(t *testing.T) {
+		resetSetupSeams(t)
+		writeCodexMemoryInstructionFilesFn = func() (string, error) { return "/tmp/instructions", nil }
+		injectCodexMCPFn = func(string) error { return nil }
+		injectCodexMemoryConfigFn = func(string, string, string) error { return errors.New("memory config failed") }
+
+		_, err := installCodex()
+		if err == nil || !strings.Contains(err.Error(), "memory config failed") {
+			t.Fatalf("expected memory config failure, got %v", err)
+		}
+	})
+}
+
+func TestGeminiAndCodexHelpersErrorPaths(t *testing.T) {
+	t.Run("injectGeminiMCP creates file from missing config", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+
+		if err := injectGeminiMCP(configPath); err != nil {
+			t.Fatalf("injectGeminiMCP failed: %v", err)
+		}
+
+		raw, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read config: %v", err)
+		}
+
+		var cfg map[string]any
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			t.Fatalf("parse config: %v", err)
+		}
+
+		mcpServers, ok := cfg["mcpServers"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected mcpServers object")
+		}
+		engram, ok := mcpServers["engram"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected engram server object")
+		}
+		if engram["command"] != "engram" {
+			t.Fatalf("expected engram command, got %#v", engram["command"])
+		}
+	})
+
+	t.Run("injectGeminiMCP marshal entry error", func(t *testing.T) {
+		resetSetupSeams(t)
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+		jsonMarshalFn = func(any) ([]byte, error) {
+			return nil, errors.New("marshal boom")
+		}
+
+		err := injectGeminiMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "marshal engram entry") {
+			t.Fatalf("expected marshal engram entry error, got %v", err)
+		}
+	})
+
+	t.Run("injectGeminiMCP marshal indent error", func(t *testing.T) {
+		resetSetupSeams(t)
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+		jsonMarshalIndentFn = func(any, string, string) ([]byte, error) {
+			return nil, errors.New("indent boom")
+		}
+
+		err := injectGeminiMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "marshal config") {
+			t.Fatalf("expected marshal config error, got %v", err)
+		}
+	})
+
+	t.Run("injectGeminiMCP marshal mcpServers error", func(t *testing.T) {
+		resetSetupSeams(t)
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+		calls := 0
+		jsonMarshalFn = func(v any) ([]byte, error) {
+			calls++
+			if calls == 2 {
+				return nil, errors.New("mcp marshal boom")
+			}
+			return json.Marshal(v)
+		}
+
+		err := injectGeminiMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "marshal mcpServers block") {
+			t.Fatalf("expected marshal mcpServers block error, got %v", err)
+		}
+	})
+
+	t.Run("injectGeminiMCP write error", func(t *testing.T) {
+		resetSetupSeams(t)
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+		writeFileFn = func(string, []byte, os.FileMode) error {
+			return errors.New("write boom")
+		}
+
+		err := injectGeminiMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "write config") {
+			t.Fatalf("expected write config error, got %v", err)
+		}
+	})
+
+	t.Run("injectGeminiMCP parse error", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+		if err := os.WriteFile(configPath, []byte("{"), 0644); err != nil {
+			t.Fatalf("write invalid json: %v", err)
+		}
+		err := injectGeminiMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "parse config") {
+			t.Fatalf("expected parse config error, got %v", err)
+		}
+	})
+
+	t.Run("injectGeminiMCP parse mcpServers error", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+		if err := os.WriteFile(configPath, []byte(`{"mcpServers":"bad"}`), 0644); err != nil {
+			t.Fatalf("write invalid mcpServers: %v", err)
+		}
+		err := injectGeminiMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "parse mcpServers block") {
+			t.Fatalf("expected parse mcpServers error, got %v", err)
+		}
+	})
+
+	t.Run("injectGeminiMCP create config dir error", func(t *testing.T) {
+		base := t.TempDir()
+		parent := filepath.Join(base, "blocked")
+		if err := os.WriteFile(parent, []byte("x"), 0644); err != nil {
+			t.Fatalf("write blocking file: %v", err)
+		}
+		err := injectGeminiMCP(filepath.Join(parent, "settings.json"))
+		if err == nil || !strings.Contains(err.Error(), "create config dir") {
+			t.Fatalf("expected create config dir error, got %v", err)
+		}
+	})
+
+	t.Run("ensureGeminiEnvOverride replaces existing value", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		envPath := filepath.Join(home, ".gemini", ".env")
+		if err := os.MkdirAll(filepath.Dir(envPath), 0755); err != nil {
+			t.Fatalf("mkdir env dir: %v", err)
+		}
+		if err := os.WriteFile(envPath, []byte("OTHER=1\r\nGEMINI_SYSTEM_MD=0\r\n"), 0644); err != nil {
+			t.Fatalf("write env file: %v", err)
+		}
+
+		if err := ensureGeminiEnvOverride(); err != nil {
+			t.Fatalf("ensureGeminiEnvOverride failed: %v", err)
+		}
+		raw, err := os.ReadFile(envPath)
+		if err != nil {
+			t.Fatalf("read env file: %v", err)
+		}
+		text := string(raw)
+		if strings.Count(text, "GEMINI_SYSTEM_MD=1") != 1 || strings.Contains(text, "GEMINI_SYSTEM_MD=0") {
+			t.Fatalf("expected single GEMINI_SYSTEM_MD=1, got:\n%s", text)
+		}
+	})
+
+	t.Run("ensureGeminiEnvOverride appends line to non-empty env", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		envPath := filepath.Join(home, ".gemini", ".env")
+		if err := os.MkdirAll(filepath.Dir(envPath), 0755); err != nil {
+			t.Fatalf("mkdir env dir: %v", err)
+		}
+		if err := os.WriteFile(envPath, []byte("OTHER=1\n"), 0644); err != nil {
+			t.Fatalf("write env file: %v", err)
+		}
+
+		if err := ensureGeminiEnvOverride(); err != nil {
+			t.Fatalf("ensureGeminiEnvOverride failed: %v", err)
+		}
+
+		raw, err := os.ReadFile(envPath)
+		if err != nil {
+			t.Fatalf("read env file: %v", err)
+		}
+		text := string(raw)
+		if !strings.Contains(text, "OTHER=1\nGEMINI_SYSTEM_MD=1\n") {
+			t.Fatalf("expected appended GEMINI_SYSTEM_MD line, got:\n%s", text)
+		}
+	})
+
+	t.Run("ensureGeminiEnvOverride already set is no-op", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		envPath := filepath.Join(home, ".gemini", ".env")
+		if err := os.MkdirAll(filepath.Dir(envPath), 0755); err != nil {
+			t.Fatalf("mkdir env dir: %v", err)
+		}
+		if err := os.WriteFile(envPath, []byte("GEMINI_SYSTEM_MD=1\n"), 0644); err != nil {
+			t.Fatalf("write env file: %v", err)
+		}
+
+		writeCalls := 0
+		writeFileFn = func(path string, data []byte, perm os.FileMode) error {
+			writeCalls++
+			return os.WriteFile(path, data, perm)
+		}
+
+		if err := ensureGeminiEnvOverride(); err != nil {
+			t.Fatalf("ensureGeminiEnvOverride failed: %v", err)
+		}
+		if writeCalls != 0 {
+			t.Fatalf("expected no write when line already correct, got %d writes", writeCalls)
+		}
+	})
+
+	t.Run("ensureGeminiEnvOverride write error when replacing", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		envPath := filepath.Join(home, ".gemini", ".env")
+		if err := os.MkdirAll(filepath.Dir(envPath), 0755); err != nil {
+			t.Fatalf("mkdir env dir: %v", err)
+		}
+		if err := os.WriteFile(envPath, []byte("GEMINI_SYSTEM_MD=0\n"), 0644); err != nil {
+			t.Fatalf("write env file: %v", err)
+		}
+
+		writeFileFn = func(string, []byte, os.FileMode) error {
+			return errors.New("write env boom")
+		}
+
+		err := ensureGeminiEnvOverride()
+		if err == nil || !strings.Contains(err.Error(), "write gemini env file") {
+			t.Fatalf("expected write gemini env file error, got %v", err)
+		}
+	})
+
+	t.Run("ensureGeminiEnvOverride write error when appending", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		envPath := filepath.Join(home, ".gemini", ".env")
+		if err := os.MkdirAll(filepath.Dir(envPath), 0755); err != nil {
+			t.Fatalf("mkdir env dir: %v", err)
+		}
+		if err := os.WriteFile(envPath, []byte("OTHER=1\n"), 0644); err != nil {
+			t.Fatalf("write env file: %v", err)
+		}
+
+		writeFileFn = func(string, []byte, os.FileMode) error {
+			return errors.New("append write boom")
+		}
+
+		err := ensureGeminiEnvOverride()
+		if err == nil || !strings.Contains(err.Error(), "write gemini env file") {
+			t.Fatalf("expected write gemini env file error, got %v", err)
+		}
+	})
+
+	t.Run("ensureGeminiEnvOverride create dir error", func(t *testing.T) {
+		resetSetupSeams(t)
+		blocked := filepath.Join(t.TempDir(), "home-as-file")
+		if err := os.WriteFile(blocked, []byte("x"), 0644); err != nil {
+			t.Fatalf("write home file: %v", err)
+		}
+		userHomeDir = func() (string, error) { return blocked, nil }
+		runtimeGOOS = "linux"
+
+		err := ensureGeminiEnvOverride()
+		if err == nil || !strings.Contains(err.Error(), "create gemini env dir") {
+			t.Fatalf("expected create gemini env dir error, got %v", err)
+		}
+	})
+
+	t.Run("writeGeminiSystemPrompt create dir error", func(t *testing.T) {
+		resetSetupSeams(t)
+		blocked := filepath.Join(t.TempDir(), "home-as-file")
+		if err := os.WriteFile(blocked, []byte("x"), 0644); err != nil {
+			t.Fatalf("write home file: %v", err)
+		}
+		userHomeDir = func() (string, error) { return blocked, nil }
+		runtimeGOOS = "linux"
+
+		err := writeGeminiSystemPrompt()
+		if err == nil || !strings.Contains(err.Error(), "create gemini system prompt dir") {
+			t.Fatalf("expected create dir error, got %v", err)
+		}
+	})
+
+	t.Run("injectCodexMCP read error", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "config.toml")
+		if err := os.MkdirAll(configPath, 0755); err != nil {
+			t.Fatalf("make config path directory: %v", err)
+		}
+
+		err := injectCodexMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "read config") {
+			t.Fatalf("expected read config error, got %v", err)
+		}
+	})
+
+	t.Run("injectCodexMemoryConfig read error", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "config.toml")
+		if err := os.MkdirAll(configPath, 0755); err != nil {
+			t.Fatalf("make config path directory: %v", err)
+		}
+
+		err := injectCodexMemoryConfig(configPath, "/tmp/instructions.md", "/tmp/compact.md")
+		if err == nil || !strings.Contains(err.Error(), "read config") {
+			t.Fatalf("expected read config error, got %v", err)
+		}
+	})
+
+	t.Run("injectCodexMemoryConfig creates missing config", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "config.toml")
+
+		err := injectCodexMemoryConfig(configPath, "/tmp/instructions.md", "/tmp/compact.md")
+		if err != nil {
+			t.Fatalf("injectCodexMemoryConfig failed: %v", err)
+		}
+
+		raw, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read config: %v", err)
+		}
+		text := string(raw)
+		if !strings.Contains(text, "model_instructions_file = \"/tmp/instructions.md\"") {
+			t.Fatalf("expected model_instructions_file in config, got:\n%s", text)
+		}
+		if !strings.Contains(text, "experimental_compact_prompt_file = \"/tmp/compact.md\"") {
+			t.Fatalf("expected compact prompt file in config, got:\n%s", text)
+		}
+	})
+
+	t.Run("injectCodexMemoryConfig write error", func(t *testing.T) {
+		resetSetupSeams(t)
+		configPath := filepath.Join(t.TempDir(), "config.toml")
+		writeFileFn = func(string, []byte, os.FileMode) error {
+			return errors.New("write config boom")
+		}
+
+		err := injectCodexMemoryConfig(configPath, "/tmp/instructions.md", "/tmp/compact.md")
+		if err == nil || !strings.Contains(err.Error(), "write config") {
+			t.Fatalf("expected write config error, got %v", err)
+		}
+	})
+
+	t.Run("upsertCodexEngramBlock replaces section before another section", func(t *testing.T) {
+		input := strings.Join([]string{
+			"[mcp_servers.engram]",
+			"command = \"wrong\"",
+			"args = [\"wrong\"]",
+			"",
+			"[mcp_servers.other]",
+			"command = \"other\"",
+		}, "\n")
+
+		output := upsertCodexEngramBlock(input)
+		if strings.Count(output, "[mcp_servers.engram]") != 1 {
+			t.Fatalf("expected one engram block, got:\n%s", output)
+		}
+		if !strings.Contains(output, "[mcp_servers.other]") {
+			t.Fatalf("expected other section preserved, got:\n%s", output)
+		}
+	})
+
+	t.Run("upsertCodexEngramBlock from empty content", func(t *testing.T) {
+		output := upsertCodexEngramBlock("\n\n")
+		if output != codexEngramBlock+"\n" {
+			t.Fatalf("unexpected output for empty content:\n%s", output)
+		}
+	})
+}
+
+func TestInstallRoutesForOpenCodeAndClaude(t *testing.T) {
+	t.Run("opencode route", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+		result, err := Install("opencode")
+		if err != nil {
+			t.Fatalf("Install(opencode) failed: %v", err)
+		}
+		if result.Agent != "opencode" {
+			t.Fatalf("expected opencode result, got %#v", result)
+		}
+	})
+
+	t.Run("claude-code route", func(t *testing.T) {
+		resetSetupSeams(t)
+		lookPathFn = func(string) (string, error) { return "claude", nil }
+		runCommand = func(string, ...string) ([]byte, error) { return []byte("ok"), nil }
+
+		result, err := Install("claude-code")
+		if err != nil {
+			t.Fatalf("Install(claude-code) failed: %v", err)
+		}
+		if result.Agent != "claude-code" {
+			t.Fatalf("expected claude-code result, got %#v", result)
+		}
+	})
+}
+
+func TestAdditionalHelperBranches(t *testing.T) {
+	t.Run("installOpenCode mkdir error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		blocked := filepath.Join(home, "xdg-block")
+		if err := os.WriteFile(blocked, []byte("x"), 0644); err != nil {
+			t.Fatalf("write blocker file: %v", err)
+		}
+		t.Setenv("XDG_CONFIG_HOME", blocked)
+
+		_, err := installOpenCode()
+		if err == nil || !strings.Contains(err.Error(), "create plugin dir") {
+			t.Fatalf("expected create plugin dir error, got %v", err)
+		}
+	})
+
+	t.Run("injectOpenCodeMCP write error when parent missing", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+		err := injectOpenCodeMCP()
+		if err == nil || !strings.Contains(err.Error(), "write config") {
+			t.Fatalf("expected write config error, got %v", err)
+		}
+	})
+
+	t.Run("injectCodexMCP create config dir error", func(t *testing.T) {
+		base := t.TempDir()
+		blocked := filepath.Join(base, "blocked")
+		if err := os.WriteFile(blocked, []byte("x"), 0644); err != nil {
+			t.Fatalf("write blocker: %v", err)
+		}
+
+		err := injectCodexMCP(filepath.Join(blocked, "config.toml"))
+		if err == nil || !strings.Contains(err.Error(), "create config dir") {
+			t.Fatalf("expected create config dir error, got %v", err)
+		}
+	})
+
+	t.Run("injectCodexMCP write error", func(t *testing.T) {
+		resetSetupSeams(t)
+		configPath := filepath.Join(t.TempDir(), "codex", "config.toml")
+		writeFileFn = func(string, []byte, os.FileMode) error {
+			return errors.New("write codex boom")
+		}
+
+		err := injectCodexMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "write config") {
+			t.Fatalf("expected write config error, got %v", err)
+		}
+	})
+
+	t.Run("writeCodexMemoryInstructionFiles instructions write error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		instructionsPath := filepath.Join(home, ".codex", "engram-instructions.md")
+		if err := os.MkdirAll(instructionsPath, 0755); err != nil {
+			t.Fatalf("create instructions path as dir: %v", err)
+		}
+
+		_, err := writeCodexMemoryInstructionFiles()
+		if err == nil || !strings.Contains(err.Error(), "write codex instructions") {
+			t.Fatalf("expected instructions write error, got %v", err)
+		}
+	})
+
+	t.Run("writeCodexMemoryInstructionFiles compact write error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		compactPath := filepath.Join(home, ".codex", "engram-compact-prompt.md")
+		if err := os.MkdirAll(compactPath, 0755); err != nil {
+			t.Fatalf("create compact path as dir: %v", err)
+		}
+
+		_, err := writeCodexMemoryInstructionFiles()
+		if err == nil || !strings.Contains(err.Error(), "write codex compact prompt") {
+			t.Fatalf("expected compact prompt write error, got %v", err)
+		}
+	})
+
+	t.Run("ensureGeminiEnvOverride read error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		envPath := filepath.Join(home, ".gemini", ".env")
+		if err := os.MkdirAll(envPath, 0755); err != nil {
+			t.Fatalf("create env path as dir: %v", err)
+		}
+
+		err := ensureGeminiEnvOverride()
+		if err == nil || !strings.Contains(err.Error(), "read gemini env file") {
+			t.Fatalf("expected read env error, got %v", err)
+		}
+	})
+
+	t.Run("injectGeminiMCP read error", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "settings.json")
+		if err := os.MkdirAll(configPath, 0755); err != nil {
+			t.Fatalf("create config path as dir: %v", err)
+		}
+
+		err := injectGeminiMCP(configPath)
+		if err == nil || !strings.Contains(err.Error(), "read config") {
+			t.Fatalf("expected read config error, got %v", err)
+		}
+	})
+
+	t.Run("writeGeminiSystemPrompt write error", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		runtimeGOOS = "linux"
+
+		systemPath := filepath.Join(home, ".gemini", "system.md")
+		if err := os.MkdirAll(systemPath, 0755); err != nil {
+			t.Fatalf("create system path as dir: %v", err)
+		}
+
+		err := writeGeminiSystemPrompt()
+		if err == nil || !strings.Contains(err.Error(), "write gemini system prompt") {
+			t.Fatalf("expected write system prompt error, got %v", err)
+		}
+	})
+
+	t.Run("writeCodexMemoryInstructionFiles create dir error", func(t *testing.T) {
+		resetSetupSeams(t)
+		blocked := filepath.Join(t.TempDir(), "home-as-file")
+		if err := os.WriteFile(blocked, []byte("x"), 0644); err != nil {
+			t.Fatalf("write home file: %v", err)
+		}
+		userHomeDir = func() (string, error) { return blocked, nil }
+		runtimeGOOS = "linux"
+
+		_, err := writeCodexMemoryInstructionFiles()
+		if err == nil || !strings.Contains(err.Error(), "create codex instructions dir") {
+			t.Fatalf("expected create instructions dir error, got %v", err)
+		}
+	})
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"database/sql"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,6 +26,33 @@ func newTestStore(t *testing.T) *Store {
 		_ = s.Close()
 	})
 	return s
+}
+
+type fakeRows struct {
+	next    []bool
+	scanErr error
+	err     error
+}
+
+func (f *fakeRows) Next() bool {
+	if len(f.next) == 0 {
+		return false
+	}
+	v := f.next[0]
+	f.next = f.next[1:]
+	return v
+}
+
+func (f *fakeRows) Scan(dest ...any) error {
+	return f.scanErr
+}
+
+func (f *fakeRows) Err() error {
+	return f.err
+}
+
+func (f *fakeRows) Close() error {
+	return nil
 }
 
 func TestAddObservationDeduplicatesWithinWindow(t *testing.T) {
@@ -880,4 +909,1537 @@ func TestSessionsOrderedByMostRecentActivity(t *testing.T) {
 	if recent[0].ID != "s-older" {
 		t.Fatalf("expected s-older first in recent sessions, got %s", recent[0].ID)
 	}
+}
+
+func TestSessionObservationsAddPromptImportAndSyncChunks(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "Auth",
+		Content:   "Use middleware chain",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	longPrompt := strings.Repeat("x", s.cfg.MaxObservationLength+25)
+	promptID, err := s.AddPrompt(AddPromptParams{SessionID: "s1", Content: longPrompt, Project: "engram"})
+	if err != nil {
+		t.Fatalf("add prompt: %v", err)
+	}
+	if promptID <= 0 {
+		t.Fatalf("expected valid prompt id, got %d", promptID)
+	}
+
+	sessionObs, err := s.SessionObservations("s1", 0)
+	if err != nil {
+		t.Fatalf("session observations: %v", err)
+	}
+	if len(sessionObs) != 1 {
+		t.Fatalf("expected 1 session observation, got %d", len(sessionObs))
+	}
+
+	exported, err := s.Export()
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	dst, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new destination store: %v", err)
+	}
+	t.Cleanup(func() { _ = dst.Close() })
+
+	imported, err := dst.Import(exported)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if imported.SessionsImported < 1 || imported.ObservationsImported < 1 || imported.PromptsImported < 1 {
+		t.Fatalf("expected non-zero import counts, got %+v", imported)
+	}
+
+	if err := dst.RecordSyncedChunk("chunk-1"); err != nil {
+		t.Fatalf("record synced chunk: %v", err)
+	}
+	chunks, err := dst.GetSyncedChunks()
+	if err != nil {
+		t.Fatalf("get synced chunks: %v", err)
+	}
+	if !chunks["chunk-1"] {
+		t.Fatalf("expected chunk-1 to be marked as synced")
+	}
+}
+
+func TestUtilityHelpersCoverage(t *testing.T) {
+	if got := derefString(nil); got != "" {
+		t.Fatalf("expected empty string for nil pointer, got %q", got)
+	}
+	v := "value"
+	if got := derefString(&v); got != "value" {
+		t.Fatalf("expected dereferenced value, got %q", got)
+	}
+
+	if got := maxInt(10, 5); got != 10 {
+		t.Fatalf("expected maxInt(10,5)=10, got %d", got)
+	}
+	if got := maxInt(3, 7); got != 7 {
+		t.Fatalf("expected maxInt(3,7)=7, got %d", got)
+	}
+
+	if got := dedupeWindowExpression(0); got != "-15 minutes" {
+		t.Fatalf("expected default dedupe window, got %q", got)
+	}
+	if got := dedupeWindowExpression(20 * time.Second); got != "-1 minutes" {
+		t.Fatalf("expected minimum 1 minute window, got %q", got)
+	}
+
+	cases := map[string]string{
+		"write":   "file_change",
+		"patch":   "file_change",
+		"bash":    "command",
+		"read":    "file_read",
+		"glob":    "search",
+		"unknown": "tool_use",
+	}
+	for in, want := range cases {
+		if got := ClassifyTool(in); got != want {
+			t.Fatalf("ClassifyTool(%q): expected %q, got %q", in, want, got)
+		}
+	}
+}
+
+func TestEndSessionAndTimelineDefaults(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-end", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	firstID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-end",
+		Type:      "note",
+		Title:     "first",
+		Content:   "first note",
+		Project:   "engram",
+	})
+	if err != nil {
+		t.Fatalf("add first observation: %v", err)
+	}
+	_, err = s.AddObservation(AddObservationParams{
+		SessionID: "s-end",
+		Type:      "note",
+		Title:     "second",
+		Content:   "second note",
+		Project:   "engram",
+	})
+	if err != nil {
+		t.Fatalf("add second observation: %v", err)
+	}
+
+	if err := s.EndSession("s-end", "finished session"); err != nil {
+		t.Fatalf("end session: %v", err)
+	}
+
+	sess, err := s.GetSession("s-end")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if sess.EndedAt == nil {
+		t.Fatalf("expected ended_at to be set")
+	}
+	if sess.Summary == nil || *sess.Summary != "finished session" {
+		t.Fatalf("expected summary to be stored, got %+v", sess.Summary)
+	}
+
+	timeline, err := s.Timeline(firstID, 0, -1)
+	if err != nil {
+		t.Fatalf("timeline with default before/after: %v", err)
+	}
+	if timeline.SessionInfo == nil {
+		t.Fatalf("expected session info in timeline")
+	}
+	if timeline.TotalInRange != 2 {
+		t.Fatalf("expected total_in_range=2, got %d", timeline.TotalInRange)
+	}
+}
+
+func TestInferTopicFamilyCoverage(t *testing.T) {
+	cases := []struct {
+		name    string
+		typ     string
+		title   string
+		content string
+		want    string
+	}{
+		{name: "type architecture", typ: "architecture", want: "architecture"},
+		{name: "type bugfix", typ: "bugfix", want: "bug"},
+		{name: "type decision", typ: "decision", want: "decision"},
+		{name: "type pattern", typ: "pattern", want: "pattern"},
+		{name: "type config", typ: "config", want: "config"},
+		{name: "type discovery", typ: "discovery", want: "discovery"},
+		{name: "type learning", typ: "learning", want: "learning"},
+		{name: "type session summary", typ: "session_summary", want: "session"},
+		{name: "text bug", title: "", content: "this caused a crash regression", want: "bug"},
+		{name: "text architecture", title: "", content: "new boundary design", want: "architecture"},
+		{name: "text decision", title: "", content: "we chose this tradeoff", want: "decision"},
+		{name: "text pattern", title: "", content: "naming convention for handlers", want: "pattern"},
+		{name: "text config", title: "", content: "docker env setup", want: "config"},
+		{name: "text discovery", title: "", content: "root cause found", want: "discovery"},
+		{name: "text learning", title: "", content: "key learning from this issue", want: "learning"},
+		{name: "fallback type", typ: "Custom Type", want: "custom-type"},
+		{name: "default topic", typ: "manual", title: "", content: "", want: "topic"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inferTopicFamily(tc.typ, tc.title, tc.content)
+			if got != tc.want {
+				t.Fatalf("inferTopicFamily(%q,%q,%q): expected %q, got %q", tc.typ, tc.title, tc.content, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestStoreAdditionalQueryAndMutationBranches(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-q", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	longContent := strings.Repeat("x", s.cfg.MaxObservationLength+100)
+	obsID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-q",
+		Type:      "note",
+		Title:     "Private <private>secret</private> title",
+		Content:   longContent + " <private>token</private>",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	obs, err := s.GetObservation(obsID)
+	if err != nil {
+		t.Fatalf("get observation: %v", err)
+	}
+	if !strings.Contains(obs.Title, "[REDACTED]") {
+		t.Fatalf("expected private tags redacted in title, got %q", obs.Title)
+	}
+	if !strings.Contains(obs.Content, "... [truncated]") {
+		t.Fatalf("expected truncated content marker, got %q", obs.Content)
+	}
+
+	newProject := ""
+	newTopic := ""
+	updated, err := s.UpdateObservation(obsID, UpdateObservationParams{Project: &newProject, TopicKey: &newTopic})
+	if err != nil {
+		t.Fatalf("update observation: %v", err)
+	}
+	if updated.Project != nil {
+		t.Fatalf("expected nil project after empty update")
+	}
+	if updated.TopicKey != nil {
+		t.Fatalf("expected nil topic key after empty update")
+	}
+
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-q", Content: "alpha prompt", Project: "alpha"}); err != nil {
+		t.Fatalf("add alpha prompt: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-q", Content: "beta prompt", Project: "beta"}); err != nil {
+		t.Fatalf("add beta prompt: %v", err)
+	}
+
+	recentPrompts, err := s.RecentPrompts("beta", 1)
+	if err != nil {
+		t.Fatalf("recent prompts with project filter: %v", err)
+	}
+	if len(recentPrompts) != 1 || recentPrompts[0].Project != "beta" {
+		t.Fatalf("expected one beta prompt, got %+v", recentPrompts)
+	}
+
+	searchPrompts, err := s.SearchPrompts("prompt", "alpha", 0)
+	if err != nil {
+		t.Fatalf("search prompts with project filter/default limit: %v", err)
+	}
+	if len(searchPrompts) != 1 || searchPrompts[0].Project != "alpha" {
+		t.Fatalf("expected one alpha prompt search result, got %+v", searchPrompts)
+	}
+
+	searchResults, err := s.Search("title", SearchOptions{Scope: "project", Limit: 9999})
+	if err != nil {
+		t.Fatalf("search with clamped limit: %v", err)
+	}
+	if len(searchResults) == 0 {
+		t.Fatalf("expected search results")
+	}
+
+	ctx, err := s.FormatContext("", "project")
+	if err != nil {
+		t.Fatalf("format context: %v", err)
+	}
+	if !strings.Contains(ctx, "Recent User Prompts") {
+		t.Fatalf("expected prompts section in context output")
+	}
+}
+
+func TestStoreErrorBranchesWithClosedDatabase(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	if _, err := s.GetSession("missing"); err == nil {
+		t.Fatalf("expected GetSession error when db is closed")
+	}
+	if _, err := s.AllSessions("", 1); err == nil {
+		t.Fatalf("expected AllSessions error when db is closed")
+	}
+	if _, err := s.RecentSessions("", 1); err == nil {
+		t.Fatalf("expected RecentSessions error when db is closed")
+	}
+	if _, err := s.SearchPrompts("x", "", 1); err == nil {
+		t.Fatalf("expected SearchPrompts error when db is closed")
+	}
+	if _, err := s.Search("x", SearchOptions{}); err == nil {
+		t.Fatalf("expected Search error when db is closed")
+	}
+	if _, err := s.Export(); err == nil {
+		t.Fatalf("expected Export error when db is closed")
+	}
+	if _, err := s.Timeline(1, 1, 1); err == nil {
+		t.Fatalf("expected Timeline error when db is closed")
+	}
+}
+
+func TestEndSessionEdgeCases(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-edge", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if err := s.EndSession("missing", "ignored"); err != nil {
+		t.Fatalf("end missing session should be no-op: %v", err)
+	}
+
+	if err := s.EndSession("s-edge", ""); err != nil {
+		t.Fatalf("end session with empty summary: %v", err)
+	}
+
+	sess, err := s.GetSession("s-edge")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if sess.EndedAt == nil {
+		t.Fatalf("expected ended_at to be set")
+	}
+	if sess.Summary != nil {
+		t.Fatalf("expected empty summary to persist as NULL, got %q", *sess.Summary)
+	}
+}
+
+func TestTimelineHandlesMissingSessionRecord(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.db.Exec("PRAGMA foreign_keys = OFF"); err != nil {
+		t.Fatalf("disable fk: %v", err)
+	}
+	defer func() {
+		_, _ = s.db.Exec("PRAGMA foreign_keys = ON")
+	}()
+
+	res, err := s.db.Exec(
+		`INSERT INTO observations (session_id, type, title, content, project, scope, normalized_hash, revision_count, duplicate_count, last_seen_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 1, 1, datetime('now'), datetime('now'))`,
+		"manual-save", "manual", "orphan", "orphan content", "engram", "project", hashNormalized("orphan content"),
+	)
+	if err != nil {
+		t.Fatalf("insert orphan observation: %v", err)
+	}
+	obsID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+
+	timeline, err := s.Timeline(obsID, 1, 1)
+	if err != nil {
+		t.Fatalf("timeline: %v", err)
+	}
+	if timeline.SessionInfo != nil {
+		t.Fatalf("expected nil session info for missing session, got %+v", timeline.SessionInfo)
+	}
+	if timeline.TotalInRange != 1 {
+		t.Fatalf("expected total in range=1, got %d", timeline.TotalInRange)
+	}
+}
+
+func TestQueryObservationsScanError(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.queryObservations("SELECT 1"); err == nil {
+		t.Fatalf("expected scan error for mismatched projection")
+	}
+}
+
+func TestMigrationAndHelperEdgeBranches(t *testing.T) {
+	t.Run("migrate is idempotent with existing triggers", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.migrate(); err != nil {
+			t.Fatalf("second migrate should succeed: %v", err)
+		}
+	})
+
+	t.Run("legacy migrate skips table without id column", func(t *testing.T) {
+		s := newTestStore(t)
+
+		if _, err := s.db.Exec(`
+			DROP TRIGGER IF EXISTS obs_fts_insert;
+			DROP TRIGGER IF EXISTS obs_fts_update;
+			DROP TRIGGER IF EXISTS obs_fts_delete;
+			DROP TABLE IF EXISTS observations_fts;
+			DROP TABLE observations;
+			CREATE TABLE observations (
+				session_id TEXT,
+				type TEXT,
+				title TEXT,
+				content TEXT
+			);
+		`); err != nil {
+			t.Fatalf("recreate observations without id: %v", err)
+		}
+
+		if err := s.migrateLegacyObservationsTable(); err != nil {
+			t.Fatalf("legacy migrate should skip tables without id: %v", err)
+		}
+	})
+
+	t.Run("topic helpers normalize edge cases", func(t *testing.T) {
+		if got := SuggestTopicKey("decision", "decision", ""); got != "decision/general" {
+			t.Fatalf("expected decision/general, got %q", got)
+		}
+		if got := SuggestTopicKey("bugfix", "bug-auth-panic", ""); got != "bug/auth-panic" {
+			t.Fatalf("expected bug/auth-panic, got %q", got)
+		}
+		if got := SuggestTopicKey("manual", "!!!", "..."); got != "topic/general" {
+			t.Fatalf("expected topic/general fallback, got %q", got)
+		}
+
+		longSegment := normalizeTopicSegment(strings.Repeat("abc", 50))
+		if len(longSegment) != 100 {
+			t.Fatalf("expected topic segment truncation to 100, got %d", len(longSegment))
+		}
+
+		longKey := normalizeTopicKey(strings.Repeat("k", 200))
+		if len(longKey) != 120 {
+			t.Fatalf("expected topic key truncation to 120, got %d", len(longKey))
+		}
+	})
+
+	t.Run("format context empty returns empty string", func(t *testing.T) {
+		s := newTestStore(t)
+		ctx, err := s.FormatContext("", "")
+		if err != nil {
+			t.Fatalf("format context: %v", err)
+		}
+		if ctx != "" {
+			t.Fatalf("expected empty context when no data, got %q", ctx)
+		}
+	})
+}
+
+func TestExportImportEdgeBranches(t *testing.T) {
+	t.Run("export fails when observations query fails", func(t *testing.T) {
+		s := newTestStore(t)
+
+		if _, err := s.db.Exec(`
+			DROP TRIGGER IF EXISTS obs_fts_insert;
+			DROP TRIGGER IF EXISTS obs_fts_update;
+			DROP TRIGGER IF EXISTS obs_fts_delete;
+			DROP TABLE IF EXISTS observations_fts;
+			DROP TABLE observations;
+		`); err != nil {
+			t.Fatalf("drop observations: %v", err)
+		}
+
+		_, err := s.Export()
+		if err == nil || !strings.Contains(err.Error(), "export observations") {
+			t.Fatalf("expected observations export error, got %v", err)
+		}
+	})
+
+	t.Run("export fails when prompts query fails", func(t *testing.T) {
+		s := newTestStore(t)
+
+		if _, err := s.db.Exec(`
+			DROP TRIGGER IF EXISTS prompt_fts_insert;
+			DROP TRIGGER IF EXISTS prompt_fts_update;
+			DROP TRIGGER IF EXISTS prompt_fts_delete;
+			DROP TABLE IF EXISTS prompts_fts;
+			DROP TABLE user_prompts;
+		`); err != nil {
+			t.Fatalf("drop prompts: %v", err)
+		}
+
+		_, err := s.Export()
+		if err == nil || !strings.Contains(err.Error(), "export prompts") {
+			t.Fatalf("expected prompts export error, got %v", err)
+		}
+	})
+
+	t.Run("import begin tx fails on closed db", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+
+		_, err := s.Import(&ExportData{})
+		if err == nil || !strings.Contains(err.Error(), "begin tx") {
+			t.Fatalf("expected begin tx import error, got %v", err)
+		}
+	})
+
+	t.Run("import fails on observation fk error", func(t *testing.T) {
+		s := newTestStore(t)
+		_, err := s.Import(&ExportData{
+			Observations: []Observation{{
+				ID:        1,
+				SessionID: "missing-session",
+				Type:      "bugfix",
+				Title:     "x",
+				Content:   "y",
+				Scope:     "project",
+				CreatedAt: Now(),
+				UpdatedAt: Now(),
+			}},
+		})
+		if err == nil || !strings.Contains(err.Error(), "import observation") {
+			t.Fatalf("expected observation import error, got %v", err)
+		}
+	})
+
+	t.Run("import fails on prompt fk error", func(t *testing.T) {
+		s := newTestStore(t)
+		_, err := s.Import(&ExportData{
+			Prompts: []Prompt{{
+				ID:        1,
+				SessionID: "missing-session",
+				Content:   "prompt",
+				Project:   "engram",
+				CreatedAt: Now(),
+			}},
+		})
+		if err == nil || !strings.Contains(err.Error(), "import prompt") {
+			t.Fatalf("expected prompt import error, got %v", err)
+		}
+	})
+}
+
+func TestNewErrorBranches(t *testing.T) {
+	t.Run("fails when data dir is a file", func(t *testing.T) {
+		base := t.TempDir()
+		badPath := filepath.Join(base, "not-a-dir")
+		if err := os.WriteFile(badPath, []byte("x"), 0600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		cfg := DefaultConfig()
+		cfg.DataDir = badPath
+
+		_, err := New(cfg)
+		if err == nil || !strings.Contains(err.Error(), "create data dir") {
+			t.Fatalf("expected create data dir error, got %v", err)
+		}
+	})
+
+	t.Run("fails when db path is a directory", func(t *testing.T) {
+		dataDir := t.TempDir()
+		dbAsDir := filepath.Join(dataDir, "engram.db")
+		if err := os.Mkdir(dbAsDir, 0755); err != nil {
+			t.Fatalf("mkdir db path: %v", err)
+		}
+
+		cfg := DefaultConfig()
+		cfg.DataDir = dataDir
+
+		_, err := New(cfg)
+		if err == nil {
+			t.Fatalf("expected New to fail when db path is a directory")
+		}
+	})
+
+	t.Run("fails when migration encounters conflicting object", func(t *testing.T) {
+		dataDir := t.TempDir()
+		dbPath := filepath.Join(dataDir, "engram.db")
+
+		db, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		_, err = db.Exec(`
+			CREATE TABLE sessions (
+				id TEXT PRIMARY KEY,
+				project TEXT NOT NULL,
+				directory TEXT NOT NULL,
+				started_at TEXT NOT NULL,
+				ended_at TEXT,
+				summary TEXT
+			);
+			CREATE TABLE user_prompts (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				session_id TEXT NOT NULL,
+				content TEXT NOT NULL,
+				created_at TEXT NOT NULL
+			);
+		`)
+		if err != nil {
+			_ = db.Close()
+			t.Fatalf("create conflicting view: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close db: %v", err)
+		}
+
+		cfg := DefaultConfig()
+		cfg.DataDir = dataDir
+
+		_, err = New(cfg)
+		if err == nil || !strings.Contains(err.Error(), "migration") {
+			t.Fatalf("expected migration error, got %v", err)
+		}
+	})
+}
+
+func TestMigrationInternalErrorAndNoopBranches(t *testing.T) {
+	t.Run("addColumnIfNotExists adds then noops", func(t *testing.T) {
+		s := newTestStore(t)
+		if _, err := s.db.Exec(`CREATE TABLE extra_table (id INTEGER)`); err != nil {
+			t.Fatalf("create extra table: %v", err)
+		}
+
+		if err := s.addColumnIfNotExists("extra_table", "name", "TEXT"); err != nil {
+			t.Fatalf("add column: %v", err)
+		}
+		if err := s.addColumnIfNotExists("extra_table", "name", "TEXT"); err != nil {
+			t.Fatalf("add existing column should noop: %v", err)
+		}
+
+		if err := s.addColumnIfNotExists("missing_table", "x", "TEXT"); err == nil {
+			t.Fatalf("expected missing table error")
+		}
+	})
+
+	t.Run("legacy migrate noops when id is primary key", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.migrateLegacyObservationsTable(); err != nil {
+			t.Fatalf("expected noop for modern schema: %v", err)
+		}
+	})
+
+	t.Run("legacy migrate fails if temp table already exists", func(t *testing.T) {
+		s := newTestStore(t)
+		if _, err := s.db.Exec(`
+			DROP TRIGGER IF EXISTS obs_fts_insert;
+			DROP TRIGGER IF EXISTS obs_fts_update;
+			DROP TRIGGER IF EXISTS obs_fts_delete;
+			DROP TABLE IF EXISTS observations_fts;
+			DROP TABLE observations;
+			CREATE TABLE observations (
+				id INT,
+				session_id TEXT,
+				type TEXT,
+				title TEXT,
+				content TEXT,
+				created_at TEXT
+			);
+			CREATE TABLE observations_migrated (id INTEGER PRIMARY KEY);
+		`); err != nil {
+			t.Fatalf("prepare legacy schema: %v", err)
+		}
+
+		err := s.migrateLegacyObservationsTable()
+		if err == nil || !strings.Contains(err.Error(), "create table") {
+			t.Fatalf("expected create table error, got %v", err)
+		}
+	})
+
+	t.Run("migrate returns deterministic exec hook errors", func(t *testing.T) {
+		s := newTestStore(t)
+
+		origExec := s.hooks.exec
+		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+			if strings.Contains(query, "UPDATE observations SET scope = 'project'") {
+				return nil, errors.New("forced migrate update failure")
+			}
+			return origExec(db, query, args...)
+		}
+
+		err := s.migrate()
+		if err == nil || !strings.Contains(err.Error(), "forced migrate update failure") {
+			t.Fatalf("expected forced migrate failure, got %v", err)
+		}
+	})
+
+	t.Run("migrate fails when creating missing triggers", func(t *testing.T) {
+		s := newTestStore(t)
+
+		if _, err := s.db.Exec(`
+			DROP TRIGGER IF EXISTS obs_fts_insert;
+			DROP TRIGGER IF EXISTS obs_fts_update;
+			DROP TRIGGER IF EXISTS obs_fts_delete;
+		`); err != nil {
+			t.Fatalf("drop obs triggers: %v", err)
+		}
+
+		origExec := s.hooks.exec
+		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+			if strings.Contains(query, "CREATE TRIGGER obs_fts_insert") {
+				return nil, errors.New("forced obs trigger failure")
+			}
+			return origExec(db, query, args...)
+		}
+
+		err := s.migrate()
+		if err == nil || !strings.Contains(err.Error(), "forced obs trigger failure") {
+			t.Fatalf("expected forced trigger failure, got %v", err)
+		}
+	})
+
+	t.Run("legacy migrate surfaces begin and commit hook failures", func(t *testing.T) {
+		prepareLegacyStore := func(t *testing.T) *Store {
+			t.Helper()
+			s := newTestStore(t)
+			if _, err := s.db.Exec(`
+				DROP TRIGGER IF EXISTS obs_fts_insert;
+				DROP TRIGGER IF EXISTS obs_fts_update;
+				DROP TRIGGER IF EXISTS obs_fts_delete;
+				DROP TABLE IF EXISTS observations_fts;
+				DROP TABLE observations;
+				INSERT OR IGNORE INTO sessions (id, project, directory) VALUES ('s1', 'engram', '/tmp/engram');
+				CREATE TABLE observations (
+					id INT,
+					session_id TEXT,
+					type TEXT,
+					title TEXT,
+					content TEXT,
+					tool_name TEXT,
+					project TEXT,
+					scope TEXT,
+					topic_key TEXT,
+					normalized_hash TEXT,
+					revision_count INTEGER,
+					duplicate_count INTEGER,
+					last_seen_at TEXT,
+					created_at TEXT,
+					updated_at TEXT,
+					deleted_at TEXT
+				);
+				INSERT INTO observations (id, session_id, type, title, content, project, created_at, updated_at)
+				VALUES (1, 's1', 'bugfix', 'legacy', 'legacy row', 'engram', datetime('now'), datetime('now'));
+			`); err != nil {
+				t.Fatalf("prepare legacy table: %v", err)
+			}
+			return s
+		}
+
+		t.Run("begin tx", func(t *testing.T) {
+			s := prepareLegacyStore(t)
+			s.hooks.beginTx = func(_ *sql.DB) (*sql.Tx, error) {
+				return nil, errors.New("forced begin failure")
+			}
+
+			err := s.migrateLegacyObservationsTable()
+			if err == nil || !strings.Contains(err.Error(), "forced begin failure") {
+				t.Fatalf("expected begin failure, got %v", err)
+			}
+		})
+
+		t.Run("commit", func(t *testing.T) {
+			s := prepareLegacyStore(t)
+			s.hooks.commit = func(_ *sql.Tx) error {
+				return errors.New("forced legacy commit failure")
+			}
+
+			err := s.migrateLegacyObservationsTable()
+			if err == nil || !strings.Contains(err.Error(), "forced legacy commit failure") {
+				t.Fatalf("expected commit failure, got %v", err)
+			}
+		})
+	})
+}
+
+func TestImportExportSeamErrors(t *testing.T) {
+	t.Run("export query hooks", func(t *testing.T) {
+		s := newTestStore(t)
+
+		origQueryIt := s.hooks.queryIt
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "FROM sessions") {
+				return nil, errors.New("forced sessions export query error")
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Export(); err == nil || !strings.Contains(err.Error(), "export sessions") {
+			t.Fatalf("expected sessions export error, got %v", err)
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "FROM observations") {
+				return nil, errors.New("forced observations export query error")
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Export(); err == nil || !strings.Contains(err.Error(), "export observations") {
+			t.Fatalf("expected observations export error, got %v", err)
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "FROM user_prompts") {
+				return nil, errors.New("forced prompts export query error")
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Export(); err == nil || !strings.Contains(err.Error(), "export prompts") {
+			t.Fatalf("expected prompts export error, got %v", err)
+		}
+	})
+
+	t.Run("import tx and exec hooks", func(t *testing.T) {
+		s := newTestStore(t)
+
+		s.hooks.beginTx = func(_ *sql.DB) (*sql.Tx, error) {
+			return nil, errors.New("forced import begin failure")
+		}
+		if _, err := s.Import(&ExportData{}); err == nil || !strings.Contains(err.Error(), "begin tx") {
+			t.Fatalf("expected begin tx error, got %v", err)
+		}
+
+		s.hooks = defaultStoreHooks()
+		origExec := s.hooks.exec
+		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+			if strings.Contains(query, "INSERT OR IGNORE INTO sessions") {
+				return nil, errors.New("forced import session insert failure")
+			}
+			return origExec(db, query, args...)
+		}
+		if _, err := s.Import(&ExportData{Sessions: []Session{{ID: "s-x", Project: "p", Directory: "/tmp", StartedAt: Now()}}}); err == nil || !strings.Contains(err.Error(), "import session") {
+			t.Fatalf("expected session import error, got %v", err)
+		}
+
+		s.hooks = defaultStoreHooks()
+		s.hooks.commit = func(_ *sql.Tx) error {
+			return errors.New("forced import commit failure")
+		}
+		if _, err := s.Import(&ExportData{}); err == nil || !strings.Contains(err.Error(), "import: commit") {
+			t.Fatalf("expected commit error, got %v", err)
+		}
+	})
+}
+
+func TestHookFallbacksAndAdditionalBranches(t *testing.T) {
+	t.Run("hook fallbacks call default DB methods", func(t *testing.T) {
+		s := newTestStore(t)
+		s.hooks = storeHooks{}
+
+		if _, err := s.execHook(s.db, "SELECT 1"); err != nil {
+			t.Fatalf("exec hook fallback: %v", err)
+		}
+		rows, err := s.queryHook(s.db, "SELECT 1")
+		if err != nil {
+			t.Fatalf("query hook fallback: %v", err)
+		}
+		_ = rows.Close()
+
+		iter, err := s.queryItHook(s.db, "SELECT 1")
+		if err != nil {
+			t.Fatalf("query iterator fallback: %v", err)
+		}
+		_ = iter.Close()
+
+		tx, err := s.beginTxHook()
+		if err != nil {
+			t.Fatalf("begin tx hook fallback: %v", err)
+		}
+		if err := s.commitHook(tx); err != nil {
+			t.Fatalf("commit hook fallback: %v", err)
+		}
+
+		s2 := newTestStore(t)
+		rows2, err := s2.queryHook(s2.db, "SELECT 1")
+		if err != nil {
+			t.Fatalf("query hook default closure: %v", err)
+		}
+		_ = rows2.Close()
+
+		s.hooks.query = func(db queryer, query string, args ...any) (*sql.Rows, error) {
+			return nil, errors.New("forced query hook error")
+		}
+		s.hooks.queryIt = nil
+		if _, err := s.queryItHook(s.db, "SELECT 1"); err == nil {
+			t.Fatalf("expected queryItHook error through queryHook fallback")
+		}
+	})
+
+	t.Run("sessions and observations filters with default limits", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("s-p", "proj-a", "/tmp/proj-a"); err != nil {
+			t.Fatalf("create session proj-a: %v", err)
+		}
+		if err := s.CreateSession("s-q", "proj-b", "/tmp/proj-b"); err != nil {
+			t.Fatalf("create session proj-b: %v", err)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-p", Type: "note", Title: "a", Content: "a", Project: "proj-a", Scope: "project"}); err != nil {
+			t.Fatalf("add observation proj-a: %v", err)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-q", Type: "note", Title: "b", Content: "b", Project: "proj-b", Scope: "project"}); err != nil {
+			t.Fatalf("add observation proj-b: %v", err)
+		}
+
+		recent, err := s.RecentSessions("proj-a", 0)
+		if err != nil {
+			t.Fatalf("recent sessions filtered: %v", err)
+		}
+		if len(recent) != 1 || recent[0].Project != "proj-a" {
+			t.Fatalf("expected one proj-a recent session, got %+v", recent)
+		}
+
+		all, err := s.AllSessions("proj-b", -1)
+		if err != nil {
+			t.Fatalf("all sessions filtered: %v", err)
+		}
+		if len(all) != 1 || all[0].Project != "proj-b" {
+			t.Fatalf("expected one proj-b session, got %+v", all)
+		}
+
+		obs, err := s.AllObservations("proj-a", "project", 0)
+		if err != nil {
+			t.Fatalf("all observations defaults: %v", err)
+		}
+		if len(obs) != 1 || obs[0].SessionID != "s-p" {
+			t.Fatalf("expected one proj-a observation, got %+v", obs)
+		}
+
+		sessionObs, err := s.SessionObservations("s-p", 0)
+		if err != nil {
+			t.Fatalf("session observations default limit: %v", err)
+		}
+		if len(sessionObs) != 1 {
+			t.Fatalf("expected one session observation, got %d", len(sessionObs))
+		}
+
+		recentObs, err := s.RecentObservations("proj-a", "project", 0)
+		if err != nil {
+			t.Fatalf("recent observations default limit: %v", err)
+		}
+		if len(recentObs) != 1 {
+			t.Fatalf("expected one recent observation, got %d", len(recentObs))
+		}
+
+		recentPrompts, err := s.RecentPrompts("", 0)
+		if err != nil {
+			t.Fatalf("recent prompts default limit: %v", err)
+		}
+		if len(recentPrompts) != 0 {
+			t.Fatalf("expected zero prompts, got %d", len(recentPrompts))
+		}
+	})
+
+	t.Run("timeline includes before and after in chronological order", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("s-tl", "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+
+		firstID, err := s.AddObservation(AddObservationParams{SessionID: "s-tl", Type: "note", Title: "1", Content: "one", Project: "engram"})
+		if err != nil {
+			t.Fatalf("add first observation: %v", err)
+		}
+		middleID, err := s.AddObservation(AddObservationParams{SessionID: "s-tl", Type: "note", Title: "2", Content: "two", Project: "engram"})
+		if err != nil {
+			t.Fatalf("add middle observation: %v", err)
+		}
+		lastID, err := s.AddObservation(AddObservationParams{SessionID: "s-tl", Type: "note", Title: "3", Content: "three", Project: "engram"})
+		if err != nil {
+			t.Fatalf("add last observation: %v", err)
+		}
+
+		tl, err := s.Timeline(middleID, 5, 5)
+		if err != nil {
+			t.Fatalf("timeline middle: %v", err)
+		}
+		if len(tl.Before) != 1 || tl.Before[0].ID != firstID {
+			t.Fatalf("expected first in before list, got %+v", tl.Before)
+		}
+		if len(tl.After) != 1 || tl.After[0].ID != lastID {
+			t.Fatalf("expected last in after list, got %+v", tl.After)
+		}
+	})
+
+	t.Run("format context returns specific query stage errors", func(t *testing.T) {
+		t.Run("recent sessions error", func(t *testing.T) {
+			s := newTestStore(t)
+			_ = s.Close()
+			if _, err := s.FormatContext("", ""); err == nil {
+				t.Fatalf("expected format context to fail from recent sessions")
+			}
+		})
+
+		t.Run("recent observations error", func(t *testing.T) {
+			s := newTestStore(t)
+			if err := s.CreateSession("s-ctx", "engram", "/tmp/engram"); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			if _, err := s.db.Exec("DROP TABLE observations"); err != nil {
+				t.Fatalf("drop observations: %v", err)
+			}
+			if _, err := s.FormatContext("", ""); err == nil {
+				t.Fatalf("expected format context to fail from recent observations")
+			}
+		})
+
+		t.Run("recent prompts error", func(t *testing.T) {
+			s := newTestStore(t)
+			if err := s.CreateSession("s-ctx2", "engram", "/tmp/engram"); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			if _, err := s.db.Exec("DROP TABLE user_prompts"); err != nil {
+				t.Fatalf("drop prompts: %v", err)
+			}
+			if _, err := s.FormatContext("", ""); err == nil {
+				t.Fatalf("expected format context to fail from recent prompts")
+			}
+		})
+	})
+}
+
+func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
+	t.Run("new open database hook error", func(t *testing.T) {
+		orig := openDB
+		t.Cleanup(func() { openDB = orig })
+		openDB = func(driverName, dataSourceName string) (*sql.DB, error) {
+			return nil, errors.New("forced open error")
+		}
+
+		cfg := DefaultConfig()
+		cfg.DataDir = t.TempDir()
+		if _, err := New(cfg); err == nil || !strings.Contains(err.Error(), "open database") {
+			t.Fatalf("expected open database error, got %v", err)
+		}
+	})
+
+	t.Run("migrate forced failures for remaining exec branches", func(t *testing.T) {
+		failCases := []string{
+			"CREATE INDEX IF NOT EXISTS idx_obs_scope",
+			"UPDATE observations SET topic_key = NULL",
+			"UPDATE observations SET revision_count = 1",
+			"UPDATE observations SET duplicate_count = 1",
+			"UPDATE observations SET updated_at = created_at",
+			"UPDATE user_prompts SET project = ''",
+			"CREATE TRIGGER prompt_fts_insert",
+		}
+		for _, needle := range failCases {
+			t.Run(needle, func(t *testing.T) {
+				s := newTestStore(t)
+				if strings.Contains(needle, "CREATE TRIGGER prompt_fts_insert") {
+					if _, err := s.db.Exec(`
+						DROP TRIGGER IF EXISTS prompt_fts_insert;
+						DROP TRIGGER IF EXISTS prompt_fts_update;
+						DROP TRIGGER IF EXISTS prompt_fts_delete;
+					`); err != nil {
+						t.Fatalf("drop prompt triggers: %v", err)
+					}
+				}
+				origExec := s.hooks.exec
+				s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+					if strings.Contains(query, needle) {
+						return nil, errors.New("forced migrate failure")
+					}
+					return origExec(db, query, args...)
+				}
+				if err := s.migrate(); err == nil {
+					t.Fatalf("expected migrate error for %q", needle)
+				}
+			})
+		}
+	})
+
+	t.Run("migrate addColumn and legacy-call propagation", func(t *testing.T) {
+		t.Run("propagates addColumn error", func(t *testing.T) {
+			s := newTestStore(t)
+			origQueryIt := s.hooks.queryIt
+			called := 0
+			s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+				if strings.Contains(query, "PRAGMA table_info(observations)") {
+					called++
+					if called == 1 {
+						return nil, errors.New("forced addColumn failure")
+					}
+				}
+				return origQueryIt(db, query, args...)
+			}
+			if err := s.migrate(); err == nil {
+				t.Fatalf("expected migrate to propagate addColumn failure")
+			}
+		})
+
+		t.Run("propagates legacy migrate error", func(t *testing.T) {
+			s := newTestStore(t)
+			origQueryIt := s.hooks.queryIt
+			called := 0
+			s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+				if strings.Contains(query, "PRAGMA table_info(observations)") {
+					called++
+					if called == 9 {
+						return nil, errors.New("forced legacy call failure")
+					}
+				}
+				return origQueryIt(db, query, args...)
+			}
+			if err := s.migrate(); err == nil {
+				t.Fatalf("expected migrate to propagate legacy migrate failure")
+			}
+		})
+	})
+
+	t.Run("add observation, prompt, update forced errors", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("s-e", "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-e", Type: "note", Title: "top", Content: "x", Project: "engram", TopicKey: "x"}); err != nil {
+			t.Fatalf("seed topic observation: %v", err)
+		}
+		origExec := s.hooks.exec
+		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+			if strings.Contains(query, "SET type = ?") {
+				return nil, errors.New("forced topic update error")
+			}
+			return origExec(db, query, args...)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-e", Type: "note", Title: "top", Content: "x", Project: "engram", TopicKey: "x"}); err == nil {
+			t.Fatalf("expected topic upsert exec error")
+		}
+
+		s.hooks = defaultStoreHooks()
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-e", Type: "note", Title: "dup", Content: "dup content", Project: "engram"}); err != nil {
+			t.Fatalf("seed dedupe observation: %v", err)
+		}
+		origExec = s.hooks.exec
+		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+			if strings.Contains(query, "SET duplicate_count = duplicate_count + 1") {
+				return nil, errors.New("forced dedupe update error")
+			}
+			return origExec(db, query, args...)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-e", Type: "note", Title: "dup", Content: "dup content", Project: "engram"}); err == nil {
+			t.Fatalf("expected dedupe exec error")
+		}
+
+		if err := s.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-e", Type: "note", Title: "x", Content: "y", Project: "engram", TopicKey: "t"}); err == nil {
+			t.Fatalf("expected topic query error on closed db")
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-e", Type: "note", Title: "x", Content: "y", Project: "engram"}); err == nil {
+			t.Fatalf("expected dedupe query error on closed db")
+		}
+		if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-e", Content: "x"}); err == nil {
+			t.Fatalf("expected add prompt error on closed db")
+		}
+	})
+
+	t.Run("update observation remaining branches", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("s-u", "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		id, err := s.AddObservation(AddObservationParams{SessionID: "s-u", Type: "old", Title: "t", Content: "c", Project: "engram", TopicKey: "topic/key"})
+		if err != nil {
+			t.Fatalf("seed observation: %v", err)
+		}
+
+		if _, err := s.UpdateObservation(999999, UpdateObservationParams{}); err == nil {
+			t.Fatalf("expected update missing observation error")
+		}
+
+		newType := "new-type"
+		longContent := strings.Repeat("z", s.cfg.MaxObservationLength+50)
+		if _, err := s.UpdateObservation(id, UpdateObservationParams{Type: &newType, Content: &longContent}); err != nil {
+			t.Fatalf("update with type+truncation: %v", err)
+		}
+
+		origExec := s.hooks.exec
+		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+			if strings.Contains(query, "UPDATE observations") {
+				return nil, errors.New("forced update exec error")
+			}
+			return origExec(db, query, args...)
+		}
+		if _, err := s.UpdateObservation(id, UpdateObservationParams{}); err == nil {
+			t.Fatalf("expected update exec error")
+		}
+	})
+
+	t.Run("query iterator scan and rows.Err branches", func(t *testing.T) {
+		s := newTestStore(t)
+		origQueryIt := s.hooks.queryIt
+
+		setScanErr := func(match string) {
+			s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+				if strings.Contains(query, match) {
+					return &fakeRows{next: []bool{true, false}, scanErr: errors.New("forced scan error")}, nil
+				}
+				return origQueryIt(db, query, args...)
+			}
+		}
+
+		setRowsErr := func(match string) {
+			s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+				if strings.Contains(query, match) {
+					return &fakeRows{next: []bool{false}, err: errors.New("forced rows err")}, nil
+				}
+				return origQueryIt(db, query, args...)
+			}
+		}
+
+		if err := s.CreateSession("s-iter", "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-iter", Type: "note", Title: "one", Content: "one", Project: "engram"}); err != nil {
+			t.Fatalf("add observation: %v", err)
+		}
+		if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-iter", Content: "prompt", Project: "engram"}); err != nil {
+			t.Fatalf("add prompt: %v", err)
+		}
+
+		setScanErr("FROM sessions s")
+		if _, err := s.RecentSessions("", 10); err == nil {
+			t.Fatalf("expected recent sessions scan error")
+		}
+
+		setScanErr("FROM sessions s")
+		if _, err := s.AllSessions("", 10); err == nil {
+			t.Fatalf("expected all sessions scan error")
+		}
+
+		setScanErr("FROM user_prompts")
+		if _, err := s.RecentPrompts("", 10); err == nil {
+			t.Fatalf("expected recent prompts scan error")
+		}
+
+		setScanErr("FROM prompts_fts")
+		if _, err := s.SearchPrompts("prompt", "", 10); err == nil {
+			t.Fatalf("expected search prompts scan error")
+		}
+
+		setScanErr("FROM observations_fts")
+		if _, err := s.Search("one", SearchOptions{}); err == nil {
+			t.Fatalf("expected search scan error")
+		}
+
+		setRowsErr("FROM observations_fts")
+		if _, err := s.Search("one", SearchOptions{}); err == nil {
+			t.Fatalf("expected search rows err")
+		}
+
+		setScanErr("SELECT id, project, directory")
+		if _, err := s.Export(); err == nil {
+			t.Fatalf("expected export sessions scan error")
+		}
+
+		setRowsErr("SELECT id, project, directory")
+		if _, err := s.Export(); err == nil {
+			t.Fatalf("expected export sessions rows err")
+		}
+
+		setScanErr("FROM observations ORDER BY id")
+		if _, err := s.Export(); err == nil {
+			t.Fatalf("expected export observations scan error")
+		}
+
+		setRowsErr("FROM observations ORDER BY id")
+		if _, err := s.Export(); err == nil {
+			t.Fatalf("expected export observations rows err")
+		}
+
+		setScanErr("FROM user_prompts ORDER BY id")
+		if _, err := s.Export(); err == nil {
+			t.Fatalf("expected export prompts scan error")
+		}
+
+		setRowsErr("FROM user_prompts ORDER BY id")
+		if _, err := s.Export(); err == nil {
+			t.Fatalf("expected export prompts rows err")
+		}
+
+		setScanErr("FROM sync_chunks")
+		if _, err := s.GetSyncedChunks(); err == nil {
+			t.Fatalf("expected synced chunks scan error")
+		}
+
+		setRowsErr("PRAGMA table_info(extra_table)")
+		if _, err := s.db.Exec(`CREATE TABLE extra_table (id INTEGER)`); err != nil {
+			t.Fatalf("create extra table: %v", err)
+		}
+		if err := s.addColumnIfNotExists("extra_table", "n", "TEXT"); err == nil {
+			t.Fatalf("expected add column rows err")
+		}
+
+		setScanErr("PRAGMA table_info(extra_table)")
+		if err := s.addColumnIfNotExists("extra_table", "n2", "TEXT"); err == nil {
+			t.Fatalf("expected add column scan error")
+		}
+
+		setRowsErr("PRAGMA table_info(observations)")
+		if err := s.migrateLegacyObservationsTable(); err == nil {
+			t.Fatalf("expected legacy migrate pragma rows err")
+		}
+
+		setScanErr("PRAGMA table_info(observations)")
+		if err := s.migrateLegacyObservationsTable(); err == nil {
+			t.Fatalf("expected legacy migrate pragma scan error")
+		}
+
+		s.hooks.queryIt = origQueryIt
+	})
+
+	t.Run("timeline and search type filter branches", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("s-t2", "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		first, _ := s.AddObservation(AddObservationParams{SessionID: "s-t2", Type: "decision", Title: "a", Content: "a", Project: "engram"})
+		_, _ = s.AddObservation(AddObservationParams{SessionID: "s-t2", Type: "decision", Title: "aa", Content: "aa", Project: "engram"})
+		focus, _ := s.AddObservation(AddObservationParams{SessionID: "s-t2", Type: "decision", Title: "b", Content: "b", Project: "engram"})
+		_, _ = s.AddObservation(AddObservationParams{SessionID: "s-t2", Type: "decision", Title: "c", Content: "c", Project: "engram"})
+
+		if _, err := s.Search("b", SearchOptions{Type: "decision", Project: "engram", Scope: "project", Limit: 5}); err != nil {
+			t.Fatalf("search with type filter: %v", err)
+		}
+
+		origQueryIt := s.hooks.queryIt
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "id < ?") {
+				return nil, errors.New("forced before query error")
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Timeline(focus, 2, 2); err == nil {
+			t.Fatalf("expected timeline before query error")
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "id < ?") {
+				return &fakeRows{next: []bool{true, false}, scanErr: errors.New("forced before scan error")}, nil
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Timeline(focus, 2, 2); err == nil {
+			t.Fatalf("expected timeline before scan error")
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "id < ?") {
+				return &fakeRows{next: []bool{false}, err: errors.New("forced before rows err")}, nil
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Timeline(focus, 2, 2); err == nil {
+			t.Fatalf("expected timeline before rows err")
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "id > ?") {
+				return nil, errors.New("forced after query error")
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Timeline(focus, 2, 2); err == nil {
+			t.Fatalf("expected timeline after query error")
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "id > ?") {
+				return &fakeRows{next: []bool{true, false}, scanErr: errors.New("forced after scan error")}, nil
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Timeline(focus, 2, 2); err == nil {
+			t.Fatalf("expected timeline after scan error")
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "id > ?") {
+				return &fakeRows{next: []bool{false}, err: errors.New("forced after rows err")}, nil
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Timeline(focus, 2, 2); err == nil {
+			t.Fatalf("expected timeline after rows err")
+		}
+
+		s.hooks.queryIt = origQueryIt
+		tl, err := s.Timeline(first, 5, 5)
+		if err != nil {
+			t.Fatalf("timeline reverse branch run: %v", err)
+		}
+		if len(tl.After) == 0 {
+			t.Fatalf("expected timeline after entries")
+		}
+	})
+
+	t.Run("format context and stats remaining branches", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("s-c", "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "s-c", Type: "note", Title: "n", Content: "n", Project: "engram"}); err != nil {
+			t.Fatalf("add obs: %v", err)
+		}
+
+		origQueryIt := s.hooks.queryIt
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "FROM observations o") && strings.Contains(query, "WHERE o.deleted_at IS NULL") {
+				return nil, errors.New("forced recent observations error")
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.FormatContext("engram", "project"); err == nil {
+			t.Fatalf("expected format context observations error")
+		}
+
+		s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+			if strings.Contains(query, "GROUP BY project") {
+				return nil, errors.New("forced stats query error")
+			}
+			return origQueryIt(db, query, args...)
+		}
+		if _, err := s.Stats(); err != nil {
+			t.Fatalf("stats should swallow project query errors: %v", err)
+		}
+
+		if err := s.EndSession("s-c", "has summary"); err != nil {
+			t.Fatalf("end session: %v", err)
+		}
+		s.hooks.queryIt = origQueryIt
+		ctx, err := s.FormatContext("engram", "project")
+		if err != nil {
+			t.Fatalf("format context with summary: %v", err)
+		}
+		if !strings.Contains(ctx, "has summary") {
+			t.Fatalf("expected session summary included in context")
+		}
+	})
+
+	t.Run("helper query errors and legacy migration late-stage failures", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+		if _, err := s.GetSyncedChunks(); err == nil {
+			t.Fatalf("expected synced chunks query error")
+		}
+		if _, err := s.queryObservations("SELECT id FROM observations"); err == nil {
+			t.Fatalf("expected queryObservations query error")
+		}
+		if err := s.addColumnIfNotExists("observations", "x", "TEXT"); err == nil {
+			t.Fatalf("expected addColumn query error")
+		}
+		if err := s.migrateLegacyObservationsTable(); err == nil {
+			t.Fatalf("expected legacy migrate query error")
+		}
+
+		s2 := newTestStore(t)
+		if _, err := s2.db.Exec(`
+			DROP TRIGGER IF EXISTS obs_fts_insert;
+			DROP TRIGGER IF EXISTS obs_fts_update;
+			DROP TRIGGER IF EXISTS obs_fts_delete;
+			DROP TABLE IF EXISTS observations_fts;
+			DROP TABLE observations;
+			INSERT OR IGNORE INTO sessions (id, project, directory) VALUES ('s1', 'engram', '/tmp/engram');
+			CREATE TABLE observations (
+				id INT,
+				session_id TEXT,
+				type TEXT,
+				title TEXT,
+				content TEXT,
+				tool_name TEXT,
+				project TEXT,
+				scope TEXT,
+				topic_key TEXT,
+				normalized_hash TEXT,
+				revision_count INTEGER,
+				duplicate_count INTEGER,
+				last_seen_at TEXT,
+				created_at TEXT,
+				updated_at TEXT,
+				deleted_at TEXT
+			);
+			INSERT INTO observations (id, session_id, type, title, content, project, created_at, updated_at)
+			VALUES (1, 's1', 'bugfix', 'legacy', 'legacy row', 'engram', datetime('now'), datetime('now'));
+		`); err != nil {
+			t.Fatalf("prepare legacy table: %v", err)
+		}
+
+		lateFail := []string{"INSERT INTO observations_migrated", "DROP TABLE observations", "RENAME TO observations", "CREATE VIRTUAL TABLE observations_fts"}
+		for _, needle := range lateFail {
+			t.Run(needle, func(t *testing.T) {
+				s3 := newTestStore(t)
+				if _, err := s3.db.Exec(`
+					DROP TRIGGER IF EXISTS obs_fts_insert;
+					DROP TRIGGER IF EXISTS obs_fts_update;
+					DROP TRIGGER IF EXISTS obs_fts_delete;
+					DROP TABLE IF EXISTS observations_fts;
+					DROP TABLE observations;
+					INSERT OR IGNORE INTO sessions (id, project, directory) VALUES ('s1', 'engram', '/tmp/engram');
+					CREATE TABLE observations (
+						id INT,
+						session_id TEXT,
+						type TEXT,
+						title TEXT,
+						content TEXT,
+						tool_name TEXT,
+						project TEXT,
+						scope TEXT,
+						topic_key TEXT,
+						normalized_hash TEXT,
+						revision_count INTEGER,
+						duplicate_count INTEGER,
+						last_seen_at TEXT,
+						created_at TEXT,
+						updated_at TEXT,
+						deleted_at TEXT
+					);
+					INSERT INTO observations (id, session_id, type, title, content, project, created_at, updated_at)
+					VALUES (1, 's1', 'bugfix', 'legacy', 'legacy row', 'engram', datetime('now'), datetime('now'));
+				`); err != nil {
+					t.Fatalf("prepare legacy schema: %v", err)
+				}
+
+				origExec := s3.hooks.exec
+				s3.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+					if strings.Contains(query, needle) {
+						return nil, errors.New("forced legacy late failure")
+					}
+					return origExec(db, query, args...)
+				}
+				if err := s3.migrateLegacyObservationsTable(); err == nil {
+					t.Fatalf("expected legacy migrate error for %q", needle)
+				}
+			})
+		}
+	})
 }

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,0 +1,795 @@
+package sync
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alanbuscaglia/engram/internal/store"
+)
+
+func newTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	cfg := store.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+	return s
+}
+
+func seedStoreForSync(t *testing.T, s *store.Store) {
+	t.Helper()
+
+	if err := s.CreateSession("s-proj", "proj-a", "/tmp/proj-a"); err != nil {
+		t.Fatalf("create session proj-a: %v", err)
+	}
+	if err := s.CreateSession("s-other", "proj-b", "/tmp/proj-b"); err != nil {
+		t.Fatalf("create session proj-b: %v", err)
+	}
+
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-proj",
+		Type:      "decision",
+		Title:     "project observation",
+		Content:   "project scoped content",
+		Project:   "proj-a",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add proj-a observation: %v", err)
+	}
+
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-other",
+		Type:      "decision",
+		Title:     "other observation",
+		Content:   "other scoped content",
+		Project:   "proj-b",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add proj-b observation: %v", err)
+	}
+
+	if _, err := s.AddPrompt(store.AddPromptParams{SessionID: "s-proj", Content: "prompt-a", Project: "proj-a"}); err != nil {
+		t.Fatalf("add proj-a prompt: %v", err)
+	}
+	if _, err := s.AddPrompt(store.AddPromptParams{SessionID: "s-other", Content: "prompt-b", Project: "proj-b"}); err != nil {
+		t.Fatalf("add proj-b prompt: %v", err)
+	}
+}
+
+func writeManifestFile(t *testing.T, dir string, m *Manifest) {
+	t.Helper()
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sync dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func resetSyncTestHooks(t *testing.T) {
+	t.Helper()
+	origJSONMarshalChunk := jsonMarshalChunk
+	origJSONMarshalManifest := jsonMarshalManifest
+	origOSCreateFile := osCreateFile
+	origGzipWriterFactory := gzipWriterFactory
+	origOSHostname := osHostname
+	origStoreGetSynced := storeGetSynced
+	origStoreExportData := storeExportData
+	origStoreImportData := storeImportData
+	origStoreRecordSynced := storeRecordSynced
+
+	t.Cleanup(func() {
+		jsonMarshalChunk = origJSONMarshalChunk
+		jsonMarshalManifest = origJSONMarshalManifest
+		osCreateFile = origOSCreateFile
+		gzipWriterFactory = origGzipWriterFactory
+		osHostname = origOSHostname
+		storeGetSynced = origStoreGetSynced
+		storeExportData = origStoreExportData
+		storeImportData = origStoreImportData
+		storeRecordSynced = origStoreRecordSynced
+	})
+}
+
+type fakeGzipWriter struct {
+	writeErr error
+	closeErr error
+}
+
+func (f *fakeGzipWriter) Write(_ []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return 1, nil
+}
+
+func (f *fakeGzipWriter) Close() error {
+	return f.closeErr
+}
+
+func TestNew(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+	sy := New(s, syncDir)
+
+	if sy == nil {
+		t.Fatal("expected non-nil syncer")
+	}
+	if sy.store != s {
+		t.Fatal("store pointer not preserved")
+	}
+	if sy.syncDir != syncDir {
+		t.Fatalf("sync dir mismatch: got %q want %q", sy.syncDir, syncDir)
+	}
+}
+
+func TestExportImportFlowWithProjectFilter(t *testing.T) {
+	srcStore := newTestStore(t)
+	seedStoreForSync(t, srcStore)
+
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+	exporter := New(srcStore, syncDir)
+
+	exportResult, err := exporter.Export("alice", "proj-a")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if exportResult.IsEmpty {
+		t.Fatal("expected non-empty export")
+	}
+	if exportResult.SessionsExported != 1 || exportResult.ObservationsExported != 1 || exportResult.PromptsExported != 1 {
+		t.Fatalf("unexpected export counts: %+v", exportResult)
+	}
+
+	chunkPath := filepath.Join(syncDir, "chunks", exportResult.ChunkID+".jsonl.gz")
+	if _, err := os.Stat(chunkPath); err != nil {
+		t.Fatalf("chunk file missing: %v", err)
+	}
+
+	manifest, err := exporter.readManifest()
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if len(manifest.Chunks) != 1 || manifest.Chunks[0].ID != exportResult.ChunkID {
+		t.Fatalf("unexpected manifest after export: %+v", manifest.Chunks)
+	}
+
+	secondExport, err := exporter.Export("alice", "proj-a")
+	if err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+	if !secondExport.IsEmpty {
+		t.Fatalf("expected second export to be empty, got %+v", secondExport)
+	}
+
+	dstStore := newTestStore(t)
+	importer := New(dstStore, syncDir)
+
+	importResult, err := importer.Import()
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if importResult.ChunksImported != 1 || importResult.ChunksSkipped != 0 {
+		t.Fatalf("unexpected chunk import counts: %+v", importResult)
+	}
+	if importResult.SessionsImported != 1 || importResult.ObservationsImported != 1 || importResult.PromptsImported != 1 {
+		t.Fatalf("unexpected imported row counts: %+v", importResult)
+	}
+
+	importAgain, err := importer.Import()
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if importAgain.ChunksImported != 0 || importAgain.ChunksSkipped != 1 {
+		t.Fatalf("unexpected second import result: %+v", importAgain)
+	}
+
+	dstData, err := dstStore.Export()
+	if err != nil {
+		t.Fatalf("export destination data: %v", err)
+	}
+	if len(dstData.Sessions) != 1 || dstData.Sessions[0].Project != "proj-a" {
+		t.Fatalf("unexpected destination sessions: %+v", dstData.Sessions)
+	}
+}
+
+func TestExportErrors(t *testing.T) {
+	t.Run("create chunks dir", func(t *testing.T) {
+		s := newTestStore(t)
+		badPath := filepath.Join(t.TempDir(), "not-a-dir")
+		if err := os.WriteFile(badPath, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		sy := New(s, badPath)
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "create chunks dir") {
+			t.Fatalf("expected create chunks dir error, got %v", err)
+		}
+	})
+
+	t.Run("invalid manifest", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(syncDir, "manifest.json"), []byte("not-json"), 0o644); err != nil {
+			t.Fatalf("write invalid manifest: %v", err)
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+			t.Fatalf("expected parse manifest error, got %v", err)
+		}
+	})
+
+	t.Run("get synced chunks", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		if err := s.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "get synced chunks") {
+			t.Fatalf("expected get synced chunks error, got %v", err)
+		}
+	})
+
+	t.Run("already known chunk id", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreForSync(t, s)
+		sy := New(s, t.TempDir())
+
+		data, err := s.Export()
+		if err != nil {
+			t.Fatalf("store export: %v", err)
+		}
+		chunk := sy.filterNewData(data, "")
+		chunkJSON, err := json.Marshal(chunk)
+		if err != nil {
+			t.Fatalf("marshal chunk: %v", err)
+		}
+		hash := sha256.Sum256(chunkJSON)
+		chunkID := hex.EncodeToString(hash[:])[:8]
+
+		writeManifestFile(t, sy.syncDir, &Manifest{
+			Version: 1,
+			Chunks: []ChunkEntry{{
+				ID:        chunkID,
+				CreatedBy: "alice",
+				CreatedAt: "2000-01-01T00:00:00Z",
+			}},
+		})
+
+		res, err := sy.Export("alice", "")
+		if err != nil {
+			t.Fatalf("export: %v", err)
+		}
+		if !res.IsEmpty {
+			t.Fatalf("expected empty export for known chunk hash, got %+v", res)
+		}
+	})
+
+	t.Run("store export error", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		s := newTestStore(t)
+		sy := New(s, t.TempDir())
+
+		storeExportData = func(_ *store.Store) (*store.ExportData, error) {
+			return nil, errors.New("boom export")
+		}
+
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "export data") {
+			t.Fatalf("expected export data error, got %v", err)
+		}
+	})
+
+	t.Run("marshal chunk error", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		s := newTestStore(t)
+		seedStoreForSync(t, s)
+		sy := New(s, t.TempDir())
+
+		jsonMarshalChunk = func(v any) ([]byte, error) {
+			return nil, fmt.Errorf("forced marshal error: %T", v)
+		}
+
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "marshal chunk") {
+			t.Fatalf("expected marshal chunk error, got %v", err)
+		}
+	})
+
+	t.Run("write chunk error", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		s := newTestStore(t)
+		seedStoreForSync(t, s)
+		sy := New(s, t.TempDir())
+
+		gzipWriterFactory = func(_ *os.File) gzipWriter {
+			return &fakeGzipWriter{writeErr: errors.New("forced gzip write")}
+		}
+
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "write chunk") {
+			t.Fatalf("expected write chunk error, got %v", err)
+		}
+	})
+
+	t.Run("write manifest error", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		s := newTestStore(t)
+		seedStoreForSync(t, s)
+		syncDir := t.TempDir()
+		jsonMarshalManifest = func(v any, prefix, indent string) ([]byte, error) {
+			_ = v
+			_ = prefix
+			_ = indent
+			return nil, errors.New("forced manifest marshal failure")
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "write manifest") {
+			t.Fatalf("expected write manifest error, got %v", err)
+		}
+	})
+
+	t.Run("record synced chunk error", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		s := newTestStore(t)
+		seedStoreForSync(t, s)
+		sy := New(s, t.TempDir())
+
+		storeRecordSynced = func(_ *store.Store, _ string) error {
+			return errors.New("forced record failure")
+		}
+
+		if _, err := sy.Export("alice", ""); err == nil || !strings.Contains(err.Error(), "record synced chunk") {
+			t.Fatalf("expected record synced chunk error, got %v", err)
+		}
+	})
+}
+
+func TestImportBranches(t *testing.T) {
+	t.Run("read manifest error", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(syncDir, "manifest.json"), []byte("{bad"), 0o644); err != nil {
+			t.Fatalf("write invalid manifest: %v", err)
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+			t.Fatalf("expected parse manifest error, got %v", err)
+		}
+	})
+
+	t.Run("empty manifest", func(t *testing.T) {
+		s := newTestStore(t)
+		sy := New(s, t.TempDir())
+
+		res, err := sy.Import()
+		if err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		if *res != (ImportResult{}) {
+			t.Fatalf("expected empty result, got %+v", res)
+		}
+	})
+
+	t.Run("missing chunk file is skipped", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		writeManifestFile(t, syncDir, &Manifest{
+			Version: 1,
+			Chunks:  []ChunkEntry{{ID: "missing", CreatedBy: "alice", CreatedAt: time.Now().UTC().Format(time.RFC3339)}},
+		})
+
+		sy := New(s, syncDir)
+		res, err := sy.Import()
+		if err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		if res.ChunksImported != 0 || res.ChunksSkipped != 1 {
+			t.Fatalf("expected one skipped chunk, got %+v", res)
+		}
+	})
+
+	t.Run("invalid chunk json", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		id := "badjson"
+		writeManifestFile(t, syncDir, &Manifest{
+			Version: 1,
+			Chunks:  []ChunkEntry{{ID: id, CreatedBy: "alice", CreatedAt: time.Now().UTC().Format(time.RFC3339)}},
+		})
+
+		chunksDir := filepath.Join(syncDir, "chunks")
+		if err := os.MkdirAll(chunksDir, 0o755); err != nil {
+			t.Fatalf("mkdir chunks: %v", err)
+		}
+		if err := writeGzip(filepath.Join(chunksDir, id+".jsonl.gz"), []byte("{not-valid-json")); err != nil {
+			t.Fatalf("write bad gzip chunk: %v", err)
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "parse chunk") {
+			t.Fatalf("expected parse chunk error, got %v", err)
+		}
+	})
+
+	t.Run("store import error", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		id := "broken"
+		writeManifestFile(t, syncDir, &Manifest{
+			Version: 1,
+			Chunks:  []ChunkEntry{{ID: id, CreatedBy: "alice", CreatedAt: time.Now().UTC().Format(time.RFC3339)}},
+		})
+
+		chunk := ChunkData{
+			Observations: []store.Observation{{
+				ID:        1,
+				SessionID: "missing-session",
+				Type:      "bugfix",
+				Title:     "broken",
+				Content:   "missing session should violate FK",
+				Scope:     "project",
+				CreatedAt: "2025-01-01 00:00:01",
+				UpdatedAt: "2025-01-01 00:00:01",
+			}},
+		}
+		payload, err := json.Marshal(chunk)
+		if err != nil {
+			t.Fatalf("marshal chunk: %v", err)
+		}
+
+		chunksDir := filepath.Join(syncDir, "chunks")
+		if err := os.MkdirAll(chunksDir, 0o755); err != nil {
+			t.Fatalf("mkdir chunks: %v", err)
+		}
+		if err := writeGzip(filepath.Join(chunksDir, id+".jsonl.gz"), payload); err != nil {
+			t.Fatalf("write gzip chunk: %v", err)
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "import chunk") {
+			t.Fatalf("expected import chunk error, got %v", err)
+		}
+	})
+
+	t.Run("get synced chunks", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: "c1", CreatedAt: time.Now().UTC().Format(time.RFC3339)}}})
+		if err := s.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "get synced chunks") {
+			t.Fatalf("expected get synced chunks error, got %v", err)
+		}
+	})
+
+	t.Run("record chunk error", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		id := "okchunk"
+		writeManifestFile(t, syncDir, &Manifest{
+			Version: 1,
+			Chunks:  []ChunkEntry{{ID: id, CreatedBy: "alice", CreatedAt: "2025-01-01T00:00:00Z"}},
+		})
+
+		chunk := ChunkData{
+			Sessions: []store.Session{{ID: "s1", Project: "p", Directory: "/tmp", StartedAt: "2025-01-01 00:00:00"}},
+		}
+		payload, err := json.Marshal(chunk)
+		if err != nil {
+			t.Fatalf("marshal chunk: %v", err)
+		}
+		chunksDir := filepath.Join(syncDir, "chunks")
+		if err := os.MkdirAll(chunksDir, 0o755); err != nil {
+			t.Fatalf("mkdir chunks: %v", err)
+		}
+		if err := writeGzip(filepath.Join(chunksDir, id+".jsonl.gz"), payload); err != nil {
+			t.Fatalf("write gzip chunk: %v", err)
+		}
+
+		storeRecordSynced = func(_ *store.Store, _ string) error {
+			return errors.New("forced import record fail")
+		}
+
+		sy := New(s, syncDir)
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "record chunk") {
+			t.Fatalf("expected record chunk error, got %v", err)
+		}
+	})
+}
+
+func TestManifestReadWrite(t *testing.T) {
+	syncDir := t.TempDir()
+	sy := New(nil, syncDir)
+
+	missing, err := sy.readManifest()
+	if err != nil {
+		t.Fatalf("read missing manifest: %v", err)
+	}
+	if missing.Version != 1 || len(missing.Chunks) != 0 {
+		t.Fatalf("unexpected default manifest: %+v", missing)
+	}
+
+	want := &Manifest{
+		Version: 1,
+		Chunks:  []ChunkEntry{{ID: "abc12345", CreatedBy: "alice", CreatedAt: "2025-01-01T00:00:00Z", Sessions: 1, Memories: 2, Prompts: 3}},
+	}
+	if err := sy.writeManifest(want); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	got, err := sy.readManifest()
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if len(got.Chunks) != 1 || got.Chunks[0].ID != want.Chunks[0].ID || got.Chunks[0].Memories != 2 {
+		t.Fatalf("manifest roundtrip mismatch: %+v", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(syncDir, "manifest.json"), []byte("{"), 0o644); err != nil {
+		t.Fatalf("write invalid manifest: %v", err)
+	}
+	if _, err := sy.readManifest(); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+		t.Fatalf("expected parse manifest error, got %v", err)
+	}
+
+	badSyncPath := filepath.Join(t.TempDir(), "not-dir")
+	if err := os.WriteFile(badSyncPath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write non-dir sync path: %v", err)
+	}
+	syBad := New(nil, badSyncPath)
+	if _, err := syBad.readManifest(); err == nil || !strings.Contains(err.Error(), "read manifest") {
+		t.Fatalf("expected read manifest error, got %v", err)
+	}
+	if err := syBad.writeManifest(&Manifest{Version: 1}); err == nil {
+		t.Fatal("expected write manifest error for non-directory sync path")
+	}
+
+	t.Run("marshal manifest error", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		sy := New(nil, t.TempDir())
+		jsonMarshalManifest = func(v any, prefix, indent string) ([]byte, error) {
+			_ = v
+			_ = prefix
+			_ = indent
+			return nil, errors.New("forced manifest marshal error")
+		}
+
+		if err := sy.writeManifest(&Manifest{Version: 1}); err == nil || !strings.Contains(err.Error(), "marshal manifest") {
+			t.Fatalf("expected marshal manifest error, got %v", err)
+		}
+	})
+}
+
+func TestStatus(t *testing.T) {
+	t.Run("read manifest error", func(t *testing.T) {
+		s := newTestStore(t)
+		syncDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(syncDir, "manifest.json"), []byte("not-json"), 0o644); err != nil {
+			t.Fatalf("write invalid manifest: %v", err)
+		}
+
+		sy := New(s, syncDir)
+		if _, _, _, err := sy.Status(); err == nil {
+			t.Fatal("expected status to fail on invalid manifest")
+		}
+	})
+
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	sy := New(s, syncDir)
+
+	if err := sy.writeManifest(&Manifest{
+		Version: 1,
+		Chunks:  []ChunkEntry{{ID: "c1", CreatedAt: "2025-01-01T00:00:00Z"}, {ID: "c2", CreatedAt: "2025-01-02T00:00:00Z"}},
+	}); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := s.RecordSyncedChunk("c1"); err != nil {
+		t.Fatalf("record synced chunk: %v", err)
+	}
+
+	local, remote, pending, err := sy.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if local != 1 || remote != 2 || pending != 1 {
+		t.Fatalf("unexpected status values: local=%d remote=%d pending=%d", local, remote, pending)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if _, _, _, err := sy.Status(); err == nil {
+		t.Fatal("expected status error with closed store")
+	}
+}
+
+func TestFilterFunctionsAndTimeNormalization(t *testing.T) {
+	data := &store.ExportData{
+		Version:    "0.1.0",
+		ExportedAt: "2025-01-01 00:00:00",
+		Sessions: []store.Session{
+			{ID: "s1", Project: "proj-a", StartedAt: "2025-01-01 10:00:00"},
+			{ID: "s2", Project: "proj-b", StartedAt: "2025-01-01 11:00:00"},
+		},
+		Observations: []store.Observation{
+			{ID: 1, SessionID: "s1", CreatedAt: "2025-01-01 10:00:00"},
+			{ID: 2, SessionID: "s2", CreatedAt: "2025-01-01 11:00:00"},
+		},
+		Prompts: []store.Prompt{
+			{ID: 1, SessionID: "s1", CreatedAt: "2025-01-01 10:00:00"},
+			{ID: 2, SessionID: "s2", CreatedAt: "2025-01-01 11:00:00"},
+		},
+	}
+
+	projectOnly := filterByProject(data, "proj-a")
+	if len(projectOnly.Sessions) != 1 || projectOnly.Sessions[0].ID != "s1" {
+		t.Fatalf("unexpected filtered sessions: %+v", projectOnly.Sessions)
+	}
+	if len(projectOnly.Observations) != 1 || projectOnly.Observations[0].SessionID != "s1" {
+		t.Fatalf("unexpected filtered observations: %+v", projectOnly.Observations)
+	}
+	if len(projectOnly.Prompts) != 1 || projectOnly.Prompts[0].SessionID != "s1" {
+		t.Fatalf("unexpected filtered prompts: %+v", projectOnly.Prompts)
+	}
+
+	sy := New(nil, t.TempDir())
+	all := sy.filterNewData(data, "")
+	if len(all.Sessions) != 2 || len(all.Observations) != 2 || len(all.Prompts) != 2 {
+		t.Fatalf("expected first sync to include all data, got %+v", all)
+	}
+
+	newOnly := sy.filterNewData(data, "2025-01-01T10:30:00Z")
+	if len(newOnly.Sessions) != 1 || newOnly.Sessions[0].ID != "s2" {
+		t.Fatalf("unexpected new sessions: %+v", newOnly.Sessions)
+	}
+	if len(newOnly.Observations) != 1 || newOnly.Observations[0].ID != 2 {
+		t.Fatalf("unexpected new observations: %+v", newOnly.Observations)
+	}
+	if len(newOnly.Prompts) != 1 || newOnly.Prompts[0].ID != 2 {
+		t.Fatalf("unexpected new prompts: %+v", newOnly.Prompts)
+	}
+
+	if got := normalizeTime("2025-01-01T15:04:05Z"); got != "2025-01-01 15:04:05" {
+		t.Fatalf("unexpected RFC3339 normalization: %q", got)
+	}
+	if got := normalizeTime(" 2025-01-01 15:04:05 "); got != "2025-01-01 15:04:05" {
+		t.Fatalf("unexpected plain normalization: %q", got)
+	}
+
+	m := &Manifest{Chunks: []ChunkEntry{{ID: "old", CreatedAt: "2025-01-01T00:00:00Z"}, {ID: "new", CreatedAt: "2025-02-01T00:00:00Z"}}}
+	if got := sy.lastChunkTime(m); got != "2025-02-01T00:00:00Z" {
+		t.Fatalf("unexpected last chunk time: %q", got)
+	}
+}
+
+func TestGzipHelpers(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "chunk.jsonl.gz")
+		payload := []byte(`{"sessions":1,"observations":2}`)
+
+		if err := writeGzip(path, payload); err != nil {
+			t.Fatalf("write gzip: %v", err)
+		}
+
+		got, err := readGzip(path)
+		if err != nil {
+			t.Fatalf("read gzip: %v", err)
+		}
+		if string(got) != string(payload) {
+			t.Fatalf("gzip mismatch: got %q want %q", got, payload)
+		}
+	})
+
+	t.Run("write error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing", "chunk.gz")
+		if err := writeGzip(path, []byte("x")); err == nil {
+			t.Fatal("expected writeGzip error for missing parent dir")
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "not-gzip")
+		if err := os.WriteFile(path, []byte("plain text"), 0o644); err != nil {
+			t.Fatalf("write plain file: %v", err)
+		}
+
+		if _, err := readGzip(path); err == nil {
+			t.Fatal("expected readGzip error for non-gzip file")
+		}
+	})
+
+	t.Run("gzip write and close errors", func(t *testing.T) {
+		resetSyncTestHooks(t)
+		path := filepath.Join(t.TempDir(), "chunk.gz")
+
+		gzipWriterFactory = func(_ *os.File) gzipWriter {
+			return &fakeGzipWriter{writeErr: errors.New("forced write error")}
+		}
+		if err := writeGzip(path, []byte("x")); err == nil {
+			t.Fatal("expected forced gzip write error")
+		}
+
+		gzipWriterFactory = func(_ *os.File) gzipWriter {
+			return &fakeGzipWriter{closeErr: errors.New("forced close error")}
+		}
+		if err := writeGzip(path, []byte("x")); err == nil {
+			t.Fatal("expected forced gzip close error")
+		}
+	})
+}
+
+func TestGetUsernameAndManifestSummary(t *testing.T) {
+	t.Run("username precedence", func(t *testing.T) {
+		t.Setenv("USER", "")
+		t.Setenv("USERNAME", "windows-user")
+		if got := GetUsername(); got != "windows-user" {
+			t.Fatalf("expected USERNAME fallback, got %q", got)
+		}
+
+		t.Setenv("USER", "unix-user")
+		t.Setenv("USERNAME", "windows-user")
+		if got := GetUsername(); got != "unix-user" {
+			t.Fatalf("expected USER to win, got %q", got)
+		}
+
+		t.Setenv("USER", "")
+		t.Setenv("USERNAME", "")
+		if got := GetUsername(); got == "" {
+			t.Fatal("expected hostname or unknown fallback")
+		}
+
+		resetSyncTestHooks(t)
+		osHostname = func() (string, error) {
+			return "", errors.New("forced no hostname")
+		}
+		if got := GetUsername(); got != "unknown" {
+			t.Fatalf("expected unknown fallback, got %q", got)
+		}
+	})
+
+	t.Run("manifest summary", func(t *testing.T) {
+		empty := ManifestSummary(&Manifest{Version: 1})
+		if empty != "No chunks synced yet." {
+			t.Fatalf("unexpected empty summary: %q", empty)
+		}
+
+		summary := ManifestSummary(&Manifest{Chunks: []ChunkEntry{
+			{ID: "1", CreatedBy: "bob", Sessions: 1, Memories: 2},
+			{ID: "2", CreatedBy: "alice", Sessions: 2, Memories: 3},
+			{ID: "3", CreatedBy: "alice", Sessions: 1, Memories: 1},
+		}})
+
+		if !strings.Contains(summary, "3 chunks") || !strings.Contains(summary, "6 memories") || !strings.Contains(summary, "4 sessions") {
+			t.Fatalf("summary totals missing: %q", summary)
+		}
+		if !strings.Contains(summary, "alice (2 chunks), bob (1 chunks)") {
+			t.Fatalf("summary contributors not sorted or counted: %q", summary)
+		}
+	})
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -206,7 +206,9 @@ func loadSessionObservations(s *store.Store, sessionID string) tea.Cmd {
 
 func installAgent(agentName string) tea.Cmd {
 	return func() tea.Msg {
-		result, err := setup.Install(agentName)
+		result, err := installAgentFn(agentName)
 		return setupInstallMsg{result: result, err: err}
 	}
 }
+
+var installAgentFn = setup.Install

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alanbuscaglia/engram/internal/setup"
+	"github.com/alanbuscaglia/engram/internal/store"
+)
+
+type testFixture struct {
+	store        *store.Store
+	sessionID    string
+	obsID        int64
+	secondObs    int64
+	otherSession string
+}
+
+func newTestFixture(t *testing.T) testFixture {
+	t.Helper()
+
+	cfg := store.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.CreateSession("session-1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session-1: %v", err)
+	}
+	if err := s.CreateSession("session-2", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session-2: %v", err)
+	}
+
+	obsID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "session-1",
+		Type:      "bugfix",
+		Title:     "Needle observation",
+		Content:   "needle content for deterministic search",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add first observation: %v", err)
+	}
+
+	secondObs, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "session-1",
+		Type:      "decision",
+		Title:     "Second observation",
+		Content:   "timeline sibling",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add second observation: %v", err)
+	}
+
+	return testFixture{store: s, sessionID: "session-1", obsID: obsID, secondObs: secondObs, otherSession: "session-2"}
+}
+
+func TestNewInitializesModelDefaults(t *testing.T) {
+	m := New(nil)
+
+	if m.Screen != ScreenDashboard {
+		t.Fatalf("screen = %v, want %v", m.Screen, ScreenDashboard)
+	}
+	if m.SearchInput.Placeholder != "Search memories..." {
+		t.Fatalf("placeholder = %q", m.SearchInput.Placeholder)
+	}
+	if m.SearchInput.CharLimit != 256 {
+		t.Fatalf("char limit = %d", m.SearchInput.CharLimit)
+	}
+	if m.SearchInput.Width != 60 {
+		t.Fatalf("width = %d", m.SearchInput.Width)
+	}
+	if m.SetupSpinner.Spinner.Frames == nil {
+		t.Fatal("spinner was not initialized")
+	}
+}
+
+func TestInitReturnsCommand(t *testing.T) {
+	m := New(newTestFixture(t).store)
+	if cmd := m.Init(); cmd == nil {
+		t.Fatal("init should return a startup command")
+	}
+}
+
+func TestDataLoadingCommands(t *testing.T) {
+	fx := newTestFixture(t)
+
+	t.Run("loadStats", func(t *testing.T) {
+		msg := loadStats(fx.store)()
+		loaded, ok := msg.(statsLoadedMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if loaded.err != nil {
+			t.Fatalf("unexpected error: %v", loaded.err)
+		}
+		if loaded.stats == nil || loaded.stats.TotalSessions < 2 {
+			t.Fatalf("unexpected stats: %+v", loaded.stats)
+		}
+	})
+
+	t.Run("searchMemories", func(t *testing.T) {
+		msg := searchMemories(fx.store, "needle")()
+		loaded, ok := msg.(searchResultsMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if loaded.err != nil {
+			t.Fatalf("unexpected error: %v", loaded.err)
+		}
+		if loaded.query != "needle" {
+			t.Fatalf("query = %q", loaded.query)
+		}
+		if len(loaded.results) == 0 {
+			t.Fatal("expected at least one search result")
+		}
+	})
+
+	t.Run("loadRecentObservations", func(t *testing.T) {
+		msg := loadRecentObservations(fx.store)()
+		loaded, ok := msg.(recentObservationsMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if loaded.err != nil {
+			t.Fatalf("unexpected error: %v", loaded.err)
+		}
+		if len(loaded.observations) < 2 {
+			t.Fatalf("observations = %d, want >= 2", len(loaded.observations))
+		}
+	})
+
+	t.Run("loadObservationDetail", func(t *testing.T) {
+		msg := loadObservationDetail(fx.store, fx.obsID)()
+		loaded, ok := msg.(observationDetailMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if loaded.err != nil {
+			t.Fatalf("unexpected error: %v", loaded.err)
+		}
+		if loaded.observation == nil || loaded.observation.ID != fx.obsID {
+			t.Fatalf("unexpected observation: %+v", loaded.observation)
+		}
+	})
+
+	t.Run("loadTimeline", func(t *testing.T) {
+		msg := loadTimeline(fx.store, fx.secondObs)()
+		loaded, ok := msg.(timelineMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if loaded.err != nil {
+			t.Fatalf("unexpected error: %v", loaded.err)
+		}
+		if loaded.timeline == nil || loaded.timeline.Focus.ID != fx.secondObs {
+			t.Fatalf("unexpected timeline focus: %+v", loaded.timeline)
+		}
+	})
+
+	t.Run("loadRecentSessions", func(t *testing.T) {
+		msg := loadRecentSessions(fx.store)()
+		loaded, ok := msg.(recentSessionsMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if loaded.err != nil {
+			t.Fatalf("unexpected error: %v", loaded.err)
+		}
+		if len(loaded.sessions) < 2 {
+			t.Fatalf("sessions = %d, want >= 2", len(loaded.sessions))
+		}
+	})
+
+	t.Run("loadSessionObservations", func(t *testing.T) {
+		msg := loadSessionObservations(fx.store, fx.sessionID)()
+		loaded, ok := msg.(sessionObservationsMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if loaded.err != nil {
+			t.Fatalf("unexpected error: %v", loaded.err)
+		}
+		if len(loaded.observations) < 2 {
+			t.Fatalf("observations = %d, want >= 2", len(loaded.observations))
+		}
+	})
+}
+
+func TestInstallAgentCommand(t *testing.T) {
+	original := installAgentFn
+	t.Cleanup(func() { installAgentFn = original })
+
+	t.Run("success", func(t *testing.T) {
+		installAgentFn = func(agentName string) (*setup.Result, error) {
+			if agentName != "opencode" {
+				t.Fatalf("agentName = %q", agentName)
+			}
+			return &setup.Result{Agent: agentName, Destination: "/tmp/plugins", Files: 1}, nil
+		}
+
+		msg := installAgent("opencode")()
+		res, ok := msg.(setupInstallMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v", res.err)
+		}
+		if res.result == nil || res.result.Agent != "opencode" {
+			t.Fatalf("unexpected result: %+v", res.result)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		installAgentFn = func(string) (*setup.Result, error) {
+			return nil, errors.New("install failed")
+		}
+
+		msg := installAgent("claude-code")()
+		res, ok := msg.(setupInstallMsg)
+		if !ok {
+			t.Fatalf("message type = %T", msg)
+		}
+		if res.err == nil || res.err.Error() != "install failed" {
+			t.Fatalf("expected install error, got %v", res.err)
+		}
+	})
+}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1,0 +1,819 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alanbuscaglia/engram/internal/setup"
+	"github.com/alanbuscaglia/engram/internal/store"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestUpdateHandlesWindowSizeAndCtrlC(t *testing.T) {
+	m := New(nil)
+
+	updatedModel, cmd := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	updated := updatedModel.(Model)
+	if updated.Width != 120 || updated.Height != 40 {
+		t.Fatalf("size = %dx%d", updated.Width, updated.Height)
+	}
+	if cmd != nil {
+		t.Fatal("window size update should not return command")
+	}
+
+	_, quitCmd := updated.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if quitCmd == nil {
+		t.Fatal("ctrl+c should return quit command")
+	}
+}
+
+func TestUpdateSearchInputFocusedHandlesEscAndEnter(t *testing.T) {
+	fx := newTestFixture(t)
+	m := New(fx.store)
+	m.Screen = ScreenSearch
+	m.PrevScreen = ScreenDashboard
+	m.SearchInput.Focus()
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := updatedModel.(Model)
+	if updated.Screen != ScreenDashboard {
+		t.Fatalf("screen = %v, want %v", updated.Screen, ScreenDashboard)
+	}
+	if updated.SearchInput.Focused() {
+		t.Fatal("search input should blur on esc")
+	}
+	if cmd != nil {
+		t.Fatal("esc should not return command")
+	}
+
+	m = New(fx.store)
+	m.Screen = ScreenSearch
+	m.PrevScreen = ScreenDashboard
+	m.SearchInput.Focus()
+	m.SearchInput.SetValue("needle")
+
+	updatedModel, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedModel.(Model)
+	if updated.SearchInput.Focused() {
+		t.Fatal("search input should blur on enter")
+	}
+	if cmd == nil {
+		t.Fatal("enter with query should return search command")
+	}
+}
+
+func TestUpdateSearchResultsAndDetailScreenTransitions(t *testing.T) {
+	m := New(nil)
+	m.Screen = ScreenSearchResults
+	m.Height = 14
+	m.SearchResults = []store.SearchResult{
+		{Observation: store.Observation{ID: 1}},
+		{Observation: store.Observation{ID: 2}},
+		{Observation: store.Observation{ID: 3}},
+		{Observation: store.Observation{ID: 4}},
+	}
+	m.Cursor = 2
+	m.Scroll = 0
+
+	updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated := updatedModel.(Model)
+	if updated.Cursor != 3 {
+		t.Fatalf("cursor = %d, want 3", updated.Cursor)
+	}
+	if updated.Scroll != 1 {
+		t.Fatalf("scroll = %d, want 1", updated.Scroll)
+	}
+
+	updatedModel, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSearch {
+		t.Fatalf("screen = %v, want %v", updated.Screen, ScreenSearch)
+	}
+	if !updated.SearchInput.Focused() {
+		t.Fatal("search input should be focused after leaving results")
+	}
+}
+
+func TestUpdateObservationDetailEscRefreshesPrevScreen(t *testing.T) {
+	fx := newTestFixture(t)
+	m := New(fx.store)
+	m.Screen = ScreenObservationDetail
+	m.PrevScreen = ScreenRecent
+	m.DetailScroll = 3
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := updatedModel.(Model)
+	if updated.Screen != ScreenRecent {
+		t.Fatalf("screen = %v, want %v", updated.Screen, ScreenRecent)
+	}
+	if updated.DetailScroll != 0 {
+		t.Fatalf("detail scroll = %d, want 0", updated.DetailScroll)
+	}
+	if cmd == nil {
+		t.Fatal("expected refresh command when leaving detail view")
+	}
+}
+
+func TestUpdateSetupFlowAndSpinnerTick(t *testing.T) {
+	fx := newTestFixture(t)
+	m := New(fx.store)
+	m.Screen = ScreenSetup
+	m.SetupAgents = []setup.Agent{{Name: "opencode", Description: "OpenCode", InstallDir: "/tmp"}}
+	m.SetupDone = true
+	m.SetupResult = &setup.Result{Agent: "opencode", Destination: "/tmp", Files: 1}
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(Model)
+	if updated.Screen != ScreenDashboard {
+		t.Fatalf("screen = %v, want %v", updated.Screen, ScreenDashboard)
+	}
+	if updated.SetupDone {
+		t.Fatal("setup done should reset after leaving setup screen")
+	}
+	if cmd == nil {
+		t.Fatal("expected stats refresh command when leaving setup")
+	}
+
+	updated.SetupInstalling = false
+	_, tickCmd := updated.Update(spinner.TickMsg{})
+	if tickCmd != nil {
+		t.Fatal("spinner tick should be ignored when not installing")
+	}
+
+	updated.SetupInstalling = true
+	_, tickCmd = updated.Update(spinner.TickMsg{})
+	if tickCmd == nil {
+		t.Fatal("spinner tick should be forwarded while installing")
+	}
+}
+
+func TestHandleDashboardAndSearchKeyPaths(t *testing.T) {
+	fx := newTestFixture(t)
+	m := New(fx.store)
+
+	updatedModel, _ := m.handleDashboardKeys("s")
+	updated := updatedModel.(Model)
+	if updated.Screen != ScreenSearch || !updated.SearchInput.Focused() {
+		t.Fatal("dashboard shortcut should open focused search")
+	}
+
+	m = New(fx.store)
+	m.Cursor = 1
+	updatedModel, cmd := m.handleDashboardSelection()
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenRecent {
+		t.Fatalf("screen = %v, want %v", updated.Screen, ScreenRecent)
+	}
+	if cmd == nil {
+		t.Fatal("recent selection should load observations")
+	}
+
+	m = New(fx.store)
+	m.Cursor = 2
+	updatedModel, cmd = m.handleDashboardSelection()
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSessions {
+		t.Fatalf("screen = %v, want %v", updated.Screen, ScreenSessions)
+	}
+	if cmd == nil {
+		t.Fatal("sessions selection should load sessions")
+	}
+
+	m = New(fx.store)
+	m.Cursor = 3
+	updatedModel, cmd = m.handleDashboardSelection()
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSetup || len(updated.SetupAgents) == 0 {
+		t.Fatal("setup selection should initialize setup screen")
+	}
+	if cmd != nil {
+		t.Fatal("setup selection should not return command")
+	}
+
+	m = New(nil)
+	m.Screen = ScreenSearch
+	m.PrevScreen = ScreenDashboard
+	updatedModel, _ = m.handleSearchKeys("esc")
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenDashboard {
+		t.Fatalf("screen = %v, want %v", updated.Screen, ScreenDashboard)
+	}
+
+	m = New(nil)
+	m.Screen = ScreenSearch
+	updatedModel, _ = m.handleSearchKeys("/")
+	updated = updatedModel.(Model)
+	if !updated.SearchInput.Focused() {
+		t.Fatal("search key should focus search input")
+	}
+}
+
+func TestHandleRecentTimelineSessionsAndDetailKeyPaths(t *testing.T) {
+	fx := newTestFixture(t)
+	m := New(fx.store)
+	m.Height = 14
+	m.Screen = ScreenRecent
+	m.RecentObservations = []store.Observation{{ID: fx.obsID}, {ID: fx.secondObs}, {ID: 33}, {ID: 44}}
+	m.Cursor = 2
+
+	updatedModel, _ := m.handleRecentKeys("down")
+	updated := updatedModel.(Model)
+	if updated.Cursor != 3 || updated.Scroll != 1 {
+		t.Fatalf("cursor/scroll = %d/%d, want 3/1", updated.Cursor, updated.Scroll)
+	}
+
+	updatedModel, cmd := updated.handleRecentKeys("enter")
+	updated = updatedModel.(Model)
+	if updated.PrevScreen != ScreenRecent || cmd == nil {
+		t.Fatal("recent enter should request observation detail")
+	}
+
+	updatedModel, cmd = updated.handleRecentKeys("t")
+	updated = updatedModel.(Model)
+	if updated.PrevScreen != ScreenRecent || cmd == nil {
+		t.Fatal("recent t should request timeline")
+	}
+
+	updatedModel, cmd = updated.handleRecentKeys("esc")
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenDashboard || cmd == nil {
+		t.Fatal("recent esc should return dashboard and refresh stats")
+	}
+
+	m = New(fx.store)
+	m.Screen = ScreenTimeline
+	m.PrevScreen = ScreenDashboard
+	m.Scroll = 2
+	updatedModel, _ = m.handleTimelineKeys("up")
+	updated = updatedModel.(Model)
+	if updated.Scroll != 1 {
+		t.Fatalf("scroll = %d, want 1", updated.Scroll)
+	}
+	updatedModel, cmd = updated.handleTimelineKeys("esc")
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenDashboard || cmd == nil {
+		t.Fatal("timeline esc should return previous screen and refresh")
+	}
+
+	m = New(fx.store)
+	m.Height = 12
+	m.Screen = ScreenSessions
+	m.Sessions = []store.SessionSummary{{ID: fx.sessionID}, {ID: fx.otherSession}, {ID: "s3"}, {ID: "s4"}, {ID: "s5"}, {ID: "s6"}}
+	m.Cursor = 4
+	updatedModel, _ = m.handleSessionsKeys("down")
+	updated = updatedModel.(Model)
+	if updated.Cursor != 5 || updated.Scroll != 1 {
+		t.Fatalf("cursor/scroll = %d/%d, want 5/1", updated.Cursor, updated.Scroll)
+	}
+	updated.Cursor = 0
+	updatedModel, cmd = updated.handleSessionsKeys("enter")
+	updated = updatedModel.(Model)
+	if updated.SelectedSessionIdx != 0 || updated.PrevScreen != ScreenSessions || cmd == nil {
+		t.Fatal("sessions enter should load selected session observations")
+	}
+
+	m = New(fx.store)
+	m.Height = 18
+	m.Screen = ScreenSessionDetail
+	m.SelectedSessionIdx = 0
+	m.SessionObservations = []store.Observation{{ID: fx.obsID}, {ID: fx.secondObs}, {ID: 3}, {ID: 4}}
+	m.Cursor = 2
+	updatedModel, _ = m.handleSessionDetailKeys("down")
+	updated = updatedModel.(Model)
+	if updated.Cursor != 3 || updated.SessionDetailScroll != 1 {
+		t.Fatalf("cursor/detailScroll = %d/%d, want 3/1", updated.Cursor, updated.SessionDetailScroll)
+	}
+	updatedModel, cmd = updated.handleSessionDetailKeys("enter")
+	updated = updatedModel.(Model)
+	if updated.PrevScreen != ScreenSessionDetail || cmd == nil {
+		t.Fatal("session detail enter should load observation detail")
+	}
+	updatedModel, cmd = updated.handleSessionDetailKeys("t")
+	updated = updatedModel.(Model)
+	if updated.PrevScreen != ScreenSessionDetail || cmd == nil {
+		t.Fatal("session detail t should load timeline")
+	}
+	updatedModel, cmd = updated.handleSessionDetailKeys("esc")
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSessions || cmd == nil {
+		t.Fatal("session detail esc should return to sessions and refresh list")
+	}
+}
+
+func TestRefreshScreen(t *testing.T) {
+	m := New(newTestFixture(t).store)
+
+	if cmd := m.refreshScreen(ScreenDashboard); cmd == nil {
+		t.Fatal("dashboard refresh should return stats command")
+	}
+	if cmd := m.refreshScreen(ScreenRecent); cmd == nil {
+		t.Fatal("recent refresh should return observations command")
+	}
+	if cmd := m.refreshScreen(ScreenSessions); cmd == nil {
+		t.Fatal("sessions refresh should return sessions command")
+	}
+	if cmd := m.refreshScreen(ScreenSearch); cmd != nil {
+		t.Fatal("search refresh should not return command")
+	}
+}
+
+func TestUpdateDataMessageBranches(t *testing.T) {
+	m := New(nil)
+
+	updatedModel, _ := m.Update(statsLoadedMsg{err: errors.New("stats err")})
+	updated := updatedModel.(Model)
+	if updated.ErrorMsg != "stats err" {
+		t.Fatalf("error = %q", updated.ErrorMsg)
+	}
+
+	stats := &store.Stats{TotalSessions: 2}
+	updatedModel, _ = m.Update(statsLoadedMsg{stats: stats})
+	updated = updatedModel.(Model)
+	if updated.Stats == nil || updated.Stats.TotalSessions != 2 {
+		t.Fatal("stats should be set from successful message")
+	}
+
+	updatedModel, _ = m.Update(searchResultsMsg{err: errors.New("search err")})
+	updated = updatedModel.(Model)
+	if updated.ErrorMsg != "search err" {
+		t.Fatalf("error = %q", updated.ErrorMsg)
+	}
+
+	results := []store.SearchResult{{Observation: store.Observation{ID: 9}}}
+	updatedModel, _ = m.Update(searchResultsMsg{results: results, query: "needle"})
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSearchResults || updated.Cursor != 0 || updated.Scroll != 0 {
+		t.Fatal("search results message should switch to results screen and reset cursor/scroll")
+	}
+
+	updatedModel, _ = m.Update(recentObservationsMsg{err: errors.New("recent err")})
+	updated = updatedModel.(Model)
+	if updated.ErrorMsg != "recent err" {
+		t.Fatalf("error = %q", updated.ErrorMsg)
+	}
+
+	obsList := []store.Observation{{ID: 1}}
+	updatedModel, _ = m.Update(recentObservationsMsg{observations: obsList})
+	updated = updatedModel.(Model)
+	if len(updated.RecentObservations) != 1 {
+		t.Fatal("recent observations should be updated")
+	}
+
+	updatedModel, _ = m.Update(observationDetailMsg{err: errors.New("detail err")})
+	updated = updatedModel.(Model)
+	if updated.ErrorMsg != "detail err" {
+		t.Fatalf("error = %q", updated.ErrorMsg)
+	}
+
+	selected := &store.Observation{ID: 99}
+	updatedModel, _ = m.Update(observationDetailMsg{observation: selected})
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenObservationDetail || updated.DetailScroll != 0 {
+		t.Fatal("observation detail message should open detail screen and reset scroll")
+	}
+
+	updatedModel, _ = m.Update(timelineMsg{err: errors.New("timeline err")})
+	updated = updatedModel.(Model)
+	if updated.ErrorMsg != "timeline err" {
+		t.Fatalf("error = %q", updated.ErrorMsg)
+	}
+
+	tl := &store.TimelineResult{Focus: store.Observation{ID: 99}}
+	updatedModel, _ = m.Update(timelineMsg{timeline: tl})
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenTimeline || updated.Scroll != 0 {
+		t.Fatal("timeline message should open timeline and reset scroll")
+	}
+
+	updatedModel, _ = m.Update(recentSessionsMsg{err: errors.New("sessions err")})
+	updated = updatedModel.(Model)
+	if updated.ErrorMsg != "sessions err" {
+		t.Fatalf("error = %q", updated.ErrorMsg)
+	}
+
+	sessions := []store.SessionSummary{{ID: "s1"}}
+	updatedModel, _ = m.Update(recentSessionsMsg{sessions: sessions})
+	updated = updatedModel.(Model)
+	if len(updated.Sessions) != 1 {
+		t.Fatal("sessions should be updated")
+	}
+
+	updatedModel, _ = m.Update(sessionObservationsMsg{err: errors.New("session detail err")})
+	updated = updatedModel.(Model)
+	if updated.ErrorMsg != "session detail err" {
+		t.Fatalf("error = %q", updated.ErrorMsg)
+	}
+
+	sessionObs := []store.Observation{{ID: 1}, {ID: 2}}
+	updatedModel, _ = m.Update(sessionObservationsMsg{observations: sessionObs})
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSessionDetail || updated.Cursor != 0 || updated.SessionDetailScroll != 0 {
+		t.Fatal("session observations message should open session detail and reset cursor/scroll")
+	}
+
+	updated.SetupInstalling = true
+	updatedModel, _ = updated.Update(setupInstallMsg{err: errors.New("setup err")})
+	updated = updatedModel.(Model)
+	if updated.SetupInstalling || !updated.SetupDone || updated.SetupError != "setup err" {
+		t.Fatal("setup error should end install and surface setup error")
+	}
+
+	updated.SetupInstalling = true
+	setupRes := &setup.Result{Agent: "opencode", Destination: "/tmp", Files: 2}
+	updatedModel, _ = updated.Update(setupInstallMsg{result: setupRes})
+	updated = updatedModel.(Model)
+	if updated.SetupInstalling || !updated.SetupDone || updated.SetupResult == nil || updated.SetupError != "" {
+		t.Fatal("setup success should persist result and clear errors")
+	}
+
+	unchangedModel, cmd := updated.Update(struct{ X int }{X: 1})
+	if cmd != nil {
+		t.Fatal("unknown message should not return command")
+	}
+	if unchangedModel.(Model).Screen != updated.Screen {
+		t.Fatal("unknown message should keep state unchanged")
+	}
+}
+
+func TestHandleKeyPressRouterAndClearsError(t *testing.T) {
+	m := New(nil)
+	m.ErrorMsg = "old error"
+
+	for _, screen := range []Screen{
+		ScreenDashboard,
+		ScreenSearch,
+		ScreenSearchResults,
+		ScreenRecent,
+		ScreenObservationDetail,
+		ScreenTimeline,
+		ScreenSessions,
+		ScreenSessionDetail,
+		ScreenSetup,
+	} {
+		m.Screen = screen
+		m.ErrorMsg = "old error"
+		updatedModel, _ := m.handleKeyPress("x")
+		updated := updatedModel.(Model)
+		if updated.ErrorMsg != "" {
+			t.Fatalf("screen %v should clear error on key press", screen)
+		}
+	}
+}
+
+func TestHandleDashboardKeysAndSelectionRemainingBranches(t *testing.T) {
+	m := New(nil)
+
+	m.Cursor = 0
+	updatedModel, _ := m.handleDashboardKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("cursor should stay at top boundary")
+	}
+
+	m.Cursor = len(dashboardMenuItems) - 1
+	updatedModel, _ = m.handleDashboardKeys("down")
+	if updatedModel.(Model).Cursor != len(dashboardMenuItems)-1 {
+		t.Fatal("cursor should stay at bottom boundary")
+	}
+
+	m.Cursor = 4
+	_, cmd := m.handleDashboardKeys(" ")
+	if cmd == nil {
+		t.Fatal("space on quit item should return quit command")
+	}
+
+	_, cmd = m.handleDashboardKeys("q")
+	if cmd == nil {
+		t.Fatal("q should return quit command")
+	}
+
+	m.Cursor = 0
+	updatedModel, _ = m.handleDashboardSelection()
+	updated := updatedModel.(Model)
+	if updated.Screen != ScreenSearch || !updated.SearchInput.Focused() {
+		t.Fatal("cursor 0 selection should open search")
+	}
+
+	m.Cursor = 4
+	_, cmd = m.handleDashboardSelection()
+	if cmd == nil {
+		t.Fatal("cursor 4 selection should quit")
+	}
+
+	m.Cursor = 99
+	updatedModel, cmd = m.handleDashboardSelection()
+	if updatedModel.(Model).Cursor != 99 || cmd != nil {
+		t.Fatal("out-of-range dashboard selection should be no-op")
+	}
+}
+
+func TestHandleSearchResultsAndObservationDetailRemainingBranches(t *testing.T) {
+	m := New(nil)
+	m.Height = 16
+	m.Screen = ScreenSearchResults
+
+	updatedModel, _ := m.handleSearchResultsKeys("enter")
+	updated := updatedModel.(Model)
+	if updated.Screen != ScreenSearchResults {
+		t.Fatal("enter with no results should keep current screen")
+	}
+
+	updatedModel, _ = m.handleSearchResultsKeys("t")
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSearchResults {
+		t.Fatal("timeline key with no results should keep current screen")
+	}
+
+	m.SearchResults = []store.SearchResult{{Observation: store.Observation{ID: 1}}}
+	m.Cursor = 0
+	updatedModel, cmd := m.handleSearchResultsKeys("enter")
+	updated = updatedModel.(Model)
+	if updated.PrevScreen != ScreenSearchResults || cmd == nil {
+		t.Fatal("enter with selection should request detail command")
+	}
+
+	updatedModel, cmd = m.handleSearchResultsKeys("t")
+	updated = updatedModel.(Model)
+	if updated.PrevScreen != ScreenSearchResults || cmd == nil {
+		t.Fatal("t with selection should request timeline command")
+	}
+
+	updatedModel, _ = m.handleSearchResultsKeys("/")
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSearch || !updated.SearchInput.Focused() {
+		t.Fatal("slash should switch to focused search input")
+	}
+
+	m.Screen = ScreenObservationDetail
+	m.SelectedObservation = &store.Observation{ID: 5}
+	updatedModel, _ = m.handleObservationDetailKeys("down")
+	updated = updatedModel.(Model)
+	if updated.DetailScroll != 1 {
+		t.Fatal("down should increase detail scroll")
+	}
+	updatedModel, _ = updated.handleObservationDetailKeys("up")
+	if updatedModel.(Model).DetailScroll != 0 {
+		t.Fatal("up should decrease detail scroll")
+	}
+	_, cmd = updated.handleObservationDetailKeys("t")
+	if cmd == nil {
+		t.Fatal("timeline key with selected observation should return command")
+	}
+
+	m.SelectedObservation = nil
+	_, cmd = m.handleObservationDetailKeys("t")
+	if cmd != nil {
+		t.Fatal("timeline key without selected observation should not return command")
+	}
+}
+
+func TestHandleSessionsAndSetupRemainingBranches(t *testing.T) {
+	fx := newTestFixture(t)
+	m := New(fx.store)
+	m.Height = 12
+	m.Sessions = []store.SessionSummary{{ID: "s1"}, {ID: "s2"}, {ID: "s3"}, {ID: "s4"}, {ID: "s5"}, {ID: "s6"}}
+
+	m.Cursor = 0
+	updatedModel, _ := m.handleSessionsKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("sessions up at top should stay at zero")
+	}
+
+	m.Cursor = len(m.Sessions) - 1
+	updatedModel, _ = m.handleSessionsKeys("down")
+	if updatedModel.(Model).Cursor != len(m.Sessions)-1 {
+		t.Fatal("sessions down at bottom should stay at last item")
+	}
+
+	m.Sessions = nil
+	_, cmd := m.handleSessionsKeys("enter")
+	if cmd != nil {
+		t.Fatal("sessions enter with no sessions should not return command")
+	}
+
+	m = New(fx.store)
+	m.Screen = ScreenSetup
+	m.SetupInstalling = true
+	updatedModel, cmd = m.handleSetupKeys("esc")
+	updated := updatedModel.(Model)
+	if updated.Screen != ScreenSetup || cmd != nil {
+		t.Fatal("setup should ignore keys while installing")
+	}
+
+	m.SetupInstalling = false
+	m.SetupDone = true
+	updatedModel, cmd = m.handleSetupKeys("x")
+	updated = updatedModel.(Model)
+	if updated.Screen != ScreenSetup || cmd != nil {
+		t.Fatal("setup done with non-exit key should do nothing")
+	}
+
+	m.SetupDone = false
+	m.SetupAgents = []setup.Agent{{Name: "opencode"}, {Name: "claude-code"}}
+	m.Cursor = 0
+	updatedModel, _ = m.handleSetupKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("setup up at top should stay at zero")
+	}
+	updatedModel, _ = m.handleSetupKeys("down")
+	if updatedModel.(Model).Cursor != 1 {
+		t.Fatal("setup down should move cursor")
+	}
+	updatedModel, _ = updatedModel.(Model).handleSetupKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("setup up with cursor>0 should decrement cursor")
+	}
+
+	original := installAgentFn
+	t.Cleanup(func() { installAgentFn = original })
+	installAgentFn = func(name string) (*setup.Result, error) {
+		return &setup.Result{Agent: name, Destination: "/tmp", Files: 1}, nil
+	}
+
+	m.Cursor = 1
+	updatedModel, cmd = m.handleSetupKeys("enter")
+	updated = updatedModel.(Model)
+	if !updated.SetupInstalling || updated.SetupInstallingName != "claude-code" || cmd == nil {
+		t.Fatal("setup enter with valid agent should start install and return batch command")
+	}
+
+	m.SetupInstalling = false
+	m.SetupAgents = nil
+	_, cmd = m.handleSetupKeys("enter")
+	if cmd != nil {
+		t.Fatal("setup enter with no agents should not return command")
+	}
+}
+
+func TestAdditionalKeyAliasAndBoundaryBranches(t *testing.T) {
+	fx := newTestFixture(t)
+	m := New(fx.store)
+
+	// handleKeyPress default branch (unknown screen)
+	m.Screen = Screen(999)
+	updatedModel, cmd := m.handleKeyPress("x")
+	if cmd != nil || updatedModel.(Model).Screen != Screen(999) {
+		t.Fatal("unknown screen keypress should be a no-op")
+	}
+
+	// Search input remaining branches
+	m = New(fx.store)
+	m.Screen = ScreenSearch
+	m.PrevScreen = ScreenDashboard
+	m.SearchInput.Focus()
+	updatedModel, cmd = m.handleSearchInputKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil || updatedModel.(Model).Screen != ScreenSearch {
+		t.Fatal("enter with empty search input should not run command")
+	}
+	updatedModel, cmd = m.handleSearchInputKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	if cmd == nil || updatedModel.(Model).SearchInput.Value() == "" {
+		t.Fatal("non-control key should update search input")
+	}
+
+	// Dashboard alias branch
+	m = New(nil)
+	updatedModel, _ = m.handleDashboardKeys("/")
+	if updatedModel.(Model).Screen != ScreenSearch {
+		t.Fatal("dashboard slash should open search")
+	}
+
+	// Search results aliases and boundaries
+	m = New(fx.store)
+	m.Height = 14
+	m.SearchResults = []store.SearchResult{{Observation: store.Observation{ID: 1}}, {Observation: store.Observation{ID: 2}}, {Observation: store.Observation{ID: 3}}, {Observation: store.Observation{ID: 4}}}
+	m.Cursor = 0
+	updatedModel, _ = m.handleSearchResultsKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("search results up at top should stay at zero")
+	}
+	m.Cursor = len(m.SearchResults) - 1
+	updatedModel, _ = m.handleSearchResultsKeys("down")
+	if updatedModel.(Model).Cursor != len(m.SearchResults)-1 {
+		t.Fatal("search results down at bottom should stay at last")
+	}
+	updatedModel, _ = m.handleSearchResultsKeys("s")
+	if updatedModel.(Model).Screen != ScreenSearch {
+		t.Fatal("search results s should jump to search")
+	}
+
+	// Recent aliases/boundaries
+	m = New(fx.store)
+	m.Height = 14
+	m.RecentObservations = []store.Observation{{ID: 1}}
+	m.Cursor = 0
+	updatedModel, _ = m.handleRecentKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("recent up at top should stay at zero")
+	}
+	m.Cursor = 0
+	updatedModel, _ = m.handleRecentKeys("t")
+	if updatedModel.(Model).PrevScreen != ScreenRecent {
+		t.Fatal("recent timeline key should set previous screen")
+	}
+
+	// Timeline down branch
+	m = New(nil)
+	updatedModel, _ = m.handleTimelineKeys("down")
+	if updatedModel.(Model).Scroll != 1 {
+		t.Fatal("timeline down should increment scroll")
+	}
+
+	// Sessions esc/q branches
+	m = New(fx.store)
+	m.Screen = ScreenSessions
+	updatedModel, cmd = m.handleSessionsKeys("q")
+	if updatedModel.(Model).Screen != ScreenDashboard || cmd == nil {
+		t.Fatal("sessions q should return to dashboard and refresh")
+	}
+
+	// Session detail boundary and q branch
+	m = New(fx.store)
+	m.Height = 16
+	m.Screen = ScreenSessionDetail
+	m.SelectedSessionIdx = 0
+	m.SessionObservations = []store.Observation{{ID: 1}}
+	updatedModel, _ = m.handleSessionDetailKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("session detail up at top should stay at zero")
+	}
+	updatedModel, cmd = m.handleSessionDetailKeys("q")
+	if updatedModel.(Model).Screen != ScreenSessions || cmd == nil {
+		t.Fatal("session detail q should go back to sessions and refresh")
+	}
+
+	// Setup q/esc branch with no install state
+	m = New(fx.store)
+	m.Screen = ScreenSetup
+	updatedModel, cmd = m.handleSetupKeys("q")
+	if updatedModel.(Model).Screen != ScreenDashboard || cmd == nil {
+		t.Fatal("setup q should return dashboard and refresh stats")
+	}
+}
+
+func TestNavigationScrollAndSelectionBranches(t *testing.T) {
+	fx := newTestFixture(t)
+
+	// Dashboard increment/decrement and enter path
+	m := New(fx.store)
+	m.Cursor = 1
+	updatedModel, _ := m.handleDashboardKeys("up")
+	if updatedModel.(Model).Cursor != 0 {
+		t.Fatal("dashboard up should decrement cursor when above zero")
+	}
+	updatedModel, _ = updatedModel.(Model).handleDashboardKeys("down")
+	if updatedModel.(Model).Cursor != 1 {
+		t.Fatal("dashboard down should increment cursor when not at bottom")
+	}
+	_, cmd := updatedModel.(Model).handleDashboardKeys("enter")
+	if cmd == nil {
+		t.Fatal("dashboard enter on recent item should return loader command")
+	}
+
+	// Search results scroll-up branch
+	m = New(fx.store)
+	m.Height = 14
+	m.SearchResults = []store.SearchResult{{Observation: store.Observation{ID: 1}}, {Observation: store.Observation{ID: 2}}, {Observation: store.Observation{ID: 3}}}
+	m.Cursor = 2
+	m.Scroll = 2
+	updatedModel, _ = m.handleSearchResultsKeys("up")
+	updated := updatedModel.(Model)
+	if updated.Cursor != 1 || updated.Scroll != 1 {
+		t.Fatalf("search results up should update cursor/scroll, got %d/%d", updated.Cursor, updated.Scroll)
+	}
+
+	// Recent scroll-up branch
+	m = New(fx.store)
+	m.Height = 14
+	m.RecentObservations = []store.Observation{{ID: 1}, {ID: 2}, {ID: 3}}
+	m.Cursor = 2
+	m.Scroll = 2
+	updatedModel, _ = m.handleRecentKeys("up")
+	updated = updatedModel.(Model)
+	if updated.Cursor != 1 || updated.Scroll != 1 {
+		t.Fatalf("recent up should update cursor/scroll, got %d/%d", updated.Cursor, updated.Scroll)
+	}
+
+	// Sessions scroll-up branch
+	m = New(fx.store)
+	m.Height = 12
+	m.Sessions = []store.SessionSummary{{ID: "s1"}, {ID: "s2"}, {ID: "s3"}}
+	m.Cursor = 2
+	m.Scroll = 2
+	updatedModel, _ = m.handleSessionsKeys("up")
+	updated = updatedModel.(Model)
+	if updated.Cursor != 1 || updated.Scroll != 1 {
+		t.Fatalf("sessions up should update cursor/scroll, got %d/%d", updated.Cursor, updated.Scroll)
+	}
+
+	// Session detail scroll-up branch
+	m = New(fx.store)
+	m.Height = 16
+	m.SessionObservations = []store.Observation{{ID: 1}, {ID: 2}, {ID: 3}}
+	m.Cursor = 2
+	m.SessionDetailScroll = 2
+	updatedModel, _ = m.handleSessionDetailKeys("up")
+	updated = updatedModel.(Model)
+	if updated.Cursor != 1 || updated.SessionDetailScroll != 1 {
+		t.Fatalf("session detail up should update cursor/detail scroll, got %d/%d", updated.Cursor, updated.SessionDetailScroll)
+	}
+}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1,0 +1,368 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alanbuscaglia/engram/internal/setup"
+	"github.com/alanbuscaglia/engram/internal/store"
+)
+
+func TestTruncateStr(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{name: "unchanged", in: "short", max: 10, want: "short"},
+		{name: "replaces newlines", in: "a\nb", max: 10, want: "a b"},
+		{name: "truncated", in: "abcdefghijklmnopqrstuvwxyz", max: 5, want: "abcde..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateStr(tt.in, tt.max)
+			if got != tt.want {
+				t.Fatalf("truncateStr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderObservationListItem(t *testing.T) {
+	m := New(nil)
+	m.Cursor = 1
+	project := "engram"
+
+	line := m.renderObservationListItem(
+		1,
+		42,
+		"bugfix",
+		"Title here",
+		"content line 1\ncontent line 2",
+		"2026-01-01",
+		&project,
+	)
+
+	if !strings.Contains(line, "▸") {
+		t.Fatal("selected item should include cursor marker")
+	}
+	if !strings.Contains(line, "Title here") {
+		t.Fatal("line should include title")
+	}
+	if !strings.Contains(line, "content line 1 content line 2") {
+		t.Fatal("content preview should be rendered on second line")
+	}
+	if !strings.Contains(line, "engram") {
+		t.Fatal("project label should be rendered when project is set")
+	}
+}
+
+func TestViewRouterAndErrorRendering(t *testing.T) {
+	m := New(nil)
+	m.Screen = Screen(999)
+	m.ErrorMsg = "boom"
+
+	out := m.View()
+	if !strings.Contains(out, "Unknown screen") {
+		t.Fatal("unknown screen fallback text missing")
+	}
+	if !strings.Contains(out, "Error: boom") {
+		t.Fatal("error message should be appended to view")
+	}
+}
+
+func TestViewSearchResultsAndScrollIndicator(t *testing.T) {
+	m := New(nil)
+	m.Screen = ScreenSearchResults
+	m.Height = 14
+	m.SearchQuery = "needle"
+	m.SearchResults = []store.SearchResult{
+		{Observation: store.Observation{ID: 1, Type: "bugfix", Title: "one", Content: "a", CreatedAt: "2026-01-01"}},
+		{Observation: store.Observation{ID: 2, Type: "bugfix", Title: "two", Content: "b", CreatedAt: "2026-01-01"}},
+		{Observation: store.Observation{ID: 3, Type: "bugfix", Title: "three", Content: "c", CreatedAt: "2026-01-01"}},
+		{Observation: store.Observation{ID: 4, Type: "bugfix", Title: "four", Content: "d", CreatedAt: "2026-01-01"}},
+	}
+
+	out := m.viewSearchResults()
+	if !strings.Contains(out, "Search: \"needle\"") {
+		t.Fatal("search header missing")
+	}
+	if !strings.Contains(out, "showing 1-3 of 4") {
+		t.Fatal("scroll indicator missing for overflowing list")
+	}
+
+	m.SearchResults = nil
+	out = m.viewSearchResults()
+	if !strings.Contains(out, "No memories found") {
+		t.Fatal("empty result state missing")
+	}
+}
+
+func TestViewSetupBranches(t *testing.T) {
+	m := New(nil)
+	m.Screen = ScreenSetup
+
+	m.SetupInstalling = true
+	m.SetupInstallingName = "opencode"
+	out := m.viewSetup()
+	if !strings.Contains(out, "Installing opencode plugin") {
+		t.Fatal("installing state should render progress line")
+	}
+
+	m.SetupInstalling = false
+	m.SetupDone = true
+	m.SetupResult = &setup.Result{Agent: "opencode", Destination: "/tmp/plugins", Files: 2}
+	out = m.viewSetup()
+	if !strings.Contains(out, "Installed opencode plugin") {
+		t.Fatal("success state should render install result")
+	}
+	if !strings.Contains(out, "Next Steps") {
+		t.Fatal("success state should render post-install instructions")
+	}
+
+	m.SetupResult = nil
+	m.SetupError = "permission denied"
+	out = m.viewSetup()
+	if !strings.Contains(out, "Installation failed") {
+		t.Fatal("error state should render failure message")
+	}
+}
+
+func TestViewDashboardSearchAndRecent(t *testing.T) {
+	m := New(nil)
+	m.Cursor = 1
+	m.Stats = &store.Stats{
+		TotalSessions:     3,
+		TotalObservations: 7,
+		TotalPrompts:      2,
+		Projects:          []string{"a", "b", "c", "d", "e", "f"},
+	}
+
+	out := m.viewDashboard()
+	if !strings.Contains(out, "engram") || !strings.Contains(out, "Actions") {
+		t.Fatal("dashboard should include header and actions")
+	}
+	if !strings.Contains(out, "...and 1 more projects") {
+		t.Fatal("dashboard should show overflow projects indicator")
+	}
+
+	m.Stats = nil
+	out = m.viewDashboard()
+	if !strings.Contains(out, "Loading stats") {
+		t.Fatal("dashboard should render loading state when stats are nil")
+	}
+
+	m.Screen = ScreenSearch
+	out = m.viewSearch()
+	if !strings.Contains(out, "Search Memories") {
+		t.Fatal("search view should render title")
+	}
+
+	m.Height = 14
+	m.RecentObservations = []store.Observation{
+		{ID: 1, Type: "bugfix", Title: "one", Content: "a", CreatedAt: "2026-01-01"},
+		{ID: 2, Type: "bugfix", Title: "two", Content: "b", CreatedAt: "2026-01-01"},
+		{ID: 3, Type: "bugfix", Title: "three", Content: "c", CreatedAt: "2026-01-01"},
+		{ID: 4, Type: "bugfix", Title: "four", Content: "d", CreatedAt: "2026-01-01"},
+	}
+	out = m.viewRecent()
+	if !strings.Contains(out, "Recent Observations") {
+		t.Fatal("recent view should render title")
+	}
+	if !strings.Contains(out, "showing 1-3 of 4") {
+		t.Fatal("recent view should render scroll indicator when needed")
+	}
+
+	m.RecentObservations = nil
+	out = m.viewRecent()
+	if !strings.Contains(out, "No observations yet") {
+		t.Fatal("recent view should render empty state")
+	}
+
+	// Force minimum visible items branch
+	m.Height = 8
+	m.RecentObservations = []store.Observation{{ID: 1, Type: "bugfix", Title: "one", Content: "a", CreatedAt: "2026-01-01"}}
+	out = m.viewRecent()
+	if !strings.Contains(out, "Recent Observations") {
+		t.Fatal("recent view should still render when height is very small")
+	}
+}
+
+func TestViewObservationDetailTimelineSessionsAndSessionDetail(t *testing.T) {
+	m := New(nil)
+	m.Height = 22
+
+	out := m.viewObservationDetail()
+	if !strings.Contains(out, "Loading") {
+		t.Fatal("detail view should render loading state when observation is nil")
+	}
+
+	tool := "bash"
+	project := "engram"
+	m.SelectedObservation = &store.Observation{
+		ID:        42,
+		Type:      "decision",
+		Title:     "Architecture decision",
+		SessionID: "session-1",
+		CreatedAt: "2026-01-01",
+		ToolName:  &tool,
+		Project:   &project,
+		Content:   strings.Repeat("line\n", 20),
+	}
+	m.DetailScroll = 99
+	out = m.viewObservationDetail()
+	if !strings.Contains(out, "Observation #42") || !strings.Contains(out, "Content") {
+		t.Fatal("detail view should render metadata and content section")
+	}
+	if !strings.Contains(out, "line") {
+		t.Fatal("detail view should render content lines")
+	}
+
+	out = m.viewTimeline()
+	if !strings.Contains(out, "Loading") {
+		t.Fatal("timeline should render loading state when nil")
+	}
+
+	m.Timeline = &store.TimelineResult{
+		Focus:        store.Observation{ID: 42, Type: "decision", Title: "focus", Content: "focus content"},
+		Before:       []store.TimelineEntry{{ID: 40, Type: "bugfix", Title: "before title"}},
+		After:        []store.TimelineEntry{{ID: 43, Type: "pattern", Title: "after title"}},
+		SessionInfo:  &store.Session{ID: "session-1", Project: "engram"},
+		TotalInRange: 3,
+	}
+	out = m.viewTimeline()
+	if !strings.Contains(out, "Timeline") || !strings.Contains(out, "Before") || !strings.Contains(out, "After") {
+		t.Fatal("timeline should render focus and before/after sections")
+	}
+
+	m.Sessions = nil
+	out = m.viewSessions()
+	if !strings.Contains(out, "No sessions yet") {
+		t.Fatal("sessions view should render empty state")
+	}
+
+	summary := "session summary"
+	m.Height = 14
+	m.Sessions = []store.SessionSummary{
+		{ID: "s1", Project: "engram", StartedAt: "2026-01-01", Summary: &summary, ObservationCount: 2},
+		{ID: "s2", Project: "engram", StartedAt: "2026-01-02", ObservationCount: 1},
+		{ID: "s3", Project: "engram", StartedAt: "2026-01-03", ObservationCount: 1},
+		{ID: "s4", Project: "engram", StartedAt: "2026-01-04", ObservationCount: 1},
+		{ID: "s5", Project: "engram", StartedAt: "2026-01-05", ObservationCount: 1},
+		{ID: "s6", Project: "engram", StartedAt: "2026-01-06", ObservationCount: 1},
+		{ID: "s7", Project: "engram", StartedAt: "2026-01-07", ObservationCount: 1},
+	}
+	out = m.viewSessions()
+	if !strings.Contains(out, "Sessions") || !strings.Contains(out, "showing 1-6 of 7") {
+		t.Fatal("sessions view should render list and scroll indicator")
+	}
+
+	// Force minimum visible items branch
+	m.Height = 2
+	out = m.viewSessions()
+	if !strings.Contains(out, "Sessions") {
+		t.Fatal("sessions view should render when height is very small")
+	}
+
+	m.SelectedSessionIdx = 99
+	out = m.viewSessionDetail()
+	if !strings.Contains(out, "Session not found") {
+		t.Fatal("session detail should guard invalid index")
+	}
+
+	m.SelectedSessionIdx = 0
+	m.SessionObservations = nil
+	out = m.viewSessionDetail()
+	if !strings.Contains(out, "No observations in this session") {
+		t.Fatal("session detail should render empty observations state")
+	}
+
+	m.Height = 16
+	m.SessionObservations = []store.Observation{
+		{ID: 1, Type: "bugfix", Title: "one", Content: "a", CreatedAt: "2026-01-01"},
+		{ID: 2, Type: "bugfix", Title: "two", Content: "b", CreatedAt: "2026-01-01"},
+		{ID: 3, Type: "bugfix", Title: "three", Content: "c", CreatedAt: "2026-01-01"},
+		{ID: 4, Type: "bugfix", Title: "four", Content: "d", CreatedAt: "2026-01-01"},
+	}
+	out = m.viewSessionDetail()
+	if !strings.Contains(out, "Observations (4)") {
+		t.Fatal("session detail should show observations heading")
+	}
+}
+
+func TestViewRouterCoversAllScreens(t *testing.T) {
+	m := New(nil)
+	m.Stats = &store.Stats{}
+	m.SearchResults = []store.SearchResult{{Observation: store.Observation{ID: 1, Type: "bugfix", Title: "t", Content: "c", CreatedAt: "now"}}}
+	m.SearchQuery = "q"
+	m.RecentObservations = []store.Observation{{ID: 1, Type: "bugfix", Title: "t", Content: "c", CreatedAt: "now"}}
+	m.SelectedObservation = &store.Observation{ID: 1, Type: "bugfix", Title: "t", Content: "c", CreatedAt: "now", SessionID: "s1"}
+	m.Timeline = &store.TimelineResult{Focus: store.Observation{ID: 1, Type: "bugfix", Title: "t", Content: "c"}, TotalInRange: 1}
+	m.Sessions = []store.SessionSummary{{ID: "s1", Project: "engram", StartedAt: "now", ObservationCount: 1}}
+	m.SelectedSessionIdx = 0
+	m.SessionObservations = []store.Observation{{ID: 1, Type: "bugfix", Title: "t", Content: "c", CreatedAt: "now"}}
+	m.SetupAgents = []setup.Agent{{Name: "opencode", Description: "OpenCode", InstallDir: "/tmp"}}
+	m.Height = 20
+
+	tests := []struct {
+		screen Screen
+		want   string
+	}{
+		{screen: ScreenDashboard, want: "Actions"},
+		{screen: ScreenSearch, want: "Search Memories"},
+		{screen: ScreenSearchResults, want: "Search:"},
+		{screen: ScreenRecent, want: "Recent Observations"},
+		{screen: ScreenObservationDetail, want: "Observation #"},
+		{screen: ScreenTimeline, want: "Timeline"},
+		{screen: ScreenSessions, want: "Sessions"},
+		{screen: ScreenSessionDetail, want: "Session:"},
+		{screen: ScreenSetup, want: "Setup"},
+	}
+
+	for _, tt := range tests {
+		m.Screen = tt.screen
+		out := m.View()
+		if !strings.Contains(out, tt.want) {
+			t.Fatalf("screen %v output missing %q", tt.screen, tt.want)
+		}
+	}
+}
+
+func TestViewSetupRemainingBranches(t *testing.T) {
+	m := New(nil)
+	m.Screen = ScreenSetup
+	m.SetupAgents = []setup.Agent{
+		{Name: "claude-code", Description: "Claude Code", InstallDir: "/tmp/claude"},
+		{Name: "opencode", Description: "OpenCode", InstallDir: "/tmp/opencode"},
+	}
+
+	out := m.viewSetup()
+	if !strings.Contains(out, "Select an agent to set up") || !strings.Contains(out, "Install to") {
+		t.Fatal("setup selection mode should render options and install paths")
+	}
+
+	m.SetupInstalling = true
+	m.SetupInstallingName = "claude-code"
+	out = m.viewSetup()
+	if !strings.Contains(out, "Running claude plugin marketplace add + install") {
+		t.Fatal("setup installing should render claude-code specific progress text")
+	}
+
+	m.SetupInstalling = false
+	m.SetupDone = true
+	m.SetupError = ""
+	m.SetupResult = &setup.Result{Agent: "claude-code", Destination: "/tmp/claude", Files: 0}
+	out = m.viewSetup()
+	if !strings.Contains(out, "Verify with: claude plugin list") {
+		t.Fatal("setup success for claude-code should render next steps")
+	}
+
+	m.SetupResult = nil
+	m.SetupError = ""
+	out = m.viewSetup()
+	if !strings.Contains(out, "enter/esc back to dashboard") {
+		t.Fatal("setup done without result/error should still render return help")
+	}
+}


### PR DESCRIPTION
## Summary

This PR drives automated test coverage to **100.0% of statements** across the entire codebase.

### Final coverage

- `cmd/engram`: 100.0%
- `internal/mcp`: 100.0%
- `internal/server`: 100.0%
- `internal/setup`: 100.0%
- `internal/store`: 100.0%
- `internal/sync`: 100.0%
- `internal/tui`: 100.0%
- **Total**: 100.0%

## What changed

- Added comprehensive test suites for previously low/no-coverage packages:
  - `cmd/engram/main_test.go`, `cmd/engram/main_extra_test.go`
  - `internal/server/server_test.go` (+ expanded e2e suite)
  - `internal/sync/sync_test.go`
  - `internal/tui/model_test.go`, `internal/tui/update_test.go`, `internal/tui/view_test.go`
- Greatly expanded existing tests in:
  - `internal/mcp/mcp_test.go`
  - `internal/setup/setup_test.go`
  - `internal/store/store_test.go`
- Introduced **minimal behavior-preserving test seams** in production code to deterministically trigger hard-to-reach error branches (DB/IO/command/system boundaries), while preserving runtime defaults.

## Validation

Executed:

```bash
go test ./...
go test -coverprofile=coverage-all.out ./...
go tool cover -func=coverage-all.out
```

Result: `total: (statements) 100.0%`