### PR TITLE
feat: team sync — cross-user observation sharing with author attribution

### DIFF
--- a/cmd/engram/cloud_config_test.go
+++ b/cmd/engram/cloud_config_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"testing"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestIsTeamSyncEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *CloudConfig
+		envVar   string
+		expected bool
+	}{
+		{
+			name:     "nil config defaults to true",
+			config:   nil,
+			expected: true,
+		},
+		{
+			name:     "nil TeamSync defaults to true",
+			config:   &CloudConfig{},
+			expected: true,
+		},
+		{
+			name:     "TeamSync explicitly true",
+			config:   &CloudConfig{TeamSync: boolPtr(true)},
+			expected: true,
+		},
+		{
+			name:     "TeamSync explicitly false",
+			config:   &CloudConfig{TeamSync: boolPtr(false)},
+			expected: false,
+		},
+		{
+			name:     "env var true overrides config false",
+			config:   &CloudConfig{TeamSync: boolPtr(false)},
+			envVar:   "true",
+			expected: true,
+		},
+		{
+			name:     "env var 1 overrides config false",
+			config:   &CloudConfig{TeamSync: boolPtr(false)},
+			envVar:   "1",
+			expected: true,
+		},
+		{
+			name:     "env var false overrides config true",
+			config:   &CloudConfig{TeamSync: boolPtr(true)},
+			envVar:   "false",
+			expected: false,
+		},
+		{
+			name:     "env var 0 overrides config true",
+			config:   &CloudConfig{TeamSync: boolPtr(true)},
+			envVar:   "0",
+			expected: false,
+		},
+		{
+			name:     "env var false overrides nil config",
+			config:   nil,
+			envVar:   "false",
+			expected: false,
+		},
+		{
+			name:     "env var arbitrary string treated as true",
+			config:   &CloudConfig{TeamSync: boolPtr(false)},
+			envVar:   "yes",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envVar != "" {
+				t.Setenv("ENGRAM_TEAM_SYNC", tc.envVar)
+			} else {
+				t.Setenv("ENGRAM_TEAM_SYNC", "")
+			}
+
+			got := tc.config.IsTeamSyncEnabled()
+			if got != tc.expected {
+				t.Fatalf("IsTeamSyncEnabled() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -215,12 +215,15 @@ func tryStartAutosync(s *store.Store, dataDir string) (*autosync.Manager, contex
 		return nil, nil
 	}
 
-	// Configure token refresh if available.
-	if cc, err := loadCloudConfig(dataDir); err == nil && cc != nil && cc.ServerURL == serverURL && cc.RefreshToken != "" {
-		rt.SetTokenRefresher(cc.RefreshToken, func(newToken string) error {
-			cc.Token = newToken
-			return saveCloudConfig(dataDir, cc)
-		})
+	// Configure token refresh and team sync if available.
+	if cc, err := loadCloudConfig(dataDir); err == nil && cc != nil && cc.ServerURL == serverURL {
+		if cc.RefreshToken != "" {
+			rt.SetTokenRefresher(cc.RefreshToken, func(newToken string) error {
+				cc.Token = newToken
+				return saveCloudConfig(dataDir, cc)
+			})
+		}
+		rt.SetTeamSync(cc.IsTeamSyncEnabled())
 	}
 
 	cfg := autosyncDefaultCg()
@@ -1018,6 +1021,19 @@ type CloudConfig struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 	UserID       string `json:"user_id"`
 	Username     string `json:"username"`
+	TeamSync     *bool  `json:"team_sync,omitempty"` // nil = enabled (default true)
+}
+
+// IsTeamSyncEnabled returns whether team sync is enabled.
+// Defaults to true if not explicitly set. Can also be overridden via ENGRAM_TEAM_SYNC env var.
+func (cc *CloudConfig) IsTeamSyncEnabled() bool {
+	if v := os.Getenv("ENGRAM_TEAM_SYNC"); v != "" {
+		return v != "false" && v != "0"
+	}
+	if cc != nil && cc.TeamSync != nil {
+		return *cc.TeamSync
+	}
+	return true // default enabled
 }
 
 func cloudConfigPath(dataDir string) string {
@@ -1614,6 +1630,9 @@ func cmdCloudEnroll(cfg store.Config) {
 	}
 
 	fmt.Printf("Project %q enrolled for cloud sync.\n", project)
+
+	// Best-effort: push enrollment list to server for team sync.
+	pushEnrollmentsToServer(cfg, s)
 }
 
 // cmdCloudUnenroll removes a project from cloud sync enrollment.
@@ -1637,6 +1656,44 @@ func cmdCloudUnenroll(cfg store.Config) {
 	}
 
 	fmt.Printf("Project %q unenrolled from cloud sync.\n", project)
+
+	// Best-effort: push updated enrollment list to server for team sync.
+	pushEnrollmentsToServer(cfg, s)
+}
+
+// pushEnrollmentsToServer pushes the current enrolled project list to the
+// cloud server so other team members can see shared project observations.
+// This is best-effort — failures are logged but don't block the command.
+func pushEnrollmentsToServer(cfg store.Config, s *store.Store) {
+	serverURL, token, err := resolveCloudClientConfig(cfg.DataDir, "", "", true)
+	if err != nil || serverURL == "" || token == "" {
+		return // no cloud config, skip silently
+	}
+
+	rt, err := remoteTransportNew(serverURL, token)
+	if err != nil {
+		return
+	}
+	if cc, loadErr := loadCloudConfig(cfg.DataDir); loadErr == nil && cc != nil && cc.ServerURL == serverURL && cc.RefreshToken != "" {
+		rt.SetTokenRefresher(cc.RefreshToken, func(newToken string) error {
+			cc.Token = newToken
+			return saveCloudConfig(cfg.DataDir, cc)
+		})
+	}
+
+	enrolled, err := s.ListEnrolledProjects()
+	if err != nil {
+		return
+	}
+	projects := make([]string, len(enrolled))
+	for i, ep := range enrolled {
+		projects[i] = ep.Project
+	}
+	if err := rt.SyncEnrollments(projects); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not sync enrollments to server: %v\n", err)
+	} else {
+		fmt.Println("Enrollment list synced to cloud server (team sync enabled).")
+	}
 }
 
 // cmdCloudProjects lists all projects currently enrolled for cloud sync.

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -353,6 +353,7 @@ func (m *Manager) pull(ctx context.Context) error {
 				Op:         rm.Op,
 				Payload:    string(rm.Payload),
 				Source:     store.SyncSourceRemote,
+				Author:     rm.Author,
 				OccurredAt: rm.OccurredAt,
 			}
 			if err := m.store.ApplyPulledMutation(m.cfg.TargetKey, localMut); err != nil {

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -112,6 +112,10 @@ func (s *CloudServer) routes() {
 	s.mux.HandleFunc("POST /sync/mutations/push", s.withAuth(s.handleMutationPush))
 	s.mux.HandleFunc("GET /sync/mutations/pull", s.withAuth(s.handleMutationPull))
 
+	// Enrollment sync routes (auth required) — for team/cross-user sync
+	s.mux.HandleFunc("POST /sync/enrollments", s.withAuth(s.handleEnrollmentSync))
+	s.mux.HandleFunc("GET /sync/enrollments", s.withAuth(s.handleEnrollmentList))
+
 	// Search & context (auth required)
 	s.mux.HandleFunc("GET /sync/search", s.withAuth(s.handleSearch))
 	s.mux.HandleFunc("GET /sync/context", s.withAuth(s.handleContext))

--- a/internal/cloud/cloudserver/push_pull.go
+++ b/internal/cloud/cloudserver/push_pull.go
@@ -347,7 +347,9 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 }
 
 // handleMutationPull returns mutations for the authenticated user with seq > since_seq.
-// GET /sync/mutations/pull?since_seq=N&limit=M
+// When team_sync=true (default), also includes observation mutations from teammates
+// enrolled in the same projects (excludes personal-scoped observations).
+// GET /sync/mutations/pull?since_seq=N&limit=M&team_sync=true
 //
 // Response: {"mutations": [...], "has_more": bool}
 func (s *CloudServer) handleMutationPull(w http.ResponseWriter, r *http.Request) {
@@ -369,11 +371,76 @@ func (s *CloudServer) handleMutationPull(w http.ResponseWriter, r *http.Request)
 		limit = 1000
 	}
 
-	result, err := s.store.PullMutations(userID, sinceSeq, limit)
+	// Check if team sync is requested (defaults to true).
+	teamSync := r.URL.Query().Get("team_sync")
+	useTeamSync := teamSync != "false"
+
+	var result *cloudstore.PullMutationsResult
+	var err error
+	if useTeamSync {
+		result, err = s.store.PullMutationsWithTeamSync(userID, sinceSeq, limit)
+	} else {
+		result, err = s.store.PullMutations(userID, sinceSeq, limit)
+	}
 	if err != nil {
 		writeStoreError(w, err, "failed to pull mutations: "+err.Error())
 		return
 	}
 
 	jsonResponse(w, http.StatusOK, result)
+}
+
+// ─── Enrollment Sync Handler ─────────────────────────────────────────────────
+
+// handleEnrollmentSync receives a list of enrolled projects from a client and
+// syncs them to the server. This enables cross-user team sync.
+// POST /sync/enrollments
+//
+// Request body: {"projects": ["project-a", "project-b"]}
+// Response: {"status": "synced", "project_count": N}
+func (s *CloudServer) handleEnrollmentSync(w http.ResponseWriter, r *http.Request) {
+	userID := getUserID(r)
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB limit
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "failed to read body: "+err.Error())
+		return
+	}
+
+	var req struct {
+		Projects []string `json:"projects"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json: "+err.Error())
+		return
+	}
+
+	if err := s.store.SyncEnrollments(userID, req.Projects); err != nil {
+		writeStoreError(w, err, "failed to sync enrollments: "+err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]any{
+		"status":        "synced",
+		"project_count": len(req.Projects),
+	})
+}
+
+// handleEnrollmentList returns the user's current server-side enrollment list.
+// GET /sync/enrollments
+//
+// Response: {"projects": ["project-a", "project-b"]}
+func (s *CloudServer) handleEnrollmentList(w http.ResponseWriter, r *http.Request) {
+	userID := getUserID(r)
+
+	projects, err := s.store.ListEnrolledProjects(userID)
+	if err != nil {
+		writeStoreError(w, err, "failed to list enrollments: "+err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]any{
+		"projects": projects,
+	})
 }

--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -1030,6 +1030,7 @@ func (cs *CloudStore) UserProjects(userID string) ([]string, error) {
 type CloudMutation struct {
 	Seq        int64           `json:"seq"`
 	UserID     string          `json:"user_id"`
+	Author     string          `json:"author,omitempty"`
 	Entity     string          `json:"entity"`
 	EntityKey  string          `json:"entity_key"`
 	Op         string          `json:"op"`

--- a/internal/cloud/cloudstore/schema.go
+++ b/internal/cloud/cloudstore/schema.go
@@ -127,4 +127,14 @@ CREATE TABLE IF NOT EXISTS cloud_mutations (
     occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_cloud_mutations_user_seq ON cloud_mutations(user_id, seq);
+
+-- ── Project Enrollments (tracks which users are enrolled in which projects) ──
+CREATE TABLE IF NOT EXISTS cloud_project_enrollments (
+    user_id     UUID NOT NULL REFERENCES cloud_users(id) ON DELETE CASCADE,
+    project     TEXT NOT NULL,
+    enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, project)
+);
+CREATE INDEX IF NOT EXISTS idx_cloud_enrollments_project ON cloud_project_enrollments(project);
+CREATE INDEX IF NOT EXISTS idx_cloud_enrollments_user    ON cloud_project_enrollments(user_id);
 `

--- a/internal/cloud/cloudstore/team_sync.go
+++ b/internal/cloud/cloudstore/team_sync.go
@@ -1,0 +1,242 @@
+package cloudstore
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ─── Project Enrollment (server-side team sync) ─────────────────────────────
+
+// EnrollProject registers a user's enrollment in a project on the server.
+// Idempotent — re-enrolling is a no-op (updates enrolled_at timestamp).
+func (cs *CloudStore) EnrollProject(userID, project string) error {
+	project = strings.TrimSpace(project)
+	if project == "" {
+		return fmt.Errorf("cloudstore: project must not be empty")
+	}
+	_, err := cs.db.Exec(
+		`INSERT INTO cloud_project_enrollments (user_id, project)
+		 VALUES ($1, $2)
+		 ON CONFLICT (user_id, project) DO UPDATE SET enrolled_at = NOW()`,
+		userID, project,
+	)
+	if err != nil {
+		return fmt.Errorf("cloudstore: enroll project: %w", err)
+	}
+	return nil
+}
+
+// UnenrollProject removes a user's enrollment from a project on the server.
+// Idempotent — unenrolling a non-enrolled project is a no-op.
+func (cs *CloudStore) UnenrollProject(userID, project string) error {
+	project = strings.TrimSpace(project)
+	if project == "" {
+		return fmt.Errorf("cloudstore: project must not be empty")
+	}
+	_, err := cs.db.Exec(
+		`DELETE FROM cloud_project_enrollments WHERE user_id = $1 AND project = $2`,
+		userID, project,
+	)
+	if err != nil {
+		return fmt.Errorf("cloudstore: unenroll project: %w", err)
+	}
+	return nil
+}
+
+// SyncEnrollments replaces a user's entire enrollment list atomically.
+// This is called when the client pushes its full enrollment list.
+func (cs *CloudStore) SyncEnrollments(userID string, projects []string) error {
+	tx, err := cs.db.Begin()
+	if err != nil {
+		return fmt.Errorf("cloudstore: begin sync enrollments: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Clear existing enrollments for this user.
+	if _, err := tx.Exec(`DELETE FROM cloud_project_enrollments WHERE user_id = $1`, userID); err != nil {
+		return fmt.Errorf("cloudstore: clear enrollments: %w", err)
+	}
+
+	// Insert new enrollments.
+	for _, project := range projects {
+		project = strings.TrimSpace(project)
+		if project == "" {
+			continue
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO cloud_project_enrollments (user_id, project) VALUES ($1, $2)
+			 ON CONFLICT (user_id, project) DO NOTHING`,
+			userID, project,
+		); err != nil {
+			return fmt.Errorf("cloudstore: insert enrollment %q: %w", project, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("cloudstore: commit sync enrollments: %w", err)
+	}
+	return nil
+}
+
+// ListEnrolledProjects returns the projects a user is enrolled in.
+func (cs *CloudStore) ListEnrolledProjects(userID string) ([]string, error) {
+	rows, err := cs.db.Query(
+		`SELECT project FROM cloud_project_enrollments WHERE user_id = $1 ORDER BY project ASC`,
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cloudstore: list enrolled projects: %w", err)
+	}
+	defer rows.Close()
+
+	var projects []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, fmt.Errorf("cloudstore: scan enrollment: %w", err)
+		}
+		projects = append(projects, p)
+	}
+	if projects == nil {
+		projects = []string{}
+	}
+	return projects, rows.Err()
+}
+
+// ─── Cross-User Pull (team sync) ────────────────────────────────────────────
+
+// PullMutationsWithTeamSync returns mutations for a user including cross-user
+// observation mutations from teammates enrolled in the same projects.
+//
+// Rules:
+//   - Always returns the user's own mutations (sessions, observations, prompts)
+//   - Also returns observation mutations from other users who share enrolled projects
+//   - Excludes observations with scope='personal' from other users
+//   - Excludes sessions and prompts from other users (those are per-developer workflow)
+//   - Falls back to user-only mode if no enrollment data exists
+func (cs *CloudStore) PullMutationsWithTeamSync(userID string, sinceSeq int64, limit int) (*PullMutationsResult, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	// Check if the enrollment table has any data for this user.
+	hasEnrollments, err := cs.userHasEnrollments(userID)
+	if err != nil {
+		return nil, fmt.Errorf("cloudstore: check enrollments: %w", err)
+	}
+	if !hasEnrollments {
+		// Fall back to user-only pull if no enrollment data exists on the server.
+		return cs.PullMutations(userID, sinceSeq, limit)
+	}
+
+	var mutations []CloudMutation
+	lastSeq := sinceSeq
+	hasMore := false
+
+	for len(mutations) < limit+1 {
+		// Combined query: own mutations + cross-user observation mutations.
+		// The query uses a UNION to merge:
+		//   1. All mutations from the requesting user (same as current behavior)
+		//   2. Observation-entity mutations from OTHER users who share enrolled projects,
+		//      excluding scope='personal'
+		// JOIN cloud_users to get the username for author attribution on cross-user mutations.
+		rows, err := cs.db.Query(
+			`SELECT cm.seq, cm.user_id,
+			        CASE WHEN cm.user_id != $1 THEN COALESCE(cu.username, '') ELSE '' END AS author,
+			        cm.entity, cm.entity_key, cm.op, cm.payload, cm.occurred_at
+			 FROM cloud_mutations cm
+			 LEFT JOIN cloud_users cu ON cu.id = cm.user_id
+			 WHERE cm.seq > $2 AND (
+			   -- Own mutations (all entities)
+			   cm.user_id = $1
+			   OR
+			   -- Cross-user: observation mutations from teammates on shared projects
+			   (
+			     cm.user_id != $1
+			     AND cm.entity = 'observation'
+			     AND EXISTS (
+			       SELECT 1 FROM cloud_project_enrollments AS my
+			       WHERE my.user_id = $1
+			         AND my.project = (cm.payload->>'project')
+			         AND EXISTS (
+			           SELECT 1 FROM cloud_project_enrollments AS their
+			           WHERE their.user_id = cm.user_id
+			             AND their.project = my.project
+			         )
+			     )
+			     -- Exclude personal-scoped observations from other users
+			     AND COALESCE(cm.payload->>'scope', 'project') != 'personal'
+			   )
+			 )
+			 ORDER BY cm.seq ASC
+			 LIMIT $3`,
+			userID, lastSeq, limit+1,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("cloudstore: pull team mutations: %w", err)
+		}
+
+		fetched := 0
+		for rows.Next() {
+			fetched++
+			var m CloudMutation
+			if err := rows.Scan(&m.Seq, &m.UserID, &m.Author, &m.Entity, &m.EntityKey, &m.Op, &m.Payload, &m.OccurredAt); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("cloudstore: scan team mutation: %w", err)
+			}
+			lastSeq = m.Seq
+
+			// Check project sync controls (paused projects).
+			project, err := projectFromMutation(m.Entity, m.Payload)
+			if err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("cloudstore: pull project from team mutation: %w", err)
+			}
+			enabled, err := cs.IsProjectSyncEnabled(project)
+			if err != nil {
+				rows.Close()
+				return nil, err
+			}
+			if !enabled {
+				continue
+			}
+
+			mutations = append(mutations, m)
+			if len(mutations) > limit {
+				hasMore = true
+				break
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("cloudstore: pull team mutations rows: %w", err)
+		}
+		rows.Close()
+		if hasMore || fetched < limit+1 {
+			break
+		}
+	}
+
+	if len(mutations) > limit {
+		mutations = mutations[:limit]
+	}
+	if mutations == nil {
+		mutations = []CloudMutation{}
+	}
+	return &PullMutationsResult{Mutations: mutations, HasMore: hasMore}, nil
+}
+
+// userHasEnrollments returns true if the user has at least one project enrollment
+// on the server. Used to determine whether team sync should be active.
+func (cs *CloudStore) userHasEnrollments(userID string) (bool, error) {
+	var count int
+	err := cs.db.QueryRow(
+		`SELECT COUNT(*) FROM cloud_project_enrollments WHERE user_id = $1`,
+		userID,
+	).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+

--- a/internal/cloud/cloudstore/team_sync_test.go
+++ b/internal/cloud/cloudstore/team_sync_test.go
@@ -1,0 +1,563 @@
+package cloudstore
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Gentleman-Programming/engram/internal/cloud"
+)
+
+// teamTestSetup creates a CloudStore with two users enrolled in the same project.
+// Returns (store, userA_ID, userB_ID).
+func teamTestSetup(t *testing.T) (*CloudStore, string, string) {
+	t.Helper()
+	dsn := testDSN(t)
+	cs, err := New(cloud.Config{DSN: dsn, MaxPool: 5})
+	if err != nil {
+		t.Fatalf("cloudstore.New: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	userA, err := cs.CreateUser("alice", "alice@test.com", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser A: %v", err)
+	}
+
+	userB, err := cs.CreateUser("bob", "bob@test.com", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser B: %v", err)
+	}
+
+	return cs, userA.ID, userB.ID
+}
+
+// ── Enrollment CRUD ──────────────────────────────────────────────────────────
+
+func TestEnrollProject(t *testing.T) {
+	cs, userA, _ := teamTestSetup(t)
+
+	if err := cs.EnrollProject(userA, "my-project"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+
+	projects, err := cs.ListEnrolledProjects(userA)
+	if err != nil {
+		t.Fatalf("ListEnrolledProjects: %v", err)
+	}
+	if len(projects) != 1 || projects[0] != "my-project" {
+		t.Fatalf("expected [my-project], got %v", projects)
+	}
+}
+
+func TestEnrollProjectIdempotent(t *testing.T) {
+	cs, userA, _ := teamTestSetup(t)
+
+	if err := cs.EnrollProject(userA, "proj"); err != nil {
+		t.Fatalf("first EnrollProject: %v", err)
+	}
+	if err := cs.EnrollProject(userA, "proj"); err != nil {
+		t.Fatalf("second EnrollProject: %v", err)
+	}
+
+	projects, err := cs.ListEnrolledProjects(userA)
+	if err != nil {
+		t.Fatalf("ListEnrolledProjects: %v", err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(projects))
+	}
+}
+
+func TestUnenrollProject(t *testing.T) {
+	cs, userA, _ := teamTestSetup(t)
+
+	if err := cs.EnrollProject(userA, "proj"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+	if err := cs.UnenrollProject(userA, "proj"); err != nil {
+		t.Fatalf("UnenrollProject: %v", err)
+	}
+
+	projects, err := cs.ListEnrolledProjects(userA)
+	if err != nil {
+		t.Fatalf("ListEnrolledProjects: %v", err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("expected 0 projects, got %d", len(projects))
+	}
+}
+
+func TestSyncEnrollments(t *testing.T) {
+	cs, userA, _ := teamTestSetup(t)
+
+	// Enroll initially.
+	if err := cs.EnrollProject(userA, "old-project"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+
+	// Sync replaces the entire list.
+	if err := cs.SyncEnrollments(userA, []string{"proj-1", "proj-2"}); err != nil {
+		t.Fatalf("SyncEnrollments: %v", err)
+	}
+
+	projects, err := cs.ListEnrolledProjects(userA)
+	if err != nil {
+		t.Fatalf("ListEnrolledProjects: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("expected 2 projects, got %d: %v", len(projects), projects)
+	}
+	if projects[0] != "proj-1" || projects[1] != "proj-2" {
+		t.Fatalf("expected [proj-1, proj-2], got %v", projects)
+	}
+}
+
+func TestEnrollProjectEmptyNameFails(t *testing.T) {
+	cs, userA, _ := teamTestSetup(t)
+
+	if err := cs.EnrollProject(userA, ""); err == nil {
+		t.Fatal("expected error for empty project name")
+	}
+}
+
+func TestEnrollmentIsolation(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	if err := cs.EnrollProject(userA, "alice-only"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+
+	// User B should have no enrollments.
+	projects, err := cs.ListEnrolledProjects(userB)
+	if err != nil {
+		t.Fatalf("ListEnrolledProjects B: %v", err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("expected 0 projects for user B, got %d", len(projects))
+	}
+}
+
+// ── Cross-User Pull (Team Sync) ─────────────────────────────────────────────
+
+func TestTeamSyncPullCrossUserObservations(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both users enroll in the same project.
+	if err := cs.EnrollProject(userA, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A pushes an observation mutation.
+	obsPayload := json.RawMessage(`{"sync_id":"obs-1","session_id":"s1","type":"decision","title":"Team decision","content":"We chose X","project":"shared-proj","scope":"project"}`)
+	_, err := cs.AppendMutation(userA, "observation", "obs-1", "upsert", obsPayload)
+	if err != nil {
+		t.Fatalf("AppendMutation A obs: %v", err)
+	}
+
+	// User B pulls with team sync — should see user A's observation.
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync B: %v", err)
+	}
+	if len(result.Mutations) != 1 {
+		t.Fatalf("expected 1 cross-user mutation, got %d", len(result.Mutations))
+	}
+	if result.Mutations[0].Entity != "observation" {
+		t.Fatalf("expected observation entity, got %s", result.Mutations[0].Entity)
+	}
+	if result.Mutations[0].UserID != userA {
+		t.Fatalf("expected mutation from user A (%s), got %s", userA, result.Mutations[0].UserID)
+	}
+}
+
+func TestTeamSyncExcludesPersonalScope(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both enroll in the same project.
+	if err := cs.EnrollProject(userA, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A pushes a personal-scoped observation.
+	personalPayload := json.RawMessage(`{"sync_id":"obs-personal","session_id":"s1","type":"note","title":"Private note","content":"My personal thought","project":"shared-proj","scope":"personal"}`)
+	_, err := cs.AppendMutation(userA, "observation", "obs-personal", "upsert", personalPayload)
+	if err != nil {
+		t.Fatalf("AppendMutation A personal: %v", err)
+	}
+
+	// User A also pushes a project-scoped observation.
+	projectPayload := json.RawMessage(`{"sync_id":"obs-public","session_id":"s1","type":"decision","title":"Public decision","content":"Team knows this","project":"shared-proj","scope":"project"}`)
+	_, err = cs.AppendMutation(userA, "observation", "obs-public", "upsert", projectPayload)
+	if err != nil {
+		t.Fatalf("AppendMutation A project: %v", err)
+	}
+
+	// User B pulls — should only see the project-scoped observation, not the personal one.
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync B: %v", err)
+	}
+	if len(result.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation (only project-scoped), got %d", len(result.Mutations))
+	}
+	if result.Mutations[0].EntityKey != "obs-public" {
+		t.Fatalf("expected obs-public, got %s", result.Mutations[0].EntityKey)
+	}
+}
+
+func TestTeamSyncExcludesSessionsAndPrompts(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both enroll.
+	if err := cs.EnrollProject(userA, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A pushes a session mutation.
+	_, err := cs.AppendMutation(userA, "session", "s-a", "upsert",
+		json.RawMessage(`{"id":"s-a","project":"shared-proj","directory":"/work"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A session: %v", err)
+	}
+
+	// User A pushes a prompt mutation.
+	_, err = cs.AppendMutation(userA, "prompt", "p-a", "upsert",
+		json.RawMessage(`{"session_id":"s-a","content":"test prompt","project":"shared-proj"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A prompt: %v", err)
+	}
+
+	// User A pushes an observation mutation.
+	_, err = cs.AppendMutation(userA, "observation", "obs-a", "upsert",
+		json.RawMessage(`{"sync_id":"obs-a","session_id":"s-a","type":"decision","title":"Shared","content":"Team info","project":"shared-proj","scope":"project"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A obs: %v", err)
+	}
+
+	// User B pulls — should only see the observation, not the session or prompt.
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync B: %v", err)
+	}
+	if len(result.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation (only observation), got %d", len(result.Mutations))
+	}
+	if result.Mutations[0].Entity != "observation" {
+		t.Fatalf("expected observation entity, got %s", result.Mutations[0].Entity)
+	}
+}
+
+func TestTeamSyncOwnMutationsStillIncluded(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both enroll.
+	if err := cs.EnrollProject(userA, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A pushes a session + observation.
+	_, err := cs.AppendMutation(userA, "session", "s-a", "upsert",
+		json.RawMessage(`{"id":"s-a","project":"shared-proj","directory":"/work"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A session: %v", err)
+	}
+	_, err = cs.AppendMutation(userA, "observation", "obs-a", "upsert",
+		json.RawMessage(`{"sync_id":"obs-a","session_id":"s-a","type":"decision","title":"Test","content":"Content","project":"shared-proj","scope":"project"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A obs: %v", err)
+	}
+
+	// User A pulls — should see both (own session + own observation).
+	result, err := cs.PullMutationsWithTeamSync(userA, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync A: %v", err)
+	}
+	if len(result.Mutations) != 2 {
+		t.Fatalf("expected 2 own mutations, got %d", len(result.Mutations))
+	}
+}
+
+func TestTeamSyncNoEnrollmentsFallsBackToUserOnly(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// User A pushes an observation (no enrollments at all).
+	_, err := cs.AppendMutation(userA, "observation", "obs-a", "upsert",
+		json.RawMessage(`{"sync_id":"obs-a","session_id":"s-a","type":"decision","title":"Test","content":"Content","project":"some-proj","scope":"project"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A: %v", err)
+	}
+
+	// User B pulls with team sync but has no enrollments — should get nothing
+	// (falls back to user-only PullMutations).
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync B: %v", err)
+	}
+	if len(result.Mutations) != 0 {
+		t.Fatalf("expected 0 mutations (no enrollments = user-only), got %d", len(result.Mutations))
+	}
+}
+
+func TestTeamSyncDifferentProjectsNoLeakage(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// User A enrolls in project-X, user B enrolls in project-Y (different projects).
+	if err := cs.EnrollProject(userA, "project-X"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "project-Y"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A pushes observation for project-X.
+	_, err := cs.AppendMutation(userA, "observation", "obs-x", "upsert",
+		json.RawMessage(`{"sync_id":"obs-x","session_id":"s-a","type":"decision","title":"X-only","content":"Private to X","project":"project-X","scope":"project"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A: %v", err)
+	}
+
+	// User B pulls — should see nothing because they are enrolled in a different project.
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync B: %v", err)
+	}
+	if len(result.Mutations) != 0 {
+		t.Fatalf("expected 0 mutations (different projects), got %d", len(result.Mutations))
+	}
+}
+
+func TestTeamSyncMultipleSharedProjects(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both enroll in two projects.
+	for _, proj := range []string{"proj-1", "proj-2"} {
+		if err := cs.EnrollProject(userA, proj); err != nil {
+			t.Fatalf("EnrollProject A %s: %v", proj, err)
+		}
+		if err := cs.EnrollProject(userB, proj); err != nil {
+			t.Fatalf("EnrollProject B %s: %v", proj, err)
+		}
+	}
+
+	// User A pushes observations for both projects.
+	_, err := cs.AppendMutation(userA, "observation", "obs-p1", "upsert",
+		json.RawMessage(`{"sync_id":"obs-p1","session_id":"s1","type":"decision","title":"P1","content":"Project 1","project":"proj-1","scope":"project"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A proj-1: %v", err)
+	}
+	_, err = cs.AppendMutation(userA, "observation", "obs-p2", "upsert",
+		json.RawMessage(`{"sync_id":"obs-p2","session_id":"s1","type":"decision","title":"P2","content":"Project 2","project":"proj-2","scope":"project"}`))
+	if err != nil {
+		t.Fatalf("AppendMutation A proj-2: %v", err)
+	}
+
+	// User B pulls — should see both.
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync B: %v", err)
+	}
+	if len(result.Mutations) != 2 {
+		t.Fatalf("expected 2 cross-user mutations, got %d", len(result.Mutations))
+	}
+}
+
+func TestTeamSyncPaginationWorks(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both enroll.
+	if err := cs.EnrollProject(userA, "proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "proj"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A pushes 5 observation mutations.
+	for i := 0; i < 5; i++ {
+		payload := json.RawMessage(`{"sync_id":"obs-` + string(rune('a'+i)) + `","session_id":"s1","type":"decision","title":"Test","content":"Content","project":"proj","scope":"project"}`)
+		_, err := cs.AppendMutation(userA, "observation", "obs-"+string(rune('a'+i)), "upsert", payload)
+		if err != nil {
+			t.Fatalf("AppendMutation %d: %v", i, err)
+		}
+	}
+
+	// User B pulls with limit=2 — should see 2 mutations with has_more=true.
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 2)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync page 1: %v", err)
+	}
+	if len(result.Mutations) != 2 {
+		t.Fatalf("expected 2 mutations on page 1, got %d", len(result.Mutations))
+	}
+	if !result.HasMore {
+		t.Fatal("expected has_more=true on page 1")
+	}
+
+	// Pull next page.
+	lastSeq := result.Mutations[1].Seq
+	result2, err := cs.PullMutationsWithTeamSync(userB, lastSeq, 10)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync page 2: %v", err)
+	}
+	if len(result2.Mutations) != 3 {
+		t.Fatalf("expected 3 mutations on page 2, got %d", len(result2.Mutations))
+	}
+	if result2.HasMore {
+		t.Fatal("expected has_more=false on last page")
+	}
+}
+
+func TestUserHasEnrollments(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Initially no enrollments.
+	has, err := cs.userHasEnrollments(userA)
+	if err != nil {
+		t.Fatalf("userHasEnrollments: %v", err)
+	}
+	if has {
+		t.Fatal("expected no enrollments initially")
+	}
+
+	// Enroll user A.
+	if err := cs.EnrollProject(userA, "proj"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+	has, err = cs.userHasEnrollments(userA)
+	if err != nil {
+		t.Fatalf("userHasEnrollments after enroll: %v", err)
+	}
+	if !has {
+		t.Fatal("expected enrollments after enroll")
+	}
+
+	// User B still has none.
+	has, err = cs.userHasEnrollments(userB)
+	if err != nil {
+		t.Fatalf("userHasEnrollments B: %v", err)
+	}
+	if has {
+		t.Fatal("expected no enrollments for user B")
+	}
+}
+
+// ── Author Attribution ───────────────────────────────────────────────────────
+
+func TestTeamSyncCrossUserMutationsHaveAuthor(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both users enroll in the same project.
+	if err := cs.EnrollProject(userA, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A (alice) pushes an observation.
+	obsPayload := json.RawMessage(`{"sync_id":"obs-auth-1","session_id":"s1","type":"decision","title":"Alice's decision","content":"We chose X","project":"shared-proj","scope":"project"}`)
+	_, err := cs.AppendMutation(userA, "observation", "obs-auth-1", "upsert", obsPayload)
+	if err != nil {
+		t.Fatalf("AppendMutation A: %v", err)
+	}
+
+	// User B pulls with team sync — cross-user mutation should have author="alice".
+	result, err := cs.PullMutationsWithTeamSync(userB, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync B: %v", err)
+	}
+	if len(result.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation, got %d", len(result.Mutations))
+	}
+	if result.Mutations[0].Author != "alice" {
+		t.Fatalf("expected author='alice', got %q", result.Mutations[0].Author)
+	}
+}
+
+func TestTeamSyncOwnMutationsHaveEmptyAuthor(t *testing.T) {
+	cs, userA, _ := teamTestSetup(t)
+
+	// User A enrolls.
+	if err := cs.EnrollProject(userA, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+
+	// User A pushes an observation.
+	obsPayload := json.RawMessage(`{"sync_id":"obs-own-1","session_id":"s1","type":"decision","title":"Own decision","content":"My stuff","project":"shared-proj","scope":"project"}`)
+	_, err := cs.AppendMutation(userA, "observation", "obs-own-1", "upsert", obsPayload)
+	if err != nil {
+		t.Fatalf("AppendMutation A: %v", err)
+	}
+
+	// User A pulls their own mutations — author should be empty (own mutations).
+	result, err := cs.PullMutationsWithTeamSync(userA, 0, 100)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync A: %v", err)
+	}
+	if len(result.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation, got %d", len(result.Mutations))
+	}
+	if result.Mutations[0].Author != "" {
+		t.Fatalf("expected empty author for own mutation, got %q", result.Mutations[0].Author)
+	}
+}
+
+func TestTeamSyncAuthorPreservedThroughRoundtrip(t *testing.T) {
+	cs, userA, userB := teamTestSetup(t)
+
+	// Both enroll.
+	if err := cs.EnrollProject(userA, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject A: %v", err)
+	}
+	if err := cs.EnrollProject(userB, "shared-proj"); err != nil {
+		t.Fatalf("EnrollProject B: %v", err)
+	}
+
+	// User A (alice) pushes multiple observations.
+	for i := 0; i < 3; i++ {
+		payload := json.RawMessage(`{"sync_id":"obs-rt-` + string(rune('a'+i)) + `","session_id":"s1","type":"decision","title":"Decision","content":"Content","project":"shared-proj","scope":"project"}`)
+		_, err := cs.AppendMutation(userA, "observation", "obs-rt-"+string(rune('a'+i)), "upsert", payload)
+		if err != nil {
+			t.Fatalf("AppendMutation %d: %v", i, err)
+		}
+	}
+
+	// User B pulls page 1 (limit=2).
+	result1, err := cs.PullMutationsWithTeamSync(userB, 0, 2)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync page 1: %v", err)
+	}
+	if len(result1.Mutations) != 2 {
+		t.Fatalf("expected 2 mutations on page 1, got %d", len(result1.Mutations))
+	}
+	for i, m := range result1.Mutations {
+		if m.Author != "alice" {
+			t.Fatalf("page 1 mutation[%d]: expected author='alice', got %q", i, m.Author)
+		}
+	}
+
+	// User B pulls page 2.
+	lastSeq := result1.Mutations[1].Seq
+	result2, err := cs.PullMutationsWithTeamSync(userB, lastSeq, 10)
+	if err != nil {
+		t.Fatalf("PullMutationsWithTeamSync page 2: %v", err)
+	}
+	if len(result2.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation on page 2, got %d", len(result2.Mutations))
+	}
+	if result2.Mutations[0].Author != "alice" {
+		t.Fatalf("page 2 mutation: expected author='alice', got %q", result2.Mutations[0].Author)
+	}
+}

--- a/internal/cloud/remote/team_sync_test.go
+++ b/internal/cloud/remote/team_sync_test.go
@@ -1,0 +1,281 @@
+package remote
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ─── SetTeamSync Tests ──────────────────────────────────────────────────────
+
+func TestSetTeamSyncDefaultTrue(t *testing.T) {
+	rt, err := NewRemoteTransport("http://localhost", "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+	if !rt.teamSync {
+		t.Fatal("expected teamSync to be true by default")
+	}
+}
+
+func TestSetTeamSyncDisable(t *testing.T) {
+	rt, err := NewRemoteTransport("http://localhost", "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+	rt.SetTeamSync(false)
+	if rt.teamSync {
+		t.Fatal("expected teamSync to be false after SetTeamSync(false)")
+	}
+}
+
+func TestSetTeamSyncReEnable(t *testing.T) {
+	rt, err := NewRemoteTransport("http://localhost", "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+	rt.SetTeamSync(false)
+	rt.SetTeamSync(true)
+	if !rt.teamSync {
+		t.Fatal("expected teamSync to be true after re-enabling")
+	}
+}
+
+// ─── PullMutations team_sync query param ─────────────────────────────────────
+
+func TestPullMutationsTeamSyncParamDefaultTrue(t *testing.T) {
+	var receivedTeamSync string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedTeamSync = r.URL.Query().Get("team_sync")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"mutations":[],"has_more":false}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	if _, err := rt.PullMutations(0, 100); err != nil {
+		t.Fatalf("PullMutations: %v", err)
+	}
+	if receivedTeamSync != "true" {
+		t.Fatalf("expected team_sync=true, got %q", receivedTeamSync)
+	}
+}
+
+func TestPullMutationsTeamSyncParamFalse(t *testing.T) {
+	var receivedTeamSync string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedTeamSync = r.URL.Query().Get("team_sync")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"mutations":[],"has_more":false}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+	rt.SetTeamSync(false)
+
+	if _, err := rt.PullMutations(0, 100); err != nil {
+		t.Fatalf("PullMutations: %v", err)
+	}
+	if receivedTeamSync != "false" {
+		t.Fatalf("expected team_sync=false, got %q", receivedTeamSync)
+	}
+}
+
+// ─── SyncEnrollments Tests ──────────────────────────────────────────────────
+
+func TestSyncEnrollmentsSuccess(t *testing.T) {
+	var receivedBody []byte
+	var receivedAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/sync/enrollments" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		receivedAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "my-token")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	if err := rt.SyncEnrollments([]string{"proj-a", "proj-b"}); err != nil {
+		t.Fatalf("SyncEnrollments: %v", err)
+	}
+
+	if receivedAuth != "Bearer my-token" {
+		t.Fatalf("auth: got %q want %q", receivedAuth, "Bearer my-token")
+	}
+
+	var req map[string][]string
+	if err := json.Unmarshal(receivedBody, &req); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	projects := req["projects"]
+	if len(projects) != 2 || projects[0] != "proj-a" || projects[1] != "proj-b" {
+		t.Fatalf("expected [proj-a, proj-b], got %v", projects)
+	}
+}
+
+func TestSyncEnrollmentsEmptyList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/sync/enrollments" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string][]string
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("unmarshal body: %v", err)
+		}
+		if len(req["projects"]) != 0 {
+			t.Errorf("expected empty projects, got %v", req["projects"])
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	if err := rt.SyncEnrollments([]string{}); err != nil {
+		t.Fatalf("SyncEnrollments: %v", err)
+	}
+}
+
+func TestSyncEnrollmentsServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(403)
+		w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	err = rt.SyncEnrollments([]string{"proj"})
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Fatalf("error should mention 403: %v", err)
+	}
+}
+
+// ─── ListEnrollments Tests ──────────────────────────────────────────────────
+
+func TestListEnrollmentsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/sync/enrollments" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("auth: got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string][]string{
+			"projects": {"proj-1", "proj-2", "proj-3"},
+		})
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	projects, err := rt.ListEnrollments()
+	if err != nil {
+		t.Fatalf("ListEnrollments: %v", err)
+	}
+	if len(projects) != 3 {
+		t.Fatalf("expected 3 projects, got %d", len(projects))
+	}
+	if projects[0] != "proj-1" || projects[1] != "proj-2" || projects[2] != "proj-3" {
+		t.Fatalf("unexpected projects: %v", projects)
+	}
+}
+
+func TestListEnrollmentsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"projects":[]}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	projects, err := rt.ListEnrollments()
+	if err != nil {
+		t.Fatalf("ListEnrollments: %v", err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("expected empty projects, got %d", len(projects))
+	}
+}
+
+func TestListEnrollmentsServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(401)
+		w.Write([]byte(`{"error":"invalid credentials"}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "bad-tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	_, err = rt.ListEnrollments()
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("error should mention 401: %v", err)
+	}
+}
+
+func TestListEnrollmentsInvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	_, err = rt.ListEnrollments()
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}

--- a/internal/cloud/remote/transport.go
+++ b/internal/cloud/remote/transport.go
@@ -31,6 +31,7 @@ type RemoteTransport struct {
 	mu             sync.Mutex
 	refreshToken   string
 	onTokenRefresh func(string) error
+	teamSync       bool // enable cross-user team sync on pull (default: true)
 }
 
 // NewRemoteTransport creates a RemoteTransport targeting the given cloud server.
@@ -47,6 +48,7 @@ func NewRemoteTransport(baseURL, token string) (*RemoteTransport, error) {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		teamSync: true, // enabled by default
 	}, nil
 }
 
@@ -56,6 +58,15 @@ func (rt *RemoteTransport) SetTokenRefresher(refreshToken string, onTokenRefresh
 	defer rt.mu.Unlock()
 	rt.refreshToken = strings.TrimSpace(refreshToken)
 	rt.onTokenRefresh = onTokenRefresh
+}
+
+// SetTeamSync enables or disables cross-user team sync on pull operations.
+// When enabled (default), pull requests include observation mutations from
+// teammates enrolled in the same projects.
+func (rt *RemoteTransport) SetTeamSync(enabled bool) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	rt.teamSync = enabled
 }
 
 func validateBaseURL(raw string) (string, error) {
@@ -376,6 +387,7 @@ type PushMutationsResult struct {
 // PullMutationResult represents a single mutation returned by the server.
 type PullMutationResult struct {
 	Seq        int64           `json:"seq"`
+	Author     string          `json:"author,omitempty"`
 	Entity     string          `json:"entity"`
 	EntityKey  string          `json:"entity_key"`
 	Op         string          `json:"op"`
@@ -422,13 +434,22 @@ func (rt *RemoteTransport) PushMutations(mutations []MutationEntry) (*PushMutati
 }
 
 // PullMutations fetches mutations from the cloud server since a given sequence.
-// GET /sync/mutations/pull?since_seq=N&limit=M
+// When teamSync is true (via the transport setting), includes cross-user
+// observation mutations from teammates enrolled in the same projects.
+// GET /sync/mutations/pull?since_seq=N&limit=M&team_sync=true|false
 func (rt *RemoteTransport) PullMutations(sinceSeq int64, limit int) (*PullMutationsResponse, error) {
 	if limit <= 0 {
 		limit = 100
 	}
 
-	u := fmt.Sprintf("%s/sync/mutations/pull?since_seq=%d&limit=%d", rt.baseURL, sinceSeq, limit)
+	teamSyncParam := "true"
+	rt.mu.Lock()
+	if !rt.teamSync {
+		teamSyncParam = "false"
+	}
+	rt.mu.Unlock()
+
+	u := fmt.Sprintf("%s/sync/mutations/pull?since_seq=%d&limit=%d&team_sync=%s", rt.baseURL, sinceSeq, limit, teamSyncParam)
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cloud: build mutation pull request: %w", err)
@@ -450,6 +471,63 @@ func (rt *RemoteTransport) PullMutations(sinceSeq int64, limit int) (*PullMutati
 		return nil, fmt.Errorf("cloud: decode mutation pull response: %w", err)
 	}
 	return &result, nil
+}
+
+// ─── Enrollment Sync ─────────────────────────────────────────────────────────
+
+// SyncEnrollments pushes the client's enrolled project list to the server.
+// POST /sync/enrollments
+func (rt *RemoteTransport) SyncEnrollments(projects []string) error {
+	body, err := json.Marshal(map[string]any{"projects": projects})
+	if err != nil {
+		return fmt.Errorf("cloud: marshal enrollment sync: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", rt.baseURL+"/sync/enrollments", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("cloud: build enrollment sync request: %w", err)
+	}
+	rt.setAuthorization(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := rt.doWithRetry(req)
+	if err != nil {
+		return fmt.Errorf("cloud: enrollment sync: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return rt.httpError("enrollment sync", resp)
+	}
+	return nil
+}
+
+// ListEnrollments fetches the server-side enrolled project list.
+// GET /sync/enrollments
+func (rt *RemoteTransport) ListEnrollments() ([]string, error) {
+	req, err := http.NewRequest("GET", rt.baseURL+"/sync/enrollments", nil)
+	if err != nil {
+		return nil, fmt.Errorf("cloud: build enrollment list request: %w", err)
+	}
+	rt.setAuthorization(req)
+
+	resp, err := rt.doWithRetry(req)
+	if err != nil {
+		return nil, fmt.Errorf("cloud: enrollment list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, rt.httpError("enrollment list", resp)
+	}
+
+	var result struct {
+		Projects []string `json:"projects"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("cloud: decode enrollment list: %w", err)
+	}
+	return result.Projects, nil
 }
 
 // ─── Data Conversion ─────────────────────────────────────────────────────────

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -608,8 +608,12 @@ func handleSearch(s *store.Store) server.ToolHandlerFunc {
 			if r.Project != nil {
 				project = fmt.Sprintf(" | project: %s", *r.Project)
 			}
-			fmt.Fprintf(&b, "[%d] #%d (%s) — %s\n    %s\n    %s%s | scope: %s\n\n",
-				i+1, r.ID, r.Type, r.Title,
+			authorTag := ""
+			if r.Author != "" {
+				authorTag = fmt.Sprintf(" (by %s)", r.Author)
+			}
+			fmt.Fprintf(&b, "[%d] #%d (%s) — %s%s\n    %s\n    %s%s | scope: %s\n\n",
+				i+1, r.ID, r.Type, r.Title, authorTag,
 				truncate(r.Content, 300),
 				r.CreatedAt, project, r.Scope)
 		}
@@ -906,13 +910,17 @@ func handleGetObservation(s *store.Store) server.ToolHandlerFunc {
 		if obs.ToolName != nil {
 			toolName = fmt.Sprintf("\nTool: %s", *obs.ToolName)
 		}
+		authorMeta := ""
+		if obs.Author != "" {
+			authorMeta = fmt.Sprintf("\nAuthor: %s", obs.Author)
+		}
 		duplicateMeta := fmt.Sprintf("\nDuplicates: %d", obs.DuplicateCount)
 		revisionMeta := fmt.Sprintf("\nRevisions: %d", obs.RevisionCount)
 
 		result := fmt.Sprintf("#%d [%s] %s\n%s\nSession: %s%s%s\nCreated: %s",
 			obs.ID, obs.Type, obs.Title,
 			obs.Content,
-			obs.SessionID, project+scope+topic, toolName+duplicateMeta+revisionMeta,
+			obs.SessionID, project+scope+topic+authorMeta, toolName+duplicateMeta+revisionMeta,
 			obs.CreatedAt,
 		)
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,6 +46,7 @@ type Observation struct {
 	Project        *string `json:"project,omitempty"`
 	Scope          string  `json:"scope"`
 	TopicKey       *string `json:"topic_key,omitempty"`
+	Author         string  `json:"author,omitempty"`
 	RevisionCount  int     `json:"revision_count"`
 	DuplicateCount int     `json:"duplicate_count"`
 	LastSeenAt     *string `json:"last_seen_at,omitempty"`
@@ -85,6 +86,7 @@ type TimelineEntry struct {
 	Project        *string `json:"project,omitempty"`
 	Scope          string  `json:"scope"`
 	TopicKey       *string `json:"topic_key,omitempty"`
+	Author         string  `json:"author,omitempty"`
 	RevisionCount  int     `json:"revision_count"`
 	DuplicateCount int     `json:"duplicate_count"`
 	LastSeenAt     *string `json:"last_seen_at,omitempty"`
@@ -187,6 +189,7 @@ type SyncMutation struct {
 	Payload    string  `json:"payload"`
 	Source     string  `json:"source"`
 	Project    string  `json:"project"`
+	Author     string  `json:"author,omitempty"`
 	OccurredAt string  `json:"occurred_at"`
 	AckedAt    *string `json:"acked_at,omitempty"`
 }
@@ -215,6 +218,7 @@ type syncObservationPayload struct {
 	Project    *string `json:"project,omitempty"`
 	Scope      string  `json:"scope"`
 	TopicKey   *string `json:"topic_key,omitempty"`
+	Author     string  `json:"author,omitempty"`
 	Deleted    bool    `json:"deleted,omitempty"`
 	DeletedAt  *string `json:"deleted_at,omitempty"`
 	HardDelete bool    `json:"hard_delete,omitempty"`
@@ -553,6 +557,7 @@ func (s *Store) migrate() error {
 		{name: "last_seen_at", definition: "TEXT"},
 		{name: "updated_at", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "deleted_at", definition: "TEXT"},
+		{name: "author", definition: "TEXT NOT NULL DEFAULT ''"},
 	}
 	for _, c := range observationColumns {
 		if err := s.addColumnIfNotExists("observations", c.name, c.definition); err != nil {
@@ -845,7 +850,7 @@ func (s *Store) AllObservations(project, scope string, limit int) ([]Observation
 
 	query := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at
+		       o.scope, o.topic_key, ifnull(o.author, '') as author, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at
 		FROM observations o
 		WHERE o.deleted_at IS NULL
 	`
@@ -874,7 +879,7 @@ func (s *Store) SessionObservations(sessionID string, limit int) ([]Observation,
 
 	query := `
 		SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		       scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		FROM observations
 		WHERE session_id = ? AND deleted_at IS NULL
 		ORDER BY created_at ASC
@@ -1017,7 +1022,7 @@ func (s *Store) RecentObservations(project, scope string, limit int) ([]Observat
 
 	query := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at
+		       o.scope, o.topic_key, ifnull(o.author, '') as author, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at
 		FROM observations o
 		WHERE o.deleted_at IS NULL
 	`
@@ -1151,13 +1156,13 @@ func (s *Store) SearchPrompts(query string, project string, limit int) ([]Prompt
 func (s *Store) GetObservation(id int64) (*Observation, error) {
 	row := s.db.QueryRow(
 		`SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		        scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		 FROM observations WHERE id = ? AND deleted_at IS NULL`, id,
 	)
 	var o Observation
 	if err := row.Scan(
 		&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
-		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
+		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.Author, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
 		&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
 	); err != nil {
 		return nil, err
@@ -1309,7 +1314,7 @@ func (s *Store) Timeline(observationID int64, before, after int) (*TimelineResul
 	// 3. Get observations BEFORE the focus (same session, older, chronological order)
 	beforeRows, err := s.queryItHook(s.db, `
 		SELECT id, session_id, type, title, content, tool_name, project,
-		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		       scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		FROM observations
 		WHERE session_id = ? AND id < ? AND deleted_at IS NULL
 		ORDER BY id DESC
@@ -1325,7 +1330,7 @@ func (s *Store) Timeline(observationID int64, before, after int) (*TimelineResul
 		var e TimelineEntry
 		if err := beforeRows.Scan(
 			&e.ID, &e.SessionID, &e.Type, &e.Title, &e.Content,
-			&e.ToolName, &e.Project, &e.Scope, &e.TopicKey, &e.RevisionCount, &e.DuplicateCount, &e.LastSeenAt,
+			&e.ToolName, &e.Project, &e.Scope, &e.TopicKey, &e.Author, &e.RevisionCount, &e.DuplicateCount, &e.LastSeenAt,
 			&e.CreatedAt, &e.UpdatedAt, &e.DeletedAt,
 		); err != nil {
 			return nil, err
@@ -1343,7 +1348,7 @@ func (s *Store) Timeline(observationID int64, before, after int) (*TimelineResul
 	// 4. Get observations AFTER the focus (same session, newer, chronological order)
 	afterRows, err := s.queryItHook(s.db, `
 		SELECT id, session_id, type, title, content, tool_name, project,
-		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		       scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		FROM observations
 		WHERE session_id = ? AND id > ? AND deleted_at IS NULL
 		ORDER BY id ASC
@@ -1359,7 +1364,7 @@ func (s *Store) Timeline(observationID int64, before, after int) (*TimelineResul
 		var e TimelineEntry
 		if err := afterRows.Scan(
 			&e.ID, &e.SessionID, &e.Type, &e.Title, &e.Content,
-			&e.ToolName, &e.Project, &e.Scope, &e.TopicKey, &e.RevisionCount, &e.DuplicateCount, &e.LastSeenAt,
+			&e.ToolName, &e.Project, &e.Scope, &e.TopicKey, &e.Author, &e.RevisionCount, &e.DuplicateCount, &e.LastSeenAt,
 			&e.CreatedAt, &e.UpdatedAt, &e.DeletedAt,
 		); err != nil {
 			return nil, err
@@ -1401,7 +1406,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 
 	sql := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at,
+		       o.scope, o.topic_key, ifnull(o.author, '') as author, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at,
 		       fts.rank
 		FROM observations_fts fts
 		JOIN observations o ON o.id = fts.rowid
@@ -1438,7 +1443,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		var sr SearchResult
 		if err := rows.Scan(
 			&sr.ID, &sr.SyncID, &sr.SessionID, &sr.Type, &sr.Title, &sr.Content,
-			&sr.ToolName, &sr.Project, &sr.Scope, &sr.TopicKey, &sr.RevisionCount, &sr.DuplicateCount,
+			&sr.ToolName, &sr.Project, &sr.Scope, &sr.TopicKey, &sr.Author, &sr.RevisionCount, &sr.DuplicateCount,
 			&sr.LastSeenAt, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
 			&sr.Rank,
 		); err != nil {
@@ -1523,8 +1528,12 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 	if len(observations) > 0 {
 		b.WriteString("### Recent Observations\n")
 		for _, obs := range observations {
-			fmt.Fprintf(&b, "- [%s] **%s**: %s\n",
-				obs.Type, obs.Title, truncate(obs.Content, 300))
+			authorTag := ""
+			if obs.Author != "" {
+				authorTag = fmt.Sprintf(" (by %s)", obs.Author)
+			}
+			fmt.Fprintf(&b, "- [%s] **%s**%s: %s\n",
+				obs.Type, obs.Title, authorTag, truncate(obs.Content, 300))
 		}
 		b.WriteString("\n")
 	}
@@ -1562,7 +1571,7 @@ func (s *Store) Export() (*ExportData, error) {
 	// Observations
 	obsRows, err := s.queryItHook(s.db,
 		`SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		        scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		 FROM observations ORDER BY id`,
 	)
 	if err != nil {
@@ -1573,7 +1582,7 @@ func (s *Store) Export() (*ExportData, error) {
 		var o Observation
 		if err := obsRows.Scan(
 			&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
-			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
+			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.Author, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
 			&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
 		); err != nil {
 			return nil, err
@@ -1953,6 +1962,10 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 			if err := decodeSyncPayload([]byte(mutation.Payload), &payload); err != nil {
 				return err
 			}
+			// Propagate author from the mutation (set by team sync for cross-user observations).
+			if mutation.Author != "" && payload.Author == "" {
+				payload.Author = mutation.Author
+			}
 			if mutation.Op == SyncOpDelete {
 				if err := s.applyObservationDeleteTx(tx, payload); err != nil {
 					return err
@@ -1987,12 +2000,12 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 func (s *Store) GetObservationBySyncID(syncID string) (*Observation, error) {
 	row := s.db.QueryRow(
 		`SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		        scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		 FROM observations WHERE sync_id = ? AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`,
 		syncID,
 	)
 	var o Observation
-	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
+	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.Author, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
 		return nil, err
 	}
 	return &o, nil
@@ -2363,11 +2376,11 @@ func decodeSyncPayload(payload []byte, dest any) error {
 func (s *Store) getObservationTx(tx *sql.Tx, id int64) (*Observation, error) {
 	row := tx.QueryRow(
 		`SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		        scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		 FROM observations WHERE id = ? AND deleted_at IS NULL`, id,
 	)
 	var o Observation
-	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
+	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.Author, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
 		return nil, err
 	}
 	return &o, nil
@@ -2375,7 +2388,7 @@ func (s *Store) getObservationTx(tx *sql.Tx, id int64) (*Observation, error) {
 
 func (s *Store) getObservationBySyncIDTx(tx *sql.Tx, syncID string, includeDeleted bool) (*Observation, error) {
 	query := `SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		        scope, topic_key, ifnull(author, '') as author, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
 		 FROM observations WHERE sync_id = ?`
 	if !includeDeleted {
 		query += ` AND deleted_at IS NULL`
@@ -2383,7 +2396,7 @@ func (s *Store) getObservationBySyncIDTx(tx *sql.Tx, syncID string, includeDelet
 	query += ` ORDER BY id DESC LIMIT 1`
 	row := tx.QueryRow(query, syncID)
 	var o Observation
-	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
+	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.Author, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
 		return nil, err
 	}
 	return &o, nil
@@ -2421,20 +2434,27 @@ func (s *Store) applyObservationUpsertTx(tx *sql.Tx, payload syncObservationPayl
 	existing, err := s.getObservationBySyncIDTx(tx, payload.SyncID, true)
 	if err == sql.ErrNoRows {
 		_, err = s.execHook(tx,
-			`INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, revision_count, duplicate_count, updated_at, deleted_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, datetime('now'), NULL)`,
-			payload.SyncID, payload.SessionID, payload.Type, payload.Title, payload.Content, payload.ToolName, payload.Project, normalizeScope(payload.Scope), payload.TopicKey, hashNormalized(payload.Content),
+			`INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, author, revision_count, duplicate_count, updated_at, deleted_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, datetime('now'), NULL)`,
+			payload.SyncID, payload.SessionID, payload.Type, payload.Title, payload.Content, payload.ToolName, payload.Project, normalizeScope(payload.Scope), payload.TopicKey, hashNormalized(payload.Content), payload.Author,
 		)
 		return err
 	}
 	if err != nil {
 		return err
 	}
+	// Preserve existing author if the incoming payload doesn't provide one.
+	// This prevents echo mutations (re-pushed by the local user) from clearing
+	// the author that was set by a cross-user team sync pull.
+	authorToUse := payload.Author
+	if authorToUse == "" && existing.Author != "" {
+		authorToUse = existing.Author
+	}
 	_, err = s.execHook(tx,
 		`UPDATE observations
-		 SET session_id = ?, type = ?, title = ?, content = ?, tool_name = ?, project = ?, scope = ?, topic_key = ?, normalized_hash = ?, revision_count = revision_count + 1, updated_at = datetime('now'), deleted_at = NULL
+		 SET session_id = ?, type = ?, title = ?, content = ?, tool_name = ?, project = ?, scope = ?, topic_key = ?, normalized_hash = ?, author = ?, revision_count = revision_count + 1, updated_at = datetime('now'), deleted_at = NULL
 		 WHERE id = ?`,
-		payload.SessionID, payload.Type, payload.Title, payload.Content, payload.ToolName, payload.Project, normalizeScope(payload.Scope), payload.TopicKey, hashNormalized(payload.Content), existing.ID,
+		payload.SessionID, payload.Type, payload.Title, payload.Content, payload.ToolName, payload.Project, normalizeScope(payload.Scope), payload.TopicKey, hashNormalized(payload.Content), authorToUse, existing.ID,
 	)
 	return err
 }
@@ -2495,7 +2515,7 @@ func (s *Store) queryObservations(query string, args ...any) ([]Observation, err
 		var o Observation
 		if err := rows.Scan(
 			&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
-			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
+			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.Author, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
 			&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
 		); err != nil {
 			return nil, err
@@ -2590,6 +2610,7 @@ func (s *Store) migrateLegacyObservationsTable() error {
 			created_at TEXT    NOT NULL DEFAULT (datetime('now')),
 			updated_at TEXT    NOT NULL DEFAULT (datetime('now')),
 			deleted_at TEXT,
+			author     TEXT    NOT NULL DEFAULT '',
 			FOREIGN KEY (session_id) REFERENCES sessions(id)
 		);
 	`); err != nil {
@@ -2600,7 +2621,7 @@ func (s *Store) migrateLegacyObservationsTable() error {
 		INSERT INTO observations_migrated (
 			id, sync_id, session_id, type, title, content, tool_name, project,
 			scope, topic_key, normalized_hash, revision_count, duplicate_count,
-			last_seen_at, created_at, updated_at, deleted_at
+			last_seen_at, created_at, updated_at, deleted_at, author
 		)
 		SELECT
 			CASE
@@ -2623,7 +2644,8 @@ func (s *Store) migrateLegacyObservationsTable() error {
 			last_seen_at,
 			COALESCE(NULLIF(created_at, ''), datetime('now')),
 			COALESCE(NULLIF(updated_at, ''), NULLIF(created_at, ''), datetime('now')),
-			deleted_at
+			deleted_at,
+			COALESCE(NULLIF(author, ''), '')
 		FROM observations
 		ORDER BY rowid;
 	`); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2049,7 +2049,8 @@ func TestMigrationInternalErrorAndNoopBranches(t *testing.T) {
 					last_seen_at TEXT,
 					created_at TEXT,
 					updated_at TEXT,
-					deleted_at TEXT
+					deleted_at TEXT,
+					author TEXT
 				);
 				INSERT INTO observations (id, session_id, type, title, content, project, created_at, updated_at)
 				VALUES (1, 's1', 'bugfix', 'legacy', 'legacy row', 'engram', datetime('now'), datetime('now'));
@@ -2792,7 +2793,8 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 				last_seen_at TEXT,
 				created_at TEXT,
 				updated_at TEXT,
-				deleted_at TEXT
+				deleted_at TEXT,
+				author TEXT NOT NULL DEFAULT ''
 			);
 			INSERT INTO observations (id, session_id, type, title, content, project, created_at, updated_at)
 			VALUES (1, 's1', 'bugfix', 'legacy', 'legacy row', 'engram', datetime('now'), datetime('now'));
@@ -2827,7 +2829,8 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 						last_seen_at TEXT,
 						created_at TEXT,
 						updated_at TEXT,
-						deleted_at TEXT
+						deleted_at TEXT,
+						author TEXT NOT NULL DEFAULT ''
 					);
 					INSERT INTO observations (id, session_id, type, title, content, project, created_at, updated_at)
 					VALUES (1, 's1', 'bugfix', 'legacy', 'legacy row', 'engram', datetime('now'), datetime('now'));


### PR DESCRIPTION
## Problem

I work on personal projects with my brother, and we both use Claude Code with engram
as our persistent memory system. We have a shared cloud server syncing our observations,
but each user can only see their own data. There's no way for my AI agent to know what
my brother's agent discovered, decided, or fixed — and vice versa.

This defeats the purpose of having a shared cloud: two developers working on the same
codebase, both using AI agents, but their agents are completely blind to each other's work.

## Solution

**Team Sync** — an opt-in (enabled by default) mechanism that shares observation
memories between users enrolled in the same project, with full author attribution.

### How it works

1. Users enroll in projects: `engram cloud enroll <project>`
2. When pulling mutations, the server checks enrollment overlap — if two users are
   enrolled in the same project, their observations are shared
3. Each cross-user observation carries the author's username, so the AI agent can
   distinguish "this was discovered by fernando" vs "this is my own memory"
4. Personal-scoped observations (`scope: personal`) are never shared
5. Only observations are shared — sessions and prompts remain private

### MCP display

When searching or viewing context, authored observations show attribution:

```
- [bugfix] Fixed N+1 query in UserList (by fernando)
- [architecture] sdd-init/factuarea
```

The AI agent sees exactly who wrote each memory and can reason about it accordingly.

## Changes

### New files
| File | Description |
|------|-------------|
| `internal/cloud/cloudstore/team_sync.go` | Server-side enrollment CRUD + cross-user pull query |
| `internal/cloud/cloudstore/team_sync_test.go` | 16 tests: security boundaries, isolation, author attribution |
| `internal/cloud/remote/team_sync_test.go` | 12 tests: transport client methods, query params, error handling |
| `cmd/engram/cloud_config_test.go` | 10 tests: config defaults, env var overrides |

### Modified files
| File | Change |
|------|--------|
| `cmd/engram/main.go` | `TeamSync` config field, enrollment push on enroll/unenroll |
| `internal/cloud/autosync/manager.go` | Propagate `Author` from pull to local store |
| `internal/cloud/cloudserver/cloudserver.go` | Register enrollment routes |
| `internal/cloud/cloudserver/push_pull.go` | `team_sync` query param + enrollment handlers |
| `internal/cloud/cloudstore/cloudstore.go` | `Author` field on `CloudMutation` |
| `internal/cloud/cloudstore/schema.go` | `cloud_project_enrollments` table |
| `internal/cloud/remote/transport.go` | `SetTeamSync()`, enrollment client methods |
| `internal/mcp/mcp.go` | Author display in search/context/get |
| `internal/store/store.go` | `Author` field across all structs, SQL queries, echo protection |
| `internal/store/store_test.go` | Updated legacy test fixtures for author column |

### Stats
- **~1,600 lines** net (including ~1,100 lines of tests)
- **38 test cases** covering enrollment CRUD, cross-user visibility, personal scope
  exclusion, project isolation, transport client, config defaults, env var overrides

## Backward Compatibility

- **Fully backward compatible** — `Author` uses `json:"author,omitempty"`, invisible to older clients
- **Safe default** — team sync is enabled by default, but requires explicit enrollment
  (`engram cloud enroll <project>`) to activate. No enrollments = identical behavior to current version
- **Schema safe** — new table uses `CREATE TABLE IF NOT EXISTS`, author column uses `addColumnIfNotExists`
- **Opt-out** — set `"team_sync": false` in `cloud.json` or `ENGRAM_TEAM_SYNC=false` env var

## Security considerations

- Personal-scoped observations are **never** shared (filtered server-side in SQL)
- Sessions and prompts are **never** shared (only entity type `observation` crosses user boundaries)
- Enrollment is **bilateral** — both users must be enrolled in the same project for sharing to work
- No enrollment = no data leakage, even with team_sync enabled

## Test plan

- [x] Enrollment CRUD (enroll, unenroll, sync, list, idempotency)
- [x] Cross-user observation pull with author attribution
- [x] Personal scope exclusion
- [x] Session/prompt entity exclusion
- [x] Project isolation (no leakage between unrelated projects)
- [x] Own-mutation inclusion (user's own data always returned)
- [x] Pagination with cross-user mutations
- [x] Author preservation on re-upsert (echo protection)
- [x] Transport client methods (SyncEnrollments, ListEnrollments, SetTeamSync)
- [x] PullMutations team_sync query param
- [x] CloudConfig.IsTeamSyncEnabled() defaults and env var override

🤖 Generated with [Claude Code](https://claude.com/claude-code)