### PR TITLE
docs: add issue-first contribution and skill standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Engram
+
+Thanks for contributing.
+
+## Contribution Flow (Issue First)
+
+Before opening a PR, open an issue to discuss the change:
+
+1. Problem statement (what is broken or missing)
+2. Proposed approach (high-level)
+3. Risks/tradeoffs
+4. Affected areas (API, CLI, TUI, plugins, docs, skills)
+
+After alignment in the issue, open the PR and link it to the issue.
+
+## PR Rules
+
+- Keep PR scope focused (one logical change)
+- Include validation evidence (`go test ./...`, targeted tests)
+- Update docs in the same PR when behavior changes
+- Do not reference endpoints/scripts that do not exist in code
+- Use conventional commit messages
+- Do not include `Co-Authored-By` trailers in commits
+
+## Skill Authoring Standard
+
+Repository skills live in `skills/`.
+
+Use a **hybrid format**:
+
+1. Structured base (purpose, when to use, critical rules, checklists)
+2. Cookbook section (`If / Then / Example`) for repetitive actions
+
+Why hybrid:
+- Structured base protects correctness and architecture intent
+- Cookbook improves execution consistency for common flows
+
+## Agent Skill Linking
+
+Run:
+
+```bash
+./setup.sh
+```
+
+This links repo `skills/*` into project-local:
+- `.claude/skills/*`
+- `.codex/skills/*`
+- `.gemini/skills/*`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#how-it-works">How It Works</a> &bull;
   <a href="#agent-setup">Agent Setup</a> &bull;
+  <a href="CONTRIBUTING.md">Contributing</a> &bull;
   <a href="#why-not-claude-mem">Why Not claude-mem?</a> &bull;
   <a href="#tui">Terminal UI</a> &bull;
   <a href="DOCS.md">Full Docs</a>


### PR DESCRIPTION
## Summary

This PR formalizes contribution workflow and AI skill standards for the repository.

### Added
- `CONTRIBUTING.md` with:
  - issue-first policy (discuss before implementation)
  - PR guardrails (scope, tests, docs alignment, commit hygiene)
  - explicit rule: no `Co-Authored-By` trailers
  - hybrid skill standard: structured base + cookbook section
  - `./setup.sh` guidance for project-local skill links

### Updated
- `README.md` top navigation now links to `CONTRIBUTING.md`

## Why

Recent PR review showed the need to align contributors on process before implementation and to standardize how skills are authored for consistency and correctness.