### PR TITLE
ci: pin workflows to go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.24"
 
       - name: Run unit tests
         run: go test ./...
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.24"
 
       - name: Run e2e tests
         run: go test -tags e2e ./internal/server/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.24"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Summary
- replace non-existent Go 1.25 with Go 1.24 in CI workflow
- replace non-existent Go 1.25 with Go 1.24 in release workflow

## Rationale
Go 1.25 is not available on setup-go, causing workflow failures.

## Validation
- workflow YAML updated in .github/workflows/ci.yml and .github/workflows/release.yml