### PR TITLE
fix: load deferred memory tools at session start in Claude Code

### DIFF
--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -47,7 +47,7 @@ This protocol is MANDATORY and ALWAYS ACTIVE.
 
 ### FIRST ACTION — load memory tools
 Memory tools are deferred and must be loaded before use. Call ToolSearch NOW with:
-select:mcp__plugin_engram_engram__mem_save,mcp__plugin_engram_engram__mem_context,mcp__plugin_engram_engram__mem_search,mcp__plugin_engram_engram__mem_session_summary
+select:mcp__plugin_engram_engram__mem_save,mcp__plugin_engram_engram__mem_context,mcp__plugin_engram_engram__mem_search,mcp__plugin_engram_engram__mem_session_summary,mcp__plugin_engram_engram__mem_session_end
 
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:

--- a/plugin/claude-code/skills/memory/SKILL.md
+++ b/plugin/claude-code/skills/memory/SKILL.md
@@ -11,7 +11,7 @@ This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on d
 ## FIRST ACTION (session start)
 
 Memory tools are deferred and must be loaded before use. At the start of every session, call ToolSearch with:
-`select:mcp__plugin_engram_engram__mem_save,mcp__plugin_engram_engram__mem_context,mcp__plugin_engram_engram__mem_search,mcp__plugin_engram_engram__mem_session_summary`
+`select:mcp__plugin_engram_engram__mem_save,mcp__plugin_engram_engram__mem_context,mcp__plugin_engram_engram__mem_search,mcp__plugin_engram_engram__mem_session_summary,mcp__plugin_engram_engram__mem_session_end`
 
 ## PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 


### PR DESCRIPTION
## Summary

- Instruct the agent to call ToolSearch at session start so core memory tools are available before any proactive save triggers fire.
- Applied in both `session-start.sh` (hook context) and `SKILL.md` (always-active skill).

## Motivation

Closes #42

All Claude Code plugin tools are placed in the deferred pool by the platform, regardless of the `defer_loading` MCP annotation. The agent receives the Memory Protocol telling it to call `mem_save`, but the tool is unknown until ToolSearch discovers it. This results in 0 observations saved across all sessions.

## Changes

- `plugin/claude-code/scripts/session-start.sh`: added `FIRST ACTION` section to the injected protocol with the exact ToolSearch query for the four core tools
- `plugin/claude-code/skills/memory/SKILL.md`: added `FIRST ACTION` section at the top of the protocol so the agent loads tools even when the hook context  is not available (e.g. after compaction)

## Test plan

- [x] `go test ./...` passes
- [x] Manually tested: opened a fresh Claude Code session, confirmed ToolSearch was called at session start, confirmed `mem_save` successfully persisted an observation, verified with `engram stats` that `Observations` is no longer 0
