### PR TITLE
fix(mcp): run checkForUpdates async for mcp and serve subcommands

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -531,9 +531,18 @@ func main() {
 	}
 
 	// Check for updates on every invocation.
-	if result := checkForUpdates(version); result.Status != versioncheck.StatusUpToDate && result.Message != "" {
-		fmt.Fprintln(os.Stderr, result.Message)
-		fmt.Fprintln(os.Stderr)
+	// For long-running server subcommands (mcp, serve) run asynchronously so the
+	// server starts immediately without blocking on a network request.
+	printUpdate := func() {
+		if result := checkForUpdates(version); result.Status != versioncheck.StatusUpToDate && result.Message != "" {
+			fmt.Fprintln(os.Stderr, result.Message)
+			fmt.Fprintln(os.Stderr)
+		}
+	}
+	if os.Args[1] == "mcp" || os.Args[1] == "serve" {
+		go printUpdate()
+	} else {
+		printUpdate()
 	}
 
 	cfg, cfgErr := store.DefaultConfig()

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Gentleman-Programming/engram/internal/mcp"
 	"github.com/Gentleman-Programming/engram/internal/obsidian"
 	"github.com/Gentleman-Programming/engram/internal/setup"
+	engramsrv "github.com/Gentleman-Programming/engram/internal/server"
 	"github.com/Gentleman-Programming/engram/internal/store"
 	engramsync "github.com/Gentleman-Programming/engram/internal/sync"
 	versioncheck "github.com/Gentleman-Programming/engram/internal/version"
@@ -689,6 +690,51 @@ func TestMainPrintsUpdateFailuresAndUpdates(t *testing.T) {
 			t.Fatalf("stderr = %q, want empty", stderr)
 		}
 	})
+}
+
+func TestMCPAndServeDoNotBlockOnUpdateCheck(t *testing.T) {
+	for _, subcmd := range []string{"mcp", "serve"} {
+		t.Run(subcmd, func(t *testing.T) {
+			resetMainSeams(t)
+			stubExitWithPanic(t)
+			withArgs(t, "engram", subcmd)
+
+			unblock := make(chan struct{})
+			started := make(chan struct{})
+
+			checkForUpdates = func(string) versioncheck.CheckResult {
+				<-unblock
+				return versioncheck.CheckResult{Status: versioncheck.StatusUpToDate}
+			}
+
+			switch subcmd {
+			case "mcp":
+				oldServeMCP := serveMCP
+				serveMCP = func(s *mcpserver.MCPServer, opts ...mcpserver.StdioOption) error {
+					close(started)
+					return oldServeMCP(s, opts...)
+				}
+				t.Cleanup(func() { serveMCP = oldServeMCP })
+			case "serve":
+				oldStartHTTP := startHTTP
+				startHTTP = func(s *engramsrv.Server) error {
+					close(started)
+					return oldStartHTTP(s)
+				}
+				t.Cleanup(func() { startHTTP = oldStartHTTP })
+			}
+
+			go func() { main() }()
+
+			select {
+			case <-started:
+			case <-time.After(2 * time.Second):
+				t.Errorf("%s subcommand blocked on checkForUpdates — expected async startup", subcmd)
+			}
+
+			close(unblock)
+		})
+	}
 }
 
 func TestMainExitPaths(t *testing.T) {

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -695,7 +695,7 @@ func TestMainPrintsUpdateFailuresAndUpdates(t *testing.T) {
 func TestMCPAndServeDoNotBlockOnUpdateCheck(t *testing.T) {
 	for _, subcmd := range []string{"mcp", "serve"} {
 		t.Run(subcmd, func(t *testing.T) {
-			resetMainSeams(t)
+			stubRuntimeHooks(t)
 			stubExitWithPanic(t)
 			withArgs(t, "engram", subcmd)
 


### PR DESCRIPTION
## Problem

`checkForUpdates` runs **synchronously** in `main()` before `cmdMCP` is called (`cmd/engram/main.go:534`). This means the MCP server does not start listening until the GitHub API call completes or times out.

```go
// main.go:534 — runs BEFORE cmdMCP
if result := checkForUpdates(version); ... {
    fmt.Fprintln(os.Stderr, result.Message)
}
cmdMCP(cfg) // ← never reached until the HTTP call above finishes
```

## Root cause

- Uses `http.DefaultClient` with no transport-level timeout (only a 2s `context.WithTimeout`)
- On Windows, DNS resolution and TCP operations can hang at the OS level beyond the context deadline — Go cancels the context but the underlying `WSARecv` call may not unblock immediately
- Claude Code has a stream idle timeout of `idleDeadlineMs=300000` (5 minutes). If MCP never starts responding, Claude Code waits the full 5 minutes then kills the connection

## Observed impact

- Measured MCP startup of **6417ms** vs **1775ms** baseline in debug logs (Windows 11)
- Suspected root cause of intermittent **5-minute hangs** reported by users on Windows

## Fix

Run the update check in a goroutine so `cmdMCP` starts immediately:

```go
go func() {
    if result := checkForUpdates(version); result.Status != versioncheck.StatusUpToDate && result.Message != "" {
        fmt.Fprintln(os.Stderr, result.Message)
    }
}()
cmdMCP(cfg)
```

Interactive subcommands (`save`, `search`, `tui`, etc.) keep the synchronous check so the update message appears before command output.

## Environment

- Windows 11, Claude Code with Engram MCP plugin
- Related: #263 (GitHub API 403 — same `checkForUpdates` call)

Closes #269
