### PR TITLE
feat(claude-code-plugin): honor ENGRAM_URL env var in hooks

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -200,6 +200,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 |---|---|---|
 | `ENGRAM_DATA_DIR` | Override data directory | `~/.engram` |
 | `ENGRAM_PORT` | Override HTTP server port | `7437` |
+| `ENGRAM_URL` | Override the URL Claude Code hooks talk to (multi-machine / remote backend setups). When set to a non-default value, the hooks will not auto-spawn a local `engram serve`. | `http://127.0.0.1:${ENGRAM_PORT}` |
 | `ENGRAM_PROJECT` | Override project name for MCP server | auto-detected via git |
 
 ### Cloud CLI (opt-in)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -141,6 +141,7 @@ The binary includes SQLite (via [modernc.org/sqlite](https://pkg.go.dev/modernc.
 |---|---|---|
 | `ENGRAM_DATA_DIR` | Data directory | `~/.engram` (Windows: `%USERPROFILE%\.engram`) |
 | `ENGRAM_PORT` | HTTP server port | `7437` |
+| `ENGRAM_URL` | Override the URL Claude Code hooks talk to (multi-machine / remote backend setups). When set to a non-default value, the hooks will not auto-spawn a local `engram serve`. | `http://127.0.0.1:${ENGRAM_PORT}` |
 
 ---
 

--- a/plugin/claude-code/scripts/post-compaction.sh
+++ b/plugin/claude-code/scripts/post-compaction.sh
@@ -5,7 +5,7 @@
 # the agent to persist the compacted summary via mem_session_summary.
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
-ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+ENGRAM_URL="${ENGRAM_URL:-http://127.0.0.1:${ENGRAM_PORT}}"
 
 # Load shared helpers
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -7,7 +7,8 @@
 # 4. Injects Memory Protocol instructions + memory context
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
-ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+ENGRAM_URL_DEFAULT="http://127.0.0.1:${ENGRAM_PORT}"
+ENGRAM_URL="${ENGRAM_URL:-${ENGRAM_URL_DEFAULT}}"
 IMPORT_TIMEOUT_SECS=8
 LOCK_TTL_SECS=$((IMPORT_TIMEOUT_SECS + 4))
 LOCK_METADATA_STALE_SECS=$((LOCK_TTL_SECS * 5))
@@ -23,10 +24,15 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 OLD_PROJECT=$(basename "$CWD")
 PROJECT=$(detect_project "$CWD")
 
-# Ensure engram server is running
-if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then
-  engram serve &>/dev/null &
-  sleep 0.5
+# Ensure engram server is running.
+# Only auto-spawn `engram serve` when ENGRAM_URL is the default localhost URL.
+# If the user pointed ENGRAM_URL at a remote backend (e.g. NAS, k8s, dev container),
+# spawning a local binary would be wrong — fail silent and let the remote answer.
+if [ "$ENGRAM_URL" = "$ENGRAM_URL_DEFAULT" ]; then
+  if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then
+    engram serve &>/dev/null &
+    sleep 0.5
+  fi
 fi
 
 # Migrate project name if it changed (one-time, idempotent)

--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -5,7 +5,7 @@
 # Runs async so it doesn't block Claude's response.
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
-ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+ENGRAM_URL="${ENGRAM_URL:-http://127.0.0.1:${ENGRAM_PORT}}"
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -6,7 +6,7 @@
 # Go server — this script is intentionally minimal.
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
-ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+ENGRAM_URL="${ENGRAM_URL:-http://127.0.0.1:${ENGRAM_PORT}}"
 
 # Load shared helpers
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -11,7 +11,7 @@
 # MUST exit 0 always and output valid JSON — otherwise Claude Code blocks the message.
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
-ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+ENGRAM_URL="${ENGRAM_URL:-http://127.0.0.1:${ENGRAM_PORT}}"
 
 # Load shared helpers
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary

Restore `ENGRAM_URL` env var override in the Claude Code plugin hooks. Default behavior unchanged.

## Motivation

Some users run engram as a centralized server (Synology, k8s, dev container) shared by multiple Macs / containers. Currently the hooks hardcode `127.0.0.1:7437` so these users have to fork and patch on every release.

This change:
1. Adds `${ENGRAM_URL:-http://127.0.0.1:${ENGRAM_PORT}}` fallback — same default
2. Skips the auto-spawn `engram serve` block in `session-start.sh` when `ENGRAM_URL` was overridden (the user is pointing at a remote server, not a local binary, so spawning a local `engram serve` would be wrong)

## Files changed

- `plugin/claude-code/scripts/session-start.sh` — env override + skip auto-spawn when overridden
- `plugin/claude-code/scripts/post-compaction.sh` — env override
- `plugin/claude-code/scripts/user-prompt-submit.sh` — env override
- `plugin/claude-code/scripts/session-stop.sh` — env override
- `plugin/claude-code/scripts/subagent-stop.sh` — env override
- `docs/INSTALLATION.md` — document `ENGRAM_URL`
- `DOCS.md` — document `ENGRAM_URL`

Total: 7 files, +17 / -9.

## Test plan

- [ ] Default install (no `ENGRAM_URL`): hooks behave identically to before — `session-start.sh` still auto-spawns `engram serve` if localhost is unreachable
- [ ] `ENGRAM_URL=http://192.168.1.10:7437 claude`: hooks talk to remote server; no local `engram serve` spawn attempted
- [ ] `ENGRAM_URL` empty / unset: same as default

## Compatibility

Backward compatible. Existing users who don't set `ENGRAM_URL` see no change.

## Out of scope

The OpenCode plugin (`plugin/opencode/engram.ts`) has the same hardcoded URL pattern. Happy to do a follow-up PR for that if this approach is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)