### PR TITLE
fix: call sessions end endpoint from session-stop hook

### DIFF
--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
 # Engram — Stop hook for Claude Code (async)
 #
-# Tracks tool call count per session. Runs async so it doesn't
-# block Claude's response.
+# Marks the session as ended via the HTTP API.
+# Runs async so it doesn't block Claude's response.
 
-# Nothing heavy to do here — the Memory Protocol in the skill
-# instructs the agent to call mem_session_summary before ending.
-# This hook exists as a placeholder for future heartbeat/tracking.
+ENGRAM_PORT="${ENGRAM_PORT:-7437}"
+ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}/end" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  > /dev/null 2>&1
 
 exit 0


### PR DESCRIPTION
## Summary

- Implement `session-stop.sh` to call `POST /sessions/{id}/end` when Claude Code stops, so `ended_at` is always set regardless of agent cooperation

## Motivation

Closes #46

`session-stop.sh` was a placeholder that did nothing. The server already exposed `POST /sessions/{id}/end`, and the Stop hook already received `session_id` via stdin, but the connection was never made. As a result, every session in the database has `ended_at = NULL` and sessions grow unbounded with no duration data.

The fix mirrors the pattern already used in `session-start.sh`: read `session_id` from stdin, call the HTTP API.

## Changes

- `plugin/claude-code/scripts/session-stop.sh` — replaced placeholder with a curl call to `POST /sessions/{id}/end`. Reads `session_id` from stdin (same as `session-start.sh`), exits cleanly if no session_id is present. Runs async (already configured in `hooks.json`) so it never blocks Claude's response.

## Test plan

- [x] `go test ./...` passes
- [x] Manually tested end-to-end:
  1. Created a session via `POST /sessions`
  2. Confirmed `ended_at = NULL` in the database
  3. Simulated the hook: `echo '{"session_id":"test","cwd":"/tmp"}' | bash session-stop.sh`
  4. Confirmed `ended_at` was set correctly in the database
