### PR TITLE
fix(tui): resolve escape loop and stale input in search flow

### DIFF
--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -174,6 +174,7 @@ func (m Model) handleDashboardKeys(key string) (tea.Model, tea.Cmd) {
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenSearch
 		m.Cursor = 0
+		m.SearchInput.SetValue("")
 		m.SearchInput.Focus()
 		return m, nil
 	case "q":
@@ -188,6 +189,7 @@ func (m Model) handleDashboardSelection() (tea.Model, tea.Cmd) {
 		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenSearch
 		m.Cursor = 0
+		m.SearchInput.SetValue("")
 		m.SearchInput.Focus()
 		return m, nil
 	case 1: // Recent observations
@@ -300,6 +302,7 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 		m.SearchInput.Focus()
 		return m, nil
 	case "esc", "q":
+		m.PrevScreen = ScreenDashboard
 		m.Screen = ScreenSearch
 		m.Cursor = 0
 		m.Scroll = 0


### PR DESCRIPTION
## Summary
- Fix escape key loop when navigating back from search detail/observation views — pressing Esc from search results now correctly resets `PrevScreen` to `ScreenDashboard`, so escaping the search input returns to the dashboard instead of bouncing back to results
- Clear search input when entering search from the dashboard so previous queries don't persist across visits

## Test plan
- [x] All 28 existing TUI tests pass
- [x] Manual: search a term → enter a result → press Esc back to results → Esc to search input → Esc should return to dashboard (no loop)
- [x] Manual: search a term → Esc to dashboard → re-enter search → input should be empty