### PR TITLE
perf(claude-code): shrink SessionStart hook injection from ~10 KB to ~2 KB

### DIFF
--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -4,10 +4,21 @@
 # 1. Ensures the engram server is running
 # 2. Creates a session in engram
 # 3. Auto-imports git-synced chunks if .engram/manifest.json exists
-# 4. Injects Memory Protocol instructions + memory context
+# 4. Injects a minimal tool-availability pointer + compacted memory context
+#
+# Memory protocol (when/what to save, search, close) lives in the
+# `engram:memory` skill shipped with this plugin and is loaded on demand.
+# Re-injecting the full protocol on every SessionStart wastes ~1.8 KB of
+# context window per session, so this script only emits a short pointer.
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
 ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+
+# Tunables (override via env)
+#   ENGRAM_CONTEXT_LIMIT   — max observations to inject (default 8)
+#   ENGRAM_CONTEXT_MAXLEN  — max chars per observation line (default 140)
+CTX_LIMIT="${ENGRAM_CONTEXT_LIMIT:-8}"
+CTX_MAXLEN="${ENGRAM_CONTEXT_MAXLEN:-140}"
 
 # Load shared helpers
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -55,46 +66,50 @@ fi
 ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
 CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
 
-# Inject Memory Protocol + context — stdout goes to Claude as additionalContext
+# Compact the "### Recent Observations" section: keep at most $CTX_LIMIT
+# observations, each flattened onto a single line and truncated to
+# $CTX_MAXLEN chars. The server inlines up to 300 chars of raw content per
+# bullet (often multi-line, since session summaries are markdown documents),
+# so a raw /context response for a busy project is ~8 KB. This awk pass
+# concatenates each bullet's continuation lines, collapses whitespace, and
+# caps both the count and per-bullet length — typical injected context drops
+# to ~1.5 KB. Headers, recent sessions, and recent prompts pass through.
+if [ -n "$CONTEXT" ]; then
+  CONTEXT=$(printf '%s\n' "$CONTEXT" | awk -v lim="$CTX_LIMIT" -v max="$CTX_MAXLEN" '
+    function flush() {
+      if (buf == "") return
+      if (kept < lim) {
+        gsub(/[[:space:]]+/, " ", buf)
+        if (length(buf) > max) buf = substr(buf, 1, max - 1) "…"
+        print buf
+        kept++
+      }
+      buf = ""
+    }
+    /^### Recent Observations/ { flush(); in_obs = 1; print; next }
+    /^### / { flush(); in_obs = 0; print; next }
+    in_obs && /^- \[/ { flush(); buf = $0; next }
+    in_obs { if (buf != "") buf = buf " " $0; next }
+    { print }
+    END { flush() }
+  ')
+fi
+
+# Inject minimal protocol pointer + compacted context as additionalContext.
 cat <<'PROTOCOL'
-## Engram Persistent Memory — ACTIVE PROTOCOL
+## Engram Memory — active
 
-You have engram memory tools. This protocol is MANDATORY and ALWAYS ACTIVE.
+Core tools (always available): mem_save, mem_search, mem_context,
+mem_session_summary, mem_get_observation, mem_suggest_topic_key, mem_update,
+mem_session_start, mem_session_end, mem_save_prompt.
+Admin tools via ToolSearch: mem_stats, mem_delete, mem_timeline, mem_capture_passive.
 
-### CORE TOOLS — always available, no ToolSearch needed
-mem_save, mem_search, mem_context, mem_session_summary, mem_get_observation, mem_save_prompt
-
-Use ToolSearch for other tools: mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end, mem_stats, mem_delete, mem_timeline, mem_capture_passive
-
-### PROACTIVE SAVE — do NOT wait for user to ask
-Call `mem_save` IMMEDIATELY after ANY of these:
-- Decision made (architecture, convention, workflow, tool choice)
-- Bug fixed (include root cause)
-- Convention or workflow documented/updated
-- Notion/Jira/GitHub artifact created or updated with significant content
-- Non-obvious discovery, gotcha, or edge case found
-- Pattern established (naming, structure, approach)
-- User preference or constraint learned
-- Feature implemented with non-obvious approach
-- User confirms your recommendation ("dale", "go with that", "sounds good", "sí, esa")
-- User rejects an approach or expresses a preference ("no, better X", "I prefer X", "siempre hacé X")
-- Discussion concludes with a clear direction chosen
-
-**Self-check after EVERY task**: "Did I or the user just make a decision, confirm a recommendation, express a preference, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
-
-### SEARCH MEMORY when:
-- User asks to recall anything ("remember", "what did we do", "acordate", "qué hicimos")
-- Starting work on something that might have been done before
-- User mentions a topic you have no context on
-- User's FIRST message references the project, a feature, or a problem — call `mem_search` with keywords from their message to check for prior work before responding
-
-### SESSION CLOSE — before saying "done"/"listo":
-Call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+Full protocol (when/what to save, search rules, session close) lives in the
+`engram:memory` skill — load it on demand when you need the rules.
 PROTOCOL
 
-# Inject memory context if available
 if [ -n "$CONTEXT" ]; then
-  printf "\n%s\n" "$CONTEXT"
+  printf '\n%s\n' "$CONTEXT"
 fi
 
 exit 0


### PR DESCRIPTION
Addresses #163 (partial — this PR captures the shell-only win; full fix lands with #162).

## Motivation

Every time a user starts a new Claude Code session (or a session is recovered from compaction), the engram plugin's `SessionStart` hook in [`plugin/claude-code/scripts/session-start.sh`](../blob/main/plugin/claude-code/scripts/session-start.sh) injects the contents of `stdout` into the agent's context window as `additionalContext`. On a busy project I benchmarked against (200+ observations across several months of work), that injection was **~9.8 KB** — roughly **2,500 tokens burned on every single session start**, before the user has typed a single word.

That's a meaningful ongoing cost:
- Claude Code users open many sessions per day (one per VSCode window, one per `claude` invocation, one per `/clear`, etc.). On my machine I routinely have 5–7 concurrent runtimes alive.
- The injected content is 80%+ redundant — either a verbatim copy of the `engram:memory` skill (which already auto-loads on demand) or inline 300-char previews of observations the agent rarely needs the body of at session start (titles alone are enough to jog memory).
- Token budgets matter more than ever now that agent memory systems are stacking on top of each other. Engram competing with its own hook for context window space is a bad look.

Breakdown of the original 9.8 KB:

1. **~1.8 KB** is a hardcoded `## Engram Persistent Memory — ACTIVE PROTOCOL` heredoc that exhaustively re-teaches the save/search/close protocol on every session. That protocol is **already shipped in `skills/memory/SKILL.md`** in this same plugin, and the skill auto-loads on demand via Claude Code's skill system. Teaching it eagerly + teaching it lazily via skill is pure duplication.
2. **~8 KB** is the rendered `/context` payload. The server-side `FormatContext` in [`internal/store/store.go`](../blob/main/internal/store/store.go) inlines up to 300 characters of **raw, unflattened** `obs.Content` into each observation bullet. Since `obs.Content` is often multi-line markdown (session summaries are whole documents), a single observation can easily spill across 5+ lines in the output. Combined with the default `MaxContextResults=20`, a busy project's `/context` response routinely hits 8 KB.

The motivating question: how do we cut this without losing anything the agent actually uses?

## Design

This PR does the minimum viable fix — **shell-only, single file**. A follow-up PR (stacked, coming next) does the cleaner server-side version; this PR lets users who can't easily upgrade their engram binary capture most of the win via a plugin update alone.

### Change 1: Shrink the `PROTOCOL` heredoc (35 lines → 9 lines)

The new heredoc keeps:
- One line announcing that engram memory is active
- The full list of core + admin tool names (so the agent can reference them without a ToolSearch round-trip)
- A pointer to the `engram:memory` skill for the full protocol

It drops the 30-line "PROACTIVE SAVE / SEARCH MEMORY / SESSION CLOSE" block, because that block is the exact content of `skills/memory/SKILL.md`. The skill system will pull it when the agent needs it.

### Change 2: Compact the `/context` response via `awk`

Since this PR doesn't touch the server, we post-process the server response in the hook. The awk pass:

1. **Concatenates each observation's continuation lines** into a single logical line. The server's raw output has multi-line observation bodies; we flatten them.
2. **Collapses whitespace** (`gsub(/[[:space:]]+/, " ", buf)`).
3. **Caps per-bullet length** at `$CTX_MAXLEN` chars (default 140) with a `…` ellipsis.
4. **Caps bullet count** at `$CTX_LIMIT` (default 8).
5. Passes headers, the sessions section, and the prompts section through unchanged.

Both caps are env-overridable (`ENGRAM_CONTEXT_LIMIT`, `ENGRAM_CONTEXT_MAXLEN`) so anyone who wants the old verbose behavior back can get it without editing the hook.

### Byte-compatibility & risk

- **Zero Go changes.** The engram binary is untouched. Users upgrading the plugin without upgrading their binary lose nothing.
- **Server contract unchanged.** `/context` still takes `project` and `scope`; response shape is the same `{context: string}`.
- **awk portability.** The script uses only POSIX awk features (`function`, `gsub`, `substr`, `[[:space:]]` class). Verified on gawk; should work on mawk and BSD awk.
- **Rollback is `git revert`.** Nothing to migrate, nothing to un-migrate.
- **UTF-8 nit.** `substr()` truncates at byte count, not rune count, so a bullet cut at byte 140 could emit a half-encoded multi-byte character before `…`. In practice observation bodies are overwhelmingly ASCII, and the downstream consumer is an LLM which tolerates malformed UTF-8. Not fixing inline; happy to if a reviewer cares.

## Measurement

Benchmarked on a real project with 200+ observations:

| | Before | After | Δ |
|---|---:|---:|---:|
| `/context` payload (rendered) | 7961 B | 1487 B | **−81%** |
| `PROTOCOL` heredoc | ~1800 B | ~450 B | **−75%** |
| **Total hook stdout** (`additionalContext`) | **~9800 B** | **~1900 B** | **−80%** |

Token savings scale with observation volume; empty/small projects see less dramatic numbers because the observations section is already short.

## Test plan

- [x] End-to-end smoke: `echo '{"session_id":"t","cwd":"/tmp"}' | bash plugin/claude-code/scripts/session-start.sh` produces well-formed output, correct byte count
- [x] awk pass handles multi-line observation bodies (session summaries with embedded markdown headers/lists) — verified against a real `/context` payload
- [x] Empty project still produces a minimal well-formed injection (just the PROTOCOL pointer)
- [x] `ENGRAM_CONTEXT_LIMIT=0` returns no observations; `ENGRAM_CONTEXT_MAXLEN=9999` returns full bullets — both behave as expected
- [ ] Reviewer to sanity-check on a fresh project

## Follow-up

I have a stacked PR ready that adds `limit=N` and `compact=1` query parameters to `GET /context` in the Go server, with a byte-compatible `FormatContext` wrapper that keeps all existing callers unchanged. That brings the end-to-end hook injection down from ~1.9 KB (this PR) to ~1.1 KB (this PR + the follow-up) and removes the need for the awk pass on matched-version deployments. I'll open it against this branch as soon as this lands — or against `main` directly if you'd prefer to review them independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
