### PR TITLE
fix(store,chunkcodec): add relation entity support to cloud sync pipeline

### DIFF
--- a/internal/cloud/chunkcodec/chunkcodec.go
+++ b/internal/cloud/chunkcodec/chunkcodec.go
@@ -316,7 +316,7 @@ func validateSupportedMutation(entity, op string) error {
 			return fmt.Errorf("unsupported mutation %q/%q", entity, op)
 		}
 		return nil
-	case store.SyncEntityObservation, store.SyncEntityPrompt:
+	case store.SyncEntityObservation, store.SyncEntityPrompt, store.SyncEntityRelation:
 		if op != store.SyncOpUpsert && op != store.SyncOpDelete {
 			return fmt.Errorf("unsupported mutation %q/%q", entity, op)
 		}
@@ -324,6 +324,24 @@ func validateSupportedMutation(entity, op string) error {
 	default:
 		return fmt.Errorf("unsupported mutation %q/%q", entity, op)
 	}
+}
+
+type mutationRelationPayload struct {
+	SyncID         string   `json:"sync_id"`
+	SourceID       string   `json:"source_id"`
+	TargetID       string   `json:"target_id"`
+	Relation       string   `json:"relation"`
+	Reason         *string  `json:"reason,omitempty"`
+	Evidence       *string  `json:"evidence,omitempty"`
+	Confidence     *float64 `json:"confidence,omitempty"`
+	JudgmentStatus string   `json:"judgment_status"`
+	MarkedByActor  *string  `json:"marked_by_actor,omitempty"`
+	MarkedByKind   *string  `json:"marked_by_kind,omitempty"`
+	MarkedByModel  *string  `json:"marked_by_model,omitempty"`
+	SessionID      *string  `json:"session_id,omitempty"`
+	Project        string   `json:"project"`
+	CreatedAt      string   `json:"created_at,omitempty"`
+	UpdatedAt      string   `json:"updated_at,omitempty"`
 }
 
 func normalizeMutationPayload(entity, op, payload, project string) (normalizedPayload string, expectedEntityKey string, err error) {
@@ -420,6 +438,48 @@ func normalizeMutationPayload(entity, op, payload, project string) (normalizedPa
 		}
 		projectValue := project
 		body.Project = &projectValue
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return "", "", fmt.Errorf("encode mutation payload: %w", err)
+		}
+		return string(encoded), body.SyncID, nil
+	case store.SyncEntityRelation:
+		var body mutationRelationPayload
+		if err := DecodeSyncMutationPayload(payload, &body); err != nil {
+			return "", "", fmt.Errorf("decode mutation payload: %w", err)
+		}
+		body.SyncID = strings.TrimSpace(body.SyncID)
+		body.SourceID = strings.TrimSpace(body.SourceID)
+		body.TargetID = strings.TrimSpace(body.TargetID)
+		body.Relation = strings.TrimSpace(body.Relation)
+		body.JudgmentStatus = strings.TrimSpace(body.JudgmentStatus)
+		body.Project = strings.TrimSpace(body.Project)
+		body.CreatedAt = strings.TrimSpace(body.CreatedAt)
+		body.UpdatedAt = strings.TrimSpace(body.UpdatedAt)
+		if body.SyncID == "" {
+			return "", "", fmt.Errorf("relation payload sync_id is required")
+		}
+		if op == store.SyncOpUpsert {
+			if body.SourceID == "" {
+				return "", "", fmt.Errorf("relation payload source_id is required for upsert")
+			}
+			if body.TargetID == "" {
+				return "", "", fmt.Errorf("relation payload target_id is required for upsert")
+			}
+			if body.Relation == "" {
+				return "", "", fmt.Errorf("relation payload relation is required for upsert")
+			}
+			if body.JudgmentStatus == "" {
+				return "", "", fmt.Errorf("relation payload judgment_status is required for upsert")
+			}
+			if body.CreatedAt == "" {
+				return "", "", fmt.Errorf("relation payload created_at is required for upsert")
+			}
+			if body.UpdatedAt == "" {
+				return "", "", fmt.Errorf("relation payload updated_at is required for upsert")
+			}
+		}
+		body.Project = project
 		encoded, err := json.Marshal(body)
 		if err != nil {
 			return "", "", fmt.Errorf("encode mutation payload: %w", err)

--- a/internal/cloud/chunkcodec/chunkcodec_test.go
+++ b/internal/cloud/chunkcodec/chunkcodec_test.go
@@ -2,6 +2,7 @@ package chunkcodec
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Gentleman-Programming/engram/internal/store"
@@ -197,6 +198,105 @@ func TestCanonicalizeForProjectDerivesSessionOwnershipFromPayloadIDWhenEntityKey
 	}
 	if decoded.Mutations[0].EntityKey != "sess-owned" {
 		t.Fatalf("expected canonicalized mutation entity_key to be derived from payload id, got %q", decoded.Mutations[0].EntityKey)
+	}
+}
+
+func TestCanonicalizeForProjectAcceptsRelationUpsertMutation(t *testing.T) {
+	raw := []byte(`{
+		"mutations": [
+			{
+				"entity": "relation",
+				"op": "upsert",
+				"project": "wrong",
+				"entity_key": "rel-123",
+				"payload": "{\"sync_id\":\"rel-123\",\"source_id\":\"obs-a\",\"target_id\":\"obs-b\",\"relation\":\"related\",\"judgment_status\":\"judged\",\"project\":\"wrong\",\"created_at\":\"2026-05-04T00:00:00Z\",\"updated_at\":\"2026-05-04T00:00:00Z\"}"
+			}
+		]
+	}`)
+
+	normalized, err := CanonicalizeForProject(raw, "proj-a")
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+
+	var chunk struct {
+		Mutations []store.SyncMutation `json:"mutations"`
+	}
+	if err := json.Unmarshal(normalized, &chunk); err != nil {
+		t.Fatalf("decode canonicalized chunk: %v", err)
+	}
+	if len(chunk.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation, got %d", len(chunk.Mutations))
+	}
+	mutation := chunk.Mutations[0]
+	if mutation.Entity != store.SyncEntityRelation || mutation.Op != store.SyncOpUpsert || mutation.EntityKey != "rel-123" {
+		t.Fatalf("expected canonical relation/upsert mutation, got %+v", mutation)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(mutation.Payload), &payload); err != nil {
+		t.Fatalf("decode canonical payload: %v", err)
+	}
+	if payload["sync_id"] != "rel-123" {
+		t.Fatalf("expected payload sync_id rel-123, got %#v", payload["sync_id"])
+	}
+	if payload["project"] != "proj-a" {
+		t.Fatalf("expected payload project rewritten to proj-a, got %#v", payload["project"])
+	}
+}
+
+func TestCanonicalizeForProjectRejectsRelationMissingRequiredFields(t *testing.T) {
+	raw := []byte(`{
+		"mutations": [
+			{
+				"entity": "relation",
+				"op": "upsert",
+				"project": "proj-a",
+				"entity_key": "rel-123",
+				"payload": "{\"sync_id\":\"rel-123\",\"source_id\":\"obs-a\",\"relation\":\"related\",\"judgment_status\":\"judged\",\"project\":\"proj-a\",\"created_at\":\"2026-05-04T00:00:00Z\",\"updated_at\":\"2026-05-04T00:00:00Z\"}"
+			}
+		]
+	}`)
+
+	_, err := CanonicalizeForProject(raw, "proj-a")
+	if err == nil {
+		t.Fatal("expected error for relation upsert missing target_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "target_id is required") {
+		t.Fatalf("expected target_id required error, got %v", err)
+	}
+}
+
+func TestCanonicalizeForProjectAcceptsRelationDeleteMutation(t *testing.T) {
+	raw := []byte(`{
+		"mutations": [
+			{
+				"entity": "relation",
+				"op": "delete",
+				"project": "wrong",
+				"entity_key": "rel-del",
+				"payload": "{\"sync_id\":\"rel-del\",\"project\":\"wrong\"}"
+			}
+		]
+	}`)
+
+	normalized, err := CanonicalizeForProject(raw, "proj-a")
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+
+	var chunk struct {
+		Mutations []store.SyncMutation `json:"mutations"`
+	}
+	if err := json.Unmarshal(normalized, &chunk); err != nil {
+		t.Fatalf("decode canonicalized chunk: %v", err)
+	}
+	if len(chunk.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation, got %d", len(chunk.Mutations))
+	}
+	mutation := chunk.Mutations[0]
+	if mutation.Entity != store.SyncEntityRelation || mutation.Op != store.SyncOpDelete || mutation.EntityKey != "rel-del" {
+		t.Fatalf("expected canonical relation/delete mutation, got %+v", mutation)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1443,7 +1443,7 @@ func (s *Store) evaluateCloudUpgradeLegacyMutationTx(tx *sql.Tx, mutation SyncMu
 	}
 
 	supported := (entity == SyncEntitySession && (op == SyncOpUpsert || op == SyncOpDelete)) ||
-		((entity == SyncEntityObservation || entity == SyncEntityPrompt) && (op == SyncOpUpsert || op == SyncOpDelete))
+		((entity == SyncEntityObservation || entity == SyncEntityPrompt || entity == SyncEntityRelation) && (op == SyncOpUpsert || op == SyncOpDelete))
 	if !supported {
 		return blocked(UpgradeReasonBlockedLegacyMutationManual, fmt.Sprintf("unsupported legacy mutation %q/%q", entity, op)), nil
 	}
@@ -1619,6 +1619,130 @@ func (s *Store) evaluateCloudUpgradeLegacyMutationTx(tx *sql.Tx, mutation SyncMu
 			return cloudUpgradeLegacyMutationEvaluation{}, err
 		}
 		return repairable("prompt payload is missing required fields for canonical bootstrap", "repair fills missing prompt fields from local prompts table", string(encoded)), nil
+
+	case SyncEntityRelation:
+		var body syncRelationPayload
+		if err := decodeSyncPayload([]byte(payload), &body); err != nil {
+			return blocked(UpgradeReasonBlockedLegacyMutationManual, fmt.Sprintf("decode relation payload: %v", err)), nil
+		}
+		body.SyncID = strings.TrimSpace(body.SyncID)
+		body.SourceID = strings.TrimSpace(body.SourceID)
+		body.TargetID = strings.TrimSpace(body.TargetID)
+		body.Relation = strings.TrimSpace(body.Relation)
+		body.JudgmentStatus = strings.TrimSpace(body.JudgmentStatus)
+		body.Project = strings.TrimSpace(body.Project)
+		body.CreatedAt = strings.TrimSpace(body.CreatedAt)
+		body.UpdatedAt = strings.TrimSpace(body.UpdatedAt)
+		changed := false
+		if body.SyncID == "" && strings.TrimSpace(mutation.EntityKey) != "" {
+			body.SyncID = strings.TrimSpace(mutation.EntityKey)
+			changed = true
+		}
+		if body.SyncID == "" {
+			return blocked(UpgradeReasonBlockedLegacyMutationManual, "relation payload sync_id is required"), nil
+		}
+		if strings.TrimSpace(mutation.EntityKey) != "" && strings.TrimSpace(mutation.EntityKey) != body.SyncID {
+			return blocked(UpgradeReasonBlockedLegacyMutationManual, fmt.Sprintf("relation entity_key %q does not match payload sync_id %q", mutation.EntityKey, body.SyncID)), nil
+		}
+		if op == SyncOpUpsert {
+			var local syncRelationPayload
+			err := tx.QueryRow(
+				`SELECT sync_id, ifnull(source_id,''), ifnull(target_id,''), relation, reason, evidence, confidence, judgment_status, ifnull(marked_by_actor,''), ifnull(marked_by_kind,''), ifnull(marked_by_model,''), ifnull(session_id,''), created_at, updated_at FROM memory_relations WHERE sync_id = ?`,
+				body.SyncID,
+			).Scan(&local.SyncID, &local.SourceID, &local.TargetID, &local.Relation, &local.Reason, &local.Evidence, &local.Confidence, &local.JudgmentStatus, &local.MarkedByActor, &local.MarkedByKind, &local.MarkedByModel, &local.SessionID, &local.CreatedAt, &local.UpdatedAt)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return cloudUpgradeLegacyMutationEvaluation{}, err
+			}
+			if strings.TrimSpace(body.SourceID) == "" && err == nil && strings.TrimSpace(local.SourceID) != "" {
+				body.SourceID = strings.TrimSpace(local.SourceID)
+				changed = true
+			}
+			if strings.TrimSpace(body.TargetID) == "" && err == nil && strings.TrimSpace(local.TargetID) != "" {
+				body.TargetID = strings.TrimSpace(local.TargetID)
+				changed = true
+			}
+			if body.Relation == "" && err == nil && strings.TrimSpace(local.Relation) != "" {
+				body.Relation = strings.TrimSpace(local.Relation)
+				changed = true
+			}
+			if body.Reason == nil && err == nil && local.Reason != nil {
+				body.Reason = local.Reason
+				changed = true
+			}
+			if body.Evidence == nil && err == nil && local.Evidence != nil {
+				body.Evidence = local.Evidence
+				changed = true
+			}
+			if body.Confidence == nil && err == nil && local.Confidence != nil {
+				body.Confidence = local.Confidence
+				changed = true
+			}
+			if body.JudgmentStatus == "" && err == nil && strings.TrimSpace(local.JudgmentStatus) != "" {
+				body.JudgmentStatus = strings.TrimSpace(local.JudgmentStatus)
+				changed = true
+			}
+			if body.MarkedByActor == nil && err == nil && local.MarkedByActor != nil {
+				body.MarkedByActor = local.MarkedByActor
+				changed = true
+			}
+			if body.MarkedByKind == nil && err == nil && local.MarkedByKind != nil {
+				body.MarkedByKind = local.MarkedByKind
+				changed = true
+			}
+			if body.MarkedByModel == nil && err == nil && local.MarkedByModel != nil {
+				body.MarkedByModel = local.MarkedByModel
+				changed = true
+			}
+			if body.SessionID == nil && err == nil && local.SessionID != nil {
+				body.SessionID = local.SessionID
+				changed = true
+			}
+			if body.Project == "" && err == nil && strings.TrimSpace(local.Project) != "" {
+				body.Project = strings.TrimSpace(local.Project)
+				changed = true
+			}
+			if body.CreatedAt == "" && err == nil && strings.TrimSpace(local.CreatedAt) != "" {
+				body.CreatedAt = strings.TrimSpace(local.CreatedAt)
+				changed = true
+			}
+			if body.UpdatedAt == "" && err == nil && strings.TrimSpace(local.UpdatedAt) != "" {
+				body.UpdatedAt = strings.TrimSpace(local.UpdatedAt)
+				changed = true
+			}
+			missing := []string{}
+			if strings.TrimSpace(body.SourceID) == "" {
+				missing = append(missing, "source_id")
+			}
+			if strings.TrimSpace(body.TargetID) == "" {
+				missing = append(missing, "target_id")
+			}
+			if body.Relation == "" {
+				missing = append(missing, "relation")
+			}
+			if body.JudgmentStatus == "" {
+				missing = append(missing, "judgment_status")
+			}
+			if body.Project == "" {
+				missing = append(missing, "project")
+			}
+			if body.CreatedAt == "" {
+				missing = append(missing, "created_at")
+			}
+			if body.UpdatedAt == "" {
+				missing = append(missing, "updated_at")
+			}
+			if len(missing) > 0 {
+				return blocked(UpgradeReasonBlockedLegacyMutationManual, fmt.Sprintf("relation payload missing required upsert fields: %s", strings.Join(missing, ", "))), nil
+			}
+		}
+		if !changed {
+			return cloudUpgradeLegacyMutationEvaluation{}, nil
+		}
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return cloudUpgradeLegacyMutationEvaluation{}, err
+		}
+		return repairable("relation payload is missing required fields for canonical bootstrap", "repair fills missing relation fields from local memory_relations table", string(encoded)), nil
 	}
 
 	return cloudUpgradeLegacyMutationEvaluation{}, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1986,6 +1986,116 @@ func TestUpgradeRepairDryRunAndApply(t *testing.T) {
 			t.Fatalf("expected no remaining legacy findings after repair, got %+v", after)
 		}
 	})
+
+	t.Run("legacy relation mutation required fields are detected and repaired from authoritative local state", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("legacy-rel-s1", "legacy-rel-proj", "/tmp/legacy-rel"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		if _, err := s.AddObservation(AddObservationParams{SessionID: "legacy-rel-s1", Type: "decision", Title: "Authoritative title", Content: "Authoritative content", Project: "legacy-rel-proj", Scope: "project"}); err != nil {
+			t.Fatalf("add observation: %v", err)
+		}
+		if err := s.EnrollProject("legacy-rel-proj"); err != nil {
+			t.Fatalf("enroll project: %v", err)
+		}
+
+		var sourceSyncID, targetSyncID string
+		if err := s.db.QueryRow(`SELECT sync_id FROM observations WHERE session_id = ? ORDER BY id ASC LIMIT 1`, "legacy-rel-s1").Scan(&sourceSyncID); err != nil {
+			t.Fatalf("lookup source observation sync id: %v", err)
+		}
+		if err := s.db.QueryRow(`SELECT sync_id FROM observations WHERE session_id = ? ORDER BY id DESC LIMIT 1`, "legacy-rel-s1").Scan(&targetSyncID); err != nil {
+			t.Fatalf("lookup target observation sync id: %v", err)
+		}
+
+		relSyncID := "rel-test-1234567890abcdef"
+		reason := "test reason"
+		evidence := "test evidence"
+		confidence := 0.95
+		markedByActor := "agent"
+		markedByKind := "agent"
+		markedByModel := "model-x"
+		if _, err := s.db.Exec(`
+			INSERT INTO memory_relations (sync_id, source_id, target_id, relation, reason, evidence, confidence, judgment_status, marked_by_actor, marked_by_kind, marked_by_model, created_at, updated_at)
+			VALUES (?, ?, ?, 'related', ?, ?, ?, 'judged', ?, ?, ?, datetime('now'), datetime('now'))
+		`, relSyncID, sourceSyncID, targetSyncID, reason, evidence, confidence, markedByActor, markedByKind, markedByModel); err != nil {
+			t.Fatalf("insert local relation: %v", err)
+		}
+
+		payload := `{"sync_id":"` + relSyncID + `","source_id":"` + sourceSyncID + `","relation":"related","judgment_status":"judged","project":"legacy-rel-proj","created_at":"2026-05-04 00:00:00","updated_at":"2026-05-04 00:00:00"}`
+		if _, err := s.execHook(s.db,
+			`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			DefaultSyncTargetKey,
+			SyncEntityRelation,
+			relSyncID,
+			SyncOpUpsert,
+			payload,
+			SyncSourceLocal,
+			"legacy-rel-proj",
+		); err != nil {
+			t.Fatalf("insert malformed legacy relation mutation: %v", err)
+		}
+
+		diagnosis, err := s.DiagnoseCloudUpgradeLegacyMutations("legacy-rel-proj")
+		if err != nil {
+			t.Fatalf("diagnose legacy relation mutations: %v", err)
+		}
+		if diagnosis.RepairableCount == 0 || diagnosis.BlockedCount != 0 {
+			t.Fatalf("expected repairable-only diagnosis for relation, got %+v", diagnosis)
+		}
+		if len(diagnosis.Findings) == 0 || !diagnosis.Findings[0].Repairable {
+			t.Fatalf("expected at least one repairable relation finding, got %+v", diagnosis.Findings)
+		}
+
+		report, err := s.RepairCloudUpgrade("legacy-rel-proj", true)
+		if err != nil {
+			t.Fatalf("repair legacy relation payload gaps: %v", err)
+		}
+		if report.Class != UpgradeRepairClassRepairable || !report.Applied {
+			t.Fatalf("expected applied repairable result for relation, got %+v", report)
+		}
+
+		var repairedPayload string
+		if err := s.db.QueryRow(`
+			SELECT payload FROM sync_mutations
+			WHERE target_key = ? AND project = ? AND entity = ? AND entity_key = ? AND op = ?
+			ORDER BY seq DESC LIMIT 1
+		`, DefaultSyncTargetKey, "legacy-rel-proj", SyncEntityRelation, relSyncID, SyncOpUpsert).Scan(&repairedPayload); err != nil {
+			t.Fatalf("load repaired relation payload: %v", err)
+		}
+		var repaired syncRelationPayload
+		if err := decodeSyncPayload([]byte(repairedPayload), &repaired); err != nil {
+			t.Fatalf("decode repaired relation payload: %v", err)
+		}
+		if strings.TrimSpace(repaired.TargetID) == "" {
+			t.Fatalf("expected repaired payload target_id from authoritative local relation, got %+v", repaired)
+		}
+		if repaired.Reason == nil || *repaired.Reason != reason {
+			t.Fatalf("expected repaired payload reason from authoritative local relation, got %+v", repaired)
+		}
+		if repaired.Evidence == nil || *repaired.Evidence != evidence {
+			t.Fatalf("expected repaired payload evidence from authoritative local relation, got %+v", repaired)
+		}
+		if repaired.Confidence == nil || *repaired.Confidence != confidence {
+			t.Fatalf("expected repaired payload confidence from authoritative local relation, got %+v", repaired)
+		}
+		if repaired.MarkedByActor == nil || *repaired.MarkedByActor != markedByActor {
+			t.Fatalf("expected repaired payload marked_by_actor from authoritative local relation, got %+v", repaired)
+		}
+		if repaired.MarkedByKind == nil || *repaired.MarkedByKind != markedByKind {
+			t.Fatalf("expected repaired payload marked_by_kind from authoritative local relation, got %+v", repaired)
+		}
+		if repaired.MarkedByModel == nil || *repaired.MarkedByModel != markedByModel {
+			t.Fatalf("expected repaired payload marked_by_model from authoritative local relation, got %+v", repaired)
+		}
+
+		after, err := s.DiagnoseCloudUpgradeLegacyMutations("legacy-rel-proj")
+		if err != nil {
+			t.Fatalf("diagnose after relation repair: %v", err)
+		}
+		if after.RepairableCount != 0 || after.BlockedCount != 0 || len(after.Findings) != 0 {
+			t.Fatalf("expected no remaining legacy relation findings after repair, got %+v", after)
+		}
+	})
 }
 
 func TestRollbackCloudUpgradeSafetyBoundary(t *testing.T) {


### PR DESCRIPTION
## Linked Issue

Closes #313

## PR Type

- [x] `type:bug` — Bug fix

## Summary

- Adds `SyncEntityRelation` to the legacy mutation evaluator so relation mutations are no longer classified as manual-action-required blockers during cloud sync preflight.
- Adds `SyncEntityRelation` to the chunk codec canonicalizer so relation payloads can be exported in push chunks.
- Fixes the server-side ingestion path automatically because `cloudserver` delegates chunk validation to the same `chunkcodec` package.
- Covers both code paths with focused unit tests.

## Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Added `SyncEntityRelation` to supported legacy entities; added full `case SyncEntityRelation:` in `evaluateCloudUpgradeLegacyMutationTx` with decode + local-state inference + validation + repairable classification. |
| `internal/store/store_test.go` | Added `legacy relation mutation required fields are detected and repaired from authoritative local state` subtest. |
| `internal/cloud/chunkcodec/chunkcodec.go` | Added `SyncEntityRelation` to `validateSupportedMutation`; added `mutationRelationPayload` struct; added `case SyncEntityRelation` in `normalizeMutationPayload` with required-field validation and project canonicalization. |
| `internal/cloud/chunkcodec/chunkcodec_test.go` | Added tests for relation upsert (project rewrite), missing required fields rejection, and relation delete. |

## Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] Focused tests pass:
  - `go test ./internal/store -run TestUpgradeRepairDryRunAndApply -v`
  - `go test ./internal/cloud/chunkcodec -v`
- [x] Manually tested the affected functionality:
  1. Ran `engram cloud upgrade doctor --project addi-challenge` → `status: ready`
  2. Ran `engram cloud upgrade repair --project addi-challenge --apply` → `applied: true`
  3. Ran `engram sync --cloud --project addi-challenge` → `Cloud sync complete` (53 mutations exported)

## Notes for Reviewers

- The server-side fix is implicit: `cloudserver.go` calls `chunkcodec.CanonicalizeForProject`, which now accepts relation mutations.
- `syncRelationPayload` already existed (Phase 2 wire format); this change only bridges it into the cloud sync export/repair paths.
- No breaking changes to existing entities (session, observation, prompt).
