### PR TITLE
fix(dashboard): show current cloud browser state

### DIFF
--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -116,7 +116,31 @@ Add to your `.claude/settings.json` (project) or `~/.claude/settings.json` (glob
 
 With bare MCP, add a [Surviving Compaction](#surviving-compaction-recommended) prompt to your `CLAUDE.md` so the agent remembers to use Engram after context resets.
 
-> **Windows note:** The Claude Code plugin hooks use bash scripts. On Windows, Claude Code runs hooks through Git Bash (bundled with [Git for Windows](https://gitforwindows.org/)) or WSL. If hooks don't fire, ensure `bash` is available in your `PATH`. Alternatively, use **Option C (Bare MCP)** which works natively on Windows without any shell dependency.
+> **Windows note:** The Claude Code plugin hooks use bash scripts. On Windows, Claude Code runs hooks through Git Bash (bundled with [Git for Windows](https://gitforwindows.org/)) or WSL. The `UserPromptSubmit` hook automatically switches to a fork-light safe path under Git Bash/MSYS2: the first-prompt ToolSearch still runs, while later save-reminder checks are skipped so prompt submission does not block. If Git Bash itself is blocked by Defender/EDR, the plugin also ships `scripts/user-prompt-submit.ps1` as a native PowerShell fallback for local override/testing. **Option C (Bare MCP)** remains the no-hook fallback and works natively on Windows without any shell dependency.
+
+PowerShell fallback test and local override example:
+
+```powershell
+'{"session_id":"edr/test:1"}' | pwsh -NoProfile -ExecutionPolicy Bypass -File "C:\path\to\engram\plugin\claude-code\scripts\user-prompt-submit.ps1"
+```
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File \"C:\\path\\to\\engram\\plugin\\claude-code\\scripts\\user-prompt-submit.ps1\"",
+            "timeout": 2
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 See [Plugins → Claude Code Plugin](PLUGINS.md#claude-code-plugin) for details on what the plugin provides.
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -99,6 +99,8 @@ plugin/claude-code/
 ├── scripts/
 │   ├── session-start.sh           # Ensures server, creates session, imports chunks, injects context
 │   ├── post-compaction.sh         # Injects previous context + recovery instructions
+│   ├── user-prompt-submit.sh      # Loads MCP tools on first prompt; Windows Git Bash safe mode
+│   ├── user-prompt-submit.ps1     # Optional Windows-native fallback for locked-down endpoints
 │   ├── subagent-stop.sh           # Passive capture trigger on subagent completion
 │   └── session-stop.sh            # Logs end-of-session event
 └── skills/memory/SKILL.md         # Memory Protocol (when to save, search, close, recover)
@@ -116,6 +118,37 @@ plugin/claude-code/
 1. Injects the previous session context + compacted summary
 2. Tells the agent: "FIRST ACTION REQUIRED — call `mem_session_summary` with this content before doing anything else"
 3. This ensures no work is lost when context is compressed
+
+**On user prompt submit**:
+1. The first prompt injects a ToolSearch instruction so Claude Code loads Engram MCP tools before responding.
+2. Later prompts may inject a save reminder if the local Engram API is fast and available.
+3. On Windows Git Bash/MSYS2, the hook uses a bash-builtin-only safe path to avoid fork-heavy helpers (`jq`, `git`, `curl`, `date`). In that mode first-prompt ToolSearch still works, but later save reminders degrade to `{}` so prompt submission stays fast.
+
+If Git Bash itself is blocked by enterprise security tooling, `scripts/user-prompt-submit.ps1` is provided as a native PowerShell fallback for manual hook testing or local override.
+
+PowerShell local override/testing example for locked-down Windows endpoints:
+
+```powershell
+# Test the native fallback directly. First run emits ToolSearch; second run emits {}.
+'{"session_id":"edr/test:1"}' | pwsh -NoProfile -ExecutionPolicy Bypass -File "C:\path\to\engram\plugin\claude-code\scripts\user-prompt-submit.ps1"
+
+# Local Claude Code override in .claude/settings.json or user settings:
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File \"C:\\path\\to\\engram\\plugin\\claude-code\\scripts\\user-prompt-submit.ps1\"",
+            "timeout": 2
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 **Memory Protocol skill** (always available):
 - Strict rules for **when to save** (mandatory after bugfixes, decisions, discoveries)

--- a/internal/cloud/cloudstore/dashboard_queries.go
+++ b/internal/cloud/cloudstore/dashboard_queries.go
@@ -109,6 +109,18 @@ type dashboardReadModel struct {
 	admin          DashboardAdminOverview
 }
 
+type dashboardEntityKey struct {
+	project   string
+	entityKey string
+}
+
+func newDashboardEntityKey(project, entityKey string) dashboardEntityKey {
+	return dashboardEntityKey{
+		project:   strings.TrimSpace(project),
+		entityKey: strings.TrimSpace(entityKey),
+	}
+}
+
 func buildDashboardReadModel(chunks []dashboardChunkRow) (dashboardReadModel, error) {
 	return buildDashboardReadModelFromRows(chunks, nil)
 }
@@ -133,9 +145,9 @@ func buildDashboardReadModelFromRows(chunks []dashboardChunkRow, mutationRows []
 	contributorProjects := make(map[string]map[string]struct{})
 	projectContributors := make(map[string]map[string]*DashboardContributorRow)
 
-	sessions := make(map[string]DashboardSessionRow)
-	observations := make(map[string]DashboardObservationRow)
-	prompts := make(map[string]DashboardPromptRow)
+	sessions := make(map[dashboardEntityKey]DashboardSessionRow)
+	observations := make(map[dashboardEntityKey]DashboardObservationRow)
+	prompts := make(map[dashboardEntityKey]DashboardPromptRow)
 
 	for _, chunk := range ordered {
 		project := strings.TrimSpace(chunk.project)
@@ -157,7 +169,8 @@ func buildDashboardReadModelFromRows(chunks []dashboardChunkRow, mutationRows []
 			// sets started_at+project; close chunk sets ended_at+summary but omits them).
 			// Inherit any non-empty field from the existing row before calling upsert.
 			trimmedID := strings.TrimSpace(session.ID)
-			if existing, ok := sessions[trimmedID]; ok {
+			sessionProject := resolveProjectValue(session.Project, project)
+			if existing, ok := sessions[newDashboardEntityKey(sessionProject, trimmedID)]; ok {
 				if session.StartedAt == "" {
 					session.StartedAt = existing.StartedAt
 				}
@@ -175,16 +188,16 @@ func buildDashboardReadModelFromRows(chunks []dashboardChunkRow, mutationRows []
 					session.Project = existing.Project
 				}
 			}
-			upsertDashboardSession(sessions, session.ID, resolveProjectValue(session.Project, project), session.StartedAt, endedAt, summary, session.Directory)
+			upsertDashboardSession(sessions, session.ID, sessionProject, session.StartedAt, endedAt, summary, session.Directory)
 		}
 		for _, obs := range chunk.parsed.Observations {
-			if obs.DeletedAt != nil && strings.TrimSpace(*obs.DeletedAt) != "" {
-				delete(observations, strings.TrimSpace(obs.SyncID))
-				continue
-			}
 			obsProject := project
 			if obs.Project != nil {
 				obsProject = resolveProjectValue(*obs.Project, project)
+			}
+			if obs.DeletedAt != nil && strings.TrimSpace(*obs.DeletedAt) != "" {
+				delete(observations, newDashboardEntityKey(obsProject, obs.SyncID))
+				continue
 			}
 			topicKey := ""
 			if obs.TopicKey != nil {
@@ -264,6 +277,7 @@ func buildDashboardReadModelFromRows(chunks []dashboardChunkRow, mutationRows []
 			return dashboardReadModel{}, fmt.Errorf("cloudstore: invalid dashboard mutation payload in cloud_mutations seq %d: %w", mutationRow.seq, err)
 		}
 	}
+	pruneDashboardEntitiesWithoutCloudMutation(orderedMutations, sessions, observations, prompts)
 
 	projects := make(map[string]*DashboardProjectRow, len(projectChunkCounts))
 	detailSessions := make(map[string][]DashboardSessionRow)
@@ -378,6 +392,82 @@ func buildDashboardReadModelFromRows(chunks []dashboardChunkRow, mutationRows []
 	}, nil
 }
 
+func pruneDashboardEntitiesWithoutCloudMutation(
+	mutationRows []dashboardMutationRow,
+	sessions map[dashboardEntityKey]DashboardSessionRow,
+	observations map[dashboardEntityKey]DashboardObservationRow,
+	prompts map[dashboardEntityKey]DashboardPromptRow,
+) {
+	// cloud_chunks remain audit history, but once cloud_mutations has rows for an
+	// entity type, dashboard browser counts should reflect the mutation-backed
+	// current-state keys instead of treating every historical chunk payload row as
+	// currently visible.
+	currentKeys := make(map[string]map[string]map[string]struct{})
+	for _, row := range mutationRows {
+		entity := strings.TrimSpace(row.entity)
+		project := strings.TrimSpace(row.project)
+		key := strings.TrimSpace(row.entityKey)
+		if entity == "" || project == "" || key == "" {
+			continue
+		}
+		if currentKeys[entity] == nil {
+			currentKeys[entity] = make(map[string]map[string]struct{})
+		}
+		if currentKeys[entity][project] == nil {
+			currentKeys[entity][project] = make(map[string]struct{})
+		}
+		currentKeys[entity][project][key] = struct{}{}
+	}
+
+	if keys, ok := currentKeys[store.SyncEntityObservation]; ok {
+		pruneDashboardRowsWithoutCloudMutation(observations, keys, func(row DashboardObservationRow) string { return row.Project }, nil)
+	}
+	if keys, ok := currentKeys[store.SyncEntityPrompt]; ok {
+		pruneDashboardRowsWithoutCloudMutation(prompts, keys, func(row DashboardPromptRow) string { return row.Project }, nil)
+	}
+
+	referencedSessions := make(map[string]map[string]struct{})
+	addReferencedSession := func(project, sessionID string) {
+		project = strings.TrimSpace(project)
+		sessionID = strings.TrimSpace(sessionID)
+		if project == "" || sessionID == "" {
+			return
+		}
+		if referencedSessions[project] == nil {
+			referencedSessions[project] = make(map[string]struct{})
+		}
+		referencedSessions[project][sessionID] = struct{}{}
+	}
+	for _, row := range observations {
+		addReferencedSession(row.Project, row.SessionID)
+	}
+	for _, row := range prompts {
+		addReferencedSession(row.Project, row.SessionID)
+	}
+	if keys, ok := currentKeys[store.SyncEntitySession]; ok {
+		pruneDashboardRowsWithoutCloudMutation(sessions, keys, func(row DashboardSessionRow) string { return row.Project }, referencedSessions)
+	}
+}
+
+func pruneDashboardRowsWithoutCloudMutation[T any](rows map[dashboardEntityKey]T, currentKeys map[string]map[string]struct{}, projectOf func(T) string, preserveKeys map[string]map[string]struct{}) {
+	for key := range rows {
+		trimmedKey := strings.TrimSpace(key.entityKey)
+		project := strings.TrimSpace(projectOf(rows[key]))
+		if keys, ok := preserveKeys[project]; ok {
+			if _, preserved := keys[trimmedKey]; preserved {
+				continue
+			}
+		}
+		keys, ok := currentKeys[project]
+		if !ok {
+			continue
+		}
+		if _, ok := keys[trimmedKey]; !ok {
+			delete(rows, key)
+		}
+	}
+}
+
 func resolveProjectValue(primary string, fallback string) string {
 	if value := strings.TrimSpace(primary); value != "" {
 		return value
@@ -385,13 +475,14 @@ func resolveProjectValue(primary string, fallback string) string {
 	return strings.TrimSpace(fallback)
 }
 
-func upsertDashboardSession(sessions map[string]DashboardSessionRow, sessionID, project, startedAt, endedAt, summary, directory string) {
+func upsertDashboardSession(sessions map[dashboardEntityKey]DashboardSessionRow, sessionID, project, startedAt, endedAt, summary, directory string) {
 	key := strings.TrimSpace(sessionID)
 	if key == "" {
 		return
 	}
-	sessions[key] = DashboardSessionRow{
-		Project:   strings.TrimSpace(project),
+	trimmedProject := strings.TrimSpace(project)
+	sessions[newDashboardEntityKey(trimmedProject, key)] = DashboardSessionRow{
+		Project:   trimmedProject,
 		SessionID: key,
 		StartedAt: strings.TrimSpace(startedAt),
 		EndedAt:   strings.TrimSpace(endedAt),
@@ -400,14 +491,15 @@ func upsertDashboardSession(sessions map[string]DashboardSessionRow, sessionID, 
 	}
 }
 
-func upsertDashboardObservation(observations map[string]DashboardObservationRow, syncID, project, sessionID, obsType, title, content, topicKey, toolName, chunkID, createdAt string) {
+func upsertDashboardObservation(observations map[dashboardEntityKey]DashboardObservationRow, syncID, project, sessionID, obsType, title, content, topicKey, toolName, chunkID, createdAt string) {
 	key := strings.TrimSpace(syncID)
 	if key == "" {
 		return
 	}
-	observations[key] = DashboardObservationRow{
+	trimmedProject := strings.TrimSpace(project)
+	observations[newDashboardEntityKey(trimmedProject, key)] = DashboardObservationRow{
 		SyncID:    key,
-		Project:   strings.TrimSpace(project),
+		Project:   trimmedProject,
 		SessionID: strings.TrimSpace(sessionID),
 		ChunkID:   strings.TrimSpace(chunkID),
 		Type:      strings.TrimSpace(obsType),
@@ -419,14 +511,15 @@ func upsertDashboardObservation(observations map[string]DashboardObservationRow,
 	}
 }
 
-func upsertDashboardPrompt(prompts map[string]DashboardPromptRow, syncID, project, sessionID, content, chunkID, createdAt string) {
+func upsertDashboardPrompt(prompts map[dashboardEntityKey]DashboardPromptRow, syncID, project, sessionID, content, chunkID, createdAt string) {
 	key := strings.TrimSpace(syncID)
 	if key == "" {
 		return
 	}
-	prompts[key] = DashboardPromptRow{
+	trimmedProject := strings.TrimSpace(project)
+	prompts[newDashboardEntityKey(trimmedProject, key)] = DashboardPromptRow{
 		SyncID:    key,
-		Project:   strings.TrimSpace(project),
+		Project:   trimmedProject,
 		SessionID: strings.TrimSpace(sessionID),
 		ChunkID:   strings.TrimSpace(chunkID),
 		Content:   strings.TrimSpace(content),
@@ -473,9 +566,9 @@ type dashboardPromptMutationPayload struct {
 func applyDashboardMutation(
 	chunkProject string,
 	mutation store.SyncMutation,
-	sessions map[string]DashboardSessionRow,
-	observations map[string]DashboardObservationRow,
-	prompts map[string]DashboardPromptRow,
+	sessions map[dashboardEntityKey]DashboardSessionRow,
+	observations map[dashboardEntityKey]DashboardObservationRow,
+	prompts map[dashboardEntityKey]DashboardPromptRow,
 ) error {
 	entity := strings.TrimSpace(mutation.Entity)
 	op := strings.TrimSpace(mutation.Op)
@@ -488,8 +581,9 @@ func applyDashboardMutation(
 			return err
 		}
 		key := resolveProjectValue(entityKey, body.ID)
+		project := resolveProjectValue(body.Project, chunkProject)
 		if op == store.SyncOpDelete || body.Deleted || body.HardDelete || (body.DeletedAt != nil && strings.TrimSpace(*body.DeletedAt) != "") {
-			delete(sessions, strings.TrimSpace(key))
+			delete(sessions, newDashboardEntityKey(project, key))
 			return nil
 		}
 		// C3 + R2-5: Preserve close fields and StartedAt from a prior sessions-array pass.
@@ -498,7 +592,7 @@ func applyDashboardMutation(
 		existingEndedAt := ""
 		existingSummary := ""
 		existingDirectory := ""
-		if existing, ok := sessions[strings.TrimSpace(key)]; ok {
+		if existing, ok := sessions[newDashboardEntityKey(project, key)]; ok {
 			existingStartedAt = existing.StartedAt
 			existingEndedAt = existing.EndedAt
 			existingSummary = existing.Summary
@@ -520,25 +614,25 @@ func applyDashboardMutation(
 		if resolvedDirectory == "" {
 			resolvedDirectory = existingDirectory
 		}
-		upsertDashboardSession(sessions, key, resolveProjectValue(body.Project, chunkProject), resolvedStartedAt, resolvedEndedAt, resolvedSummary, resolvedDirectory)
+		upsertDashboardSession(sessions, key, project, resolvedStartedAt, resolvedEndedAt, resolvedSummary, resolvedDirectory)
 	case store.SyncEntityObservation:
 		var body dashboardObservationMutationPayload
 		if err := chunkcodec.DecodeSyncMutationPayload(mutation.Payload, &body); err != nil {
 			return err
 		}
 		key := resolveProjectValue(entityKey, body.SyncID)
-		if op == store.SyncOpDelete || body.Deleted || body.HardDelete {
-			delete(observations, strings.TrimSpace(key))
-			return nil
-		}
 		project := strings.TrimSpace(chunkProject)
 		if body.Project != nil {
 			project = resolveProjectValue(*body.Project, project)
 		}
 		if project == "" {
-			if session, ok := sessions[strings.TrimSpace(body.SessionID)]; ok {
+			if session, ok := sessions[newDashboardEntityKey(project, body.SessionID)]; ok {
 				project = strings.TrimSpace(session.Project)
 			}
+		}
+		if op == store.SyncOpDelete || body.Deleted || body.HardDelete {
+			delete(observations, newDashboardEntityKey(project, key))
+			return nil
 		}
 		// R2-6 + prior fixes: Preserve all scalar fields from a prior observations-array pass.
 		// Mutations may carry only a subset of fields; any empty field inherits the stored value.
@@ -550,7 +644,7 @@ func applyDashboardMutation(
 		existingTopicKey := ""
 		existingToolName := ""
 		existingCreatedAt := ""
-		if existing, ok := observations[strings.TrimSpace(key)]; ok {
+		if existing, ok := observations[newDashboardEntityKey(project, key)]; ok {
 			existingChunkID = existing.ChunkID
 			existingSessionID = existing.SessionID
 			existingType = existing.Type
@@ -595,18 +689,18 @@ func applyDashboardMutation(
 			return err
 		}
 		key := resolveProjectValue(entityKey, body.SyncID)
-		if op == store.SyncOpDelete || body.Deleted || body.HardDelete {
-			delete(prompts, strings.TrimSpace(key))
-			return nil
-		}
 		project := strings.TrimSpace(chunkProject)
 		if body.Project != nil {
 			project = resolveProjectValue(*body.Project, project)
 		}
 		if project == "" {
-			if session, ok := sessions[strings.TrimSpace(body.SessionID)]; ok {
+			if session, ok := sessions[newDashboardEntityKey(project, body.SessionID)]; ok {
 				project = strings.TrimSpace(session.Project)
 			}
+		}
+		if op == store.SyncOpDelete || body.Deleted || body.HardDelete {
+			delete(prompts, newDashboardEntityKey(project, key))
+			return nil
 		}
 		// C2: Preserve ChunkID from a prior prompts-array pass — mutations do not
 		// carry which chunk they originated from, so inherit the stored value.
@@ -616,7 +710,7 @@ func applyDashboardMutation(
 		existingPromptContent := ""
 		existingPromptSessionID := ""
 		existingPromptCreatedAt := ""
-		if existing, ok := prompts[strings.TrimSpace(key)]; ok {
+		if existing, ok := prompts[newDashboardEntityKey(project, key)]; ok {
 			existingPromptChunkID = existing.ChunkID
 			existingPromptContent = existing.Content
 			existingPromptSessionID = existing.SessionID

--- a/internal/cloud/cloudstore/dashboard_queries_test.go
+++ b/internal/cloud/cloudstore/dashboard_queries_test.go
@@ -1227,6 +1227,274 @@ func TestStandaloneCloudMutationDeleteWinsBySeq(t *testing.T) {
 	}
 }
 
+func TestCloudMutationsDefineCurrentObservationStateWhenChunksContainHistory(t *testing.T) {
+	chunks := []dashboardChunkRow{
+		{
+			chunkID:   "chunk-history-1",
+			project:   "engram",
+			createdBy: "doctor@example.com",
+			createdAt: time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"observations":[
+					{"sync_id":"obs-historical-1","session_id":"sess-history","project":"engram","type":"decision","title":"historical one","created_at":"2026-04-20T09:10:00Z"},
+					{"sync_id":"obs-historical-2","session_id":"sess-history","project":"engram","type":"decision","title":"historical two","created_at":"2026-04-20T09:20:00Z"},
+					{"sync_id":"obs-current","session_id":"sess-current","project":"engram","type":"decision","title":"stale chunk title","created_at":"2026-04-20T09:30:00Z"}
+				]
+			}`)),
+		},
+	}
+	currentPayload, err := json.Marshal(map[string]any{
+		"sync_id":    "obs-current",
+		"session_id": "sess-current",
+		"project":    "engram",
+		"type":       "decision",
+		"title":      "current mutation title",
+		"created_at": "2026-04-21T09:30:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal current mutation payload: %v", err)
+	}
+
+	model, err := buildDashboardReadModelFromRows(chunks, []dashboardMutationRow{
+		{seq: 200, project: "engram", entity: "observation", entityKey: "obs-current", op: "upsert", payload: currentPayload, occurredAt: time.Date(2026, 4, 21, 9, 30, 0, 0, time.UTC)},
+	})
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+
+	detail, ok := model.projectDetails["engram"]
+	if !ok {
+		t.Fatal("expected engram project detail")
+	}
+	if detail.Stats.Observations != 1 {
+		t.Fatalf("expected current observation count=1, got %d (%+v)", detail.Stats.Observations, detail.Observations)
+	}
+	if len(detail.Observations) != 1 {
+		t.Fatalf("expected exactly one current observation row, got %d", len(detail.Observations))
+	}
+	if detail.Observations[0].SyncID != "obs-current" {
+		t.Fatalf("expected only obs-current to remain, got %q", detail.Observations[0].SyncID)
+	}
+	if detail.Observations[0].Title != "current mutation title" {
+		t.Fatalf("expected mutation payload to win, got %q", detail.Observations[0].Title)
+	}
+}
+
+func TestCloudMutationCurrentStatePruningIsProjectScoped(t *testing.T) {
+	chunks := []dashboardChunkRow{
+		{
+			chunkID:   "chunk-project-a",
+			project:   "project-a",
+			createdBy: "doctor@example.com",
+			createdAt: time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"observations":[
+					{"sync_id":"obs-a-history","session_id":"sess-a","project":"project-a","type":"decision","title":"historical a","created_at":"2026-04-20T09:10:00Z"},
+					{"sync_id":"obs-a-current","session_id":"sess-a","project":"project-a","type":"decision","title":"current a chunk","created_at":"2026-04-20T09:20:00Z"}
+				]
+			}`)),
+		},
+		{
+			chunkID:   "chunk-project-b",
+			project:   "project-b",
+			createdBy: "doctor@example.com",
+			createdAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"observations":[
+					{"sync_id":"obs-b-chunk-only","session_id":"sess-b","project":"project-b","type":"decision","title":"chunk only b","created_at":"2026-04-20T10:10:00Z"}
+				]
+			}`)),
+		},
+	}
+	currentPayload, err := json.Marshal(map[string]any{
+		"sync_id":    "obs-a-current",
+		"session_id": "sess-a",
+		"project":    "project-a",
+		"type":       "decision",
+		"title":      "current a mutation",
+		"created_at": "2026-04-21T09:30:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal current mutation payload: %v", err)
+	}
+
+	model, err := buildDashboardReadModelFromRows(chunks, []dashboardMutationRow{
+		{seq: 201, project: "project-a", entity: "observation", entityKey: "obs-a-current", op: "upsert", payload: currentPayload, occurredAt: time.Date(2026, 4, 21, 9, 30, 0, 0, time.UTC)},
+	})
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+
+	detailA := model.projectDetails["project-a"]
+	if detailA.Stats.Observations != 1 || len(detailA.Observations) != 1 || detailA.Observations[0].SyncID != "obs-a-current" {
+		t.Fatalf("expected project-a pruning to keep only current observation, got %+v", detailA.Observations)
+	}
+	detailB := model.projectDetails["project-b"]
+	if detailB.Stats.Observations != 1 || len(detailB.Observations) != 1 || detailB.Observations[0].SyncID != "obs-b-chunk-only" {
+		t.Fatalf("expected project-b chunk-only observation to survive project-a pruning, got %+v", detailB.Observations)
+	}
+}
+
+func TestCloudMutationSessionPruningPreservesReferencedParentSession(t *testing.T) {
+	chunks := []dashboardChunkRow{
+		{
+			chunkID:   "chunk-parent-session",
+			project:   "engram",
+			createdBy: "doctor@example.com",
+			createdAt: time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[
+					{"id":"sess-parent","project":"engram","started_at":"2026-04-20T09:00:00Z"},
+					{"id":"sess-stale","project":"engram","started_at":"2026-04-20T08:00:00Z"}
+				],
+				"observations":[
+					{"sync_id":"obs-current-parent","session_id":"sess-parent","project":"engram","type":"decision","title":"current child","created_at":"2026-04-20T09:10:00Z"}
+				]
+			}`)),
+		},
+	}
+	sessionPayload, err := json.Marshal(map[string]any{
+		"id":         "sess-current-other",
+		"project":    "engram",
+		"started_at": "2026-04-21T09:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal session mutation payload: %v", err)
+	}
+	obsPayload, err := json.Marshal(map[string]any{
+		"sync_id":    "obs-current-parent",
+		"session_id": "sess-parent",
+		"project":    "engram",
+		"type":       "decision",
+		"title":      "current child mutation",
+		"created_at": "2026-04-21T09:10:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal observation mutation payload: %v", err)
+	}
+
+	model, err := buildDashboardReadModelFromRows(chunks, []dashboardMutationRow{
+		{seq: 210, project: "engram", entity: "session", entityKey: "sess-current-other", op: "upsert", payload: sessionPayload, occurredAt: time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)},
+		{seq: 211, project: "engram", entity: "observation", entityKey: "obs-current-parent", op: "upsert", payload: obsPayload, occurredAt: time.Date(2026, 4, 21, 9, 10, 0, 0, time.UTC)},
+	})
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+
+	detail := model.projectDetails["engram"]
+	if detail.Stats.Observations != 1 || len(detail.Observations) != 1 {
+		t.Fatalf("expected one retained current observation, got %+v", detail.Observations)
+	}
+	seenParent := false
+	seenStale := false
+	for _, session := range detail.Sessions {
+		switch session.SessionID {
+		case "sess-parent":
+			seenParent = true
+		case "sess-stale":
+			seenStale = true
+		}
+	}
+	if !seenParent {
+		t.Fatalf("expected parent session referenced by retained observation to survive pruning, got %+v", detail.Sessions)
+	}
+	if seenStale {
+		t.Fatalf("expected unreferenced stale session to be pruned, got %+v", detail.Sessions)
+	}
+}
+
+func TestDashboardCurrentStateKeepsDuplicateEntityKeysAcrossProjects(t *testing.T) {
+	chunks := []dashboardChunkRow{
+		{
+			chunkID:   "chunk-duplicate-project-a",
+			project:   "project-a",
+			createdBy: "doctor@example.com",
+			createdAt: time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"shared-session","project":"project-a","started_at":"2026-04-20T09:00:00Z","summary":"project a session"}],
+				"observations":[{"sync_id":"shared-observation","session_id":"shared-session","project":"project-a","type":"decision","title":"project a observation","created_at":"2026-04-20T09:10:00Z"}],
+				"prompts":[{"sync_id":"shared-prompt","session_id":"shared-session","project":"project-a","content":"project a prompt","created_at":"2026-04-20T09:20:00Z"}]
+			}`)),
+		},
+		{
+			chunkID:   "chunk-duplicate-project-b",
+			project:   "project-b",
+			createdBy: "doctor@example.com",
+			createdAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"shared-session","project":"project-b","started_at":"2026-04-20T10:00:00Z","summary":"project b session"}],
+				"observations":[{"sync_id":"shared-observation","session_id":"shared-session","project":"project-b","type":"decision","title":"project b observation","created_at":"2026-04-20T10:10:00Z"}],
+				"prompts":[{"sync_id":"shared-prompt","session_id":"shared-session","project":"project-b","content":"project b prompt","created_at":"2026-04-20T10:20:00Z"}]
+			}`)),
+		},
+	}
+	sessionPayloadA, err := json.Marshal(map[string]any{"id": "shared-session", "project": "project-a", "started_at": "2026-04-20T09:00:00Z", "summary": "project a mutation session"})
+	if err != nil {
+		t.Fatalf("marshal project-a session payload: %v", err)
+	}
+	sessionPayloadB, err := json.Marshal(map[string]any{"id": "shared-session", "project": "project-b", "started_at": "2026-04-20T10:00:00Z", "summary": "project b mutation session"})
+	if err != nil {
+		t.Fatalf("marshal project-b session payload: %v", err)
+	}
+	observationPayloadA, err := json.Marshal(map[string]any{"sync_id": "shared-observation", "session_id": "shared-session", "project": "project-a", "type": "decision", "title": "project a mutation observation", "created_at": "2026-04-20T09:10:00Z"})
+	if err != nil {
+		t.Fatalf("marshal project-a observation payload: %v", err)
+	}
+	observationPayloadB, err := json.Marshal(map[string]any{"sync_id": "shared-observation", "session_id": "shared-session", "project": "project-b", "type": "decision", "title": "project b mutation observation", "created_at": "2026-04-20T10:10:00Z"})
+	if err != nil {
+		t.Fatalf("marshal project-b observation payload: %v", err)
+	}
+	promptPayloadA, err := json.Marshal(map[string]any{"sync_id": "shared-prompt", "session_id": "shared-session", "project": "project-a", "content": "project a mutation prompt", "created_at": "2026-04-20T09:20:00Z"})
+	if err != nil {
+		t.Fatalf("marshal project-a prompt payload: %v", err)
+	}
+	promptPayloadB, err := json.Marshal(map[string]any{"sync_id": "shared-prompt", "session_id": "shared-session", "project": "project-b", "content": "project b mutation prompt", "created_at": "2026-04-20T10:20:00Z"})
+	if err != nil {
+		t.Fatalf("marshal project-b prompt payload: %v", err)
+	}
+
+	model, err := buildDashboardReadModelFromRows(chunks, []dashboardMutationRow{
+		{seq: 300, project: "project-a", entity: "session", entityKey: "shared-session", op: "upsert", payload: sessionPayloadA, occurredAt: time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)},
+		{seq: 301, project: "project-b", entity: "session", entityKey: "shared-session", op: "upsert", payload: sessionPayloadB, occurredAt: time.Date(2026, 4, 21, 10, 0, 0, 0, time.UTC)},
+		{seq: 302, project: "project-a", entity: "observation", entityKey: "shared-observation", op: "upsert", payload: observationPayloadA, occurredAt: time.Date(2026, 4, 21, 9, 10, 0, 0, time.UTC)},
+		{seq: 303, project: "project-b", entity: "observation", entityKey: "shared-observation", op: "upsert", payload: observationPayloadB, occurredAt: time.Date(2026, 4, 21, 10, 10, 0, 0, time.UTC)},
+		{seq: 304, project: "project-a", entity: "prompt", entityKey: "shared-prompt", op: "upsert", payload: promptPayloadA, occurredAt: time.Date(2026, 4, 21, 9, 20, 0, 0, time.UTC)},
+		{seq: 305, project: "project-b", entity: "prompt", entityKey: "shared-prompt", op: "upsert", payload: promptPayloadB, occurredAt: time.Date(2026, 4, 21, 10, 20, 0, 0, time.UTC)},
+	})
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+
+	assertDuplicateProjectDetail := func(project, sessionSummary, observationTitle, promptContent string) {
+		t.Helper()
+		detail, ok := model.projectDetails[project]
+		if !ok {
+			t.Fatalf("expected project detail for %s", project)
+		}
+		if detail.Stats.Sessions != 1 || len(detail.Sessions) != 1 {
+			t.Fatalf("expected one session for %s, stats=%+v rows=%+v", project, detail.Stats, detail.Sessions)
+		}
+		if detail.Sessions[0].SessionID != "shared-session" || detail.Sessions[0].Summary != sessionSummary {
+			t.Fatalf("unexpected session for %s: %+v", project, detail.Sessions[0])
+		}
+		if detail.Stats.Observations != 1 || len(detail.Observations) != 1 {
+			t.Fatalf("expected one observation for %s, stats=%+v rows=%+v", project, detail.Stats, detail.Observations)
+		}
+		if detail.Observations[0].SyncID != "shared-observation" || detail.Observations[0].Title != observationTitle {
+			t.Fatalf("unexpected observation for %s: %+v", project, detail.Observations[0])
+		}
+		if detail.Stats.Prompts != 1 || len(detail.Prompts) != 1 {
+			t.Fatalf("expected one prompt for %s, stats=%+v rows=%+v", project, detail.Stats, detail.Prompts)
+		}
+		if detail.Prompts[0].SyncID != "shared-prompt" || detail.Prompts[0].Content != promptContent {
+			t.Fatalf("unexpected prompt for %s: %+v", project, detail.Prompts[0])
+		}
+	}
+
+	assertDuplicateProjectDetail("project-a", "project a mutation session", "project a mutation observation", "project a mutation prompt")
+	assertDuplicateProjectDetail("project-b", "project b mutation session", "project b mutation observation", "project b mutation prompt")
+}
+
 // ─── R5-4: Dedicated not-found error sentinels ───────────────────────────────
 
 // TestSessionDetailNotFoundReturnsSessionNotFoundError asserts that

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1810,7 +1810,14 @@ func TestClaudeCodeUserPromptHookDefersProjectDetectionUntilNeeded(t *testing.T)
 	text := string(data)
 
 	sessionParse := strings.Index(text, "SESSION_ID=$(echo \"$INPUT\" | jq -r '.session_id // empty')")
-	sessionKeyBranch := strings.Index(text, "if [ -n \"$SESSION_ID\" ]; then")
+	if sessionParse < 0 {
+		t.Fatalf("user prompt hook missing expected session parsing structure")
+	}
+	sessionKeyBranchRel := strings.Index(text[sessionParse:], "if [ -n \"$SESSION_ID\" ]; then")
+	sessionKeyBranch := -1
+	if sessionKeyBranchRel >= 0 {
+		sessionKeyBranch = sessionParse + sessionKeyBranchRel
+	}
 	if sessionParse < 0 || sessionKeyBranch < 0 {
 		t.Fatalf("user prompt hook missing expected session parsing/keying structure")
 	}
@@ -1829,6 +1836,72 @@ func TestClaudeCodeUserPromptHookDefersProjectDetectionUntilNeeded(t *testing.T)
 	}
 	if !strings.Contains(text[subsequentMarker:], "PROJECT=$(detect_project \"$CWD\")") {
 		t.Fatalf("user prompt hook should detect project for subsequent nudge logic after first-message handling")
+	}
+}
+
+func TestClaudeCodeUserPromptHookHasWindowsGitBashSafePath(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "plugin", "claude-code", "scripts", "user-prompt-submit.sh"))
+	if err != nil {
+		t.Fatalf("read user prompt hook: %v", err)
+	}
+	text := string(data)
+
+	safePath := strings.Index(text, "if is_windows_bash &&")
+	scriptDir := strings.Index(text, "SCRIPT_DIR=\"$(cd")
+	if safePath < 0 {
+		t.Fatalf("user prompt hook missing Windows Git Bash safe path")
+	}
+	if scriptDir < 0 || scriptDir < safePath {
+		t.Fatalf("Windows Git Bash safe path must run before dirname/pwd helper setup")
+	}
+
+	blockEnd := strings.Index(text[safePath:], "# Load shared helpers after the Windows-safe fast path")
+	if blockEnd < 0 {
+		t.Fatalf("Windows Git Bash safe path missing explicit end marker")
+	}
+	block := text[safePath : safePath+blockEnd]
+	for _, forkHeavy := range []string{"jq", "curl", "git ", "date ", "dirname", "touch", "$("} {
+		if strings.Contains(block, forkHeavy) {
+			t.Fatalf("Windows Git Bash safe path should avoid fork-heavy %q", forkHeavy)
+		}
+	}
+	if !strings.Contains(block, "printf '%s\\n' '{}'") {
+		t.Fatalf("Windows Git Bash subsequent prompts should degrade to a fast empty response")
+	}
+}
+
+func TestClaudeCodeUserPromptHookSanitizesWindowsSafeSessionKey(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "plugin", "claude-code", "scripts", "user-prompt-submit.sh"))
+	if err != nil {
+		t.Fatalf("read user prompt hook: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"sanitize_session_key_part()",
+		"[[ \"$char\" =~ [a-zA-Z0-9_-] ]]",
+		"SESSION_KEY=\"engram-claude-${JSON_VALUE}-tools-loaded\"",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("user prompt hook missing Windows session key sanitization fragment %q", want)
+		}
+	}
+}
+
+func TestClaudeCodeUserPromptHookIncludesPowerShellFallback(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "plugin", "claude-code", "scripts", "user-prompt-submit.ps1"))
+	if err != nil {
+		t.Fatalf("read PowerShell user prompt hook: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"[Console]::In.ReadToEnd()",
+		"ConvertFrom-Json",
+		"mcp__engram__mem_context",
+		"Write-EmptyHookResponse",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("PowerShell user prompt hook missing %q", want)
+		}
 	}
 }
 
@@ -1858,8 +1931,8 @@ func TestClaudeCodeUserPromptSubmitHookTimeout(t *testing.T) {
 	if hook.Command != "${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh" {
 		t.Fatalf("unexpected UserPromptSubmit command %q", hook.Command)
 	}
-	if hook.Timeout != 5 {
-		t.Fatalf("UserPromptSubmit timeout = %d, want 5", hook.Timeout)
+	if hook.Timeout != 2 {
+		t.Fatalf("UserPromptSubmit timeout = %d, want 2", hook.Timeout)
 	}
 }
 

--- a/plugin/claude-code/hooks/hooks.json
+++ b/plugin/claude-code/hooks/hooks.json
@@ -31,7 +31,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh",
-            "timeout": 5
+            "timeout": 2
           }
         ]
       }

--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -1,0 +1,42 @@
+#!/usr/bin/env pwsh
+# Engram — Windows-native UserPromptSubmit hook for Claude Code
+#
+# Optional fallback for enterprise Windows environments where Git Bash/MSYS2
+# fork emulation is slowed or blocked by Defender/EDR. Keep this script small
+# and dependency-free; it must never block prompt submission.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+function Write-EmptyHookResponse {
+  Write-Output '{}'
+}
+
+function Write-ToolSearchMessage {
+  $message = "CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:`nselect:mcp__engram__mem_save,mcp__engram__mem_search,mcp__engram__mem_context,mcp__engram__mem_session_summary,mcp__engram__mem_session_start,mcp__engram__mem_session_end,mcp__engram__mem_get_observation,mcp__engram__mem_suggest_topic_key,mcp__engram__mem_capture_passive,mcp__engram__mem_save_prompt,mcp__engram__mem_update,mcp__engram__mem_current_project,mcp__engram__mem_judge`n`nAfter loading tools, call mem_context to check for prior session history before responding."
+  [PSCustomObject]@{ systemMessage = $message } | ConvertTo-Json -Compress
+}
+
+try {
+  $inputJson = [Console]::In.ReadToEnd()
+  $payload = $inputJson | ConvertFrom-Json
+  $sessionID = [string]($payload.session_id)
+
+  if ([string]::IsNullOrWhiteSpace($sessionID)) {
+    $sessionID = "windows-$PID"
+  }
+
+  $safeSessionID = $sessionID -replace '[^a-zA-Z0-9_-]', '_'
+  $stateFile = Join-Path ([IO.Path]::GetTempPath()) "engram-claude-$safeSessionID-tools-loaded"
+
+  if (-not (Test-Path -LiteralPath $stateFile)) {
+    New-Item -ItemType File -Path $stateFile -Force | Out-Null
+    Write-ToolSearchMessage
+    exit 0
+  }
+
+  Write-EmptyHookResponse
+  exit 0
+} catch {
+  Write-EmptyHookResponse
+  exit 0
+}

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -13,7 +13,76 @@
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
 ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
 
-# Load shared helpers
+# Windows Git Bash/MSYS2 can fail while forking helper processes under
+# enterprise Defender/EDR, which makes Claude Code wait on prompt submission.
+# Keep the Windows path bash-builtin-only: no jq, git, curl, date, dirname, cat,
+# touch, or command substitutions. It preserves first-message tool loading and
+# degrades subsequent save nudges to a fast no-op instead of risking a hang.
+is_windows_bash() {
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|win32*) return 0 ;;
+  esac
+  [ -n "${MSYSTEM:-}" ] || [ -n "${MINGW_PREFIX:-}" ]
+}
+
+set_json_string_value() {
+  local key="$1"
+  local json="$2"
+  local pattern='"'"$key"'"[[:space:]]*:[[:space:]]*"([^"]*)"'
+  JSON_VALUE=""
+  if [[ "$json" =~ $pattern ]]; then
+    JSON_VALUE="${BASH_REMATCH[1]}"
+  fi
+}
+
+sanitize_session_key_part() {
+  local raw="$1"
+  local safe=""
+  local i char
+  for (( i=0; i<${#raw}; i++ )); do
+    char="${raw:i:1}"
+    if [[ "$char" =~ [a-zA-Z0-9_-] ]]; then
+      safe+="$char"
+    else
+      safe+="_"
+    fi
+  done
+  JSON_VALUE="$safe"
+}
+
+print_toolsearch_message() {
+  printf '%s\n' '{"systemMessage":"CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:\nselect:mcp__engram__mem_save,mcp__engram__mem_search,mcp__engram__mem_context,mcp__engram__mem_session_summary,mcp__engram__mem_session_start,mcp__engram__mem_session_end,mcp__engram__mem_get_observation,mcp__engram__mem_suggest_topic_key,mcp__engram__mem_capture_passive,mcp__engram__mem_save_prompt,mcp__engram__mem_update,mcp__engram__mem_current_project,mcp__engram__mem_judge\n\nAfter loading tools, call mem_context to check for prior session history before responding."}'
+}
+
+if is_windows_bash && [ "${ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE:-auto}" != "0" ]; then
+  INPUT=""
+  while IFS= read -r LINE || [ -n "$LINE" ]; do
+    INPUT+="${LINE}"$'\n'
+  done
+
+  set_json_string_value "session_id" "$INPUT"
+  SESSION_ID="$JSON_VALUE"
+  if [ -n "$SESSION_ID" ]; then
+    sanitize_session_key_part "$SESSION_ID"
+    SESSION_KEY="engram-claude-${JSON_VALUE}-tools-loaded"
+  else
+    SESSION_KEY="engram-claude-windows-$$-tools-loaded"
+  fi
+  STATE_DIR="${TMPDIR:-/tmp}"
+  STATE_FILE="${STATE_DIR}/${SESSION_KEY}"
+
+  if [ ! -f "$STATE_FILE" ]; then
+    : > "$STATE_FILE" 2>/dev/null || true
+    print_toolsearch_message
+    exit 0
+  fi
+
+  printf '%s\n' '{}'
+  exit 0
+fi
+
+# Load shared helpers after the Windows-safe fast path so Git Bash does not fork
+# for dirname/pwd before deciding whether the safe path applies.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/_helpers.sh"
 
@@ -87,11 +156,7 @@ if [ ! -f "$STATE_FILE" ]; then
   touch "$STATE_FILE" 2>/dev/null || true
 
   # Inject ToolSearch + mem_context instruction.
-  # Use --arg so jq handles all escaping; use printf to avoid echo interpreting \n.
-  TOOL_MSG="CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:"$'\n'"select:mcp__engram__mem_save,mcp__engram__mem_search,mcp__engram__mem_context,mcp__engram__mem_session_summary,mcp__engram__mem_session_start,mcp__engram__mem_session_end,mcp__engram__mem_get_observation,mcp__engram__mem_suggest_topic_key,mcp__engram__mem_capture_passive,mcp__engram__mem_save_prompt,mcp__engram__mem_update,mcp__engram__mem_current_project,mcp__engram__mem_judge"$'\n\n'"After loading tools, call mem_context to check for prior session history before responding."
-  OUTPUT=$(jq -n --arg msg "$TOOL_MSG" '{"systemMessage": $msg}')
-
-  printf '%s\n' "$OUTPUT"
+  print_toolsearch_message
   exit 0
 fi
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #291

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Fixes dashboard Browser/read-model counts so mutation-backed entities show current cloud state instead of historical chunk totals.
- Hardens Claude Code `UserPromptSubmit` on Windows Git Bash/MSYS2 with a fork-light safe path and sanitized state filenames.
- Adds PowerShell fallback docs and regression coverage for project-scoped dashboard state.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudstore/dashboard_queries.go` | Uses project-aware current-state keys, scoped pruning, and parent-session preservation. |
| `internal/cloud/cloudstore/dashboard_queries_test.go` | Adds regressions for historical chunks, duplicate IDs across projects, and retained parent sessions. |
| `plugin/claude-code/scripts/user-prompt-submit.sh` | Adds Windows Git Bash safe mode and sanitized state filename. |
| `plugin/claude-code/scripts/user-prompt-submit.ps1` | Adds native PowerShell fallback for enterprise Windows environments. |
| `docs/PLUGINS.md`, `docs/AGENT-SETUP.md` | Documents Windows safe mode and fallback testing/override. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Manual/Judgment evidence:
- Judgment Day Round 3: two blind judges returned CLEAN with zero warnings.
- Windows tester validated no `loading plugins` hang, first run returned ToolSearch in ~533ms, second run returned `{}` in ~467ms, and state filename was sanitized.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Stacked on `feat/doctor-diagnostic` so the diff stays focused on dashboard/current-state and Windows hook hardening.