### PR TITLE
docs: fix build-from-source instructions and add Claude CLI version note

### DIFF
--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -66,6 +66,11 @@ See [Plugins → OpenCode Plugin](PLUGINS.md#opencode-plugin) for details on wha
 
 > **Prerequisite**: Install the `engram` binary first (via [Homebrew](INSTALLATION.md#homebrew-macos--linux), [Windows binary](INSTALLATION.md#windows), [binary download](INSTALLATION.md#download-binary-all-platforms), or [source](INSTALLATION.md#install-from-source-macos--linux)). The plugin needs it for the MCP server and session tracking scripts.
 
+> **Minimum CLI version:** The marketplace plugin requires **Claude Code CLI >= 2.1.70**. Check with `claude --version` and update with `claude update` if needed. Older versions fail with:
+> ```
+> ✘ Failed to add marketplace: Invalid schema: plugins.0.source: Invalid input
+> ```
+
 **Option A: Plugin via marketplace (recommended)** — full session management, auto-import, compaction recovery, and Memory Protocol skill:
 
 ```bash

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,10 +51,22 @@ git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
 go install ./cmd/engram
 # Binary goes to %GOPATH%\bin\engram.exe (typically %USERPROFILE%\go\bin\)
+```
 
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
+> **Optional:** add a version stamp (otherwise `engram version` shows "dev")
+
+Build only (binary stays in the current directory):
+
+```powershell
 $v = git describe --tags --always
 go build -ldflags="-X main.version=local-$v" -o engram.exe ./cmd/engram
+```
+
+Build and install to `%GOPATH%\bin` so it's available system-wide:
+
+```powershell
+$v = git describe --tags --always
+go install -ldflags="-X main.version=local-$v" ./cmd/engram
 ```
 
 **Option C: Download the prebuilt binary**
@@ -104,9 +116,20 @@ Expand-Archive engram_*_windows_amd64.zip -DestinationPath "$env:USERPROFILE\bin
 git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
 go install ./cmd/engram
+```
 
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
+> **Optional:** add a version stamp (otherwise `engram version` shows "dev")
+
+Build only (binary stays in the current directory):
+
+```bash
 go build -ldflags="-X main.version=local-$(git describe --tags --always)" -o engram ./cmd/engram
+```
+
+Build and install to `$GOPATH/bin` so it's available system-wide:
+
+```bash
+go install -ldflags="-X main.version=local-$(git describe --tags --always)" ./cmd/engram
 ```
 
 ---

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -59,7 +59,12 @@ The OpenCode plugin uses a defense-in-depth strategy to ensure memories survive 
 
 ## Claude Code Plugin
 
-For [Claude Code](https://docs.anthropic.com/en/docs/claude-code) users, a plugin adds enhanced session management using Claude's native hook and skill system:
+For [Claude Code](https://docs.anthropic.com/en/docs/claude-code) users, a plugin adds enhanced session management using Claude's native hook and skill system.
+
+> **Minimum CLI version:** The marketplace plugin requires **Claude Code CLI >= 2.1.70**. Check with `claude --version` and update with `claude update` if needed. Older versions fail with:
+> ```
+> ✘ Failed to add marketplace: Invalid schema: plugins.0.source: Invalid input
+> ```
 
 ```bash
 # Install via Claude Code marketplace (recommended)


### PR DESCRIPTION
## Summary

- **INSTALLATION.md**: Split the optional version-stamp step into separate, copy-pasteable code blocks (`go build` for local testing vs `go install` for system-wide install). Previously `go build -o engram` left the versioned binary in the current directory without installing it — users who followed the "optional" step ended up with a stale binary in `$GOPATH/bin`.
- **AGENT-SETUP.md & PLUGINS.md**: Add a note about the minimum Claude Code CLI version required (`>= 2.1.70`) for the marketplace plugin. Older versions fail with `Invalid schema: plugins.0.source: Invalid input`.

Closes #67

## Test plan

- [ ] Verify the `go install -ldflags` command works and places the versioned binary in `$GOPATH/bin`
- [ ] Verify the `go build -ldflags` command builds the binary in the current directory
- [ ] Confirm the Claude CLI version note renders correctly in both docs