### PR TITLE
feat(plugin/claude-code): mandate mem_context at session start to prevent blind sessions

### DIFF
--- a/plugin/claude-code/skills/memory/SKILL.md
+++ b/plugin/claude-code/skills/memory/SKILL.md
@@ -75,6 +75,18 @@ Format for `mem_save`:
 - If unsure about the key, call `mem_suggest_topic_key` first, then reuse that key consistently
 - If you already know the exact ID to fix, use `mem_update`
 
+## SESSION START (mandatory)
+
+Your FIRST action in every session — before responding to any user message — is to call `mem_context`.
+
+Do this even if the first message seems unrelated to prior work (a pasted error, a build log, a greeting).
+One call. Two seconds. Prevents a blind session.
+
+If context shows prior work relevant to what the user is asking → use it immediately, don't re-explore what's already known.
+If context is empty or irrelevant → proceed normally.
+
+Do NOT skip this step. The cost of one call is negligible. The cost of a blind session is losing everything the previous session built.
+
 ## WHEN TO SEARCH MEMORY
 
 When the user asks to recall something — any variation of "remember", "recall", "what did we do",


### PR DESCRIPTION
Closes #137

---

## 🏷️ PR Type

- [x] `type:feature` — New feature

---

## 📝 Summary

- Adds a `## SESSION START (mandatory)` section to `plugin/claude-code/skills/memory/SKILL.md`
- Makes `mem_context` unconditionally required as the agent's first action on every session — before responding to any user message
- Removes the conditionality that caused agents to skip context loading when the opening message seemed unrelated to prior work

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/claude-code/skills/memory/SKILL.md` | Added `SESSION START (mandatory)` section before `WHEN TO SEARCH MEMORY` |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

No Go code changed — this is a protocol text change. Verified by starting a new Claude Code session and confirming the agent calls `mem_context` before responding to the first message, regardless of its content.

---

## 💬 Notes for Reviewers

### The problem

`session-start.sh` already fetches context and injects it via `additionalContext`. But the SKILL.md told the agent to search memory only *conditionally* — when the user's first message "references a project, a feature, or a problem." In practice, sessions often start with something unrelated (a build log, a system error, an unrelated question). The agent reads the message, sees no obvious signal of prior work, and skips loading context entirely.

The memory is there. The agent just never looks.

### Why this fix over the alternatives

**Option A — FTS fallback with individual term matching** (`internal/store/store.go`): Improves search recall when query terms don't match exactly how the memory was saved. Addresses a symptom, not the root cause. The agent still has to *decide* to search — if it skips that step, better search doesn't help. Worth pursuing as a follow-up.

**Option B — `UserPromptSubmit` hook injection**: Adds latency to every first prompt, requires heuristic relevance detection at the shell level, and duplicates what `mem_context` does with less flexibility. Adds complexity to the wrong layer.

**Option C — SKILL.md protocol change (this PR)**: One call, always, before anything else. No infrastructure change, no risk, immediate behavioral improvement. Fixes the root cause at the right layer: the agent's instructions.

### The change

```diff
+## SESSION START (mandatory)
+
+Your FIRST action in every session — before responding to any user message — is to call `mem_context`.
+
+Do this even if the first message seems unrelated to prior work (a pasted error, a build log, a greeting).
+One call. Two seconds. Prevents a blind session.
+
+If context shows prior work relevant to what the user is asking → use it immediately, don't re-explore what's already known.
+If context is empty or irrelevant → proceed normally.
+
+Do NOT skip this step. The cost of one call is negligible. The cost of a blind session is losing everything the previous session built.
+
 ## WHEN TO SEARCH MEMORY
```