### PR TITLE
docs: clarify install-from-source versioning and Claude Code requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ brew install gentleman-programming/tap/engram
 
 Windows, Linux, and other install methods → [docs/INSTALLATION.md](docs/INSTALLATION.md)
 
+> [!TIP]
+> Installing from source via `go build`? Use `-ldflags` to set the version string, or it will show as `"dev"`. See [Installation Guide](docs/INSTALLATION.md#install-from-source-macos--linux).
+
 ### Setup Your Agent
 
 | Agent | One-liner |

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -169,7 +169,9 @@ claude plugin marketplace add Gentleman-Programming/engram
 claude plugin install engram
 ```
 
-That's it. The plugin registers the MCP server, hooks, and Memory Protocol skill automatically.
+> [!IMPORTANT]
+> **Minimum Claude Code version:** Marketplace installation requires Claude Code CLI **>= 2.1.70**.
+> If you see `Failed to add marketplace: Invalid schema: plugins.0.source`, please update with `claude update`.
 
 **Option B: Plugin via `engram setup`** — same plugin, installed from the embedded binary:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -44,18 +44,24 @@ go install github.com/Gentleman-Programming/engram/cmd/engram@latest
 
 Ensure `%GOPATH%\bin` (or `%USERPROFILE%\go\bin`) is on your `PATH`.
 
-**Option B: Build from source**
+**Option B: Build from source (with version stamp)**
+
+If you want the exact version string in `engram version`, build it manually:
 
 ```powershell
 git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
-go install ./cmd/engram
-# Binary goes to %GOPATH%\bin\engram.exe (typically %USERPROFILE%\go\bin\)
 
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
+# 1. Compile with version stamp
 $v = git describe --tags --always
 go build -ldflags="-X main.version=local-$v" -o engram.exe ./cmd/engram
+
+# 2. Move to a folder in your PATH
+# (e.g. C:\Users\<you>\bin\ or similar)
 ```
+
+> [!NOTE]
+> Running `go install ./cmd/engram` puts the binary in `%GOPATH%\bin` (usually `%USERPROFILE%\go\bin\`) but sets the version to `"dev"`. To get the proper version string, you must use `go build` with `-ldflags` as shown above.
 
 **Option C: Download the prebuilt binary**
 
@@ -103,11 +109,16 @@ Expand-Archive engram_*_windows_amd64.zip -DestinationPath "$env:USERPROFILE\bin
 ```bash
 git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
-go install ./cmd/engram
 
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
+# Build with version stamp
 go build -ldflags="-X main.version=local-$(git describe --tags --always)" -o engram ./cmd/engram
+
+# Move to your PATH (e.g. /usr/local/bin or ~/bin)
+sudo mv engram /usr/local/bin/
 ```
+
+> [!NOTE]
+> Running `go install ./cmd/engram` puts the binary in `$GOPATH/bin` (usually `~/go/bin/`) but sets the version to `"dev"`. To get the proper version string, you must use `go build` with `-ldflags` as shown above.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-[← Back to README](../README.md)
+← [Back to README](../README.md)
 
 # Installation
 


### PR DESCRIPTION
Two documentation gaps addressed:

1. Clarified that go install sets version to dev. Provided the correct go build -ldflags command for Windows and macOS/Linux to get the proper version stamp.
2. Added a requirement note for Claude Code CLI >= 2.1.70 to support marketplace installation via git-subdir.

Closes #67