### PR TITLE
feat(store): add configurable timezone support via ENGRAM_TIMEZONE env var

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -122,6 +122,7 @@ All endpoints return JSON. Server listens on `127.0.0.1:7437`.
 | `ENGRAM_DATA_DIR` | Override data directory | `~/.engram` |
 | `ENGRAM_PORT` | Override HTTP server port | `7437` |
 | `ENGRAM_PROJECT` | Override project name for MCP server | auto-detected via git |
+| `ENGRAM_TIMEZONE` | Display timestamps in specified timezone (IANA format, e.g. `America/Bogota`, `Europe/London`) | UTC |
 
 ---
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1735,7 +1735,7 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 				summary = fmt.Sprintf(": %s", truncate(*sess.Summary, 200))
 			}
 			fmt.Fprintf(&b, "- **%s** (%s)%s [%d observations]\n",
-				sess.Project, sess.StartedAt, summary, sess.ObservationCount)
+				sess.Project, formatTimestamp(sess.StartedAt), summary, sess.ObservationCount)
 		}
 		b.WriteString("\n")
 	}
@@ -1743,7 +1743,7 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 	if len(prompts) > 0 {
 		b.WriteString("### Recent User Prompts\n")
 		for _, p := range prompts {
-			fmt.Fprintf(&b, "- %s: %s\n", p.CreatedAt, truncate(p.Content, 200))
+			fmt.Fprintf(&b, "- %s: %s\n", formatTimestamp(p.CreatedAt), truncate(p.Content, 200))
 		}
 		b.WriteString("\n")
 	}
@@ -3649,4 +3649,25 @@ func ClassifyTool(toolName string) string {
 // Now returns the current time formatted for SQLite.
 func Now() string {
 	return time.Now().UTC().Format("2006-01-02 15:04:05")
+}
+
+// formatTimestamp converts a UTC RFC3339 timestamp to the user's configured timezone.
+// If ENGRAM_TIMEZONE is not set or invalid, returns the original timestamp unchanged.
+func formatTimestamp(utcTimestamp string) string {
+	tz := os.Getenv("ENGRAM_TIMEZONE")
+	if tz == "" {
+		return utcTimestamp
+	}
+
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return utcTimestamp
+	}
+
+	t, err := time.Parse(time.RFC3339, utcTimestamp)
+	if err != nil {
+		return utcTimestamp
+	}
+
+	return t.In(loc).Format(time.RFC3339)
 }


### PR DESCRIPTION
## Summary
Add timezone support so users in non-UTC timezones can see timestamps in their local timezone.

## Problem
All timestamps stored and displayed by Engram use UTC internally. Users in non-UTC timezones (e.g. America/Bogota, UTC-5) see timestamps that don't match their local time.

## Solution
Add `ENGRAM_TIMEZONE` environment variable that converts displayed timestamps to the specified timezone without changing the storage format (UTC in DB, display in local tz).

## Changes
- `internal/store/store.go`:
  - Add `formatTimestamp()` function that converts UTC RFC3339 timestamps to user's timezone
  - Update `FormatContext()` to use timezone-aware timestamps for sessions and prompts
- `DOCS.md`: Document the new `ENGRAM_TIMEZONE` environment variable

## Usage
```bash
ENGRAM_TIMEZONE=America/Bogota engram mcp
# or
export ENGRAM_TIMEZONE=Europe/London
engram context
```

Fixes #169