### PR TITLE
fix(hooks): add clear to SessionStart matcher

### DIFF
--- a/plugin/claude-code/hooks/hooks.json
+++ b/plugin/claude-code/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup",
+        "matcher": "startup|clear",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Add `clear` to the SessionStart hook matcher so engram reloads memory context on `/clear`

## Motivation

Closes #75 — the SessionStart hook only matched `"startup"`, missing the `"clear"` source event.

## Changes

- `plugin/claude-code/hooks/hooks.json`: matcher `"startup"` → `"startup|clear"`

## Test plan

- [x] Manually tested: ran `/clear` in Claude Code and confirmed session-start hook fires
- [ ] `go test ./...` passes (no Go code changed — hooks.json only)