### PR TITLE
feat(mcp): save reminder on inactivity + session activity score

### DIFF
--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -1,0 +1,127 @@
+package mcp
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// SessionActivity tracks tool call activity for save reminders and activity scores.
+type SessionActivity struct {
+	mu         sync.Mutex
+	sessions   map[string]*sessionState
+	nudgeAfter time.Duration
+	now        func() time.Time // injectable for testing
+}
+
+type sessionState struct {
+	lastSaveAt    time.Time
+	toolCallCount int
+	saveCount     int
+	startedAt     time.Time
+}
+
+// NewSessionActivity creates a new activity tracker with the given nudge threshold.
+func NewSessionActivity(nudgeAfter time.Duration) *SessionActivity {
+	return &SessionActivity{
+		sessions:   make(map[string]*sessionState),
+		nudgeAfter: nudgeAfter,
+		now:        time.Now,
+	}
+}
+
+func (a *SessionActivity) getOrCreate(sessionID string) *sessionState {
+	s, ok := a.sessions[sessionID]
+	if !ok {
+		s = &sessionState{startedAt: a.now()}
+		a.sessions[sessionID] = s
+	}
+	return s
+}
+
+// RecordToolCall increments the tool call counter for a session.
+func (a *SessionActivity) RecordToolCall(sessionID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s := a.getOrCreate(sessionID)
+	s.toolCallCount++
+}
+
+// ClearSession removes the session entry, freeing memory.
+func (a *SessionActivity) ClearSession(sessionID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.sessions, sessionID)
+}
+
+// RecordSave increments the save counter and updates lastSaveAt.
+func (a *SessionActivity) RecordSave(sessionID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s := a.getOrCreate(sessionID)
+	s.saveCount++
+	s.lastSaveAt = a.now()
+}
+
+// NudgeIfNeeded returns a reminder string if too much time has passed since
+// the last save in this session. Returns empty string if no nudge needed.
+func (a *SessionActivity) NudgeIfNeeded(sessionID string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	s, ok := a.sessions[sessionID]
+	if !ok {
+		return ""
+	}
+
+	now := a.now()
+
+	// Don't nudge if session is too young
+	if now.Sub(s.startedAt) < a.nudgeAfter {
+		return ""
+	}
+
+	// Don't nudge idle/new sessions (no saves and few tool calls)
+	if s.saveCount == 0 && s.toolCallCount <= 5 {
+		return ""
+	}
+
+	// Check time since last save (or session start if no saves yet)
+	ref := s.lastSaveAt
+	if ref.IsZero() {
+		ref = s.startedAt
+	}
+
+	elapsed := now.Sub(ref)
+	if elapsed < a.nudgeAfter {
+		return ""
+	}
+
+	minutes := int(elapsed.Minutes())
+	return fmt.Sprintf("\n\n⚠️ No mem_save calls for this project in %d minutes. Did you make any decisions, fix bugs, or discover something worth persisting?", minutes)
+}
+
+// ActivityScore returns a formatted activity score string for the session.
+func (a *SessionActivity) ActivityScore(sessionID string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	s, ok := a.sessions[sessionID]
+	if !ok {
+		return ""
+	}
+
+	callLabel := "tool calls"
+	if s.toolCallCount == 1 {
+		callLabel = "tool call"
+	}
+	saveLabel := "saves"
+	if s.saveCount == 1 {
+		saveLabel = "save"
+	}
+	score := fmt.Sprintf("Session activity: %d %s, %d %s", s.toolCallCount, callLabel, s.saveCount, saveLabel)
+	if s.saveCount == 0 && s.toolCallCount > 5 {
+		score += " — high activity with no saves, consider persisting important decisions"
+	}
+	return score
+}

--- a/internal/mcp/activity_test.go
+++ b/internal/mcp/activity_test.go
@@ -1,0 +1,228 @@
+package mcp
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSessionActivity_RecordAndNudge(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	a := NewSessionActivity(10 * time.Minute)
+	a.now = func() time.Time { return now }
+
+	sid := "test-session"
+
+	// Record some tool calls
+	for i := 0; i < 6; i++ {
+		a.RecordToolCall(sid)
+	}
+
+	// Session just started, no nudge expected even with > 5 tool calls
+	nudge := a.NudgeIfNeeded(sid)
+	if nudge != "" {
+		t.Fatalf("expected no nudge for new session, got: %q", nudge)
+	}
+
+	// Advance time past threshold
+	now = now.Add(15 * time.Minute)
+
+	nudge = a.NudgeIfNeeded(sid)
+	if nudge == "" {
+		t.Fatal("expected nudge after threshold passed")
+	}
+	if !strings.Contains(nudge, "15 minutes") {
+		t.Fatalf("expected nudge to mention 15 minutes, got: %q", nudge)
+	}
+	if !strings.Contains(nudge, "No mem_save calls for this project") {
+		t.Fatalf("expected nudge text about mem_save, got: %q", nudge)
+	}
+}
+
+func TestSessionActivity_RecordSave_ResetsNudge(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	a := NewSessionActivity(10 * time.Minute)
+	a.now = func() time.Time { return now }
+
+	sid := "test-session"
+
+	// Record tool calls and advance past threshold
+	for i := 0; i < 6; i++ {
+		a.RecordToolCall(sid)
+	}
+	now = now.Add(15 * time.Minute)
+
+	// Verify nudge fires
+	nudge := a.NudgeIfNeeded(sid)
+	if nudge == "" {
+		t.Fatal("expected nudge before save")
+	}
+
+	// Now save, which should reset the timer
+	a.RecordSave(sid)
+
+	// Nudge should be gone since save just happened
+	nudge = a.NudgeIfNeeded(sid)
+	if nudge != "" {
+		t.Fatalf("expected no nudge right after save, got: %q", nudge)
+	}
+
+	// Advance time again past threshold
+	now = now.Add(12 * time.Minute)
+	nudge = a.NudgeIfNeeded(sid)
+	if nudge == "" {
+		t.Fatal("expected nudge again after threshold passed since last save")
+	}
+	if !strings.Contains(nudge, "12 minutes") {
+		t.Fatalf("expected 12 minutes in nudge, got: %q", nudge)
+	}
+}
+
+func TestSessionActivity_ActivityScore(t *testing.T) {
+	a := NewSessionActivity(10 * time.Minute)
+	sid := "test-session"
+
+	// No session yet
+	score := a.ActivityScore(sid)
+	if score != "" {
+		t.Fatalf("expected empty score for unknown session, got: %q", score)
+	}
+
+	// Record some activity
+	for i := 0; i < 8; i++ {
+		a.RecordToolCall(sid)
+	}
+
+	score = a.ActivityScore(sid)
+	if !strings.Contains(score, "8 tool calls") {
+		t.Fatalf("expected 8 tool calls in score, got: %q", score)
+	}
+	if !strings.Contains(score, "0 saves") {
+		t.Fatalf("expected 0 saves in score, got: %q", score)
+	}
+	if !strings.Contains(score, "high activity with no saves") {
+		t.Fatalf("expected high activity warning, got: %q", score)
+	}
+
+	// After a save, warning should disappear
+	a.RecordSave(sid)
+	score = a.ActivityScore(sid)
+	if !strings.Contains(score, "1 save") {
+		t.Fatalf("expected '1 save' in score, got: %q", score)
+	}
+	if strings.Contains(score, "1 saves") {
+		t.Fatalf("expected singular 'save' not 'saves', got: %q", score)
+	}
+	if strings.Contains(score, "high activity") {
+		t.Fatalf("expected no high activity warning after save, got: %q", score)
+	}
+}
+
+func TestSessionActivity_NoNudgeForIdleSessions(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	a := NewSessionActivity(10 * time.Minute)
+	a.now = func() time.Time { return now }
+
+	sid := "idle-session"
+
+	// Only 3 tool calls, no saves
+	for i := 0; i < 3; i++ {
+		a.RecordToolCall(sid)
+	}
+
+	// Advance past threshold
+	now = now.Add(20 * time.Minute)
+
+	// Should NOT nudge because toolCallCount <= 5 and saveCount == 0
+	nudge := a.NudgeIfNeeded(sid)
+	if nudge != "" {
+		t.Fatalf("expected no nudge for idle session with few tool calls, got: %q", nudge)
+	}
+}
+
+func TestSessionActivity_ClearSession(t *testing.T) {
+	a := NewSessionActivity(10 * time.Minute)
+	sid := "clear-test"
+
+	a.RecordToolCall(sid)
+	a.RecordSave(sid)
+
+	// Verify session exists
+	score := a.ActivityScore(sid)
+	if score == "" {
+		t.Fatal("expected activity score before clear")
+	}
+
+	// Clear and verify it's gone
+	a.ClearSession(sid)
+	score = a.ActivityScore(sid)
+	if score != "" {
+		t.Fatalf("expected empty score after clear, got: %q", score)
+	}
+
+	// Clearing a non-existent session should not panic
+	a.ClearSession("non-existent")
+}
+
+func TestSessionActivity_Pluralization(t *testing.T) {
+	a := NewSessionActivity(10 * time.Minute)
+	sid := "plural-test"
+
+	a.RecordToolCall(sid)
+	a.RecordSave(sid)
+
+	score := a.ActivityScore(sid)
+	if !strings.Contains(score, "1 tool call,") {
+		t.Fatalf("expected singular 'tool call', got: %q", score)
+	}
+	if !strings.Contains(score, "1 save") {
+		t.Fatalf("expected singular 'save', got: %q", score)
+	}
+
+	a.RecordToolCall(sid)
+	a.RecordSave(sid)
+
+	score = a.ActivityScore(sid)
+	if !strings.Contains(score, "2 tool calls,") {
+		t.Fatalf("expected plural 'tool calls', got: %q", score)
+	}
+	if !strings.Contains(score, "2 saves") {
+		t.Fatalf("expected plural 'saves', got: %q", score)
+	}
+}
+
+func TestSessionActivity_ConcurrentAccess(t *testing.T) {
+	a := NewSessionActivity(10 * time.Minute)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			a.RecordToolCall("concurrent-session")
+		}()
+		go func() {
+			defer wg.Done()
+			a.RecordSave("concurrent-session")
+		}()
+		go func() {
+			defer wg.Done()
+			_ = a.NudgeIfNeeded("concurrent-session")
+			_ = a.ActivityScore("concurrent-session")
+		}()
+	}
+	wg.Wait()
+
+	// Verify state is consistent
+	a.mu.Lock()
+	s := a.sessions["concurrent-session"]
+	a.mu.Unlock()
+
+	if s.toolCallCount != 100 {
+		t.Fatalf("expected 100 tool calls, got %d", s.toolCallCount)
+	}
+	if s.saveCount != 100 {
+		t.Fatalf("expected 100 saves, got %d", s.saveCount)
+	}
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	projectpkg "github.com/Gentleman-Programming/engram/internal/project"
 	"github.com/Gentleman-Programming/engram/internal/store"
@@ -146,6 +147,10 @@ func NewServerWithTools(s *store.Store, allowlist map[string]bool) *server.MCPSe
 // NewServerWithConfig creates an MCP server with full configuration including
 // default project detection and optional tool allowlist.
 func NewServerWithConfig(s *store.Store, cfg MCPConfig, allowlist map[string]bool) *server.MCPServer {
+	return newServerWithActivity(s, cfg, allowlist, NewSessionActivity(10*time.Minute))
+}
+
+func newServerWithActivity(s *store.Store, cfg MCPConfig, allowlist map[string]bool, activity *SessionActivity) *server.MCPServer {
 	srv := server.NewMCPServer(
 		"engram",
 		"0.1.0",
@@ -153,7 +158,7 @@ func NewServerWithConfig(s *store.Store, cfg MCPConfig, allowlist map[string]boo
 		server.WithInstructions(serverInstructions),
 	)
 
-	registerTools(srv, s, cfg, allowlist)
+	registerTools(srv, s, cfg, allowlist, activity)
 	return srv
 }
 
@@ -166,7 +171,7 @@ func shouldRegister(name string, allowlist map[string]bool) bool {
 	return allowlist[name]
 }
 
-func registerTools(srv *server.MCPServer, s *store.Store, cfg MCPConfig, allowlist map[string]bool) {
+func registerTools(srv *server.MCPServer, s *store.Store, cfg MCPConfig, allowlist map[string]bool, activity *SessionActivity) {
 	// ─── mem_search (profile: agent, core — always in context) ─────────
 	if shouldRegister("mem_search", allowlist) {
 		srv.AddTool(
@@ -194,7 +199,7 @@ func registerTools(srv *server.MCPServer, s *store.Store, cfg MCPConfig, allowli
 					mcp.Description("Max results (default: 10, max: 20)"),
 				),
 			),
-			handleSearch(s, cfg),
+			handleSearch(s, cfg, activity),
 		)
 	}
 
@@ -257,7 +262,7 @@ Examples:
 					mcp.Description("Optional topic identifier for upserts (e.g. architecture/auth-model). Reuses and updates the latest observation in same project+scope."),
 				),
 			),
-			handleSave(s, cfg),
+			handleSave(s, cfg, activity),
 		)
 	}
 
@@ -392,7 +397,7 @@ Examples:
 					mcp.Description("Number of observations to retrieve (default: 20)"),
 				),
 			),
-			handleContext(s, cfg),
+			handleContext(s, cfg, activity),
 		)
 	}
 
@@ -508,7 +513,7 @@ GUIDELINES:
 					mcp.Description("Project name"),
 				),
 			),
-			handleSessionSummary(s, cfg),
+			handleSessionSummary(s, cfg, activity),
 		)
 	}
 
@@ -535,7 +540,7 @@ GUIDELINES:
 					mcp.Description("Working directory"),
 				),
 			),
-			handleSessionStart(s, cfg),
+			handleSessionStart(s, cfg, activity),
 		)
 	}
 
@@ -557,8 +562,11 @@ GUIDELINES:
 				mcp.WithString("summary",
 					mcp.Description("Summary of what was accomplished"),
 				),
+				mcp.WithString("project",
+					mcp.Description("Project name (used to clear activity tracking)"),
+				),
 			),
-			handleSessionEnd(s),
+			handleSessionEnd(s, cfg, activity),
 		)
 	}
 
@@ -591,7 +599,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 					mcp.Description("Source identifier (e.g. 'subagent-stop', 'session-end')"),
 				),
 			),
-			handleCapturePassive(s, cfg),
+			handleCapturePassive(s, cfg, activity),
 		)
 	}
 
@@ -622,7 +630,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 
 // ─── Tool Handlers ───────────────────────────────────────────────────────────
 
-func handleSearch(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		query, _ := req.GetArguments()["query"].(string)
 		typ, _ := req.GetArguments()["type"].(string)
@@ -636,6 +644,9 @@ func handleSearch(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 		}
 		// Normalize project name
 		project, _ = store.NormalizeProject(project)
+
+		sessionID := defaultSessionID(project)
+		activity.RecordToolCall(sessionID)
 
 		results, err := s.Search(query, store.SearchOptions{
 			Type:    typ,
@@ -673,11 +684,15 @@ func handleSearch(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 			fmt.Fprintf(&b, "---\nResults above are previews (300 chars). To read the full content of a specific memory, call mem_get_observation(id: <ID>).\n")
 		}
 
+		if nudge := activity.NudgeIfNeeded(sessionID); nudge != "" {
+			b.WriteString(nudge)
+		}
+
 		return mcp.NewToolResultText(b.String()), nil
 	}
 }
 
-func handleSave(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		title, _ := req.GetArguments()["title"].(string)
 		content, _ := req.GetArguments()["content"].(string)
@@ -742,6 +757,8 @@ func handleSave(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError("Failed to save: " + err.Error()), nil
 		}
+
+		activity.RecordSave(defaultSessionID(project))
 
 		msg := fmt.Sprintf("Memory saved: %q (%s)", title, typ)
 		if topicKey == "" && suggestedTopicKey != "" {
@@ -880,7 +897,7 @@ func handleSavePrompt(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	}
 }
 
-func handleContext(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+func handleContext(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		project, _ := req.GetArguments()["project"].(string)
 		scope, _ := req.GetArguments()["scope"].(string)
@@ -890,6 +907,9 @@ func handleContext(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 			project = cfg.DefaultProject
 		}
 		project, _ = store.NormalizeProject(project)
+
+		sessionID := defaultSessionID(project)
+		activity.RecordToolCall(sessionID)
 
 		context, err := s.FormatContext(project, scope)
 		if err != nil {
@@ -910,6 +930,10 @@ func handleContext(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 
 		result := fmt.Sprintf("%s\n---\nMemory stats: %d sessions, %d observations across projects: %s",
 			context, stats.TotalSessions, stats.TotalObservations, projects)
+
+		if nudge := activity.NudgeIfNeeded(sessionID); nudge != "" {
+			result += nudge
+		}
 
 		return mcp.NewToolResultText(result), nil
 	}
@@ -1027,7 +1051,7 @@ func handleGetObservation(s *store.Store) server.ToolHandlerFunc {
 	}
 }
 
-func handleSessionSummary(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		content, _ := req.GetArguments()["content"].(string)
 		sessionID, _ := req.GetArguments()["session_id"].(string)
@@ -1057,11 +1081,15 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc 
 			return mcp.NewToolResultError("Failed to save session summary: " + err.Error()), nil
 		}
 
-		return mcp.NewToolResultText(fmt.Sprintf("Session summary saved for project %q", project)), nil
+		msg := fmt.Sprintf("Session summary saved for project %q", project)
+		if score := activity.ActivityScore(defaultSessionID(project)); score != "" {
+			msg += "\n" + score
+		}
+		return mcp.NewToolResultText(msg), nil
 	}
 }
 
-func handleSessionStart(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+func handleSessionStart(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, _ := req.GetArguments()["id"].(string)
 		project, _ := req.GetArguments()["project"].(string)
@@ -1073,6 +1101,8 @@ func handleSessionStart(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 		}
 		project, _ = store.NormalizeProject(project)
 
+		activity.RecordToolCall(defaultSessionID(project))
+
 		if err := s.CreateSession(id, project, directory); err != nil {
 			return mcp.NewToolResultError("Failed to start session: " + err.Error()), nil
 		}
@@ -1081,7 +1111,7 @@ func handleSessionStart(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	}
 }
 
-func handleSessionEnd(s *store.Store) server.ToolHandlerFunc {
+func handleSessionEnd(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, _ := req.GetArguments()["id"].(string)
 		summary, _ := req.GetArguments()["summary"].(string)
@@ -1090,11 +1120,19 @@ func handleSessionEnd(s *store.Store) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("Failed to end session: " + err.Error()), nil
 		}
 
+		// Determine the project for this session to clean up activity tracking
+		project := cfg.DefaultProject
+		if p, _ := req.GetArguments()["project"].(string); p != "" {
+			project = p
+		}
+		project, _ = store.NormalizeProject(project)
+		activity.ClearSession(defaultSessionID(project))
+
 		return mcp.NewToolResultText(fmt.Sprintf("Session %q completed", id)), nil
 	}
 }
 
-func handleCapturePassive(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		content, _ := req.GetArguments()["content"].(string)
 		sessionID, _ := req.GetArguments()["session_id"].(string)
@@ -1106,6 +1144,8 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc 
 			project = cfg.DefaultProject
 		}
 		project, _ = store.NormalizeProject(project)
+
+		activity.RecordToolCall(defaultSessionID(project))
 
 		if content == "" {
 			return mcp.NewToolResultError("content is required — include text with a '## Key Learnings:' section"), nil

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Gentleman-Programming/engram/internal/store"
 	mcppkg "github.com/mark3labs/mcp-go/mcp"
@@ -84,7 +85,7 @@ func TestHandleSuggestTopicKeyRequiresInput(t *testing.T) {
 
 func TestHandleSaveSuggestsTopicKeyWhenMissing(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSave(s, MCPConfig{})
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"title":   "Auth architecture",
@@ -109,7 +110,7 @@ func TestHandleSaveSuggestsTopicKeyWhenMissing(t *testing.T) {
 
 func TestHandleSaveDoesNotSuggestWhenTopicKeyProvided(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSave(s, MCPConfig{})
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"title":     "Auth architecture",
@@ -135,7 +136,7 @@ func TestHandleSaveDoesNotSuggestWhenTopicKeyProvided(t *testing.T) {
 
 func TestHandleCapturePassiveExtractsAndSaves(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleCapturePassive(s, MCPConfig{})
+	h := handleCapturePassive(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"content": "## Key Learnings:\n\n1. bcrypt cost=12 is the right balance for our server\n2. JWT refresh tokens need atomic rotation to prevent races\n",
@@ -161,7 +162,7 @@ func TestHandleCapturePassiveExtractsAndSaves(t *testing.T) {
 
 func TestHandleCapturePassiveRequiresContent(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleCapturePassive(s, MCPConfig{})
+	h := handleCapturePassive(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"project": "engram",
@@ -178,7 +179,7 @@ func TestHandleCapturePassiveRequiresContent(t *testing.T) {
 
 func TestHandleCapturePassiveWithNoLearningSection(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleCapturePassive(s, MCPConfig{})
+	h := handleCapturePassive(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"content": "plain text without learning headers",
@@ -201,7 +202,7 @@ func TestHandleCapturePassiveWithNoLearningSection(t *testing.T) {
 
 func TestHandleCapturePassiveDefaultsSourceAndSession(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleCapturePassive(s, MCPConfig{})
+	h := handleCapturePassive(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"content": "## Key Learnings:\n\n1. This learning is long enough to be persisted with default source",
@@ -230,7 +231,7 @@ func TestHandleCapturePassiveDefaultsSourceAndSession(t *testing.T) {
 
 func TestHandleCapturePassiveReturnsToolErrorOnStoreFailure(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleCapturePassive(s, MCPConfig{})
+	h := handleCapturePassive(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	// Force FK failure: explicit session_id that does not exist.
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -303,7 +304,7 @@ func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 		t.Fatalf("add observation: %v", err)
 	}
 
-	search := handleSearch(s, MCPConfig{})
+	search := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	searchReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"query":   "panic",
 		"project": "engram",
@@ -393,7 +394,7 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 		t.Fatalf("unexpected save prompt error: %s", callResultText(t, savePromptRes))
 	}
 
-	contextHandler := handleContext(s, MCPConfig{})
+	contextHandler := handleContext(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	contextReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"project": "engram",
 		"scope":   "project",
@@ -437,7 +438,7 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 		t.Fatalf("unexpected timeline error: %s", callResultText(t, timelineRes))
 	}
 
-	sessionSummary := handleSessionSummary(s, MCPConfig{})
+	sessionSummary := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	summaryReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"project": "engram",
 		"content": "## Goal\nImprove tests",
@@ -450,7 +451,7 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 		t.Fatalf("unexpected session summary error: %s", callResultText(t, summaryRes))
 	}
 
-	sessionStart := handleSessionStart(s, MCPConfig{})
+	sessionStart := handleSessionStart(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	startReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"id":        "s-new",
 		"project":   "engram",
@@ -464,7 +465,7 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 		t.Fatalf("unexpected session start error: %s", callResultText(t, startRes))
 	}
 
-	sessionEnd := handleSessionEnd(s)
+	sessionEnd := handleSessionEnd(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	endReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"id":      "s-new",
 		"summary": "done",
@@ -481,7 +482,7 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 func TestMCPHandlersErrorBranches(t *testing.T) {
 	s := newMCPTestStore(t)
 
-	search := handleSearch(s, MCPConfig{})
+	search := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	noResultsReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"query": "definitely-no-hit"}}}
 	noResultsRes, err := search(context.Background(), noResultsReq)
 	if err != nil {
@@ -570,7 +571,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("close store: %v", err)
 	}
 
-	searchRes, err := handleSearch(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"query": "title"}}})
+	searchRes, err := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"query": "title"}}})
 	if err != nil {
 		t.Fatalf("closed store search call: %v", err)
 	}
@@ -602,7 +603,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("expected save prompt to return tool error when store is closed")
 	}
 
-	contextRes, err := handleContext(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{})
+	contextRes, err := handleContext(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("closed store context call: %v", err)
 	}
@@ -634,7 +635,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("expected get observation to return tool error when store is closed")
 	}
 
-	sessionSummaryRes, err := handleSessionSummary(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "engram", "content": "summary"}}})
+	sessionSummaryRes, err := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "engram", "content": "summary"}}})
 	if err != nil {
 		t.Fatalf("closed store session summary call: %v", err)
 	}
@@ -642,7 +643,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("expected session summary to return tool error when store is closed")
 	}
 
-	sessionStartRes, err := handleSessionStart(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": "s1", "project": "engram"}}})
+	sessionStartRes, err := handleSessionStart(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": "s1", "project": "engram"}}})
 	if err != nil {
 		t.Fatalf("closed store session start call: %v", err)
 	}
@@ -650,7 +651,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("expected session start to return tool error when store is closed")
 	}
 
-	sessionEndRes, err := handleSessionEnd(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": "s1"}}})
+	sessionEndRes, err := handleSessionEnd(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": "s1"}}})
 	if err != nil {
 		t.Fatalf("closed store session end call: %v", err)
 	}
@@ -662,7 +663,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 func TestMCPAdditionalCoverageBranches(t *testing.T) {
 	s := newMCPTestStore(t)
 
-	contextRes, err := handleContext(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{})
+	contextRes, err := handleContext(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("context empty store: %v", err)
 	}
@@ -709,7 +710,7 @@ func TestMCPAdditionalCoverageBranches(t *testing.T) {
 		t.Fatalf("expected timeline session/after sections, got %q", text)
 	}
 
-	save := handleSave(s, MCPConfig{})
+	save := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	saveReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"title":   "Default values",
 		"content": "Ensure defaults for type and session are used",
@@ -798,7 +799,7 @@ func TestHandleContextWithSessionOnlyUsesNoneProjects(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 
-	res, err := handleContext(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+	res, err := handleContext(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"project": "engram",
 	}}})
 	if err != nil {
@@ -1350,7 +1351,7 @@ func TestDefaultSessionIDScopedByProject(t *testing.T) {
 
 func TestHandleSaveCreatesProjectScopedSession(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSave(s, MCPConfig{})
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	// Save from project A without session_id
 	reqA := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -1427,7 +1428,7 @@ func TestHandleSavePromptCreatesProjectScopedSession(t *testing.T) {
 
 func TestHandleSessionSummaryCreatesProjectScopedSession(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSessionSummary(s, MCPConfig{})
+	h := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"content": "Worked on auth module",
@@ -1445,7 +1446,7 @@ func TestHandleSessionSummaryCreatesProjectScopedSession(t *testing.T) {
 
 func TestHandleCapturePassiveCreatesProjectScopedSession(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleCapturePassive(s, MCPConfig{})
+	h := handleCapturePassive(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"content": "## Key Learnings:\nAuth needs rate limiting",
@@ -1463,7 +1464,7 @@ func TestHandleCapturePassiveCreatesProjectScopedSession(t *testing.T) {
 
 func TestExplicitSessionIDBypassesDefault(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSave(s, MCPConfig{})
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	// Provide explicit session_id — should NOT use defaultSessionID
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -1526,7 +1527,7 @@ func TestNewServerWithConfig(t *testing.T) {
 func TestHandleSaveDefaultProjectFillIn(t *testing.T) {
 	s := newMCPTestStore(t)
 	cfg := MCPConfig{DefaultProject: "myproject"}
-	h := handleSave(s, cfg)
+	h := handleSave(s, cfg, NewSessionActivity(10*time.Minute))
 
 	// Send empty project — should use default
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -1558,7 +1559,7 @@ func TestHandleSaveDefaultProjectFillIn(t *testing.T) {
 
 func TestHandleSaveNormalizationWarning(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSave(s, MCPConfig{})
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	// Send mixed-case project name — should be normalized and warning returned
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -1592,7 +1593,7 @@ func TestHandleSaveNormalizationWarning(t *testing.T) {
 
 func TestHandleSaveSimilarProjectWarning(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSave(s, MCPConfig{})
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	// First save to "engram" to establish an existing project
 	req1 := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -1637,7 +1638,7 @@ func TestHandleSaveSimilarProjectWarning(t *testing.T) {
 
 func TestHandleSaveNoSimilarWarningWhenProjectExists(t *testing.T) {
 	s := newMCPTestStore(t)
-	h := handleSave(s, MCPConfig{})
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
 	// Save twice to the same project — second save should NOT show similar project warning
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -1801,7 +1802,7 @@ func TestHandleMergeProjectsIsDeferred(t *testing.T) {
 func TestHandleSaveDefaultProjectDoesNotOverrideExplicit(t *testing.T) {
 	s := newMCPTestStore(t)
 	cfg := MCPConfig{DefaultProject: "default-project"}
-	h := handleSave(s, cfg)
+	h := handleSave(s, cfg, NewSessionActivity(10*time.Minute))
 
 	// Explicit project should override default
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -1825,5 +1826,184 @@ func TestHandleSaveDefaultProjectDoesNotOverrideExplicit(t *testing.T) {
 	}
 	if len(defaultObs) > 0 {
 		t.Fatal("observation should NOT be in default-project")
+	}
+}
+
+func TestSearchResponseIncludesNudgeAfterInactivity(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	// Seed a memory to search for
+	s.CreateSession("s1", "myproject", "")
+	s.AddObservation(store.AddObservationParams{
+		SessionID: "s1",
+		Type:      "manual",
+		Title:     "test memory",
+		Content:   "some content",
+		Project:   "myproject",
+	})
+
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	activity := NewSessionActivity(10 * time.Minute)
+	activity.now = func() time.Time { return now }
+
+	sessionID := defaultSessionID("myproject")
+
+	// Simulate prior activity: > 5 tool calls so nudge criteria is met
+	for i := 0; i < 6; i++ {
+		activity.RecordToolCall(sessionID)
+	}
+
+	// Advance time past nudge threshold
+	now = now.Add(15 * time.Minute)
+
+	search := handleSearch(s, MCPConfig{}, activity)
+	res, err := search(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"query":   "test memory",
+			"project": "myproject",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	text := callResultText(t, res)
+	if !strings.Contains(text, "No mem_save calls for this project") {
+		t.Fatalf("expected nudge in search response, got: %q", text)
+	}
+}
+
+func TestSessionSummaryResponseIncludesActivityScore(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	activity := NewSessionActivity(10 * time.Minute)
+	activity.now = func() time.Time { return now }
+
+	// Use defaultSessionID so we test the real wiring — session summary
+	// looks up activity via defaultSessionID(project), not an explicit session_id.
+	project := "myproject"
+	sessionID := defaultSessionID(project)
+
+	// Simulate activity
+	for i := 0; i < 12; i++ {
+		activity.RecordToolCall(sessionID)
+	}
+	activity.RecordSave(sessionID)
+	activity.RecordSave(sessionID)
+
+	summary := handleSessionSummary(s, MCPConfig{}, activity)
+	res, err := summary(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"project": project,
+			"content": "## Goal\nTest session",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	text := callResultText(t, res)
+	if !strings.Contains(text, "Session activity:") {
+		t.Fatalf("expected activity score in session summary response, got: %q", text)
+	}
+	if !strings.Contains(text, "12 tool calls") {
+		t.Fatalf("expected 12 tool calls in score, got: %q", text)
+	}
+	if !strings.Contains(text, "2 saves") {
+		t.Fatalf("expected 2 saves in score, got: %q", text)
+	}
+}
+
+func TestSessionEndClearsActivity(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	activity := NewSessionActivity(10 * time.Minute)
+	project := "myproject"
+	sessionID := defaultSessionID(project)
+
+	// Record some activity
+	activity.RecordToolCall(sessionID)
+	activity.RecordSave(sessionID)
+
+	// Verify activity exists
+	score := activity.ActivityScore(sessionID)
+	if score == "" {
+		t.Fatal("expected activity score before session end")
+	}
+
+	// Create session in store so EndSession works
+	s.CreateSession("real-session-id", project, "")
+
+	end := handleSessionEnd(s, MCPConfig{DefaultProject: project}, activity)
+	_, err := end(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"id": "real-session-id",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// Activity should be cleared
+	score = activity.ActivityScore(sessionID)
+	if score != "" {
+		t.Fatalf("expected empty activity after session end, got: %q", score)
+	}
+}
+
+func TestCapturePassiveRecordsToolCall(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	activity := NewSessionActivity(10 * time.Minute)
+	project := "myproject"
+	sessionID := defaultSessionID(project)
+
+	capture := handleCapturePassive(s, MCPConfig{DefaultProject: project}, activity)
+	_, err := capture(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"content": "## Key Learnings:\n1. Test learning",
+			"project": project,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// Verify tool call was recorded
+	score := activity.ActivityScore(sessionID)
+	if !strings.Contains(score, "1 tool call") {
+		t.Fatalf("expected 1 tool call recorded for capture passive, got: %q", score)
+	}
+}
+
+func TestSessionStartUsesDefaultSessionID(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	activity := NewSessionActivity(10 * time.Minute)
+	project := "myproject"
+
+	start := handleSessionStart(s, MCPConfig{}, activity)
+	_, err := start(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"id":      "real-unique-session-id",
+			"project": project,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// Activity should be recorded under defaultSessionID, not the real session ID
+	defaultSID := defaultSessionID(project)
+	score := activity.ActivityScore(defaultSID)
+	if !strings.Contains(score, "1 tool call") {
+		t.Fatalf("expected activity under defaultSessionID, got: %q", score)
+	}
+
+	// The real session ID should NOT have activity
+	realScore := activity.ActivityScore("real-unique-session-id")
+	if realScore != "" {
+		t.Fatalf("expected no activity under real session ID, got: %q", realScore)
 	}
 }


### PR DESCRIPTION
## Summary

- When no `mem_save` has been called for 10+ minutes in a session, a nudge is appended to `mem_search` and `mem_context` responses
- On `mem_session_summary`, an activity score (tool calls vs saves) is appended so agents can identify sessions with potential context loss
- Per-project tracking via `SessionActivity` (mutex-protected, cleaned up on session end)

## Why

AI agents have instructions to save memories proactively, but saving is an opt-in action that competes with the main task flow. When the agent is in an intense execution loop, it forgets to call `mem_save`. The server now nudges the agent instead of relying on the agent to remember.

## Implementation

- `internal/mcp/activity.go` — `SessionActivity` tracker with `RecordToolCall`, `RecordSave`, `NudgeIfNeeded`, `ActivityScore`, `ClearSession`
- Unified session ID resolution via `defaultSessionID(project)` across all handlers
- Wired into `handleSearch`, `handleContext`, `handleSave`, `handleSessionStart`, `handleSessionEnd`, `handleSessionSummary`, `handleCapturePassive`
- Injectable `now` function for deterministic testing
- ~30 tokens per nudge, zero extra tokens for activity score (piggybacks on existing responses)

## Test plan

- [x] Unit tests: nudge timing, save resets timer, activity score formatting, pluralization, clear session, idle suppression, concurrent access (7 tests)
- [x] Integration tests: nudge in search output, score in summary output, clear on session end, passive capture tracking, session start ID mapping (5 tests)
- [x] Race detection: `go test -race` passes
- [x] Full suite: `go test ./...` — 10/10 packages pass
- [x] Judgment Day: 2 rounds, both judges pass clean

Closes #177