### PR TITLE
chore: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug in engram
+labels: bug
+---
+
+## Description
+
+<!-- What happened? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What happened instead? -->
+
+## Environment
+
+- OS:
+- engram version: <!-- `engram version` -->
+- Agent: <!-- Claude Code / OpenCode / other -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem does this solve? -->
+
+## Proposed solution
+
+<!-- How should it work? -->
+
+## Alternatives considered
+
+<!-- Any other approaches you thought about? (optional) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to issue if applicable. -->
+
+## Changes
+
+<!-- List the key changes made. -->
+
+## Test plan
+
+- [ ] `go test ./...` passes
+- [ ] Manually tested the affected functionality
+
+<!-- Add specific test steps if needed. -->


### PR DESCRIPTION
## Summary

- Add pull request template with summary, motivation, changes, and test plan sections
- Add bug report issue template with reproduction steps and environment info
- Add feature request issue template

## Motivation

The repo has no GitHub templates. These provide a consistent structure for contributions and bug reports.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`

## Test plan

- [ ] PR template appears when opening a new PR
- [ ] Issue templates appear when creating a new issue