### PR TITLE
fix(sync): stabilize imports, project lock, and TUI ordering

### DIFF
--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -27,7 +27,17 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 
 ### Project auto-detection (important)
 
-**Do not pass `project` to write tools.** Engram auto-detects the project from the server's working directory (cwd) using git remote URL, repo root name, or directory basename. Agents that include `project` in `mem_save` or similar calls will have that argument silently discarded.
+**Do not pass `project` to write tools.** Engram auto-detects the project from the server's working directory (cwd) using `.engram/config.json`, git remote URL, repo root name, or directory basename. Agents that include `project` in `mem_save` or similar calls will have that argument silently discarded.
+
+To lock write tools to the canonical project for a repo, add `.engram/config.json` at the repo root:
+
+```json
+{
+  "project_name": "sias-app"
+}
+```
+
+When present, `project_name` is used for writes from the repo and its subdirectories and overrides lower-confidence cwd/git detection. This is a write lock only: read tools can still use an explicit `project` filter when you need to query another existing project. Empty or invalid `project_name` values fail writes loudly instead of falling back silently.
 
 **Recommended first call:** `mem_current_project` — confirms which project Engram detected before you start writing. Returns `project_source` (how it was detected) and `available_projects` (if cwd is ambiguous).
 

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1001,12 +1001,7 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 		// Auto-detect project from cwd; fail fast on ambiguous (REQ-308, REQ-309)
 		detRes, err := resolveWriteProject()
 		if err != nil {
-			// JW1: use AvailableProjects from detection result (repos in cwd),
-			// NOT stats.Projects (all store projects).
-			return errorWithMeta("ambiguous_project",
-				fmt.Sprintf("Cannot determine project: %s", err),
-				detRes.AvailableProjects,
-			), nil
+			return writeProjectErrorResult(detRes, err), nil
 		}
 		project := detRes.Project
 
@@ -1241,11 +1236,7 @@ func handleSavePrompt(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 
 		detRes, err := resolveWriteProject()
 		if err != nil {
-			// JW1: use AvailableProjects from detection result (repos in cwd).
-			return errorWithMeta("ambiguous_project",
-				fmt.Sprintf("Cannot determine project: %s", err),
-				detRes.AvailableProjects,
-			), nil
+			return writeProjectErrorResult(detRes, err), nil
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 
@@ -1523,11 +1514,7 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		// Auto-detect project from cwd; fail fast on ambiguous (REQ-308, REQ-309)
 		detRes, err := resolveWriteProject()
 		if err != nil {
-			// JW1: use AvailableProjects from detection result (repos in cwd).
-			return errorWithMeta("ambiguous_project",
-				fmt.Sprintf("Cannot determine project: %s", err),
-				detRes.AvailableProjects,
-			), nil
+			return writeProjectErrorResult(detRes, err), nil
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 
@@ -1567,11 +1554,7 @@ func handleSessionStart(s *store.Store, cfg MCPConfig, activity *SessionActivity
 
 		detRes, err := resolveSessionStartProject(explicitDirectory)
 		if err != nil {
-			// JW1: use AvailableProjects from detection result (repos in cwd).
-			return errorWithMeta("ambiguous_project",
-				fmt.Sprintf("Cannot determine project: %s", err),
-				detRes.AvailableProjects,
-			), nil
+			return writeProjectErrorResult(detRes, err), nil
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 
@@ -1614,6 +1597,9 @@ func handleSessionEnd(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 
 		detRes, err := resolveWriteProject()
 		if err != nil {
+			if errors.Is(err, projectpkg.ErrInvalidConfig) {
+				return writeProjectErrorResult(detRes, err), nil
+			}
 			// For session end, still complete the operation even if project resolution fails.
 			// Use basename fallback.
 			cwd, _ := os.Getwd()
@@ -1645,11 +1631,7 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivi
 
 		detRes, err := resolveWriteProject()
 		if err != nil {
-			// JW1: use AvailableProjects from detection result (repos in cwd).
-			return errorWithMeta("ambiguous_project",
-				fmt.Sprintf("Cannot determine project: %s", err),
-				detRes.AvailableProjects,
-			), nil
+			return writeProjectErrorResult(detRes, err), nil
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 
@@ -1947,6 +1929,14 @@ func respondWithProject(res projectpkg.DetectionResult, text string, extra map[s
 	return mcp.NewToolResultText(string(out))
 }
 
+func writeProjectErrorResult(res projectpkg.DetectionResult, err error) *mcp.CallToolResult {
+	code := "ambiguous_project"
+	if errors.Is(err, projectpkg.ErrInvalidConfig) {
+		code = "invalid_project_config"
+	}
+	return errorWithMeta(code, fmt.Sprintf("Cannot determine project: %s", err), res.AvailableProjects)
+}
+
 // errorWithMeta returns a structured tool error result with error_code,
 // message, available_projects, and a hint for resolution.
 func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolResult {
@@ -1960,6 +1950,8 @@ func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolRe
 		envelope["hint"] = "Use mem_current_project to inspect detection results, or cd into one of the listed repositories."
 	case "unknown_project":
 		envelope["hint"] = "Use one of the available_projects values, or omit project to auto-detect."
+	case "invalid_project_config":
+		envelope["hint"] = "Fix .engram/config.json so project_name is a non-empty project name."
 	}
 	out, _ := jsonMarshal(envelope)
 	result := mcp.NewToolResultText(string(out))

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -3258,6 +3258,127 @@ func TestResolveWriteProject_AutoDetects(t *testing.T) {
 	}
 }
 
+func TestResolveWriteProject_UsesConfigFromRepoRootSubdir(t *testing.T) {
+	root := t.TempDir()
+	initTestGitRepo(t, root)
+	configDir := filepath.Join(root, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"canonical-project"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "cmd", "tool")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+
+	res, err := resolveWriteProject()
+	if err != nil {
+		t.Fatalf("resolveWriteProject: %v", err)
+	}
+	if res.Source != project.SourceConfig || res.Project != "canonical-project" {
+		t.Fatalf("expected config project, got source=%q project=%q", res.Source, res.Project)
+	}
+}
+
+func TestResolveWriteProject_InvalidConfigFailsClearly(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"bad/name"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	_, err := resolveWriteProject()
+	if !errors.Is(err, project.ErrInvalidConfig) || !strings.Contains(err.Error(), "project_name") {
+		t.Fatalf("expected clear invalid config project_name error, got %v", err)
+	}
+}
+
+func TestHandleSaveInvalidConfigFailsClearly(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":""}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title": "should fail", "content": "invalid config", "type": "decision",
+	}}})
+	if err != nil {
+		t.Fatalf("handleSave: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected invalid config to fail write, got %q", callResultText(t, res))
+	}
+	body := callResultJSON(t, res)
+	if body["error_code"] != "invalid_project_config" || !strings.Contains(body["message"].(string), "project_name") {
+		t.Fatalf("expected clear invalid project config error, got %v", body)
+	}
+}
+
+func TestHandleSaveAndPromptUseConfigProjectForWrites(t *testing.T) {
+	root := t.TempDir()
+	initTestGitRepo(t, root)
+	configDir := filepath.Join(root, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"config-locked"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "internal", "pkg")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+
+	s := newMCPTestStore(t)
+	save := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	res, err := save(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title": "config write", "content": "memory saved under config project", "type": "decision",
+	}}})
+	if err != nil || res.IsError {
+		t.Fatalf("mem_save failed: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+	body := callResultJSON(t, res)
+	if body["project"] != "config-locked" || body["project_source"] != project.SourceConfig {
+		t.Fatalf("expected mem_save config envelope, got %v", body)
+	}
+
+	prompt := handleSavePrompt(s, MCPConfig{})
+	res, err = prompt(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "prompt saved under config project",
+	}}})
+	if err != nil || res.IsError {
+		t.Fatalf("mem_save_prompt failed: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+	body = callResultJSON(t, res)
+	if body["project"] != "config-locked" || body["project_source"] != project.SourceConfig {
+		t.Fatalf("expected mem_save_prompt config envelope, got %v", body)
+	}
+
+	obs, err := s.Search("memory saved under config project", store.SearchOptions{Project: "config-locked", Limit: 5})
+	if err != nil || len(obs) != 1 {
+		t.Fatalf("expected observation written to config project, obs=%d err=%v", len(obs), err)
+	}
+	prompts, err := s.RecentPrompts("config-locked", 5)
+	if err != nil || len(prompts) != 1 {
+		t.Fatalf("expected prompt written to config project, prompts=%d err=%v", len(prompts), err)
+	}
+}
+
 // TestResolveWriteProject_AmbiguousError: assert errors.Is(err, ErrAmbiguousProject)
 func TestResolveWriteProject_AmbiguousError(t *testing.T) {
 	parent := t.TempDir()

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -7,7 +7,9 @@ package project
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +21,10 @@ import (
 // multiple git repositories and we cannot auto-select one.
 var ErrAmbiguousProject = errors.New("ambiguous project: multiple git repos found in cwd")
 
+// ErrInvalidConfig is returned when .engram/config.json exists but cannot be
+// used as a project write lock.
+var ErrInvalidConfig = errors.New("invalid .engram/config.json")
+
 // Source constants describe how the project name was resolved.
 const (
 	SourceGitRemote        = "git_remote"        // derived from git remote origin URL
@@ -28,6 +34,7 @@ const (
 	SourceAmbiguous        = "ambiguous"         // cwd contains multiple git repos (Case 4)
 	SourceExplicitOverride = "explicit_override" // JR2-2: caller explicitly supplied a project name
 	SourceRequestBody      = "request_body"      // REQ-414: project came from the request body (server-side, no filesystem path)
+	SourceConfig           = "config"            // derived from .engram/config.json project_name
 )
 
 // noiseSet lists directory names that are skipped during child-repo scanning.
@@ -74,6 +81,10 @@ func DetectProjectFull(dir string) DetectionResult {
 	// Guard against arg injection.
 	if strings.HasPrefix(dir, "-") {
 		dir = "./" + dir
+	}
+
+	if res, ok := detectFromConfig(dir); ok {
+		return res
 	}
 
 	// ── Case 1: git_remote ──────────────────────────────────────────────
@@ -152,6 +163,75 @@ basename:
 		Source:  SourceDirBasename,
 		Path:    absDir,
 	}
+}
+
+type configFile struct {
+	ProjectName string `json:"project_name"`
+}
+
+func detectFromConfig(dir string) (DetectionResult, bool) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		absDir = dir
+	}
+
+	// Project config is a project/repo lock, not a global ancestor setting. When
+	// cwd is inside git, only the repository root may define the lock. This keeps
+	// ~/.engram/config.json (the global data directory) from being inherited by
+	// every directory under $HOME.
+	if gitRoot := detectGitRootDir(absDir); gitRoot != "" {
+		return readConfigAt(gitRoot)
+	}
+
+	// Outside git, accept only the current directory's config. Do not walk to
+	// arbitrary parents such as $HOME.
+	return readConfigAt(absDir)
+}
+
+func readConfigAt(projectDir string) (DetectionResult, bool) {
+	configPath := filepath.Join(projectDir, ".engram", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DetectionResult{}, false
+		}
+		return invalidConfigResult(projectDir, fmt.Errorf("read %s: %w", configPath, err)), true
+	}
+
+	var cfg configFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return invalidConfigResult(projectDir, fmt.Errorf("parse %s: %w", configPath, err)), true
+	}
+	projectName, err := normalizeConfigProjectName(cfg.ProjectName)
+	if err != nil {
+		return invalidConfigResult(projectDir, err), true
+	}
+	return DetectionResult{Project: projectName, Source: SourceConfig, Path: projectDir}, true
+}
+
+func invalidConfigResult(path string, err error) DetectionResult {
+	return DetectionResult{
+		Project: "",
+		Source:  SourceConfig,
+		Path:    path,
+		Error:   fmt.Errorf("%w: %v", ErrInvalidConfig, err),
+	}
+}
+
+func normalizeConfigProjectName(projectName string) (string, error) {
+	trimmed := strings.TrimSpace(projectName)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: project_name is required", ErrInvalidConfig)
+	}
+	if strings.ContainsAny(trimmed, `/\\`) {
+		return "", fmt.Errorf("%w: project_name must be a name, not a path", ErrInvalidConfig)
+	}
+	for _, r := range trimmed {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("%w: project_name contains control characters", ErrInvalidConfig)
+		}
+	}
+	return normalize(trimmed), nil
 }
 
 // detectGitRootDir returns the git repository root for dir, or "" if not in a repo.

--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -220,6 +220,117 @@ func TestDetectProjectFull_Case1_Remote(t *testing.T) {
 	}
 }
 
+func TestDetectProjectFull_ConfigFromRepoRootOverridesRemoteFromSubdir(t *testing.T) {
+	root := t.TempDir()
+	initGit(t, root)
+	cmd := exec.Command("git", "-C", root, "remote", "add", "origin", "git@github.com:testuser/wrong-remote.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	configDir := filepath.Join(root, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"Canonical App"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "src", "pkg")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res := DetectProjectFull(subdir)
+
+	if res.Error != nil {
+		t.Fatalf("unexpected config detection error: %v", res.Error)
+	}
+	if res.Source != SourceConfig || res.Project != "canonical app" {
+		t.Fatalf("expected config project canonical app, got source=%q project=%q", res.Source, res.Project)
+	}
+	gotPath, _ := filepath.EvalSymlinks(res.Path)
+	wantPath, _ := filepath.EvalSymlinks(root)
+	if got, want := gotPath, wantPath; got != want {
+		t.Fatalf("expected config path %q, got %q", want, got)
+	}
+}
+
+func TestDetectProjectFull_InvalidConfigFailsClearly(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"   "}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := DetectProjectFull(dir)
+
+	if !errors.Is(res.Error, ErrInvalidConfig) {
+		t.Fatalf("expected ErrInvalidConfig, got source=%q err=%v", res.Source, res.Error)
+	}
+	if res.Source != SourceConfig || !strings.Contains(res.Error.Error(), "project_name") {
+		t.Fatalf("expected clear config project_name error, got %+v", res)
+	}
+}
+
+func TestDetectProjectFull_DoesNotInheritParentConfigOutsideGitRepo(t *testing.T) {
+	parent := t.TempDir()
+	configDir := filepath.Join(parent, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"parent-lock"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(parent, "plain-child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res := DetectProjectFull(child)
+
+	if res.Error != nil {
+		t.Fatalf("unexpected detection error: %v", res.Error)
+	}
+	if res.Source != SourceDirBasename || res.Project != "plain-child" {
+		t.Fatalf("expected child basename without inheriting parent config, got source=%q project=%q", res.Source, res.Project)
+	}
+	if got, want := res.Path, child; got != want {
+		t.Fatalf("expected child path %q, got %q", want, got)
+	}
+}
+
+func TestDetectProjectFull_InvalidRepoConfigFromSubdirFailsClearly(t *testing.T) {
+	root := t.TempDir()
+	initGit(t, root)
+	configDir := filepath.Join(root, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"bad/name"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "cmd", "tool")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res := DetectProjectFull(subdir)
+
+	if !errors.Is(res.Error, ErrInvalidConfig) {
+		t.Fatalf("expected ErrInvalidConfig from repo config, got source=%q err=%v", res.Source, res.Error)
+	}
+	if res.Source != SourceConfig || !strings.Contains(res.Error.Error(), "project_name") {
+		t.Fatalf("expected clear repo config project_name error, got %+v", res)
+	}
+	gotPath, _ := filepath.EvalSymlinks(res.Path)
+	wantPath, _ := filepath.EvalSymlinks(root)
+	if got, want := gotPath, wantPath; got != want {
+		t.Fatalf("expected invalid config path %q, got %q", want, got)
+	}
+}
+
 // TestDetectProjectFull_Case1_PathIsRepoRoot asserts that Case 1 (git_remote)
 // sets Path to the git repository root, not the input directory (JS2).
 // When called from a subdir of a remote-configured repo, Path should equal the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1874,7 +1874,7 @@ func (s *Store) RecentSessions(project string, limit int) ([]SessionSummary, err
 		args = append(args, project)
 	}
 
-	query += " GROUP BY s.id ORDER BY MAX(COALESCE(o.created_at, s.started_at)) DESC LIMIT ?"
+	query += " GROUP BY s.id ORDER BY MAX(datetime(COALESCE(o.created_at, s.started_at))) DESC, s.id DESC LIMIT ?"
 	args = append(args, limit)
 
 	rows, err := s.queryItHook(s.db, query, args...)
@@ -1914,7 +1914,7 @@ func (s *Store) AllSessions(project string, limit int) ([]SessionSummary, error)
 		args = append(args, project)
 	}
 
-	query += " GROUP BY s.id ORDER BY MAX(COALESCE(o.created_at, s.started_at)) DESC LIMIT ?"
+	query += " GROUP BY s.id ORDER BY MAX(datetime(COALESCE(o.created_at, s.started_at))) DESC, s.id DESC LIMIT ?"
 	args = append(args, limit)
 
 	rows, err := s.queryItHook(s.db, query, args...)
@@ -1957,7 +1957,7 @@ func (s *Store) AllObservations(project, scope string, limit int) ([]Observation
 		args = append(args, normalizeScope(scope))
 	}
 
-	query += " ORDER BY o.created_at DESC LIMIT ?"
+	query += " ORDER BY datetime(o.created_at) DESC, o.id DESC LIMIT ?"
 	args = append(args, limit)
 
 	return s.queryObservations(query, args...)
@@ -2149,7 +2149,7 @@ func (s *Store) RecentObservations(project, scope string, limit int) ([]Observat
 		args = append(args, normalizeScope(scope))
 	}
 
-	query += " ORDER BY o.created_at DESC LIMIT ?"
+	query += " ORDER BY datetime(o.created_at) DESC, o.id DESC LIMIT ?"
 	args = append(args, limit)
 
 	return s.queryObservations(query, args...)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6359,6 +6359,97 @@ func TestCountObservationsForProject(t *testing.T) {
 
 // ─── DeleteSession tests ─────────────────────────────────────────────────────
 
+func TestRecentObservationsOrderByCreatedAtBeforeID(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-recent-created", "proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	rows := []struct {
+		id        int64
+		title     string
+		createdAt string
+	}{
+		{id: 100, title: "older-high-id", createdAt: "2025-01-01 00:00:00"},
+		{id: 50, title: "newer-low-id", createdAt: "2025-01-02 00:00:00"},
+	}
+	for _, row := range rows {
+		if _, err := s.db.Exec(`INSERT INTO observations (id, sync_id, session_id, type, title, content, project, scope, normalized_hash, revision_count, duplicate_count, created_at, updated_at)
+			VALUES (?, ?, 's-recent-created', 'note', ?, ?, 'proj', 'project', ?, 1, 1, ?, ?)`, row.id, fmt.Sprintf("obs-%d", row.id), row.title, row.title, row.title, row.createdAt, row.createdAt); err != nil {
+			t.Fatalf("insert observation %d: %v", row.id, err)
+		}
+	}
+
+	obs, err := s.RecentObservations("proj", "project", 10)
+	if err != nil {
+		t.Fatalf("RecentObservations: %v", err)
+	}
+	if len(obs) < 2 || obs[0].Title != "newer-low-id" || obs[1].Title != "older-high-id" {
+		t.Fatalf("expected created_at desc before id desc, got %+v", obs)
+	}
+}
+
+func TestRecentObservationsSameTimestampTiesByIDDesc(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-recent-tie", "proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	for _, id := range []int64{10, 20} {
+		if _, err := s.db.Exec(`INSERT INTO observations (id, sync_id, session_id, type, title, content, project, scope, normalized_hash, revision_count, duplicate_count, created_at, updated_at)
+			VALUES (?, ?, 's-recent-tie', 'note', ?, ?, 'proj', 'project', ?, 1, 1, '2025-01-01 00:00:00', '2025-01-01 00:00:00')`, id, fmt.Sprintf("obs-tie-%d", id), fmt.Sprintf("tie-%d", id), fmt.Sprintf("tie-%d", id), fmt.Sprintf("hash-%d", id)); err != nil {
+			t.Fatalf("insert observation %d: %v", id, err)
+		}
+	}
+
+	obs, err := s.RecentObservations("proj", "project", 10)
+	if err != nil {
+		t.Fatalf("RecentObservations: %v", err)
+	}
+	if len(obs) < 2 || obs[0].ID != 20 || obs[1].ID != 10 {
+		t.Fatalf("expected id desc tie-breaker, got %+v", obs)
+	}
+}
+
+func TestRecentSessionsOrderByLatestCreatedAtDeterministically(t *testing.T) {
+	s := newTestStore(t)
+	for _, sess := range []struct {
+		id        string
+		startedAt string
+	}{
+		{id: "sess-a", startedAt: "2025-01-01 00:00:00"},
+		{id: "sess-b", startedAt: "2025-01-01 00:00:00"},
+		{id: "sess-c", startedAt: "2025-01-01 00:00:00"},
+	} {
+		if err := s.CreateSession(sess.id, "proj", "/tmp"); err != nil {
+			t.Fatalf("create session %s: %v", sess.id, err)
+		}
+		if _, err := s.db.Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, sess.startedAt, sess.id); err != nil {
+			t.Fatalf("update session %s: %v", sess.id, err)
+		}
+	}
+	for _, row := range []struct {
+		id        int64
+		sessionID string
+		createdAt string
+	}{
+		{id: 1, sessionID: "sess-a", createdAt: "2025-01-03 00:00:00"},
+		{id: 2, sessionID: "sess-b", createdAt: "2025-01-02 00:00:00"},
+		{id: 3, sessionID: "sess-c", createdAt: "2025-01-03 00:00:00"},
+	} {
+		if _, err := s.db.Exec(`INSERT INTO observations (id, sync_id, session_id, type, title, content, project, scope, normalized_hash, revision_count, duplicate_count, created_at, updated_at)
+			VALUES (?, ?, ?, 'note', ?, ?, 'proj', 'project', ?, 1, 1, ?, ?)`, row.id, fmt.Sprintf("obs-session-%d", row.id), row.sessionID, row.sessionID, row.sessionID, fmt.Sprintf("hash-session-%d", row.id), row.createdAt, row.createdAt); err != nil {
+			t.Fatalf("insert observation %d: %v", row.id, err)
+		}
+	}
+
+	sessions, err := s.RecentSessions("proj", 10)
+	if err != nil {
+		t.Fatalf("RecentSessions: %v", err)
+	}
+	if len(sessions) < 3 || sessions[0].ID != "sess-c" || sessions[1].ID != "sess-a" || sessions[2].ID != "sess-b" {
+		t.Fatalf("expected latest created_at desc with session id desc tie-breaker, got %+v", sessions)
+	}
+}
+
 func TestDeleteSession_EmptySession(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -52,7 +52,6 @@ var (
 	storeAckMutationSeq = func(s *store.Store, targetKey string, seqs []int64) error {
 		return s.AckSyncMutationSeqs(targetKey, seqs)
 	}
-	storeImportData       = func(s *store.Store, d *store.ExportData) (*store.ImportResult, error) { return s.Import(d) }
 	storeApplyPulledChunk = func(s *store.Store, targetKey, chunkID string, mutations []store.SyncMutation) error {
 		return s.ApplyPulledChunk(targetKey, chunkID, mutations)
 	}
@@ -508,81 +507,25 @@ func (sy *Syncer) Import() (*ImportResult, error) {
 		return nil, fmt.Errorf("get synced chunks: %w", err)
 	}
 
-	result := &ImportResult{}
 	entries := manifest.Chunks
 	if sy.cloudMode {
-		return sy.importCloudEntriesDependencySafe(entries, knownChunks)
+		return sy.importEntriesDependencySafe(entries, knownChunks, importModeCloud)
 	}
-
-	for _, entry := range entries {
-		// Skip already-imported chunks
-		if knownChunks[entry.ID] {
-			result.ChunksSkipped++
-			continue
-		}
-
-		// Read the chunk via transport
-		chunkJSON, err := sy.transport.ReadChunk(entry.ID)
-		if err != nil {
-			if errors.Is(err, ErrChunkNotFound) {
-				if sy.cloudMode {
-					return nil, fmt.Errorf("read chunk %s: manifest references missing remote chunk", entry.ID)
-				}
-				result.ChunksSkipped++
-				continue
-			}
-			return nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
-		}
-
-		var chunk ChunkData
-		if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
-			return nil, fmt.Errorf("parse chunk %s: %w", entry.ID, err)
-		}
-
-		importResult := &store.ImportResult{}
-		if sy.cloudMode {
-			if err := sy.importCloudChunk(entry.ID, chunk); err != nil {
-				return nil, fmt.Errorf("import chunk %s: %w", entry.ID, err)
-			}
-			importResult = estimateMutationImportResult(chunk)
-		} else {
-			// Import into DB
-			exportData := &store.ExportData{
-				Version:      "0.1.0",
-				ExportedAt:   entry.CreatedAt,
-				Sessions:     chunk.Sessions,
-				Observations: chunk.Observations,
-				Prompts:      chunk.Prompts,
-			}
-
-			legacyResult, err := storeImportData(sy.store, exportData)
-			if err != nil {
-				return nil, fmt.Errorf("import chunk %s: %w", entry.ID, err)
-			}
-			importResult = legacyResult
-		}
-
-		if !sy.cloudMode {
-			// Record this chunk as imported
-			if err := storeRecordSynced(sy.store, sy.chunkTrackingTargetKey(""), entry.ID); err != nil {
-				return nil, fmt.Errorf("record chunk %s: %w", entry.ID, err)
-			}
-		}
-		knownChunks[entry.ID] = true
-
-		result.ChunksImported++
-		result.SessionsImported += importResult.SessionsImported
-		result.ObservationsImported += importResult.ObservationsImported
-		result.PromptsImported += importResult.PromptsImported
-	}
-
-	return result, nil
+	return sy.importEntriesDependencySafe(entries, knownChunks, importModeLocal)
 }
 
-func (sy *Syncer) importCloudEntriesDependencySafe(entries []ChunkEntry, knownChunks map[string]bool) (*ImportResult, error) {
+type importMode string
+
+const (
+	importModeLocal importMode = "local"
+	importModeCloud importMode = "cloud"
+)
+
+func (sy *Syncer) importEntriesDependencySafe(entries []ChunkEntry, knownChunks map[string]bool, mode importMode) (*ImportResult, error) {
 	result := &ImportResult{}
 	pendingEntries := make([]ChunkEntry, 0, len(entries))
 	for _, entry := range entries {
+		// Skip already-imported chunks
 		if knownChunks[entry.ID] {
 			result.ChunksSkipped++
 			continue
@@ -600,10 +543,15 @@ func (sy *Syncer) importCloudEntriesDependencySafe(entries []ChunkEntry, knownCh
 		nextPending := make([]ChunkEntry, 0, len(pendingEntries))
 
 		for _, entry := range pendingEntries {
+			// Read the chunk via transport
 			chunkJSON, err := sy.transport.ReadChunk(entry.ID)
 			if err != nil {
 				if errors.Is(err, ErrChunkNotFound) {
-					return nil, fmt.Errorf("read chunk %s: manifest references missing remote chunk", entry.ID)
+					if mode == importModeCloud {
+						return nil, fmt.Errorf("read chunk %s: manifest references missing remote chunk", entry.ID)
+					}
+					result.ChunksSkipped++
+					continue
 				}
 				return nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
 			}
@@ -613,25 +561,29 @@ func (sy *Syncer) importCloudEntriesDependencySafe(entries []ChunkEntry, knownCh
 				return nil, fmt.Errorf("parse chunk %s: %w", entry.ID, err)
 			}
 
-			if err := sy.importCloudChunk(entry.ID, chunk); err != nil {
-				lastErrors[entry.ID] = err
+			if err := sy.importMutationChunk(entry.ID, chunk); err != nil {
+				lastErrors[entry.ID] = importDependencyError(chunk, err)
 				nextPending = append(nextPending, entry)
 				continue
 			}
 
 			importResult := estimateMutationImportResult(chunk)
 			knownChunks[entry.ID] = true
+			delete(lastErrors, entry.ID)
+
 			result.ChunksImported++
 			result.SessionsImported += importResult.SessionsImported
 			result.ObservationsImported += importResult.ObservationsImported
 			result.PromptsImported += importResult.PromptsImported
-			delete(lastErrors, entry.ID)
 			progress = true
 		}
 
 		if !progress {
+			if len(nextPending) == 0 {
+				return result, nil
+			}
 			stalled := nextPending[0]
-			return nil, fmt.Errorf("dependency-safe cloud import stalled after %d pass(es); chunk %s: %w", pass, stalled.ID, lastErrors[stalled.ID])
+			return nil, fmt.Errorf("dependency-safe %s import stalled after %d pass(es); chunk %s: %w", mode, pass, stalled.ID, lastErrors[stalled.ID])
 		}
 
 		pendingEntries = nextPending
@@ -640,10 +592,24 @@ func (sy *Syncer) importCloudEntriesDependencySafe(entries []ChunkEntry, knownCh
 	return result, nil
 }
 
-func (sy *Syncer) importCloudChunk(chunkID string, chunk ChunkData) error {
+func (sy *Syncer) importMutationChunk(chunkID string, chunk ChunkData) error {
 	mutations := buildImportMutations(chunk)
 	mutations = orderMutationsForApply(mutations)
 	return storeApplyPulledChunk(sy.store, sy.chunkTrackingTargetKey(""), chunkID, mutations)
+}
+
+func importDependencyError(chunk ChunkData, err error) error {
+	mutations := buildImportMutations(chunk)
+	referenced := referencedSessionIDsFromNonSessionUpserts(mutations)
+	if len(referenced) == 0 {
+		return err
+	}
+	sessions := make([]string, 0, len(referenced))
+	for sessionID := range referenced {
+		sessions = append(sessions, sessionID)
+	}
+	sort.Strings(sessions)
+	return fmt.Errorf("%w; pending session dependencies: %s", err, strings.Join(sessions, ", "))
 }
 
 func buildImportMutations(chunk ChunkData) []store.SyncMutation {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -88,6 +88,21 @@ func writeManifestFile(t *testing.T, dir string, m *Manifest) {
 	}
 }
 
+func writeLocalChunkFile(t *testing.T, dir, id string, chunk ChunkData) {
+	t.Helper()
+	payload, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal chunk %s: %v", id, err)
+	}
+	chunksDir := filepath.Join(dir, "chunks")
+	if err := os.MkdirAll(chunksDir, 0o755); err != nil {
+		t.Fatalf("mkdir chunks: %v", err)
+	}
+	if err := writeGzip(filepath.Join(chunksDir, id+".jsonl.gz"), payload); err != nil {
+		t.Fatalf("write gzip chunk %s: %v", id, err)
+	}
+}
+
 func resetSyncTestHooks(t *testing.T) {
 	t.Helper()
 	origJSONMarshalChunk := jsonMarshalChunk
@@ -100,7 +115,6 @@ func resetSyncTestHooks(t *testing.T) {
 	origStoreExportDataForProject := storeExportDataForProject
 	origStoreListMutationsAfterSeq := storeListMutationsAfterSeq
 	origStoreAckMutationSeq := storeAckMutationSeq
-	origStoreImportData := storeImportData
 	origStoreApplyPulledChunk := storeApplyPulledChunk
 	origStoreRecordSynced := storeRecordSynced
 
@@ -115,7 +129,6 @@ func resetSyncTestHooks(t *testing.T) {
 		storeExportDataForProject = origStoreExportDataForProject
 		storeListMutationsAfterSeq = origStoreListMutationsAfterSeq
 		storeAckMutationSeq = origStoreAckMutationSeq
-		storeImportData = origStoreImportData
 		storeApplyPulledChunk = origStoreApplyPulledChunk
 		storeRecordSynced = origStoreRecordSynced
 	})
@@ -960,8 +973,8 @@ func TestImportBranches(t *testing.T) {
 		}
 
 		sy := New(s, syncDir)
-		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "import chunk") {
-			t.Fatalf("expected import chunk error, got %v", err)
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "dependency-safe local import stalled") || !strings.Contains(err.Error(), "missing-session") {
+			t.Fatalf("expected dependency-safe local import error, got %v", err)
 		}
 	})
 
@@ -1004,15 +1017,128 @@ func TestImportBranches(t *testing.T) {
 			t.Fatalf("write gzip chunk: %v", err)
 		}
 
-		storeRecordSynced = func(_ *store.Store, _, _ string) error {
-			return errors.New("forced import record fail")
+		storeApplyPulledChunk = func(_ *store.Store, _, _ string, _ []store.SyncMutation) error {
+			return errors.New("forced apply pulled chunk fail")
 		}
 
 		sy := New(s, syncDir)
-		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "record chunk") {
-			t.Fatalf("expected record chunk error, got %v", err)
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "dependency-safe local import stalled") || !strings.Contains(err.Error(), "forced apply pulled chunk fail") {
+			t.Fatalf("expected apply pulled chunk import error, got %v", err)
 		}
 	})
+}
+
+func TestLocalImportDependencySafeAcrossChunksRegardlessManifestOrder(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	project := "proj-a"
+
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{
+		{ID: "chunk-dependent", CreatedAt: "2025-01-02T00:00:00Z"},
+		{ID: "chunk-session", CreatedAt: "2025-01-01T00:00:00Z"},
+	}})
+	writeLocalChunkFile(t, syncDir, "chunk-dependent", ChunkData{
+		Observations: []store.Observation{{SyncID: "obs-cross-chunk", SessionID: "sess-cross-chunk", Type: "note", Title: "cross", Content: "cross chunk observation", Project: &project, Scope: "project", CreatedAt: "2025-01-02 00:00:00", UpdatedAt: "2025-01-02 00:00:00"}},
+		Prompts:      []store.Prompt{{SyncID: "prompt-cross-chunk", SessionID: "sess-cross-chunk", Content: "cross chunk prompt", Project: project, CreatedAt: "2025-01-02 00:01:00"}},
+	})
+	writeLocalChunkFile(t, syncDir, "chunk-session", ChunkData{
+		Sessions: []store.Session{{ID: "sess-cross-chunk", Project: project, Directory: "/tmp/proj-a", StartedAt: "2025-01-01 00:00:00"}},
+	})
+
+	res, err := New(s, syncDir).Import()
+	if err != nil {
+		t.Fatalf("local import should retry dependency chunks safely: %v", err)
+	}
+	if res.ChunksImported != 2 || res.SessionsImported != 1 || res.ObservationsImported != 1 || res.PromptsImported != 1 {
+		t.Fatalf("unexpected import result: %+v", res)
+	}
+	if _, err := s.GetSession("sess-cross-chunk"); err != nil {
+		t.Fatalf("expected session imported: %v", err)
+	}
+	results, err := s.Search("cross chunk observation", store.SearchOptions{Project: project, Limit: 5})
+	if err != nil || len(results) != 1 {
+		t.Fatalf("expected imported observation, results=%d err=%v", len(results), err)
+	}
+	prompts, err := s.RecentPrompts(project, 5)
+	if err != nil || len(prompts) != 1 {
+		t.Fatalf("expected imported prompt, prompts=%d err=%v", len(prompts), err)
+	}
+}
+
+func TestLocalImportOrdersExplicitMutationsAndDirectArraysSafely(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	project := "proj-a"
+	chunkID := "mixed-local"
+
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2025-01-01T00:00:00Z"}}})
+	writeLocalChunkFile(t, syncDir, chunkID, ChunkData{
+		Sessions:     []store.Session{{ID: "sess-mixed", Project: project, Directory: "/tmp/proj-a", StartedAt: "2025-01-01 00:00:00"}},
+		Observations: []store.Observation{{SyncID: "obs-direct-mixed", SessionID: "sess-mixed", Type: "note", Title: "direct", Content: "direct local observation", Project: &project, Scope: "project", CreatedAt: "2025-01-01 00:01:00", UpdatedAt: "2025-01-01 00:01:00"}},
+		Mutations: []store.SyncMutation{{
+			Entity:    store.SyncEntityPrompt,
+			EntityKey: "prompt-explicit-mixed",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"prompt-explicit-mixed","session_id":"sess-mixed","content":"explicit prompt after session","project":"proj-a","created_at":"2025-01-01 00:02:00"}`,
+		}},
+	})
+
+	if _, err := New(s, syncDir).Import(); err != nil {
+		t.Fatalf("local import should order synthesized sessions before direct and explicit dependents: %v", err)
+	}
+	if _, err := s.GetSession("sess-mixed"); err != nil {
+		t.Fatalf("expected mixed session imported: %v", err)
+	}
+	results, err := s.Search("direct local observation", store.SearchOptions{Project: project, Limit: 5})
+	if err != nil || len(results) != 1 {
+		t.Fatalf("expected direct observation, results=%d err=%v", len(results), err)
+	}
+	prompts, err := s.RecentPrompts(project, 5)
+	if err != nil || len(prompts) != 1 || prompts[0].SyncID != "prompt-explicit-mixed" {
+		t.Fatalf("expected explicit prompt imported, prompts=%+v err=%v", prompts, err)
+	}
+}
+
+func TestLocalImportMissingSessionStallsWithUsefulError(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	chunkID := "missing-session"
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2025-01-01T00:00:00Z"}}})
+	writeLocalChunkFile(t, syncDir, chunkID, ChunkData{Observations: []store.Observation{{SyncID: "obs-missing-session", SessionID: "does-not-exist", Type: "note", Title: "missing", Content: "missing dependency", Scope: "project", CreatedAt: "2025-01-01 00:00:00", UpdatedAt: "2025-01-01 00:00:00"}}})
+
+	_, err := New(s, syncDir).Import()
+	if err == nil {
+		t.Fatal("expected missing session dependency to stall")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "dependency-safe local import stalled") || !strings.Contains(msg, chunkID) || !strings.Contains(msg, "does-not-exist") {
+		t.Fatalf("expected useful dependency-safe stall error, got %v", err)
+	}
+}
+
+func TestLocalImportSkipsAlreadyImportedChunksIdempotently(t *testing.T) {
+	resetSyncTestHooks(t)
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	chunkID := "idempotent-local"
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2025-01-01T00:00:00Z"}}})
+	writeLocalChunkFile(t, syncDir, chunkID, ChunkData{Sessions: []store.Session{{ID: "sess-idempotent", Project: "proj-a", Directory: "/tmp/proj-a", StartedAt: "2025-01-01 00:00:00"}}})
+
+	if _, err := New(s, syncDir).Import(); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	applyCalls := 0
+	storeApplyPulledChunk = func(_ *store.Store, _, _ string, _ []store.SyncMutation) error {
+		applyCalls++
+		return errors.New("already imported chunks should not be applied")
+	}
+	res, err := New(s, syncDir).Import()
+	if err != nil {
+		t.Fatalf("second import should skip known chunk: %v", err)
+	}
+	if res.ChunksImported != 0 || res.ChunksSkipped != 1 || applyCalls != 0 {
+		t.Fatalf("expected idempotent skip without apply, result=%+v applyCalls=%d", res, applyCalls)
+	}
 }
 
 func TestManifestReadWrite(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #296

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Makes local `engram sync --import` dependency-safe by converting chunks to ordered mutations and applying through the pulled-chunk path.
- Adds repo-scoped `.engram/config.json` `project_name` as a canonical write project lock.
- Stabilizes recent observation/session ordering by creation time with deterministic tie-breakers.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/sync/sync.go` | Reuses dependency-safe mutation import for local and cloud chunks. |
| `internal/project/detect.go` | Adds repo-scoped `.engram/config.json` project detection. |
| `internal/mcp/mcp.go` | Surfaces invalid project config errors clearly for write tools. |
| `internal/store/store.go` | Orders recent observations/sessions by `datetime(created_at)` with stable tie-breakers. |
| `docs/AGENT-SETUP.md` | Documents `project_name` write-lock config. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually reviewed the affected behavior against #296 failure modes

Focused tests:
- `go test ./internal/sync ./internal/project ./internal/mcp ./internal/store ./internal/tui`

---

## 💬 Notes for Reviewers

This intentionally does **not** implement the full RFC from #296. It fixes the three immediate production problems: local import FK failures, project drift on writes, and unstable recent ordering.