### PR TITLE
fix(plugin): prevent sub-agent infinite loop on session lifecycle calls

### DIFF
--- a/plugin/claude-code/scripts/post-compaction.sh
+++ b/plugin/claude-code/scripts/post-compaction.sh
@@ -60,12 +60,18 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
 
-### SESSION CLOSE — before saying "done"/"listo":
+### SUB-AGENT SCOPE
+If you are a sub-agent or delegated task (launched by an orchestrator/parent agent):
+- DO NOT call `mem_session_start`, `mem_session_end`, or `mem_session_summary`
+- You MAY call `mem_save` once for important discoveries, and `mem_search`/`mem_context` as needed
+- Return your result to the parent agent when done — that is your only "close" action
+
+### SESSION CLOSE — TOP-LEVEL AGENT ONLY, before saying "done"/"listo":
 Call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
 
 ---
 
-CRITICAL INSTRUCTION POST-COMPACTION — follow these steps IN ORDER:
+CRITICAL INSTRUCTION POST-COMPACTION (TOP-LEVEL AGENT ONLY) — follow these steps IN ORDER:
 PROTOCOL
 
 printf "\n1. FIRST: Call mem_session_summary with the content of the compacted summary above. Use project: '%s'.\n" "$PROJECT"

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -88,7 +88,13 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - User mentions a topic you have no context on
 - User's FIRST message references the project, a feature, or a problem — call `mem_search` with keywords from their message to check for prior work before responding
 
-### SESSION CLOSE — before saying "done"/"listo":
+### SUB-AGENT SCOPE
+If you are a sub-agent or delegated task (launched by an orchestrator/parent agent):
+- DO NOT call `mem_session_start`, `mem_session_end`, or `mem_session_summary`
+- You MAY call `mem_save` once for important discoveries, and `mem_search`/`mem_context` as needed
+- Return your result to the parent agent when done — that is your only "close" action
+
+### SESSION CLOSE — TOP-LEVEL AGENT ONLY, before saying "done"/"listo":
 Call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
 PROTOCOL
 

--- a/plugin/claude-code/skills/memory/SKILL.md
+++ b/plugin/claude-code/skills/memory/SKILL.md
@@ -88,9 +88,20 @@ Also search memory PROACTIVELY when:
 - The user mentions a topic you have no context on — check if past sessions covered it
 - The user's FIRST message references the project, a feature, or a problem — call `mem_search` with keywords from their message to check for prior work before responding
 
-## SESSION CLOSE PROTOCOL (mandatory)
+## SUB-AGENT / DELEGATED TASK SCOPE
 
-Before ending a session or saying "done" / "listo" / "that's it", you MUST:
+If you are running as a sub-agent, delegated task, or background worker (i.e., you were launched by an orchestrator or parent agent to perform a specific task):
+- **DO NOT** call `mem_session_start`, `mem_session_end`, or `mem_session_summary`
+- **DO NOT** follow the SESSION CLOSE PROTOCOL below
+- You MAY call `mem_save` for genuinely important discoveries (once, not repeatedly)
+- You MAY call `mem_search` or `mem_context` if needed for your task
+- When your task is complete, return your result to the parent agent. That is your only "close" action.
+
+Session lifecycle (start, summary, end) is the responsibility of the TOP-LEVEL agent that directly interacts with the human user.
+
+## SESSION CLOSE PROTOCOL (mandatory — TOP-LEVEL AGENT ONLY)
+
+Before ending a TOP-LEVEL session (direct human conversation) or saying "done" / "listo" / "that's it", you MUST:
 1. Call `mem_session_summary` with this structure:
 
 ## Goal
@@ -113,7 +124,7 @@ Before ending a session or saying "done" / "listo" / "that's it", you MUST:
 
 This is NOT optional. If you skip this, the next session starts blind.
 
-## AFTER COMPACTION
+## AFTER COMPACTION (TOP-LEVEL AGENT ONLY)
 
 If you see a message about compaction or context reset:
 1. IMMEDIATELY call `mem_session_summary` with the compacted summary content — this persists what was done before compaction


### PR DESCRIPTION
Closes #128

## Summary

- Add "SUB-AGENT SCOPE" sections to `session-start.sh`, `post-compaction.sh`, and `memory/SKILL.md` that tell sub-agents to skip session lifecycle tools (`mem_session_start`, `mem_session_end`, `mem_session_summary`)
- Scope `SESSION CLOSE` and `AFTER COMPACTION` headers as `TOP-LEVEL AGENT ONLY` so the mandatory language no longer applies to delegated tasks
- Sub-agents may still call `mem_save` (once) and `mem_search`/`mem_context` as needed

## Changes

| File | Change |
|------|--------|
| `plugin/claude-code/scripts/session-start.sh` | Added SUB-AGENT SCOPE section, scoped SESSION CLOSE as TOP-LEVEL AGENT ONLY |
| `plugin/claude-code/scripts/post-compaction.sh` | Added SUB-AGENT SCOPE section, scoped SESSION CLOSE and POST-COMPACTION as TOP-LEVEL AGENT ONLY |
| `plugin/claude-code/skills/memory/SKILL.md` | Added SUB-AGENT / DELEGATED TASK SCOPE section, scoped SESSION CLOSE PROTOCOL and AFTER COMPACTION as TOP-LEVEL AGENT ONLY |

## Test plan

- [x] `go test ./...` — 596 tests pass, no regressions
- [ ] Manual: start a Claude Code session with `bypassPermissions`, trigger an Explore sub-agent, confirm it no longer loops on `mem_session_summary`
- [ ] Manual: verify top-level agent still calls `mem_session_summary` on session close
- [ ] Manual: verify sub-agents can still call `mem_save` for important discoveries

## Checklist

- [x] Commit messages follow conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Changes are limited to protocol text — no Go code or infrastructure changes