### PR TITLE
refactor(help): update `engram --help` output to show the right configuration example for engram mcp addition

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -821,8 +821,8 @@ MCP Configuration (add to your agent's config):
     "mcp": {
       "engram": {
         "type": "stdio",
-        "command": "engram",
-        "args": ["mcp", "--tools=agent"]
+      	"command": ["engram", "mcp", "--tools=agent"],
+      	"enabled": true
       }
     }
   }


### PR DESCRIPTION
The confusing part is `engram --help` text output, not the setup flow itself.

engram setup opencode already writes the correct OpenCode configuration format. The proposed fix aligns `engram --help` text output with the actually supported OpenCode config.

<!-- 
  ⚠️ READ BEFORE SUBMITTING
  
  Every PR must:
  1. Link an approved issue (with status:approved label)
  2. Have exactly one type:* label
  3. Pass all 5 automated checks
  
  See CONTRIBUTING.md for the full workflow.
-->

## 🔗 Linked Issue

<!-- REQUIRED: Replace the # below with the issue number. -->
<!-- Automated check: "Check Issue Reference" verifies this exists. -->
<!-- Automated check: "Check Issue Has status:approved" verifies the issue is approved. -->

Closes #88

---

## 🏷️ PR Type

<!-- REQUIRED: Check exactly ONE type below, then add the matching label to the PR. -->
<!-- Automated check: "Check PR Has type:* Label" verifies the label exists. -->

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [x] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

`engram --help` currently shows wrong directions to the user.

This PR makes `engram --help` show the correct format for the user to configure `mcp.engram` in `opencode.json` without errors.


## 📂 Changes

<!-- Key files changed and what was modified in each. -->

| File | Change |
|----------------------|---------------------------------------------|
| `cmd/engram/main.go` | Shows correct directions to configure `mcp.engram` in `engram --help` output |

## 🧪 Test Plan

<!-- How did you verify this works? -->

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

1. **Without** the suggested change `opencode mcp list` shows:

```console
┌  MCP Servers
Error: Configuration is invalid at ~/.config/opencode/opencode.json
↳ Invalid input mcp.engram
```

`opencode` does not open and also shows the above error ❌ 

2. With the suggested change `opencode mcp list` shows:

```console
┌  MCP Servers
│
●  ✓ engram connected
│      engram mcp --tools=agent
...
```

`opencode` opens without errors ✅ 


---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [X] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

<!-- Optional: anything the reviewer should know — context, tradeoffs, open questions. -->
