### PR TITLE
fix: use relative path for plugin source in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,11 +14,7 @@
       "author": {
         "name": "Gentleman Programming"
       },
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/Gentleman-Programming/engram.git",
-        "path": "plugin/claude-code"
-      },
+      "source": "./plugin/claude-code",
       "category": "productivity",
       "homepage": "https://github.com/Gentleman-Programming/engram"
     }


### PR DESCRIPTION
The `source` field in `plugins[0]` used `"git-subdir"` which is not a recognized source type in the Claude Code marketplace schema. This causes `claude plugin marketplace add` to fail with:

```
✘ Failed to add marketplace: Invalid schema: plugins.0.source: Invalid input
```

Since the plugin lives in this same repo under `plugin/claude-code`, the fix is to use a relative path string (`"./plugin/claude-code"`) instead of the object form.
