### PR TITLE
ci: upgrade to Go 1.26.2 and setup-go@v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26.2"
 
       - name: Run unit tests
         run: go test ./...
@@ -33,9 +33,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26.2"
 
       - name: Run e2e tests
         run: go test -tags e2e ./internal/server/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26.2"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Gentleman-Programming/engram
 
-go 1.24.2
+go 1.26.2
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Problem

The CI and release workflows use `actions/setup-go@v5` with `go-version: "1.25"`, but:

1. `setup-go@v5` does not support Go 1.25+ — **setup-go@v6 is required** for Go ≥ 1.25
2. `go.mod` was at `go 1.24.2`, creating an inconsistency between the module directive and the toolchain version CI tries to install

## Changes

- `go.mod`: `go 1.24.2` → `go 1.26.2`
- `ci.yml` (unit-tests + e2e-tests): `setup-go@v5` + `"1.25"` → `setup-go@v6` + `"1.26.2"`
- `release.yml`: `setup-go@v5` + `"1.25"` → `setup-go@v6` + `"1.26.2"`

All three locations updated together so the module directive and the CI toolchain stay consistent.