### PR TITLE
feat: support .engram-project file for project name override

### DIFF
--- a/plugin/claude-code/scripts/post-compaction.sh
+++ b/plugin/claude-code/scripts/post-compaction.sh
@@ -11,7 +11,12 @@ ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-PROJECT=$(basename "$CWD")
+# Allow project name override via .engram-project file in the repo root
+if [ -n "$CWD" ] && [ -f "${CWD}/.engram-project" ]; then
+  PROJECT=$(tr -d '[:space:]' < "${CWD}/.engram-project")
+else
+  PROJECT=$(basename "$CWD")
+fi
 
 # Ensure session exists
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -13,7 +13,12 @@ ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-PROJECT=$(basename "$CWD")
+# Allow project name override via .engram-project file in the repo root
+if [ -n "$CWD" ] && [ -f "${CWD}/.engram-project" ]; then
+  PROJECT=$(tr -d '[:space:]' < "${CWD}/.engram-project")
+else
+  PROJECT=$(basename "$CWD")
+fi
 
 # Ensure engram server is running
 if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -13,7 +13,12 @@ INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 OUTPUT=$(echo "$INPUT" | jq -r '.stdout // empty')
-PROJECT=$(basename "$CWD")
+# Allow project name override via .engram-project file in the repo root
+if [ -n "$CWD" ] && [ -f "${CWD}/.engram-project" ]; then
+  PROJECT=$(tr -d '[:space:]' < "${CWD}/.engram-project")
+else
+  PROJECT=$(basename "$CWD")
+fi
 
 # Nothing to capture if no output
 [ -z "$OUTPUT" ] && exit 0

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -15,6 +15,8 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
+import { readFileSync, existsSync } from "fs"
+import { join } from "path"
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
@@ -154,6 +156,12 @@ async function isEngramRunning(): Promise<boolean> {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function extractProjectName(directory: string): string {
+  // Allow project name override via .engram-project file in the repo root
+  const overridePath = join(directory, ".engram-project")
+  if (existsSync(overridePath)) {
+    const name = readFileSync(overridePath, "utf-8").trim()
+    if (name) return name
+  }
   return directory.split("/").pop() ?? "unknown"
 }
 


### PR DESCRIPTION
## Summary
- Add `.engram-project` file support to override auto-detected project names
- When the file exists in the project root, its trimmed content is used as the project name
- Falls back to current `basename` behavior when the file doesn't exist (no breaking change)

## Motivation
Closes #62

In monorepo setups, `basename` produces names that don't match the desired engram project name. For example, a directory `myorg.backend-api` gets project name `myorg.backend-api` instead of `backend-api`. This causes duplicate projects when MCP tools (which accept an explicit `project` param) and hooks (which use `basename`) save to different project names.

**Usage:**
```bash
# In your project root
echo "backend-api" > .engram-project
```

## Changes
- `plugin/claude-code/scripts/session-start.sh` — check for `.engram-project` before falling back to `basename`
- `plugin/claude-code/scripts/subagent-stop.sh` — same
- `plugin/claude-code/scripts/post-compaction.sh` — same
- `plugin/opencode/engram.ts` — `extractProjectName()` reads `.engram-project` if it exists

## Test plan
- [x] `go test ./...` — all pre-existing tests pass (failures in store/sync/setup are pre-existing Windows file-locking issues, unrelated to this change)
- [x] Manual testing: created `.engram-project` with content `backend-api` in a `myorg.backend-api` directory, verified hooks resolve the correct project name