### PR TITLE
fix(plugin): skip sub-agent session registration in OpenCode plugin

### DIFF
--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -206,12 +206,22 @@ export const Engram: Plugin = async (ctx) => {
   // Track which sessions we've already ensured exist in engram
   const knownSessions = new Set<string>()
 
+  // Track sub-agent session IDs so we can suppress their tool-hook registrations.
+  // Sub-agents (Task() calls) have a parentID or a title ending in " subagent)".
+  // We must not register them as top-level Engram sessions — they cause session
+  // inflation (e.g. 170 sessions for 1 real conversation, issue #116).
+  const subAgentSessions = new Set<string>()
+
   /**
    * Ensure a session exists in engram. Idempotent — calls POST /sessions
    * which uses INSERT OR IGNORE. Safe to call multiple times.
+   *
+   * Silently skips sub-agent sessions (tracked in `subAgentSessions`).
    */
   async function ensureSession(sessionId: string): Promise<void> {
     if (!sessionId || knownSessions.has(sessionId)) return
+    // Do not register sub-agent sessions in Engram (issue #116).
+    if (subAgentSessions.has(sessionId)) return
     knownSessions.add(sessionId)
     await engramFetch("/sessions", {
       method: "POST",
@@ -272,18 +282,40 @@ export const Engram: Plugin = async (ctx) => {
     event: async ({ event }) => {
       // --- Session Created ---
       if (event.type === "session.created") {
-        const sessionId = (event.properties as any)?.id
-        if (sessionId) {
+        // Bug fix (#116): session data is nested under event.properties.info,
+        // not event.properties directly.
+        const info = (event.properties as any)?.info
+        const sessionId = info?.id
+        const parentID = info?.parentID
+        const title: string = info?.title ?? ""
+
+        // Sub-agent sessions (created via Task()) must NOT be registered as
+        // top-level Engram sessions. They cause massive session inflation
+        // (e.g. 170 sessions for 1 real conversation).
+        //
+        // Detection heuristics:
+        //   - parentID is set on all Task() sub-agent sessions
+        //   - title ends with " subagent)" as a secondary signal
+        const isSubAgent = !!parentID || title.endsWith(" subagent)")
+
+        if (sessionId && !isSubAgent) {
           await ensureSession(sessionId)
+        } else if (sessionId && isSubAgent) {
+          // Remember this as a sub-agent session so tool-hook calls
+          // to ensureSession() are also suppressed for it.
+          subAgentSessions.add(sessionId)
         }
       }
 
       // --- Session Deleted ---
       if (event.type === "session.deleted") {
-        const sessionId = (event.properties as any)?.id
+        // Same properties.info path as session.created.
+        const info = (event.properties as any)?.info
+        const sessionId = info?.id
         if (sessionId) {
           toolCounts.delete(sessionId)
           knownSessions.delete(sessionId)
+          subAgentSessions.delete(sessionId)
         }
       }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2407,3 +2407,65 @@ func TestInstallOpenCodeBakesENGRAMBIN(t *testing.T) {
 		}
 	})
 }
+
+// ─── Issue #116: Sub-agent session inflation fix ─────────────────────────────
+
+// TestPluginSubAgentFiltering verifies that the installed plugin source
+// contains the necessary logic to:
+//
+//	a) read session data from event.properties.info (not event.properties)
+//	b) suppress Task() sub-agent sessions via parentID or title suffix check
+//	c) track sub-agent IDs in subAgentSessions for cross-hook suppression
+func TestPluginSubAgentFiltering(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	runtimeGOOS = "linux"
+	osExecutable = func() (string, error) { return "/usr/local/bin/engram", nil }
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	if _, err := installOpenCode(); err != nil {
+		t.Fatalf("installOpenCode failed: %v", err)
+	}
+
+	pluginPath := filepath.Join(home, "xdg", "opencode", "plugins", "engram.ts")
+	raw, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("read installed plugin: %v", err)
+	}
+	content := string(raw)
+
+	// a) Session data must be read from event.properties.info
+	if !strings.Contains(content, `event.properties as any)?.info`) {
+		t.Fatalf("plugin must read session data from event.properties.info, got:\n%s", content)
+	}
+
+	// b) parentID check: sub-agents with a parentID must not register sessions
+	if !strings.Contains(content, `parentID`) {
+		t.Fatalf("plugin must check parentID to detect sub-agent sessions")
+	}
+
+	// b) title suffix check: secondary signal for sub-agent detection
+	if !strings.Contains(content, `subagent)`) {
+		t.Fatalf("plugin must check title suffix ' subagent)' as secondary sub-agent signal")
+	}
+
+	// b) isSubAgent gate: must guard ensureSession() call
+	if !strings.Contains(content, `isSubAgent`) {
+		t.Fatalf("plugin must use isSubAgent flag to gate ensureSession()")
+	}
+
+	// c) subAgentSessions set must exist for cross-hook suppression
+	if !strings.Contains(content, `subAgentSessions`) {
+		t.Fatalf("plugin must define subAgentSessions set for cross-hook suppression")
+	}
+
+	// Verify ensureSession itself guards against sub-agent sessions
+	if !strings.Contains(content, `subAgentSessions.has(sessionId)`) {
+		t.Fatalf("ensureSession must check subAgentSessions before registering")
+	}
+
+	// session.deleted must clean up subAgentSessions too
+	if !strings.Contains(content, `subAgentSessions.delete(sessionId)`) {
+		t.Fatalf("session.deleted handler must clean up subAgentSessions set")
+	}
+}

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -206,12 +206,22 @@ export const Engram: Plugin = async (ctx) => {
   // Track which sessions we've already ensured exist in engram
   const knownSessions = new Set<string>()
 
+  // Track sub-agent session IDs so we can suppress their tool-hook registrations.
+  // Sub-agents (Task() calls) have a parentID or a title ending in " subagent)".
+  // We must not register them as top-level Engram sessions — they cause session
+  // inflation (e.g. 170 sessions for 1 real conversation, issue #116).
+  const subAgentSessions = new Set<string>()
+
   /**
    * Ensure a session exists in engram. Idempotent — calls POST /sessions
    * which uses INSERT OR IGNORE. Safe to call multiple times.
+   *
+   * Silently skips sub-agent sessions (tracked in `subAgentSessions`).
    */
   async function ensureSession(sessionId: string): Promise<void> {
     if (!sessionId || knownSessions.has(sessionId)) return
+    // Do not register sub-agent sessions in Engram (issue #116).
+    if (subAgentSessions.has(sessionId)) return
     knownSessions.add(sessionId)
     await engramFetch("/sessions", {
       method: "POST",
@@ -272,18 +282,40 @@ export const Engram: Plugin = async (ctx) => {
     event: async ({ event }) => {
       // --- Session Created ---
       if (event.type === "session.created") {
-        const sessionId = (event.properties as any)?.id
-        if (sessionId) {
+        // Bug fix (#116): session data is nested under event.properties.info,
+        // not event.properties directly.
+        const info = (event.properties as any)?.info
+        const sessionId = info?.id
+        const parentID = info?.parentID
+        const title: string = info?.title ?? ""
+
+        // Sub-agent sessions (created via Task()) must NOT be registered as
+        // top-level Engram sessions. They cause massive session inflation
+        // (e.g. 170 sessions for 1 real conversation).
+        //
+        // Detection heuristics:
+        //   - parentID is set on all Task() sub-agent sessions
+        //   - title ends with " subagent)" as a secondary signal
+        const isSubAgent = !!parentID || title.endsWith(" subagent)")
+
+        if (sessionId && !isSubAgent) {
           await ensureSession(sessionId)
+        } else if (sessionId && isSubAgent) {
+          // Remember this as a sub-agent session so tool-hook calls
+          // to ensureSession() are also suppressed for it.
+          subAgentSessions.add(sessionId)
         }
       }
 
       // --- Session Deleted ---
       if (event.type === "session.deleted") {
-        const sessionId = (event.properties as any)?.id
+        // Same properties.info path as session.created.
+        const info = (event.properties as any)?.info
+        const sessionId = info?.id
         if (sessionId) {
           toolCounts.delete(sessionId)
           knownSessions.delete(sessionId)
+          subAgentSessions.delete(sessionId)
         }
       }
 


### PR DESCRIPTION
## Linked Issue

Closes #116

## Summary

- fix sub-agent session inflation: OpenCode Task() executions no longer register as separate Engram sessions
- fix pre-existing bug where session.created handler read the wrong property path (event.properties.id instead of event.properties.info.id)
- add test coverage verifying the plugin contains the correct filtering logic

## Problem

Every OpenCode Task() sub-agent execution fired a session.created event that the Engram plugin registered as a full session. A single user conversation could generate 170+ sessions in the DB, making session analytics completely unusable.

## Root Cause

Two bugs:
1. The session.created handler read event.properties.id (always undefined) instead of event.properties.info.id
2. No filtering existed to distinguish user sessions from Task() sub-agent sessions

## Fix

- Read session data from event.properties.info (correct path per OpenCode SDK types)
- Detect sub-agent sessions via parentID (primary signal) or title suffix " subagent)" (secondary signal)
- Skip ensureSession() for sub-agent sessions
- Track sub-agent session IDs in a Set to prevent cross-hook inflation via tool.execute.after
- Clean up the Set on session.deleted to avoid memory leaks

## Test Plan

- [x] `go test ./...` (all 8 packages pass)
- [x] Added TestPluginSubAgentFiltering verifying the installed plugin contains all required filtering markers