### PR TITLE
fix: correct marketplace.json schema key from "type" to "source"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "name": "Gentleman Programming"
       },
       "source": {
-        "type": "git-subdir",
+        "source": "git-subdir",
         "url": "https://github.com/Gentleman-Programming/engram.git",
         "path": "plugin/claude-code"
       },


### PR DESCRIPTION
## Summary

- The `marketplace.json` uses `"type": "git-subdir"` in the plugin source field, but the Claude Code marketplace schema expects `"source": "git-subdir"`
- This single-key mismatch causes plugin installation to fail with: `Invalid schema: plugins.0.source: Invalid input`
- Verified fix locally: after changing `"type"` → `"source"`, both `marketplace add` and `plugin install` succeed

## Fixes

Closes #73

## Test plan

- [x] Changed `"type"` to `"source"` in `.claude-plugin/marketplace.json`
- [x] Ran `claude plugin marketplace add` on the fixed file — succeeded
- [x] Ran `claude plugin install engram` — succeeded
- [x] Confirmed the official marketplace (claude-plugins-official) uses `"source": "git-subdir"` for other plugins (semgrep, railway, AWS, etc.)