### PR TITLE
fix(lifecycle): implement session end for OpenCode, Gemini CLI, and Codex

### DIFF
--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -109,7 +109,9 @@ Before ending a session or saying "done" / "listo" / "that's it", you MUST:
 ## Relevant Files
 - path/to/file — [what it does or what changed]
 
-This is NOT optional. If you skip this, the next session starts blind.
+2. Call \`mem_session_end\` to formally close the session.
+
+This is NOT optional. If you skip this, the next session starts blind and leaves orphaned sessions.
 
 ### AFTER COMPACTION
 
@@ -313,6 +315,9 @@ export const Engram: Plugin = async (ctx) => {
         const info = (event.properties as any)?.info
         const sessionId = info?.id
         if (sessionId) {
+          // Tell Engram the session ended
+          await engramFetch(`/sessions/${sessionId}/end`, { method: "POST" })
+          
           toolCounts.delete(sessionId)
           knownSessions.delete(sessionId)
           subAgentSessions.delete(sessionId)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -172,7 +172,9 @@ Before ending a session or saying "done" / "listo" / "that's it", you MUST:
 ## Relevant Files
 - path/to/file — [what it does or what changed]
 
-This is NOT optional. If you skip this, the next session starts blind.
+2. Call mem_session_end to formally close the session.
+
+This is NOT optional. If you skip this, the next session starts blind and leaves orphaned sessions.
 
 ### PASSIVE CAPTURE — automatic learning extraction
 


### PR DESCRIPTION
Implements session lifecycle termination for all supported agents to prevent orphaned sessions in the cloud dashboard.

- **OpenCode**: The plugin now calls POST /sessions/{id}/end directly when the session.deleted event fires.
- **Gemini CLI & Codex**: Added an explicit instruction to call mem_session_end in the Memory Protocol injected into their system prompts.
- **OpenCode (graceful)**: Also added the mem_session_end instruction to its MEMORY_INSTRUCTIONS.

Closes #48