### PR TITLE
fix(cloud): make push payload limit configurable

### DIFF
--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -106,6 +106,7 @@ var newCloudRuntime = func(cfg cloud.Config) (cloudServerRuntime, error) {
 			authenticator,
 			cfg.Port,
 			cloudserver.WithHost(cfg.BindHost),
+			cloudserver.WithMaxPushBodyBytes(cfg.MaxPushBodyBytes),
 			cloudserver.WithProjectAuthorizer(projectAuth),
 			cloudserver.WithDashboardAdminToken(cfg.AdminToken),
 			cloudserver.WithSyncStatusProvider(cloudDashboardStatusProvider{store: cs, projects: allowedProjects}),

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -1588,6 +1588,7 @@ func TestCmdCloudServeStartsCloudRuntime(t *testing.T) {
 	t.Setenv("ENGRAM_CLOUD_HOST", "0.0.0.0")
 	t.Setenv("ENGRAM_CLOUD_TOKEN", "token-abc")
 	t.Setenv("ENGRAM_CLOUD_ALLOWED_PROJECTS", "proj-a")
+	t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", "16777216")
 
 	var seen cloud.Config
 	runtimeStub := &stubCloudRuntimeServer{}
@@ -1611,6 +1612,9 @@ func TestCmdCloudServeStartsCloudRuntime(t *testing.T) {
 	}
 	if seen.BindHost != "0.0.0.0" {
 		t.Fatalf("expected cloud runtime config bind host from env, got %q", seen.BindHost)
+	}
+	if seen.MaxPushBodyBytes != 16777216 {
+		t.Fatalf("expected cloud runtime config max push bytes from env, got %d", seen.MaxPushBodyBytes)
 	}
 }
 

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -26,13 +26,14 @@ services:
         condition: service_healthy
     environment:
       ENGRAM_DATABASE_URL: postgres://engram:engram_dev@postgres:5432/engram_cloud?sslmode=disable
-      ENGRAM_JWT_SECRET: engram-dev-jwt-secret-for-local-smoke-1234
-      ENGRAM_CLOUD_INSECURE_NO_AUTH: "1"
-      ENGRAM_CLOUD_ALLOWED_PROJECTS: smoke-project
+      ENGRAM_JWT_SECRET: ${ENGRAM_JWT_SECRET}
+      ENGRAM_CLOUD_TOKEN: ${ENGRAM_CLOUD_TOKEN}
+      ENGRAM_CLOUD_ALLOWED_PROJECTS: ${ENGRAM_CLOUD_ALLOWED_PROJECTS}
       ENGRAM_CLOUD_HOST: 0.0.0.0
+      ENGRAM_CLOUD_MAX_PUSH_BYTES: ${ENGRAM_CLOUD_MAX_PUSH_BYTES:-67108864}
       ENGRAM_PORT: "18080"
     ports:
-      - "127.0.0.1:18080:18080"
+      - "0.0.0.0:18080:18080"
     command: ["cloud", "serve"]
 
 volumes:

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -46,19 +46,20 @@ type staticStatusProvider struct{ status dashboard.SyncStatus }
 func (s staticStatusProvider) Status() dashboard.SyncStatus { return s.status }
 
 type CloudServer struct {
-	store          ChunkStore
-	auth           Authenticator
-	projectAuth    ProjectAuthorizer
-	dashboardAdmin string
-	port           int
-	host           string
-	mux            *http.ServeMux
-	syncStatus     dashboard.SyncStatusProvider
-	listenAndServe func(addr string, handler http.Handler) error
+	store            ChunkStore
+	auth             Authenticator
+	projectAuth      ProjectAuthorizer
+	dashboardAdmin   string
+	port             int
+	host             string
+	maxPushBodyBytes int64
+	mux              *http.ServeMux
+	syncStatus       dashboard.SyncStatusProvider
+	listenAndServe   func(addr string, handler http.Handler) error
 }
 
 const defaultHost = "127.0.0.1"
-const maxPushBodyBytes int64 = 8 * 1024 * 1024
+const defaultMaxPushBodyBytes int64 = 8 * 1024 * 1024
 const maxDashboardLoginBodyBytes int64 = 16 * 1024
 const dashboardSessionCookieName = "engram_dashboard_token"
 
@@ -88,18 +89,27 @@ func WithDashboardAdminToken(adminToken string) Option {
 	}
 }
 
+func WithMaxPushBodyBytes(maxBytes int64) Option {
+	return func(s *CloudServer) {
+		if maxBytes > 0 {
+			s.maxPushBodyBytes = maxBytes
+		}
+	}
+}
+
 func New(store ChunkStore, authSvc Authenticator, port int, opts ...Option) *CloudServer {
 	s := &CloudServer{
-		store: store,
-		auth:  authSvc,
-		port:  port,
-		host:  defaultHost,
+		store:            store,
+		auth:             authSvc,
+		port:             port,
+		host:             defaultHost,
+		maxPushBodyBytes: defaultMaxPushBodyBytes,
 		syncStatus: staticStatusProvider{status: dashboard.SyncStatus{
 			Phase:         "degraded",
 			ReasonCode:    constants.ReasonTransportFailed,
 			ReasonMessage: "sync status provider is unavailable",
 		}},
-		listenAndServe: http.ListenAndServe,
+		listenAndServe:   http.ListenAndServe,
 	}
 	if projectAuthorizer, ok := authSvc.(ProjectAuthorizer); ok {
 		s.projectAuth = projectAuthorizer
@@ -346,7 +356,7 @@ func (s *CloudServer) handlePullChunk(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxPushBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxPushBodyBytes)
 	var req struct {
 		ChunkID         string          `json:"chunk_id"`
 		CreatedBy       string          `json:"created_by"`
@@ -357,7 +367,7 @@ func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			writeActionableError(w, http.StatusRequestEntityTooLarge, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadTooLarge, fmt.Sprintf("push payload too large (max %d bytes)", maxPushBodyBytes))
+			writeActionableError(w, http.StatusRequestEntityTooLarge, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadTooLarge, fmt.Sprintf("push payload too large (max %d bytes)", s.maxPushBodyBytes))
 			return
 		}
 		writeActionableError(w, http.StatusBadRequest, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadInvalid, fmt.Sprintf("invalid push payload: %v", err))

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	cloudauth "github.com/Gentleman-Programming/engram/internal/cloud/auth"
+	"github.com/Gentleman-Programming/engram/internal/cloud/constants"
 	"github.com/Gentleman-Programming/engram/internal/cloud/cloudstore"
 	"github.com/Gentleman-Programming/engram/internal/cloud/dashboard"
 	"github.com/Gentleman-Programming/engram/internal/store"
@@ -776,7 +777,7 @@ func TestHandlerProjectScopeForbiddenReturnsPolicyClassPayload(t *testing.T) {
 
 func TestHandlerPushRejectsOversizedPayload(t *testing.T) {
 	srv := New(&fakeStore{}, fakeAuth{}, 0)
-	tooLarge := strings.Repeat("x", int(maxPushBodyBytes)+1)
+	tooLarge := strings.Repeat("x", int(defaultMaxPushBodyBytes)+1)
 	body := bytes.NewBufferString(`{"project":"proj-a","created_by":"tester","data":"` + tooLarge + `"}`)
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/sync/push", body))
@@ -785,6 +786,27 @@ func TestHandlerPushRejectsOversizedPayload(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "payload too large") {
 		t.Fatalf("expected clear oversized payload error, got body=%q", rec.Body.String())
+	}
+}
+
+func TestHandlerPushRejectsOversizedPayloadUsingConfiguredMax(t *testing.T) {
+	srv := New(&fakeStore{}, fakeAuth{}, 0, WithMaxPushBodyBytes(32))
+	tooLarge := strings.Repeat("x", 33)
+	body := bytes.NewBufferString(`{"project":"proj-a","created_by":"tester","data":"` + tooLarge + `"}`)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/sync/push", body))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	payload := decodeActionableError(t, rec)
+	if payload.ErrorClass != constants.UpgradeErrorClassRepairable {
+		t.Fatalf("expected repairable error class, got %q", payload.ErrorClass)
+	}
+	if payload.ErrorCode != constants.UpgradeErrorCodePayloadTooLarge {
+		t.Fatalf("expected payload too large code, got %q", payload.ErrorCode)
+	}
+	if payload.Error != "push payload too large (max 32 bytes)" {
+		t.Fatalf("expected configured max in error, got %q", payload.Error)
 	}
 }
 

--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -3,6 +3,7 @@ package cloudserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -57,14 +58,19 @@ const defaultPullLimit = 100
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 // handleMutationPush handles POST /sync/mutations/push.
-// REQ-200: bearer auth, body limit 8 MiB, batch size cap 100, pause gate (409 on sync_enabled=false).
+// REQ-200: bearer auth, configurable body limit (default 8 MiB), batch size cap 100, pause gate (409 on sync_enabled=false).
 // BC2: project authorization is enforced for every distinct project in the batch.
 // BW9: 409 pause response uses writeActionableError for structured error envelope.
 func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxPushBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxPushBodyBytes)
 
 	var req mutationPushEnvelope
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeActionableError(w, http.StatusRequestEntityTooLarge, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadTooLarge, fmt.Sprintf("push payload too large (max %d bytes)", s.maxPushBodyBytes))
+			return
+		}
 		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
 		return
 	}

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -323,6 +323,33 @@ func TestMutationPushEndpointBatchTooLarge(t *testing.T) {
 	}
 }
 
+func TestMutationPushEndpointRejectsOversizedPayloadUsingConfiguredMax(t *testing.T) {
+	ms := newFakeMutationStore()
+	srv := New(ms, multiProjectAuth{token: "secret", projects: []string{"proj-a"}}, 0, WithMaxPushBodyBytes(64))
+	tooLarge := strings.Repeat("x", 65)
+	body := bytes.NewBufferString(`{"entries":[{"project":"proj-a","entity":"observation","entity_key":"obs-1","op":"upsert","payload":"` + tooLarge + `"}]}`)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	payload := decodeActionableError(t, rec)
+	if payload.ErrorClass != "repairable" {
+		t.Fatalf("expected repairable error class, got %q", payload.ErrorClass)
+	}
+	if payload.ErrorCode != "upgrade_repairable_payload_too_large" {
+		t.Fatalf("expected payload too large error code, got %q", payload.ErrorCode)
+	}
+	if payload.Error != "push payload too large (max 64 bytes)" {
+		t.Fatalf("expected configured max in error, got %q", payload.Error)
+	}
+}
+
 func TestMutationPushEndpointEmptyBatch(t *testing.T) {
 	// JC1: empty batch → 400 empty_batch (changed from prior 200 behavior).
 	// Empty batches carry no project info; they cannot be pause-gated or audited.

--- a/internal/cloud/config.go
+++ b/internal/cloud/config.go
@@ -7,26 +7,29 @@ import (
 )
 
 type Config struct {
-	DSN             string
-	JWTSecret       string
-	CORSOrigins     []string
-	MaxPool         int
-	Port            int
-	BindHost        string
-	AdminToken      string
-	AllowedProjects []string
+	DSN              string
+	JWTSecret        string
+	CORSOrigins      []string
+	MaxPool          int
+	Port             int
+	BindHost         string
+	MaxPushBodyBytes int64
+	AdminToken       string
+	AllowedProjects  []string
 }
 
 const DefaultJWTSecret = "engram-dev-jwt-secret-for-local-smoke-1234"
+const DefaultMaxPushBodyBytes int64 = 8 * 1024 * 1024
 
 func DefaultConfig() Config {
 	return Config{
-		DSN:         "postgres://engram:engram_dev@localhost:5433/engram_cloud?sslmode=disable",
-		JWTSecret:   DefaultJWTSecret,
-		CORSOrigins: []string{"*"},
-		MaxPool:     10,
-		Port:        8080,
-		BindHost:    "127.0.0.1",
+		DSN:              "postgres://engram:engram_dev@localhost:5433/engram_cloud?sslmode=disable",
+		JWTSecret:        DefaultJWTSecret,
+		CORSOrigins:      []string{"*"},
+		MaxPool:          10,
+		Port:             8080,
+		BindHost:         "127.0.0.1",
+		MaxPushBodyBytes: DefaultMaxPushBodyBytes,
 	}
 }
 
@@ -52,6 +55,11 @@ func ConfigFromEnv() Config {
 	}
 	if v := strings.TrimSpace(os.Getenv("ENGRAM_CLOUD_HOST")); v != "" {
 		cfg.BindHost = v
+	}
+	if v := strings.TrimSpace(os.Getenv("ENGRAM_CLOUD_MAX_PUSH_BYTES")); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			cfg.MaxPushBodyBytes = n
+		}
 	}
 	if v := strings.TrimSpace(os.Getenv("ENGRAM_CLOUD_ALLOWED_PROJECTS")); v != "" {
 		parts := strings.Split(v, ",")

--- a/internal/cloud/config_test.go
+++ b/internal/cloud/config_test.go
@@ -31,6 +31,41 @@ func TestConfigFromEnvAllowedProjects(t *testing.T) {
 	}
 }
 
+func TestConfigFromEnvMaxPushBodyBytes(t *testing.T) {
+	t.Run("default remains 8 MiB", func(t *testing.T) {
+		t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", "")
+		cfg := ConfigFromEnv()
+		if cfg.MaxPushBodyBytes != DefaultMaxPushBodyBytes {
+			t.Fatalf("expected default max push bytes %d, got %d", DefaultMaxPushBodyBytes, cfg.MaxPushBodyBytes)
+		}
+	})
+
+	t.Run("env override works", func(t *testing.T) {
+		t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", "67108864")
+		cfg := ConfigFromEnv()
+		if cfg.MaxPushBodyBytes != 67108864 {
+			t.Fatalf("expected env override 67108864, got %d", cfg.MaxPushBodyBytes)
+		}
+	})
+
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "invalid keeps default", value: "not-a-number"},
+		{name: "zero keeps default", value: "0"},
+		{name: "negative keeps default", value: "-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", tc.value)
+			cfg := ConfigFromEnv()
+			if cfg.MaxPushBodyBytes != DefaultMaxPushBodyBytes {
+				t.Fatalf("expected default max push bytes %d for %q, got %d", DefaultMaxPushBodyBytes, tc.value, cfg.MaxPushBodyBytes)
+			}
+		})
+	}
+}
+
 func TestIsDefaultJWTSecret(t *testing.T) {
 	t.Run("default secret returns true", func(t *testing.T) {
 		if !IsDefaultJWTSecret(DefaultJWTSecret) {


### PR DESCRIPTION
Closes #316

## Summary
- Make the Engram Cloud push body limit configurable via `ENGRAM_CLOUD_MAX_PUSH_BYTES` while preserving the existing 8 MiB default.
- Apply the configured limit consistently to chunk push and mutation push handlers.
- Wire the self-hosted cloud compose example to use a larger opt-in default for local deployments.

## Changes
| File | Change |
|------|--------|
| `internal/cloud/config.go` | Adds `MaxPushBodyBytes` config and env parsing. |
| `internal/cloud/cloudserver/*` | Uses instance-level push body limits and reports configured 413 max. |
| `cmd/engram/cloud.go` | Passes runtime config into the cloud server. |
| `docker-compose.cloud.yml` | Adds `ENGRAM_CLOUD_MAX_PUSH_BYTES` for self-hosted compose. |

## Test Plan
- [x] `docker run --rm -v "/Users/skynet/engram":/src -w /src golang:1.25 go test ./internal/cloud/...`
- [x] `docker run --rm -v "/Users/skynet/engram":/src -w /src golang:1.25 go test ./cmd/engram -run CloudServe`

## Notes
- Issue #316 currently has `status:needs-review`; a maintainer needs to add `status:approved` before this PR can pass the issue-first gate.