### PR TITLE
fix(help): update engram --help with correct OpenCode MCP example

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2164,15 +2164,28 @@ Environment:
 	                     Ignored/rejected in insecure mode (ENGRAM_CLOUD_INSECURE_NO_AUTH=1)
 
 MCP Configuration (add to your agent's config):
-  {
-    "mcp": {
-      "engram": {
-        "type": "stdio",
-        "command": "engram",
-        "args": ["mcp", "--tools=agent"]
+
+  Standard (Claude Code, Gemini CLI, Cursor):
+    {
+      "mcp": {
+        "engram": {
+          "type": "stdio",
+          "command": "engram",
+          "args": ["mcp", "--tools=agent"]
+        }
       }
     }
-  }
+
+  OpenCode:
+    {
+      "mcp": {
+        "engram": {
+          "type": "local",
+          "command": ["engram", "mcp", "--tools=agent"],
+          "enabled": true
+        }
+      }
+    }
 `, version)
 }
 


### PR DESCRIPTION
Separated MCP configuration examples into 'Standard' and 'OpenCode' to prevent configuration errors in OpenCode.

Closes #88