### PR TITLE
fix: tolerate missing directory in session upsert mutations for cloud sync

### DIFF
--- a/internal/cloud/chunkcodec/chunkcodec.go
+++ b/internal/cloud/chunkcodec/chunkcodec.go
@@ -339,7 +339,10 @@ func normalizeMutationPayload(entity, op, payload, project string) (normalizedPa
 			return "", "", fmt.Errorf("session payload id is required")
 		}
 		if op == store.SyncOpUpsert && body.Directory == "" {
-			return "", "", fmt.Errorf("session payload directory is required for upsert")
+			// Tolerate missing directory — MCP server may omit it when generating
+			// session upsert mutations (e.g. manual-save sessions). Use a safe
+			// fallback so cloud sync is not blocked. See: github.com/Gentleman-Programming/engram/issues/249
+			body.Directory = "."
 		}
 		if op == store.SyncOpDelete {
 			body.Directory = ""


### PR DESCRIPTION
## Bug Description

When using the MCP server with `ENGRAM_CLOUD_AUTOSYNC=1`, cloud sync fails with:

```
engram: canonicalize cloud chunk: mutations[N]: session payload directory is required for upsert
```

## Root Cause

The MCP server generates `sync_mutations` entries for `session` upserts that are missing the `directory` field in the JSON payload. Example of a problematic mutation payload:

```json
{"id":"manual-save-ddata","project":"ddata","started_at":"2026-04-18 00:41:04"}
```

The `directory` field is absent entirely (not empty string, but missing). The cloud chunk canonicalizer requires this field for session upserts and fails hard with no fallback.

## Repro Steps

1. Configure engram MCP with `ENGRAM_CLOUD_AUTOSYNC=1` and a cloud endpoint
2. Use `mem_save` tool from the MCP multiple times in a session
3. Run `engram sync --cloud --project <name>`
4. Observe: `mutations[N]: session payload directory is required for upsert`

## Workaround

Manually patch the affected rows before syncing:

```sql
UPDATE sync_mutations 
SET payload = json_set(payload, '$.directory', '/path/to/project')
WHERE entity = 'session' 
AND json_extract(payload, '$.directory') IS NULL;
```

## Expected Behavior

Either:
- The MCP server should always include `directory` in session mutation payloads
- OR the cloud sync canonicalizer should be tolerant of missing `directory` and use a fallback from the `sessions` table

## Environment

- engram client: v1.14.0 (Windows, scoop)
- engram server: v1.14.1 (Docker, self-hosted)
- OS: Windows 11 / PowerShell
- MCP tools profile: --tools=agent
