### PR TITLE
fix(mcp): handle string-typed numeric params in intArg

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -16,6 +16,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Gentleman-Programming/engram/internal/store"
@@ -1039,11 +1040,19 @@ func defaultSessionID(project string) string {
 }
 
 func intArg(req mcp.CallToolRequest, key string, defaultVal int) int {
-	v, ok := req.GetArguments()[key].(float64)
-	if !ok {
+	v := req.GetArguments()[key]
+	switch val := v.(type) {
+	case float64:
+		return int(val)
+	case string:
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return defaultVal
+		}
+		return n
+	default:
 		return defaultVal
 	}
-	return int(v)
 }
 
 func boolArg(req mcp.CallToolRequest, key string, defaultVal bool) bool {


### PR DESCRIPTION
## Summary
- `intArg()` only type-asserted to `float64`, silently returning `0` when the MCP transport sent numeric params as strings
- This caused `"id is required"` errors on `mem_update`, `mem_delete`, and `mem_timeline`
- Added `strconv.Atoi` fallback via type switch so both `float64` and `string` representations are handled

## Test plan
- [x] Existing `TestHandleUpdateAcceptsAllOptionalFields` passes
- [ ] Verify `mem_update`, `mem_delete`, `mem_timeline` work when `id` arrives as string

🤖 Generated with [Claude Code](https://claude.com/claude-code)