### PR TITLE
feat: add armv6/armv7 (32-bit ARM) release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,10 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - "6"
+      - "7"
     ldflags:
       - -s -w -X main.version={{.Version}}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,13 +22,18 @@ builds:
     goarm:
       - "6"
       - "7"
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
     ldflags:
       - -s -w -X main.version={{.Version}}
 
 archives:
   - formats:
       - tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{- if .Arm }}v{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
         formats:


### PR DESCRIPTION
## Summary

Engram is pure Go with `CGO_ENABLED=0`, so ARM cross-compilation works out of the box. This adds `linux/arm` (armv6 + armv7) to goreleaser, enabling prebuilt binaries for Raspberry Pi Zero/Zero 2/3/4 running 32-bit OS.

Tested on Pi Zero 2 W (armv7l, Raspbian trixie) running Engram as MCP server for PicoClaw.

## Changes

- Added `arm` to `goarch` list in `.goreleaser.yaml`
- Added `goarm: ["6", "7"]` to produce both armv6 and armv7 binaries

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)