### PR TITLE
fix: resolve multi-repo cwd ambiguity + 3 related bugs (Closes #283)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -806,13 +806,27 @@ func tryStartAutosync(ctx context.Context, s *store.Store, cfg store.Config) (au
 }
 
 func cmdMCP(cfg store.Config) {
-	// Parse --tools flag. Project is always auto-detected from cwd at call time (JR2-4).
+	// Parse flags:
+	//   --tools=PROFILE         (filter exposed tools)
+	//   --default-project NAME  (fallback project name when cwd is ambiguous)
+	// Project is always auto-detected from cwd at call time (JR2-4); the
+	// --default-project flag only kicks in when detection returns
+	// ErrAmbiguousProject (cwd has multiple git repos as children — common on
+	// home directories for MCP clients like Claude Code / OpenCode).
 	toolsFilter := ""
+	defaultProject := ""
 	for i := 2; i < len(os.Args); i++ {
-		if strings.HasPrefix(os.Args[i], "--tools=") {
-			toolsFilter = strings.TrimPrefix(os.Args[i], "--tools=")
-		} else if os.Args[i] == "--tools" && i+1 < len(os.Args) {
+		arg := os.Args[i]
+		switch {
+		case strings.HasPrefix(arg, "--tools="):
+			toolsFilter = strings.TrimPrefix(arg, "--tools=")
+		case arg == "--tools" && i+1 < len(os.Args):
 			toolsFilter = os.Args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--default-project="):
+			defaultProject = strings.TrimPrefix(arg, "--default-project=")
+		case arg == "--default-project" && i+1 < len(os.Args):
+			defaultProject = os.Args[i+1]
 			i++
 		}
 	}
@@ -822,6 +836,10 @@ func cmdMCP(cfg store.Config) {
 		fatal(err)
 	}
 	defer s.Close()
+
+	if defaultProject != "" {
+		mcp.SetDefaultProjectFallback(defaultProject)
+	}
 
 	mcpCfg := mcp.MCPConfig{}
 	allowlist := resolveMCPTools(toolsFilter)
@@ -1667,7 +1685,25 @@ type projectGroup struct {
 
 // groupSimilarProjects groups projects by name similarity and shared directories.
 // Uses a simple union-find approach.
+// maxSharedProjectsForDirMatch caps how many distinct projects may share a
+// single directory before that directory is treated as too "noisy" to be a
+// meaningful fingerprint. Without this cap, a directory like the user's home
+// (which dozens of unrelated projects' sessions transit through) would
+// transitively unite every project into a single component via union-find.
+//
+// 3 is a deliberately conservative number: a real rename or move shows up as
+// 1–2 project rows pointing to the same directory, never more.
+const maxSharedProjectsForDirMatch = 3
+
 func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
+	return groupSimilarProjectsWithMode(projects, false)
+}
+
+// groupSimilarProjectsWithMode groups projects with optional strict-similarity
+// behavior. When strictSimilarity=true, only name-based similarity is used —
+// shared-directory union is skipped entirely. This is safer for stores where
+// many projects share noisy parent directories (e.g. $HOME).
+func groupSimilarProjectsWithMode(projects []store.ProjectStats, strictSimilarity bool) []projectGroup {
 	n := len(projects)
 	if n == 0 {
 		return nil
@@ -1711,18 +1747,38 @@ func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
 		}
 	}
 
-	// Group by shared directory
-	dirToProjects := make(map[string][]int)
-	for i, p := range projects {
-		for _, dir := range p.Directories {
-			if dir != "" {
-				dirToProjects[dir] = append(dirToProjects[dir], i)
+	// Group by shared directory — opt-out via strictSimilarity, and also
+	// skip directories that are touched by more than maxSharedProjectsForDirMatch
+	// distinct projects. A directory shared by 5+ projects is almost always
+	// $HOME or some other non-fingerprint location, not a rename signal — and
+	// blindly unioning over it produces the catastrophic transitive cluster
+	// where, for example, gis ↔ jarvis ↔ forge get merged into "general".
+	if !strictSimilarity {
+		dirToProjects := make(map[string][]int)
+		for i, p := range projects {
+			for _, dir := range p.Directories {
+				if dir != "" {
+					dirToProjects[dir] = append(dirToProjects[dir], i)
+				}
 			}
 		}
-	}
-	for _, idxs := range dirToProjects {
-		for k := 1; k < len(idxs); k++ {
-			union(idxs[0], idxs[k])
+		for _, idxs := range dirToProjects {
+			// Distinct count (a project may appear multiple times in idxs if it
+			// recorded the same directory under multiple sessions).
+			seen := make(map[int]bool, len(idxs))
+			distinct := 0
+			for _, idx := range idxs {
+				if !seen[idx] {
+					seen[idx] = true
+					distinct++
+				}
+			}
+			if distinct > maxSharedProjectsForDirMatch {
+				continue // noisy parent path — skip to avoid transitive cluster
+			}
+			for k := 1; k < len(idxs); k++ {
+				union(idxs[0], idxs[k])
+			}
 		}
 	}
 
@@ -1766,12 +1822,15 @@ func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
 func cmdProjectsConsolidate(cfg store.Config) {
 	doAll := false
 	dryRun := false
+	strictSimilarity := false
 	for i := 3; i < len(os.Args); i++ {
 		switch os.Args[i] {
 		case "--all":
 			doAll = true
 		case "--dry-run":
 			dryRun = true
+		case "--strict-similarity":
+			strictSimilarity = true
 		}
 	}
 
@@ -1917,7 +1976,7 @@ func cmdProjectsConsolidate(cfg store.Config) {
 		fatal(err)
 	}
 
-	groups := groupSimilarProjects(projects)
+	groups := groupSimilarProjectsWithMode(projects, strictSimilarity)
 
 	if len(groups) == 0 {
 		fmt.Println("No similar project name groups found.")
@@ -2215,12 +2274,16 @@ Usage:
 
 Commands:
   serve [port]       Start HTTP API server (default: 7437)
-  mcp [--tools=PROFILE] [--project=NAME]
+  mcp [--tools=PROFILE] [--default-project=NAME]
                      Start MCP server (stdio transport, for any AI agent)
                        Profiles: agent (11 tools), admin (4 tools), all (default, 15)
                        Combine: --tools=agent,admin or pick individual tools
-                       --project  Override detected project name (default: git remote → cwd)
-                       Example: engram mcp --tools=agent
+                       --default-project  Project name used as fallback when cwd
+                                          contains multiple git repos (otherwise
+                                          mem_save returns ambiguous_project).
+                                          Recommended for clients whose cwd is
+                                          $HOME (Claude Code, OpenCode, etc.).
+                       Example: engram mcp --tools=agent --default-project=general
   tui                Launch interactive terminal UI
   search <query>     Search memories [--type TYPE] [--project PROJECT] [--scope SCOPE] [--limit N]
   save <title> <msg> Save a memory  [--type TYPE] [--project PROJECT] [--scope SCOPE]
@@ -2230,9 +2293,14 @@ Commands:
   export [file]      Export all memories to JSON (default: engram-export.json)
   import <file>      Import memories from a JSON export file
   projects list      List all projects with observation, session, and prompt counts
-  projects consolidate [--all] [--dry-run]
+  projects consolidate [--all] [--dry-run] [--strict-similarity]
                      Merge similar project names into one canonical name
-                       --all      Scan ALL projects for similar name groups
+                       --all                  Scan ALL projects for similar name groups
+                       --dry-run              Preview matches without merging
+                       --strict-similarity    Group only by name similarity (skip
+                                              shared-directory union — safer when
+                                              many projects share noisy parent
+                                              paths like $HOME)
                        --dry-run  Preview what would be merged (no changes)
   setup [agent]      Install/setup agent integration (opencode, claude-code, gemini-cli, codex)
   sync               Export new memories as compressed chunk to .engram/

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1446,3 +1446,72 @@ func TestObsidianExportWatchModeCallsInjectedWatcher(t *testing.T) {
 		t.Fatalf("expected non-nil Logf in WatcherConfig")
 	}
 }
+
+// TestGroupSimilarProjects_NoisyDirectoryNotMerged covers the regression where
+// groupSimilarProjects produced a single 46-project component because every
+// project shared a directory like $HOME (transitively unioned through that
+// noisy parent path). With the maxSharedProjectsForDirMatch cap, a directory
+// touched by more than 3 distinct projects is no longer used as a fingerprint
+// and unrelated projects stay in separate components.
+func TestGroupSimilarProjects_NoisyDirectoryNotMerged(t *testing.T) {
+	noisy := "/home/user"
+	// Names deliberately chosen with large pairwise Levenshtein distances so
+	// no name-similarity edges are created. The only thing they share is the
+	// directory — which exceeds the noisy threshold and is therefore ignored.
+	projects := []store.ProjectStats{
+		{Name: "redis-cache", ObservationCount: 10, Directories: []string{noisy}},
+		{Name: "postgres-db", ObservationCount: 20, Directories: []string{noisy}},
+		{Name: "frontend-ui", ObservationCount: 30, Directories: []string{noisy}},
+		{Name: "backend-api", ObservationCount: 40, Directories: []string{noisy}},
+		{Name: "metrics-svc", ObservationCount: 50, Directories: []string{noisy}},
+	}
+
+	groups := groupSimilarProjects(projects)
+
+	if len(groups) != 0 {
+		t.Errorf("expected 0 groups (noisy dir filtered), got %d: %+v", len(groups), groups)
+	}
+}
+
+// TestGroupSimilarProjects_LegitimateRenameStillMerges ensures the noisy-dir
+// filter does not over-correct and break the legitimate rename use case where
+// 2 projects share a unique directory (e.g. sdd-agent-team renamed to
+// agent-teams-lite, both rooted at the same path).
+func TestGroupSimilarProjects_LegitimateRenameStillMerges(t *testing.T) {
+	uniqueDir := "/home/user/repos/agent-teams-lite"
+	projects := []store.ProjectStats{
+		{Name: "sdd-agent-team", ObservationCount: 5, Directories: []string{uniqueDir}},
+		{Name: "agent-teams-lite", ObservationCount: 50, Directories: []string{uniqueDir}},
+		{Name: "unrelated-project", ObservationCount: 10, Directories: []string{"/home/user/other"}},
+	}
+
+	groups := groupSimilarProjects(projects)
+
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group (rename via shared dir), got %d", len(groups))
+	}
+	if len(groups[0].Names) != 2 {
+		t.Errorf("expected 2 projects in group, got %d: %v", len(groups[0].Names), groups[0].Names)
+	}
+	if groups[0].Canonical != "agent-teams-lite" {
+		t.Errorf("Canonical = %q; want %q (highest obs count)", groups[0].Canonical, "agent-teams-lite")
+	}
+}
+
+// TestGroupSimilarProjectsWithMode_StrictDisablesDirUnion verifies the
+// --strict-similarity flag: even when 2 projects share a unique directory
+// they are NOT merged unless their names also match. This is the safest mode
+// for stores where the user has reason to distrust directory-based grouping.
+func TestGroupSimilarProjectsWithMode_StrictDisablesDirUnion(t *testing.T) {
+	uniqueDir := "/home/user/repos/agent-teams-lite"
+	projects := []store.ProjectStats{
+		{Name: "sdd-agent-team", ObservationCount: 5, Directories: []string{uniqueDir}},
+		{Name: "agent-teams-lite", ObservationCount: 50, Directories: []string{uniqueDir}},
+	}
+
+	groups := groupSimilarProjectsWithMode(projects, true /* strictSimilarity */)
+
+	if len(groups) != 0 {
+		t.Errorf("expected 0 groups in strict mode (names not similar enough), got %d: %+v", len(groups), groups)
+	}
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1661,8 +1661,30 @@ func (e *unknownProjectError) Error() string {
 	return "unknown project: " + e.Name
 }
 
+// defaultProjectFallback, when non-empty, is used as the project name whenever
+// auto-detection from cwd returns ErrAmbiguousProject. This unblocks the
+// out-of-the-box experience for MCP clients (Claude Code, OpenCode) whose
+// process cwd lives in a directory that contains multiple git repos — those
+// clients have no way to `cd` into a specific repo from inside the agent.
+//
+// The fallback is opt-in: it is only set when the operator launches the MCP
+// server with `engram mcp --default-project NAME`. Default behavior (empty
+// string) preserves the historical "fail fast on ambiguity" contract.
+var defaultProjectFallback string
+
+// SetDefaultProjectFallback configures the project name used as fallback when
+// cwd-based detection returns ErrAmbiguousProject. Pass an empty string to
+// disable the fallback (default behavior). Intended to be called once at
+// server startup from cmdMCP, before tool handlers begin serving requests.
+func SetDefaultProjectFallback(name string) {
+	defaultProjectFallback = strings.TrimSpace(name)
+}
+
 // resolveWriteProject detects the current project from the process working
-// directory. Returns ErrAmbiguousProject if cwd is a parent of multiple repos.
+// directory. Behavior on ambiguous cwd (parent of multiple repos):
+//   - If SetDefaultProjectFallback was called with a non-empty name, returns
+//     that name with Source="default_fallback" and a Warning.
+//   - Otherwise returns ErrAmbiguousProject (historical behavior).
 func resolveWriteProject() (projectpkg.DetectionResult, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -1670,6 +1692,16 @@ func resolveWriteProject() (projectpkg.DetectionResult, error) {
 	}
 	res := projectpkg.DetectProjectFull(cwd)
 	if res.Error != nil {
+		if errors.Is(res.Error, projectpkg.ErrAmbiguousProject) && defaultProjectFallback != "" {
+			normalized, _ := store.NormalizeProject(defaultProjectFallback)
+			return projectpkg.DetectionResult{
+				Project:           normalized,
+				Source:            "default_fallback",
+				Path:              res.Path,
+				Warning:           fmt.Sprintf("ambiguous cwd; using --default-project=%q", normalized),
+				AvailableProjects: res.AvailableProjects,
+			}, nil
+		}
 		return res, res.Error
 	}
 	return res, nil
@@ -1677,17 +1709,38 @@ func resolveWriteProject() (projectpkg.DetectionResult, error) {
 
 // resolveReadProject validates an optional project override against the store.
 // If override is empty, falls back to auto-detection from cwd.
-// JW2: normalizes the override (lowercase+trim) before ProjectExists lookup so
-// that e.g. "MyApp" and "  myapp  " both resolve to the stored "myapp".
+// JW2: normalizes the override (lowercase+trim) before lookup so that e.g.
+// "MyApp" and "  myapp  " both resolve to the stored "myapp".
+//
+// Lookup uses Store.ResolveProjectName which falls back to case-insensitive
+// matching when the case-sensitive lookup misses. This fixes the legitimate
+// case where a user passes "E3" but the store has "E3" (case-sensitive
+// previously erroneously reported "Project 'e3' not found"). When the
+// case-insensitive fallback finds a hit, the canonical stored casing is used
+// for downstream queries — preserving the invariant that distinct casings
+// (if both are in the store) remain individually addressable.
 func resolveReadProject(s *store.Store, override string) (projectpkg.DetectionResult, error) {
 	override = strings.TrimSpace(override)
 	if override == "" {
 		return resolveWriteProject()
 	}
 	normalized, _ := store.NormalizeProject(override)
-	exists, err := s.ProjectExists(normalized)
+
+	// Try the normalized form first (matches the legacy invariant that names
+	// are stored lowercase). If that misses, ResolveProjectName falls back to
+	// case-insensitive lookup and returns the actual stored casing.
+	canonical, exists, err := s.ResolveProjectName(normalized)
 	if err != nil {
 		return projectpkg.DetectionResult{}, err
+	}
+	if !exists {
+		// Last attempt: try the raw override exactly as the user typed it,
+		// in case it was stored with a casing that survives normalization
+		// (e.g. legacy stored "E3" matches user-supplied "E3").
+		canonical, exists, err = s.ResolveProjectName(override)
+		if err != nil {
+			return projectpkg.DetectionResult{}, err
+		}
 	}
 	if !exists {
 		// Collect available projects for the error.
@@ -1698,7 +1751,7 @@ func resolveReadProject(s *store.Store, override string) (projectpkg.DetectionRe
 		}
 	}
 	return projectpkg.DetectionResult{
-		Project: normalized,
+		Project: canonical, // canonical stored casing, not the normalized input
 		Source:  projectpkg.SourceExplicitOverride, // JR2-2: use named constant
 		Path:    "",
 	}, nil

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -3201,9 +3201,79 @@ func TestResolveWriteProject_AmbiguousError(t *testing.T) {
 	}
 	t.Chdir(parent)
 
+	// Ensure no fallback is configured for this case (other test in this file
+	// may have set it; reset to preserve historical behavior).
+	t.Cleanup(func() { SetDefaultProjectFallback("") })
+	SetDefaultProjectFallback("")
+
 	_, err := resolveWriteProject()
 	if !errors.Is(err, project.ErrAmbiguousProject) {
 		t.Errorf("expected ErrAmbiguousProject, got %v", err)
+	}
+}
+
+// TestResolveWriteProject_AmbiguousFallback covers the fallback path added by
+// the --default-project flag: when the operator launches the MCP server with
+// `engram mcp --default-project=general`, an ambiguous cwd no longer raises
+// ambiguous_project — the call returns a DetectionResult whose Project is the
+// configured fallback and Source is "default_fallback", with a Warning so
+// callers (and the user) can see the rationale in the response envelope.
+func TestResolveWriteProject_AmbiguousFallback(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"repo-a", "repo-b"} {
+		child := filepath.Join(parent, name)
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initTestGitRepo(t, child)
+	}
+	t.Chdir(parent)
+
+	t.Cleanup(func() { SetDefaultProjectFallback("") })
+	SetDefaultProjectFallback("general")
+
+	res, err := resolveWriteProject()
+	if err != nil {
+		t.Fatalf("expected fallback to swallow ambiguous error, got %v", err)
+	}
+	if res.Project != "general" {
+		t.Errorf("Project = %q; want %q", res.Project, "general")
+	}
+	if res.Source != "default_fallback" {
+		t.Errorf("Source = %q; want %q", res.Source, "default_fallback")
+	}
+	if res.Warning == "" {
+		t.Error("expected non-empty Warning describing the fallback")
+	}
+	if len(res.AvailableProjects) != 2 {
+		t.Errorf("AvailableProjects len = %d; want 2 (the ambiguous candidates)", len(res.AvailableProjects))
+	}
+}
+
+// TestSetDefaultProjectFallback_NormalizesAndTrims ensures the fallback name is
+// stored as a trimmed, normalized project identifier so callers do not need to
+// pre-format the --default-project flag value.
+func TestSetDefaultProjectFallback_NormalizesAndTrims(t *testing.T) {
+	t.Cleanup(func() { SetDefaultProjectFallback("") })
+
+	parent := t.TempDir()
+	for _, name := range []string{"repo-a", "repo-b"} {
+		child := filepath.Join(parent, name)
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initTestGitRepo(t, child)
+	}
+	t.Chdir(parent)
+
+	SetDefaultProjectFallback("  General  ") // whitespace + casing
+
+	res, err := resolveWriteProject()
+	if err != nil {
+		t.Fatalf("resolveWriteProject: %v", err)
+	}
+	if res.Project != "general" {
+		t.Errorf("Project = %q; want %q (input should be trimmed + lowercased)", res.Project, "general")
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2762,6 +2762,64 @@ SELECT 1 FROM (
 	return true, nil
 }
 
+// ResolveProjectName looks up a project name with a two-stage fallback so that
+// callers can match stored projects regardless of casing variants:
+//
+//  1. Case-sensitive exact match (fast path, identical to ProjectExists).
+//  2. Case-insensitive fallback using COLLATE NOCASE — returns the canonical
+//     stored casing (e.g. "E3") so downstream queries can use the exact form.
+//
+// Returns the canonical stored name when found. When multiple casings exist in
+// the store (e.g. both "E3" and "e3"), the case-sensitive match wins; the
+// fallback only fires when the case-sensitive match fails. This preserves the
+// invariant that distinct casings remain addressable while making the common
+// "search for 'E3', stored as 'e3'" case work transparently.
+func (s *Store) ResolveProjectName(input string) (canonical string, exists bool, err error) {
+	if input == "" {
+		return "", false, nil
+	}
+	// Stage 1: case-sensitive (BINARY collation, default in SQLite).
+	const exactQuery = `
+SELECT project FROM (
+  SELECT project FROM observations WHERE project = ? AND deleted_at IS NULL
+  UNION ALL
+  SELECT project FROM sessions WHERE project = ?
+  UNION ALL
+  SELECT project FROM user_prompts WHERE project = ?
+  UNION ALL
+  SELECT project FROM sync_enrolled_projects WHERE project = ?
+) LIMIT 1`
+	var found string
+	err = s.db.QueryRow(exactQuery, input, input, input, input).Scan(&found)
+	if err == nil {
+		return found, true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", false, err
+	}
+
+	// Stage 2: case-insensitive fallback. Using COLLATE NOCASE on the WHERE
+	// clauses lets SQLite match without re-indexing.
+	const ciQuery = `
+SELECT project FROM (
+  SELECT project FROM observations WHERE project = ? COLLATE NOCASE AND deleted_at IS NULL
+  UNION ALL
+  SELECT project FROM sessions WHERE project = ? COLLATE NOCASE
+  UNION ALL
+  SELECT project FROM user_prompts WHERE project = ? COLLATE NOCASE
+  UNION ALL
+  SELECT project FROM sync_enrolled_projects WHERE project = ? COLLATE NOCASE
+) LIMIT 1`
+	err = s.db.QueryRow(ciQuery, input, input, input, input).Scan(&found)
+	if err == nil {
+		return found, true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	return "", false, err
+}
+
 // ─── Context Formatting ─────────────────────────────────────────────────────
 
 func (s *Store) FormatContext(project, scope string) (string, error) {
@@ -5409,7 +5467,8 @@ func normalizeScope(scope string) string {
 }
 
 // NormalizeProject applies canonical project name normalization:
-// lowercase + trim whitespace + collapse consecutive hyphens/underscores.
+// lowercase + trim whitespace + collapse consecutive hyphens/underscores +
+// reject filesystem paths (sanitize to basename with warning).
 // Returns the normalized name and a warning message if the name was changed
 // (empty string if no change was needed).
 // Exported so MCP and CLI handlers can surface the warning to users.
@@ -5417,6 +5476,22 @@ func NormalizeProject(project string) (normalized string, warning string) {
 	if project == "" {
 		return "", ""
 	}
+
+	// Defensive sanitization: if the input looks like an absolute filesystem
+	// path (e.g. "C:\Users\maicolj" or "/home/foo/repos/bar"), it slipped past
+	// the project detection layer (probably a fallback that used cwd verbatim).
+	// Reduce it to just the basename so we never persist paths as project names.
+	pathLike, sanitized := sanitizePathLike(project)
+	if pathLike {
+		// Continue normalizing the sanitized basename through the regular pipeline
+		// and surface a warning so the caller knows the original was a path.
+		regular, _ := NormalizeProject(sanitized)
+		if regular == "" {
+			regular = "unknown"
+		}
+		return regular, fmt.Sprintf("⚠️ Project name looked like a filesystem path; sanitized to basename: %q → %q", project, regular)
+	}
+
 	n := strings.TrimSpace(strings.ToLower(project))
 	// Collapse multiple consecutive hyphens
 	for strings.Contains(n, "--") {
@@ -5430,6 +5505,44 @@ func NormalizeProject(project string) (normalized string, warning string) {
 		return n, ""
 	}
 	return n, fmt.Sprintf("⚠️ Project name normalized: %q → %q", project, n)
+}
+
+// sanitizePathLike detects whether s looks like a filesystem path and, if so,
+// returns the basename. Detection covers:
+//   - Windows drive paths: "C:\foo" or "C:/foo"
+//   - UNC paths:           "\\server\share"
+//   - Unix absolute paths: "/foo/bar"
+//   - Anything containing a directory separator and more than one segment
+//     (e.g. "src/scripts" — not a project name).
+//
+// Single-segment values without separators (e.g. "my-project") are returned
+// unchanged with pathLike=false.
+func sanitizePathLike(s string) (pathLike bool, basename string) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return false, ""
+	}
+	hasBackslash := strings.Contains(trimmed, `\`)
+	hasForwardSlash := strings.Contains(trimmed, `/`)
+	if !hasBackslash && !hasForwardSlash {
+		return false, trimmed
+	}
+	// At least one separator → treat as path. Use forward slashes uniformly
+	// and take the last non-empty segment as the basename.
+	uniform := strings.ReplaceAll(trimmed, `\`, `/`)
+	uniform = strings.TrimRight(uniform, `/`)
+	parts := strings.Split(uniform, `/`)
+	for i := len(parts) - 1; i >= 0; i-- {
+		seg := strings.TrimSpace(parts[i])
+		// Skip drive letters like "C:" and empty segments from leading slashes.
+		if seg == "" || (len(seg) == 2 && seg[1] == ':') {
+			continue
+		}
+		return true, seg
+	}
+	// Fallback: nothing useful → mark as path-like with empty basename so caller
+	// can fall back to "unknown" via the recursion above.
+	return true, ""
 }
 
 // SuggestTopicKey generates a stable topic key suggestion from type/title/content.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5866,6 +5866,187 @@ func TestNormalizeProjectFunction(t *testing.T) {
 	}
 }
 
+// TestNormalizeProject_PathLike covers the path-sanitization branch added to
+// fix the bug where the MCP server, when it could not auto-detect a project
+// from cwd, persisted observations under a project named after the absolute
+// path (e.g. "C:\Users\maicolj"). NormalizeProject now detects path-like input
+// and reduces it to the basename with a warning, so even if a path slips
+// through the detection layer it will not pollute the project list.
+func TestNormalizeProject_PathLike(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantName    string
+		wantWarning bool
+	}{
+		{
+			name:        "windows drive path",
+			input:       `C:\Users\maicolj`,
+			wantName:    "maicolj",
+			wantWarning: true,
+		},
+		{
+			name:        "windows drive path with forward slashes",
+			input:       `C:/Users/Foo/.opencode`,
+			wantName:    ".opencode",
+			wantWarning: true,
+		},
+		{
+			name:        "unix absolute path",
+			input:       "/home/foo/repos/bar",
+			wantName:    "bar",
+			wantWarning: true,
+		},
+		{
+			name:        "relative path with forward slash",
+			input:       "src/scripts",
+			wantName:    "scripts",
+			wantWarning: true,
+		},
+		{
+			name:        "unc path",
+			input:       `\\server\share\folder`,
+			wantName:    "folder",
+			wantWarning: true,
+		},
+		{
+			name:        "trailing separator",
+			input:       `C:\SDK\jarvis\`,
+			wantName:    "jarvis",
+			wantWarning: true,
+		},
+		{
+			name:        "drive root only",
+			input:       `C:\`,
+			wantName:    "unknown", // recursive call into normalize hits empty basename → unknown
+			wantWarning: true,
+		},
+		{
+			name:        "plain name with no separators is untouched",
+			input:       "my-project",
+			wantName:    "my-project",
+			wantWarning: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warning := NormalizeProject(tc.input)
+			if got != tc.wantName {
+				t.Errorf("NormalizeProject(%q) name = %q, want %q", tc.input, got, tc.wantName)
+			}
+			if tc.wantWarning && warning == "" {
+				t.Errorf("NormalizeProject(%q) expected a warning, got empty string", tc.input)
+			}
+			if !tc.wantWarning && warning != "" {
+				t.Errorf("NormalizeProject(%q) expected no warning, got %q", tc.input, warning)
+			}
+		})
+	}
+}
+
+// TestResolveProjectName_CaseInsensitive covers the bug where a search filter
+// like project="E3" reported "Project 'e3' not found" even though the store
+// contained an observation under project="E3" — typical for legacy data
+// imported before NormalizeProject became authoritative. The new helper falls
+// back to a COLLATE NOCASE lookup and returns the canonical stored casing so
+// downstream queries can match exactly.
+//
+// The test bypasses CreateSession (which normalizes on write) and writes the
+// row with the original casing directly via SQL, simulating data that
+// pre-dates the lowercase invariant.
+func TestResolveProjectName_CaseInsensitive(t *testing.T) {
+	s := newTestStore(t)
+
+	// Seed legacy-shaped data: a session row stored with capitalized "E3".
+	if _, err := s.db.Exec(
+		`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, ?, ?)`,
+		"sess-legacy-e3", "E3", "/tmp", 0,
+	); err != nil {
+		t.Fatalf("seed legacy session: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		input         string
+		wantCanonical string
+		wantExists    bool
+	}{
+		{
+			name:          "exact match preserves casing",
+			input:         "E3",
+			wantCanonical: "E3",
+			wantExists:    true,
+		},
+		{
+			name:          "lowercase input falls back to capitalized stored project",
+			input:         "e3",
+			wantCanonical: "E3",
+			wantExists:    true,
+		},
+		{
+			name:          "truly unknown project returns false",
+			input:         "does-not-exist",
+			wantCanonical: "",
+			wantExists:    false,
+		},
+		{
+			name:          "empty input returns false without error",
+			input:         "",
+			wantCanonical: "",
+			wantExists:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			canonical, exists, err := s.ResolveProjectName(tc.input)
+			if err != nil {
+				t.Fatalf("ResolveProjectName(%q) error: %v", tc.input, err)
+			}
+			if exists != tc.wantExists {
+				t.Errorf("ResolveProjectName(%q) exists = %v, want %v", tc.input, exists, tc.wantExists)
+			}
+			if canonical != tc.wantCanonical {
+				t.Errorf("ResolveProjectName(%q) canonical = %q, want %q",
+					tc.input, canonical, tc.wantCanonical)
+			}
+		})
+	}
+}
+
+// TestResolveProjectName_PrefersExactCaseWhenBothExist verifies that when the
+// store contains BOTH "E3" and "e3" (rare but possible after data import),
+// an input matching one casing exactly resolves to that casing — not the
+// other variant. This preserves addressability of distinct casings.
+func TestResolveProjectName_PrefersExactCaseWhenBothExist(t *testing.T) {
+	s := newTestStore(t)
+
+	for _, casing := range []string{"E3", "e3"} {
+		if _, err := s.db.Exec(
+			`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, ?, ?)`,
+			"sess-"+casing, casing, "/tmp", 0,
+		); err != nil {
+			t.Fatalf("seed session %q: %v", casing, err)
+		}
+	}
+
+	// Exact matches must return the queried casing, not the other.
+	for _, casing := range []string{"E3", "e3"} {
+		canonical, exists, err := s.ResolveProjectName(casing)
+		if err != nil {
+			t.Fatalf("ResolveProjectName(%q): %v", casing, err)
+		}
+		if !exists {
+			t.Errorf("ResolveProjectName(%q) exists=false; want true", casing)
+		}
+		if canonical != casing {
+			t.Errorf("ResolveProjectName(%q) canonical = %q; want %q (exact-case match must win)",
+				casing, canonical, casing)
+		}
+	}
+}
+
 func TestAddObservationNormalizesProject(t *testing.T) {
 	s := newTestStore(t)
 


### PR DESCRIPTION
## Summary

Fixes the 4 related bugs reported in #283:

1. **`mem_save` blocks with `ambiguous_project`** when cwd has multiple `.git` children (very common when MCP server starts from `$HOME`).
2. **Path-like project names** can slip into the store (legacy `C:\Users\…` artifacts).
3. **`mem_search` with `project="E3"`** reports "Project 'e3' not found" even though the store has a row under `E3` (case-sensitivity inconsistency for legacy data).
4. **`engram projects consolidate --all`** groups dozens of unrelated projects into a single component because every project transitively shares `$HOME` as a "directory fingerprint" → unsafe merge proposed.

Closes #283

## Changes by bug

### Bug #1 — `mem_save` ambiguity fallback

- **New flag** `engram mcp --default-project=NAME` configures a project to fall back to when cwd-based detection returns `ErrAmbiguousProject`.
- New package-level setter `mcp.SetDefaultProjectFallback(name)` in `internal/mcp/mcp.go`. The fallback is **opt-in**: empty string preserves the historical "fail fast" contract.
- When the fallback fires, the response envelope keeps the original `available_projects` and adds `Source: "default_fallback"` plus a `Warning` so callers can see what happened.
- Help text updated.

**Files**: `internal/mcp/mcp.go`, `cmd/engram/main.go` (flag parsing + help text).

### Bug #2 — Reject path-like project names

- `NormalizeProject` now detects filesystem paths (Windows drive paths, UNC, Unix absolute, anything with `\` or `/`) and reduces them to the basename with a warning.
- Pure helper `sanitizePathLike` extracted for testability.
- Edge case: a drive root (`C:\`) yields empty basename → recursion bottoms out at `"unknown"` instead of leaving an empty project name.

**Files**: `internal/store/store.go`.

### Bug #3 — Case-insensitive project resolution

- New `Store.ResolveProjectName(input)` method: tries case-sensitive match first (fast path), falls back to `COLLATE NOCASE` and returns the canonical stored casing. Distinct casings (e.g. both `E3` and `e3` in store) remain individually addressable — exact-case match wins.
- `resolveReadProject` in `internal/mcp/mcp.go` now uses `ResolveProjectName` instead of `ProjectExists`, with two attempts: normalized form first, then the raw user override (in case the user passed exact stored casing that survives normalization).
- The returned `DetectionResult.Project` is the canonical stored name, not the normalized input — so downstream queries match exact rows.

**Files**: `internal/store/store.go`, `internal/mcp/mcp.go`.

### Bug #4 — Tighten `consolidate` similarity grouping

- `groupSimilarProjects` is now a thin wrapper over `groupSimilarProjectsWithMode(projects, strictSimilarity bool)`.
- New constant `maxSharedProjectsForDirMatch = 3`: when a directory is touched by more than 3 distinct projects, it is treated as too noisy to be a fingerprint and is **skipped** in the union-find. This is what eliminates the catastrophic transitive cluster where every project sharing `$HOME` got merged into one component.
- New flag **`engram projects consolidate --strict-similarity`**: disables shared-directory union entirely. Only name-similarity edges are formed. Recommended for stores where the user knows many projects share noisy parent paths.
- Help text updated.

**Files**: `cmd/engram/main.go`.

## Tests added

- `TestNormalizeProject_PathLike` (8 cases — Windows drive paths, UNC, Unix absolute, relative paths with separators, drive root edge case, plain-name passthrough).
- `TestResolveProjectName_CaseInsensitive` (legacy `E3` row inserted directly via SQL, covers exact match, lowercase fallback, unknown, empty).
- `TestResolveProjectName_PrefersExactCaseWhenBothExist` (asserts addressability of distinct casings).
- `TestResolveWriteProject_AmbiguousFallback` (fallback to `general` when `--default-project` is set, asserts envelope fields).
- `TestSetDefaultProjectFallback_NormalizesAndTrims` (confirms input normalization).
- `TestGroupSimilarProjects_NoisyDirectoryNotMerged` (5 unrelated projects sharing `$HOME` → 0 groups).
- `TestGroupSimilarProjects_LegitimateRenameStillMerges` (2 projects with unique shared dir → 1 group, canonical chosen by obs count).
- `TestGroupSimilarProjectsWithMode_StrictDisablesDirUnion` (strict mode skips dir union even for legitimate renames).

`TestResolveWriteProject_AmbiguousError` was updated to explicitly clear the fallback so it continues to assert the historical error path.

## Backward compatibility

- **No breaking changes**. All new behavior is opt-in:
  - `--default-project` is empty by default → ambiguous cwd still errors as before.
  - `--strict-similarity` is opt-in → consolidate behavior unchanged for users who do not pass it.
  - Path sanitization in `NormalizeProject` only activates when the input contains path separators — names without separators (the overwhelming majority of inputs) are unchanged.
  - `ResolveProjectName` is a new method; existing `ProjectExists` is untouched. The MCP layer now prefers the new method but case-sensitive matches still work identically.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test ./internal/project/ ./internal/store/ ./internal/mcp/ ./cmd/engram/ -count=1` — all passing locally (existing + new tests).
- [ ] Maintainer to confirm CI passes.

## Notes

- Issue #283 is currently `status:needs-review`. This PR is opened ahead of approval as a courtesy starting point so the maintainer can review the proposed shape of the fixes alongside the bug report. Happy to revise scope, split into smaller PRs, or hold until approval — whatever works best for the project.
- Two of the bugs (#1, #4) materially reduce risk for users with multi-repo home directories or large project stores accumulated over months. The fixes are conservative (opt-in flags + numeric thresholds) so the blast radius is small even if a behavior nuance was missed.

🙏 Thanks for the great tool.
