### PR TITLE
docs: add Companion plugins section linking to atlas-for-engram

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ Full CLI with all flags → [docs/ARCHITECTURE.md#cli-reference](docs/ARCHITECTU
 
 > **Dashboard contributors**: if you modify `.templ` files in `internal/cloud/dashboard/`, run `make templ` to regenerate before committing. See [DOCS.md — Dashboard templ regeneration](DOCS.md#dashboard-templ-regeneration).
 
+## Companion Plugins
+
+Community plugins built on top of engram:
+
+| Plugin | Description |
+|--------|-------------|
+| [atlas-for-engram](https://github.com/Kirilgitlsiiejah/atlas-for-engram) | Atlas-pool injection + retrieval for Obsidian Web Clipper workflows. Bridges raw clips to project-scoped engram memory with provenance hooks. Cross-OS (Windows/macOS/Linux), MIT. |
+
+These are independent community projects, not officially affiliated with engram.
+
 ## License
 
 MIT


### PR DESCRIPTION
Adding a small "Companion Plugins" section to the README linking to [atlas-for-engram](https://github.com/Kirilgitlsiiejah/atlas-for-engram) — a community plugin that bridges Obsidian Web Clipper raw clips to engram's project-scoped memory.

## Context

atlas-for-engram is a native Claude Code plugin built on top of engram. v0.1.0 was just released. It's an opinionated knowledge management layer (Obsidian + vault + atlas-pool) on top of engram's minimal memory core. We thought engram users searching for ecosystem extensions might find it useful.

## Scope

This PR is **docs only** — no code changes, no engram functionality affected. Just a section in the README pointing at the community plugin with a clear "not officially affiliated" disclaimer.

## What changed

- README.md: new "Companion Plugins" section with one row pointing at atlas-for-engram, including a brief description and the disclaimer that it's a community / non-official project. Used a markdown table to match the styling already used elsewhere in the README (Setup, MCP Tools, CLI, Documentation sections).

## What it is NOT

- No engram code changes
- No new dependencies introduced
- No commitment to maintain or endorse the linked project beyond the docs link
- Easy to revert if you don't want it

## Why community / not in engram core

atlas-for-engram is opinionated about Obsidian/vault/atlas-pool conventions, while engram is intentionally minimal and storage-agnostic. Keeping it as a separate plugin honors that separation while letting engram users discover it.

Happy to adjust wording, tone, section name, or placement if there's a preferred convention for community plugins in the engram README.

Thanks for engram — it's a great foundation to build on.