### PR TITLE
fix(sync): materialize mutation chunks for recovery

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -393,6 +393,7 @@ Inspect or replay the `sync_apply_deferred` queue.
 - `engram cloud upgrade bootstrap --project <project> [--resume]` — resumable checkpointed enroll/push/verify flow
 - `engram cloud upgrade status --project <project>` — show upgrade stage/class/reason
 - `engram cloud upgrade rollback --project <project>` — restore pre-upgrade local snapshot before `bootstrap_verified`; blocked afterwards
+- `engram cloud repair materialize-mutations --project <project> (--dry-run|--apply)` — explicit server-side Postgres repair that backfills existing `cloud_mutations` into compatible `cloud_chunks` without deleting remote data
 
 Cloud auth token is provided at runtime via `ENGRAM_CLOUD_TOKEN` (not by a dedicated CLI subcommand).
 Cloud server startup fails closed when the token is missing unless `ENGRAM_CLOUD_INSECURE_NO_AUTH=1` is explicitly set for local insecure development.
@@ -442,6 +443,17 @@ engram sync --cloud --project <project>
 ```
 
 Sync/autosync never auto-applies repairs; only the explicit `repair --apply` command mutates local repairable upgrade state.
+
+For cloud servers that already accepted mutation pushes before mutation payloads were materialized into chunk history, run the server-side backfill against the Postgres DSN used by `engram cloud serve`:
+
+```bash
+ENGRAM_DATABASE_URL='postgres://...' engram cloud repair materialize-mutations --project <project> --dry-run
+ENGRAM_DATABASE_URL='postgres://...' engram cloud repair materialize-mutations --project <project> --apply
+```
+
+The backfill is project-scoped, non-destructive, and idempotent: it inserts missing compatible chunks and leaves existing `cloud_mutations` and chunks in place.
+
+`engram cloud serve` also runs this materialization repair automatically for every configured `ENGRAM_CLOUD_ALLOWED_PROJECTS` entry at startup. The explicit repair command remains available for operator verification, dry-runs, and re-running a project after an upgrade.
 
 ### Local Cloud Bring-Up (Docker + Postgres)
 

--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -84,6 +84,10 @@ var newCloudRuntime = func(cfg cloud.Config) (cloudServerRuntime, error) {
 		return nil, err
 	}
 	allowedProjects := normalizeAllowedProjects(cfg.AllowedProjects)
+	if err := backfillAllowedProjectMutationChunks(context.Background(), cs, allowedProjects); err != nil {
+		_ = cs.Close()
+		return nil, err
+	}
 	projectAuth := auth.NewProjectScopeAuthorizer(allowedProjects)
 	token := strings.TrimSpace(os.Getenv("ENGRAM_CLOUD_TOKEN"))
 	cs.SetDashboardAllowedProjects(allowedProjects)
@@ -114,6 +118,22 @@ var newCloudRuntime = func(cfg cloud.Config) (cloudServerRuntime, error) {
 	}, nil
 }
 
+func backfillAllowedProjectMutationChunks(ctx context.Context, cs *cloudstore.CloudStore, projects []string) error {
+	for _, project := range projects {
+		report, err := cs.BackfillMutationChunks(ctx, project, true)
+		if err != nil {
+			return fmt.Errorf("cloud repair materialize-mutations for project %q: %w", project, err)
+		}
+		if report.CandidateMutations > 0 || report.ChunksInserted > 0 {
+			fmt.Fprintf(os.Stderr,
+				"engram cloud repair materialize-mutations: project=%s candidates=%d already_materialized=%d chunks_planned=%d chunks_inserted=%d\n",
+				report.Project, report.CandidateMutations, report.AlreadyMaterialized, report.ChunksPlanned, report.ChunksInserted,
+			)
+		}
+	}
+	return nil
+}
+
 var runUpgradeBootstrap = func(s *store.Store, project string, cc *cloudConfig) (*engramsync.UpgradeBootstrapResult, error) {
 	transport, err := remote.NewRemoteTransport(cc.ServerURL, cc.Token, project)
 	if err != nil {
@@ -130,12 +150,12 @@ type cloudConfig struct {
 func cmdCloud(cfg store.Config) {
 	if len(os.Args) < 3 {
 		fmt.Fprintln(os.Stderr, "usage: engram cloud <subcommand> [options]")
-		fmt.Fprintln(os.Stderr, "supported subcommands: status, enroll, config, serve, upgrade")
+		fmt.Fprintln(os.Stderr, "supported subcommands: status, enroll, config, serve, upgrade, repair")
 		exitFunc(1)
 	}
 	if os.Args[2] == "--help" || os.Args[2] == "-h" || os.Args[2] == "help" {
 		fmt.Println("usage: engram cloud <subcommand> [options]")
-		fmt.Println("supported subcommands: status, enroll, config, serve, upgrade")
+		fmt.Println("supported subcommands: status, enroll, config, serve, upgrade, repair")
 		return
 	}
 
@@ -150,11 +170,61 @@ func cmdCloud(cfg store.Config) {
 		cmdCloudServe()
 	case "upgrade":
 		cmdCloudUpgrade(cfg)
+	case "repair":
+		cmdCloudRepair()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown cloud command: %s\n", os.Args[2])
-		fmt.Fprintln(os.Stderr, "supported subcommands: status, enroll, config, serve, upgrade")
+		fmt.Fprintln(os.Stderr, "supported subcommands: status, enroll, config, serve, upgrade, repair")
 		exitFunc(1)
 	}
+}
+
+func cmdCloudRepair() {
+	if len(os.Args) < 4 || os.Args[3] == "--help" || os.Args[3] == "-h" || os.Args[3] == "help" {
+		fmt.Println("usage: engram cloud repair materialize-mutations --project <name> (--dry-run|--apply)")
+		fmt.Println("repairs existing cloud_mutations into compatible cloud_chunks without deleting remote data")
+		return
+	}
+	command := strings.TrimSpace(strings.ToLower(os.Args[3]))
+	if command != "materialize-mutations" {
+		fmt.Fprintf(os.Stderr, "unknown cloud repair command: %s\n", command)
+		fmt.Fprintln(os.Stderr, "supported cloud repair commands: materialize-mutations")
+		exitFunc(1)
+		return
+	}
+	project := parseCloudUpgradeProjectArg(os.Args[4:])
+	if project == "" {
+		fmt.Fprintln(os.Stderr, "usage: engram cloud repair materialize-mutations --project <name> (--dry-run|--apply)")
+		fmt.Fprintln(os.Stderr, "error: --project is required")
+		exitFunc(1)
+		return
+	}
+	dryRun := hasCloudUpgradeFlag(os.Args[4:], "--dry-run")
+	apply := hasCloudUpgradeFlag(os.Args[4:], "--apply")
+	if dryRun == apply {
+		fmt.Fprintln(os.Stderr, "usage: engram cloud repair materialize-mutations --project <name> (--dry-run|--apply)")
+		fmt.Fprintln(os.Stderr, "error: exactly one of --dry-run or --apply is required")
+		exitFunc(1)
+		return
+	}
+
+	cs, err := cloudstore.New(cloud.ConfigFromEnv())
+	if err != nil {
+		fatal(err)
+		return
+	}
+	defer cs.Close()
+	report, err := cs.BackfillMutationChunks(context.Background(), project, apply)
+	if err != nil {
+		fatal(err)
+		return
+	}
+	encoded, err := jsonMarshalIndent(report, "", "  ")
+	if err != nil {
+		fatal(err)
+		return
+	}
+	fmt.Println(string(encoded))
 }
 
 func cmdCloudUpgrade(cfg store.Config) {

--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -542,6 +542,23 @@ func (cs *CloudStore) migrate(ctx context.Context) error {
 		)`,
 		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS project_name TEXT`,
 		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS client_created_at TIMESTAMPTZ`,
+		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`,
+		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS payload JSONB NOT NULL DEFAULT '{}'::jsonb`,
+		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS sessions_count INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS observations_count INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS prompts_count INTEGER NOT NULL DEFAULT 0`,
+		`UPDATE cloud_chunks SET created_at = imported_at WHERE imported_at IS NOT NULL AND created_at IS NULL`,
+		`UPDATE cloud_chunks SET sessions_count = sessions WHERE sessions_count = 0 AND sessions IS NOT NULL`,
+		`UPDATE cloud_chunks SET observations_count = memories WHERE observations_count = 0 AND memories IS NOT NULL`,
+		`UPDATE cloud_chunks SET prompts_count = prompts WHERE prompts_count = 0 AND prompts IS NOT NULL`,
+		`DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'cloud_chunks' AND column_name = 'user_id'
+			) THEN
+				ALTER TABLE cloud_chunks ALTER COLUMN user_id DROP NOT NULL;
+			END IF;
+		END $$`,
 		`UPDATE cloud_chunks SET project_name = 'default' WHERE project_name IS NULL OR btrim(project_name) = ''`,
 		`ALTER TABLE cloud_chunks ALTER COLUMN project_name SET NOT NULL`,
 		`DO $$ BEGIN
@@ -572,6 +589,17 @@ func (cs *CloudStore) migrate(ctx context.Context) error {
 		    updated_by    TEXT,
 		    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
+		`DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'cloud_project_controls'
+				  AND column_name = 'updated_by'
+				  AND udt_name = 'uuid'
+			) THEN
+				ALTER TABLE cloud_project_controls DROP CONSTRAINT IF EXISTS cloud_project_controls_updated_by_fkey;
+				ALTER TABLE cloud_project_controls ALTER COLUMN updated_by TYPE TEXT USING updated_by::text;
+			END IF;
+		END $$`,
 		`CREATE INDEX IF NOT EXISTS idx_cloud_project_controls_enabled ON cloud_project_controls(sync_enabled)`,
 		// cloud_mutations: journal for fine-grained mutation sync (REQ-200, REQ-201).
 		`CREATE TABLE IF NOT EXISTS cloud_mutations (
@@ -583,6 +611,17 @@ func (cs *CloudStore) migrate(ctx context.Context) error {
 			payload    JSONB NOT NULL DEFAULT '{}',
 			occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
+		`ALTER TABLE cloud_mutations ADD COLUMN IF NOT EXISTS project TEXT`,
+		`UPDATE cloud_mutations SET project = 'default' WHERE project IS NULL OR btrim(project) = ''`,
+		`ALTER TABLE cloud_mutations ALTER COLUMN project SET NOT NULL`,
+		`DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'cloud_mutations' AND column_name = 'user_id'
+			) THEN
+				ALTER TABLE cloud_mutations ALTER COLUMN user_id DROP NOT NULL;
+			END IF;
+		END $$`,
 		`CREATE INDEX IF NOT EXISTS idx_cloud_mutations_project ON cloud_mutations(project)`,
 		`CREATE INDEX IF NOT EXISTS idx_cloud_mutations_seq ON cloud_mutations(seq)`,
 		// cloud_sync_audit_log: persistent audit trail for push-rejection events (REQ-400).
@@ -634,6 +673,15 @@ type StoredMutation struct {
 	OccurredAt string          `json:"occurred_at"`
 }
 
+type MutationChunkBackfillReport struct {
+	Project             string `json:"project"`
+	Applied             bool   `json:"applied"`
+	CandidateMutations  int    `json:"candidate_mutations"`
+	AlreadyMaterialized int    `json:"already_materialized"`
+	ChunksPlanned       int    `json:"chunks_planned"`
+	ChunksInserted      int    `json:"chunks_inserted"`
+}
+
 // InsertMutationBatch inserts a batch of mutations into the cloud_mutations journal.
 // Returns the sequence numbers assigned to each entry.
 // BW3: The entire batch is wrapped in a transaction — partial failures roll back
@@ -644,6 +692,10 @@ func (cs *CloudStore) InsertMutationBatch(ctx context.Context, batch []MutationE
 	}
 	if len(batch) == 0 {
 		return []int64{}, nil
+	}
+	chunks, err := materializedMutationBatchChunks(batch)
+	if err != nil {
+		return nil, err
 	}
 
 	tx, err := cs.db.BeginTx(ctx, nil)
@@ -679,12 +731,353 @@ func (cs *CloudStore) InsertMutationBatch(ctx context.Context, batch []MutationE
 		}
 		seqs = append(seqs, seq)
 	}
+	for _, chunk := range chunks {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO cloud_chunks (project_name, chunk_id, created_by, payload, sessions_count, observations_count, prompts_count)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (project_name, chunk_id) DO NOTHING`,
+			chunk.project, chunk.id, "mutation-push", chunk.payload, chunk.counts.sessions, chunk.counts.observations, chunk.counts.prompts,
+		); err != nil {
+			return nil, fmt.Errorf("cloudstore: materialize mutation batch chunk: %w", err)
+		}
+		if err := cs.indexChunkSessionsWith(ctx, tx, chunk.project, chunk.payload); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("cloudstore: commit mutation batch: %w", err)
 	}
 	tx = nil // mark committed so deferred Rollback is a no-op
+	if len(chunks) > 0 {
+		cs.invalidateDashboardReadModel()
+	}
 	return seqs, nil
+}
+
+const mutationBackfillChunkSize = 100
+
+func (cs *CloudStore) BackfillMutationChunks(ctx context.Context, project string, apply bool) (MutationChunkBackfillReport, error) {
+	if cs == nil || cs.db == nil {
+		return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: not initialized")
+	}
+	project = strings.TrimSpace(project)
+	if project == "" {
+		return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: project is required")
+	}
+
+	report := MutationChunkBackfillReport{Project: project, Applied: apply}
+	materialized, err := cs.existingChunkMutationSignatures(ctx, project)
+	if err != nil {
+		return MutationChunkBackfillReport{}, err
+	}
+
+	rows, err := cs.db.QueryContext(ctx, `
+		SELECT project, entity, entity_key, op, payload::text
+		FROM cloud_mutations
+		WHERE project = $1
+		ORDER BY seq ASC`, project)
+	if err != nil {
+		return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: query mutation chunk backfill candidates: %w", err)
+	}
+	defer rows.Close()
+
+	missing := make([]MutationEntry, 0)
+	for rows.Next() {
+		var entry MutationEntry
+		var payload string
+		if err := rows.Scan(&entry.Project, &entry.Entity, &entry.EntityKey, &entry.Op, &payload); err != nil {
+			return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: scan mutation chunk backfill candidate: %w", err)
+		}
+		if !isChunkMaterializableMutationEntity(entry.Entity) {
+			continue
+		}
+		entry.Payload = json.RawMessage(payload)
+		report.CandidateMutations++
+		sig, err := mutationEntrySignature(entry)
+		if err != nil {
+			return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: sign mutation chunk backfill candidate %s/%s/%s: %w", entry.Project, entry.Entity, entry.EntityKey, err)
+		}
+		if _, ok := materialized[sig]; ok {
+			report.AlreadyMaterialized++
+			continue
+		}
+		missing = append(missing, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: iterate mutation chunk backfill candidates: %w", err)
+	}
+
+	chunks := make([]materializedMutationChunk, 0)
+	for start := 0; start < len(missing); start += mutationBackfillChunkSize {
+		end := start + mutationBackfillChunkSize
+		if end > len(missing) {
+			end = len(missing)
+		}
+		batchChunks, err := materializedMutationBatchChunks(missing[start:end])
+		if err != nil {
+			return MutationChunkBackfillReport{}, err
+		}
+		chunks = append(chunks, batchChunks...)
+	}
+	report.ChunksPlanned = len(chunks)
+	if !apply || len(chunks) == 0 {
+		return report, nil
+	}
+
+	tx, err := cs.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: begin mutation chunk backfill tx: %w", err)
+	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, chunk := range chunks {
+		result, err := tx.ExecContext(ctx, `
+			INSERT INTO cloud_chunks (project_name, chunk_id, created_by, payload, sessions_count, observations_count, prompts_count)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (project_name, chunk_id) DO NOTHING`,
+			chunk.project, chunk.id, "mutation-backfill", chunk.payload, chunk.counts.sessions, chunk.counts.observations, chunk.counts.prompts,
+		)
+		if err != nil {
+			return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: insert mutation chunk backfill: %w", err)
+		}
+		if affected, err := result.RowsAffected(); err == nil && affected > 0 {
+			report.ChunksInserted++
+		}
+		if err := cs.indexChunkSessionsWith(ctx, tx, chunk.project, chunk.payload); err != nil {
+			return MutationChunkBackfillReport{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: commit mutation chunk backfill: %w", err)
+	}
+	tx = nil
+	if report.ChunksInserted > 0 {
+		cs.invalidateDashboardReadModel()
+	}
+	return report, nil
+}
+
+func (cs *CloudStore) existingChunkMutationSignatures(ctx context.Context, project string) (map[string]struct{}, error) {
+	rows, err := cs.db.QueryContext(ctx, `SELECT payload FROM cloud_chunks WHERE project_name = $1`, project)
+	if err != nil {
+		return nil, fmt.Errorf("cloudstore: query existing chunk mutations: %w", err)
+	}
+	defer rows.Close()
+
+	signatures := make(map[string]struct{})
+	for rows.Next() {
+		var payload []byte
+		if err := rows.Scan(&payload); err != nil {
+			return nil, fmt.Errorf("cloudstore: scan existing chunk mutations: %w", err)
+		}
+		chunk, err := parseChunkData(payload)
+		if err != nil {
+			return nil, fmt.Errorf("cloudstore: parse existing chunk mutations: %w", err)
+		}
+		for _, mutation := range chunk.Mutations {
+			if !isChunkMaterializableMutationEntity(mutation.Entity) {
+				continue
+			}
+			sig, err := syncMutationSignature(mutation)
+			if err != nil {
+				return nil, fmt.Errorf("cloudstore: sign existing chunk mutation %s/%s/%s: %w", mutation.Project, mutation.Entity, mutation.EntityKey, err)
+			}
+			signatures[sig] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cloudstore: iterate existing chunk mutations: %w", err)
+	}
+	return signatures, nil
+}
+
+type materializedMutationChunk struct {
+	project string
+	id      string
+	payload []byte
+	counts  chunkSummary
+}
+
+func materializedMutationBatchChunks(batch []MutationEntry) ([]materializedMutationChunk, error) {
+	if len(batch) == 0 {
+		return nil, nil
+	}
+	groups := make(map[string][]MutationEntry)
+	order := make([]string, 0)
+	for i, entry := range batch {
+		project := strings.TrimSpace(entry.Project)
+		if project == "" {
+			return nil, fmt.Errorf("cloudstore: materialize mutation batch: entries[%d].project is required", i)
+		}
+		if _, ok := groups[project]; !ok {
+			order = append(order, project)
+		}
+		groups[project] = append(groups[project], entry)
+	}
+
+	chunks := make([]materializedMutationChunk, 0, len(order))
+	for _, project := range order {
+		payload, counts, err := materializedMutationBatchChunk(groups[project])
+		if err != nil {
+			return nil, err
+		}
+		if len(payload) == 0 {
+			continue
+		}
+		chunks = append(chunks, materializedMutationChunk{project: project, id: chunkIDFromPayload(payload), payload: payload, counts: counts})
+	}
+	return chunks, nil
+}
+
+func materializedMutationBatchChunk(batch []MutationEntry) ([]byte, chunkSummary, error) {
+	if len(batch) == 0 {
+		return nil, chunkSummary{}, nil
+	}
+	project := strings.TrimSpace(batch[0].Project)
+	chunk := engramsync.ChunkData{Mutations: make([]store.SyncMutation, 0, len(batch))}
+	for i, entry := range batch {
+		entryProject := strings.TrimSpace(entry.Project)
+		if entryProject == "" {
+			return nil, chunkSummary{}, fmt.Errorf("cloudstore: materialize mutation batch: entries[%d].project is required", i)
+		}
+		if project == "" {
+			project = entryProject
+		}
+		if entryProject != project {
+			return nil, chunkSummary{}, fmt.Errorf("cloudstore: materialize mutation batch: mixed projects %q and %q", project, entryProject)
+		}
+		entity := strings.TrimSpace(entry.Entity)
+		if !isChunkMaterializableMutationEntity(entity) {
+			continue
+		}
+
+		payload := entry.Payload
+		if len(payload) == 0 {
+			payload = json.RawMessage("{}")
+		}
+		chunk.Mutations = append(chunk.Mutations, store.SyncMutation{
+			Project:   entryProject,
+			Entity:    entity,
+			EntityKey: strings.TrimSpace(entry.EntityKey),
+			Op:        strings.TrimSpace(entry.Op),
+			Payload:   string(payload),
+		})
+
+		if strings.TrimSpace(entry.Op) != store.SyncOpUpsert {
+			continue
+		}
+		switch entity {
+		case store.SyncEntitySession:
+			var session store.Session
+			if err := json.Unmarshal(payload, &session); err != nil {
+				return nil, chunkSummary{}, fmt.Errorf("cloudstore: materialize mutation batch session %q: %w", entry.EntityKey, err)
+			}
+			if strings.TrimSpace(session.ID) == "" {
+				session.ID = strings.TrimSpace(entry.EntityKey)
+			}
+			chunk.Sessions = append(chunk.Sessions, session)
+		case store.SyncEntityObservation:
+			var observation store.Observation
+			if err := json.Unmarshal(payload, &observation); err != nil {
+				return nil, chunkSummary{}, fmt.Errorf("cloudstore: materialize mutation batch observation %q: %w", entry.EntityKey, err)
+			}
+			if strings.TrimSpace(observation.SyncID) == "" {
+				observation.SyncID = strings.TrimSpace(entry.EntityKey)
+			}
+			chunk.Observations = append(chunk.Observations, observation)
+		case store.SyncEntityPrompt:
+			var prompt store.Prompt
+			if err := json.Unmarshal(payload, &prompt); err != nil {
+				return nil, chunkSummary{}, fmt.Errorf("cloudstore: materialize mutation batch prompt %q: %w", entry.EntityKey, err)
+			}
+			if strings.TrimSpace(prompt.SyncID) == "" {
+				prompt.SyncID = strings.TrimSpace(entry.EntityKey)
+			}
+			chunk.Prompts = append(chunk.Prompts, prompt)
+		}
+	}
+	if len(chunk.Mutations) == 0 {
+		return nil, chunkSummary{}, nil
+	}
+
+	payload, err := json.Marshal(chunk)
+	if err != nil {
+		return nil, chunkSummary{}, fmt.Errorf("cloudstore: marshal materialized mutation batch chunk: %w", err)
+	}
+	payload, err = chunkcodec.CanonicalizeForProject(payload, project)
+	if err != nil {
+		return nil, chunkSummary{}, fmt.Errorf("cloudstore: canonicalize materialized mutation batch chunk: %w", err)
+	}
+	return payload, chunkSummary{sessions: len(chunk.Sessions), observations: len(chunk.Observations), prompts: len(chunk.Prompts)}, nil
+}
+
+func isChunkMaterializableMutationEntity(entity string) bool {
+	switch strings.TrimSpace(entity) {
+	case store.SyncEntitySession, store.SyncEntityObservation, store.SyncEntityPrompt:
+		return true
+	default:
+		return false
+	}
+}
+
+func mutationEntrySignature(entry MutationEntry) (string, error) {
+	project := strings.TrimSpace(entry.Project)
+	if project == "" {
+		return "", fmt.Errorf("project is required")
+	}
+	payload := entry.Payload
+	if len(payload) == 0 {
+		payload = json.RawMessage("{}")
+	}
+	doc := engramsync.ChunkData{Mutations: []store.SyncMutation{{
+		Project:   project,
+		Entity:    strings.TrimSpace(entry.Entity),
+		EntityKey: strings.TrimSpace(entry.EntityKey),
+		Op:        strings.TrimSpace(entry.Op),
+		Payload:   string(payload),
+	}}}
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := chunkcodec.CanonicalizeForProject(encoded, project)
+	if err != nil {
+		return "", err
+	}
+	chunk, err := parseChunkData(canonical)
+	if err != nil {
+		return "", err
+	}
+	if len(chunk.Mutations) != 1 {
+		return "", fmt.Errorf("expected one canonical mutation, got %d", len(chunk.Mutations))
+	}
+	return syncMutationSignature(chunk.Mutations[0])
+}
+
+func syncMutationSignature(mutation store.SyncMutation) (string, error) {
+	normalized, err := canonicalMutationPayload([]byte(strings.TrimSpace(mutation.Payload)))
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{
+		strings.TrimSpace(mutation.Project),
+		strings.TrimSpace(mutation.Entity),
+		strings.TrimSpace(mutation.EntityKey),
+		strings.TrimSpace(mutation.Op),
+		normalized,
+	}, "\x00"), nil
+}
+
+func canonicalMutationPayload(payload []byte) (string, error) {
+	payload = normalizeJSON(payload)
+	if !json.Valid(payload) {
+		return "", fmt.Errorf("payload is not valid JSON")
+	}
+	return string(payload), nil
 }
 
 // ListMutationsSince returns mutations with seq > sinceSeq, filtered to allowedProjects.

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -42,6 +42,98 @@ func TestChunkIDFromPayloadStable(t *testing.T) {
 	}
 }
 
+func TestMaterializedMutationBatchChunkIncludesObservationAlongsidePromptAndSession(t *testing.T) {
+	obsPayload := json.RawMessage(`{
+		"sync_id":"obs-04081be99000bdf5",
+		"session_id":"sess-newer",
+		"type":"decision",
+		"title":"newer observation",
+		"content":"must be present in cloud_chunks",
+		"project":"sias-app",
+		"scope":"project",
+		"created_at":"2026-05-04T01:49:52Z"
+	}`)
+	promptPayload := json.RawMessage(`{"sync_id":"prompt-newer","session_id":"sess-newer","content":"newer prompt","project":"sias-app","created_at":"2026-05-04T01:50:00Z"}`)
+	sessionPayload := json.RawMessage(`{"id":"sess-newer","project":"sias-app","directory":"/work/sias-app","started_at":"2026-05-04T01:45:00Z"}`)
+
+	payload, counts, err := materializedMutationBatchChunk([]MutationEntry{
+		{Project: "sias-app", Entity: store.SyncEntitySession, EntityKey: "sess-newer", Op: store.SyncOpUpsert, Payload: sessionPayload},
+		{Project: "sias-app", Entity: store.SyncEntityPrompt, EntityKey: "prompt-newer", Op: store.SyncOpUpsert, Payload: promptPayload},
+		{Project: "sias-app", Entity: store.SyncEntityObservation, EntityKey: "obs-04081be99000bdf5", Op: store.SyncOpUpsert, Payload: obsPayload},
+	})
+	if err != nil {
+		t.Fatalf("materializedMutationBatchChunk: %v", err)
+	}
+	if counts.sessions != 1 || counts.prompts != 1 || counts.observations != 1 {
+		t.Fatalf("expected one session, prompt, and observation in chunk counts, got %+v", counts)
+	}
+
+	var chunk engramsync.ChunkData
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		t.Fatalf("decode materialized chunk: %v", err)
+	}
+	if len(chunk.Prompts) != 1 || len(chunk.Sessions) != 1 {
+		t.Fatalf("expected prompt/session materialized, got sessions=%d prompts=%d", len(chunk.Sessions), len(chunk.Prompts))
+	}
+	if len(chunk.Observations) != 1 {
+		t.Fatalf("expected newer observation mutation to be materialized into payload.observations, got %d", len(chunk.Observations))
+	}
+	if chunk.Observations[0].SyncID != "obs-04081be99000bdf5" {
+		t.Fatalf("expected missing observation sync_id to be present, got %q", chunk.Observations[0].SyncID)
+	}
+	if len(chunk.Mutations) != 3 {
+		t.Fatalf("expected mutation journal payloads retained for replay, got %d", len(chunk.Mutations))
+	}
+}
+
+func TestMaterializedMutationBatchChunksKeepProjectsSeparate(t *testing.T) {
+	chunks, err := materializedMutationBatchChunks([]MutationEntry{
+		{Project: "proj-a", Entity: store.SyncEntityPrompt, EntityKey: "prompt-a", Op: store.SyncOpUpsert, Payload: json.RawMessage(`{"sync_id":"prompt-a","session_id":"sess-a","content":"a"}`)},
+		{Project: "proj-b", Entity: store.SyncEntityObservation, EntityKey: "obs-b", Op: store.SyncOpUpsert, Payload: json.RawMessage(`{"sync_id":"obs-b","session_id":"sess-b","type":"decision","title":"b","content":"b","scope":"project"}`)},
+	})
+	if err != nil {
+		t.Fatalf("materializedMutationBatchChunks: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected one materialized chunk per project, got %d", len(chunks))
+	}
+	if chunks[0].project != "proj-a" || chunks[1].project != "proj-b" {
+		t.Fatalf("expected project order preserved, got %q then %q", chunks[0].project, chunks[1].project)
+	}
+}
+
+func TestMutationEntrySignatureMatchesCanonicalChunkMutation(t *testing.T) {
+	entry := MutationEntry{
+		Project:   "proj-signature",
+		Entity:    store.SyncEntityObservation,
+		EntityKey: "obs-signature",
+		Op:        store.SyncOpUpsert,
+		Payload:   json.RawMessage(`{"sync_id":"obs-signature","session_id":"sess-signature","type":"decision","title":"Signature","content":"canonical","scope":"project"}`),
+	}
+	entrySig, err := mutationEntrySignature(entry)
+	if err != nil {
+		t.Fatalf("mutationEntrySignature: %v", err)
+	}
+	payload, _, err := materializedMutationBatchChunk([]MutationEntry{entry})
+	if err != nil {
+		t.Fatalf("materializedMutationBatchChunk: %v", err)
+	}
+	var chunk engramsync.ChunkData
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		t.Fatalf("decode materialized chunk: %v", err)
+	}
+	if len(chunk.Mutations) != 1 {
+		t.Fatalf("expected one materialized mutation, got %d", len(chunk.Mutations))
+	}
+	chunkSig, err := syncMutationSignature(chunk.Mutations[0])
+	if err != nil {
+		t.Fatalf("syncMutationSignature: %v", err)
+	}
+	if entrySig != chunkSig {
+		t.Fatalf("expected entry signature to match canonical chunk mutation\nentry=%q\nchunk=%q", entrySig, chunkSig)
+	}
+}
+
 func TestNormalizeJSONCanonicalizesEquivalentPayloads(t *testing.T) {
 	a := []byte(`{"a":1,"b":[2,3]}`)
 	b := []byte("{\n  \"b\": [2,3], \"a\":1\n}")
@@ -344,6 +436,133 @@ func TestWriteChunkMaterializesMutationsAndIsReplayIdempotent(t *testing.T) {
 	if len(mutationsAfterReplay) != 3 {
 		t.Fatalf("expected replay not to duplicate mutations, got %d: %+v", len(mutationsAfterReplay), mutationsAfterReplay)
 	}
+}
+
+func TestBackfillMutationChunksMaterializesExistingMutationRows(t *testing.T) {
+	cs := openTestCloudStore(t)
+	ctx := context.Background()
+	project := uniqueCloudstoreTestProject("mutation-backfill")
+	cleanupCloudstoreProject(t, cs, project)
+
+	insertLegacyCloudMutation(t, cs, project, store.SyncEntitySession, "sess-backfill", store.SyncOpUpsert, `{"id":"sess-backfill","directory":"/work/backfill","started_at":"2026-05-04T01:45:00Z"}`)
+	insertLegacyCloudMutation(t, cs, project, store.SyncEntityObservation, "obs-backfill", store.SyncOpUpsert, `{"sync_id":"obs-backfill","session_id":"sess-backfill","type":"decision","title":"Backfilled observation","content":"must be reconstructed from chunks","scope":"project","created_at":"2026-05-04T01:49:52Z"}`)
+
+	dryRun, err := cs.BackfillMutationChunks(ctx, project, false)
+	if err != nil {
+		t.Fatalf("BackfillMutationChunks dry-run: %v", err)
+	}
+	if dryRun.Applied || dryRun.CandidateMutations != 2 || dryRun.ChunksPlanned != 1 || dryRun.ChunksInserted != 0 {
+		t.Fatalf("unexpected dry-run report: %+v", dryRun)
+	}
+	if got := countCloudChunksForProject(t, cs, project); got != 0 {
+		t.Fatalf("dry-run must not insert chunks, got %d", got)
+	}
+
+	report, err := cs.BackfillMutationChunks(ctx, project, true)
+	if err != nil {
+		t.Fatalf("BackfillMutationChunks apply: %v", err)
+	}
+	if !report.Applied || report.CandidateMutations != 2 || report.ChunksPlanned != 1 || report.ChunksInserted != 1 {
+		t.Fatalf("unexpected apply report: %+v", report)
+	}
+
+	chunks := readCloudChunksForProject(t, cs, project)
+	if len(chunks) != 1 {
+		t.Fatalf("expected one repair chunk, got %d", len(chunks))
+	}
+	var chunk engramsync.ChunkData
+	if err := json.Unmarshal(chunks[0], &chunk); err != nil {
+		t.Fatalf("decode repair chunk: %v", err)
+	}
+	if len(chunk.Sessions) != 1 || chunk.Sessions[0].ID != "sess-backfill" {
+		t.Fatalf("expected session upsert in repair chunk, got %+v", chunk.Sessions)
+	}
+	if len(chunk.Observations) != 1 || chunk.Observations[0].SyncID != "obs-backfill" {
+		t.Fatalf("expected observation upsert in payload.observations after repair, got %+v", chunk.Observations)
+	}
+	if len(chunk.Mutations) != 2 {
+		t.Fatalf("expected original mutation replay entries retained, got %d", len(chunk.Mutations))
+	}
+}
+
+func TestBackfillMutationChunksIsIdempotent(t *testing.T) {
+	cs := openTestCloudStore(t)
+	ctx := context.Background()
+	project := uniqueCloudstoreTestProject("mutation-backfill-idempotent")
+	cleanupCloudstoreProject(t, cs, project)
+
+	insertLegacyCloudMutation(t, cs, project, store.SyncEntityObservation, "obs-idempotent", store.SyncOpUpsert, `{"sync_id":"obs-idempotent","session_id":"sess-idempotent","type":"decision","title":"Idempotent observation","content":"materialize once","scope":"project","created_at":"2026-05-04T01:49:52Z"}`)
+
+	first, err := cs.BackfillMutationChunks(ctx, project, true)
+	if err != nil {
+		t.Fatalf("first BackfillMutationChunks: %v", err)
+	}
+	if first.ChunksInserted != 1 {
+		t.Fatalf("expected first repair to insert one chunk, got %+v", first)
+	}
+	second, err := cs.BackfillMutationChunks(ctx, project, true)
+	if err != nil {
+		t.Fatalf("second BackfillMutationChunks: %v", err)
+	}
+	if second.ChunksPlanned != 0 || second.ChunksInserted != 0 || second.AlreadyMaterialized != 1 {
+		t.Fatalf("expected second repair to be noop, got %+v", second)
+	}
+	if got := countCloudChunksForProject(t, cs, project); got != 1 {
+		t.Fatalf("expected no duplicate chunks after rerun, got %d", got)
+	}
+}
+
+func uniqueCloudstoreTestProject(prefix string) string {
+	return prefix + "-" + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "-")
+}
+
+func cleanupCloudstoreProject(t *testing.T, cs *CloudStore, project string) {
+	t.Helper()
+	t.Cleanup(func() {
+		_, _ = cs.db.ExecContext(context.Background(), `DELETE FROM cloud_chunks WHERE project_name = $1`, project)
+		_, _ = cs.db.ExecContext(context.Background(), `DELETE FROM cloud_mutations WHERE project = $1`, project)
+		_, _ = cs.db.ExecContext(context.Background(), `DELETE FROM cloud_project_sessions WHERE project_name = $1`, project)
+	})
+}
+
+func insertLegacyCloudMutation(t *testing.T, cs *CloudStore, project, entity, entityKey, op, payload string) {
+	t.Helper()
+	_, err := cs.db.ExecContext(context.Background(), `
+		INSERT INTO cloud_mutations (project, entity, entity_key, op, payload)
+		VALUES ($1, $2, $3, $4, $5)`, project, entity, entityKey, op, []byte(payload))
+	if err != nil {
+		t.Fatalf("insert legacy cloud mutation %s/%s: %v", entity, entityKey, err)
+	}
+}
+
+func countCloudChunksForProject(t *testing.T, cs *CloudStore, project string) int {
+	t.Helper()
+	var count int
+	if err := cs.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM cloud_chunks WHERE project_name = $1`, project).Scan(&count); err != nil {
+		t.Fatalf("count cloud chunks: %v", err)
+	}
+	return count
+}
+
+func readCloudChunksForProject(t *testing.T, cs *CloudStore, project string) [][]byte {
+	t.Helper()
+	rows, err := cs.db.QueryContext(context.Background(), `SELECT payload FROM cloud_chunks WHERE project_name = $1 ORDER BY created_at ASC, chunk_id ASC`, project)
+	if err != nil {
+		t.Fatalf("query cloud chunks: %v", err)
+	}
+	defer rows.Close()
+	var chunks [][]byte
+	for rows.Next() {
+		var payload []byte
+		if err := rows.Scan(&payload); err != nil {
+			t.Fatalf("scan cloud chunk: %v", err)
+		}
+		chunks = append(chunks, payload)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate cloud chunks: %v", err)
+	}
+	return chunks
 }
 
 func parseMustChunk(t *testing.T, payload []byte) engramsync.ChunkData {


### PR DESCRIPTION
Closes #321

## Summary
- Materialize accepted mutation pushes into compatible `cloud_chunks` so chunk/bootstrap recovery can restore mutation-backed sessions, observations, and prompts.
- Add explicit and startup automatic backfill for existing mutation-only cloud rows, scoped to allowed projects and idempotent/non-destructive.
- Add legacy Postgres schema migrations discovered during Docker-backed validation.

## Root Cause
`POST /sync/mutations/push` wrote accepted rows to `cloud_mutations` but did not create recoverable chunk payloads. The dashboard/current-state read model can merge `cloud_chunks + cloud_mutations`, while fresh chunk/manifest recovery only reads `cloud_chunks`, creating a parity gap.

## Repair Behavior
- New mutation pushes write `cloud_mutations` and compatible `cloud_chunks` in the same transaction.
- `engram cloud serve` automatically backfills mutation chunks for `ENGRAM_CLOUD_ALLOWED_PROJECTS` on startup.
- Operators can verify/rerun explicitly:
  ```bash
  ENGRAM_DATABASE_URL='postgres://...' engram cloud repair materialize-mutations --project sias-app --dry-run
  ENGRAM_DATABASE_URL='postgres://...' engram cloud repair materialize-mutations --project sias-app --apply
  ```

## Validation
- `CLOUDSTORE_TEST_DSN='postgres://engram:engram_dev@localhost:5433/engram_cloud?sslmode=disable' go test -v ./internal/cloud/cloudstore -run 'TestBackfillMutationChunks|TestMutationEntrySignature|TestMaterializedMutationBatch|TestProjectSyncControlPersists'`
  - Postgres-backed tests ran, not skipped.
- `CLOUDSTORE_TEST_DSN='postgres://engram:engram_dev@localhost:5433/engram_cloud?sslmode=disable' go test ./internal/cloud/cloudstore ./cmd/engram`
- `go test ./internal/cloud/cloudserver ./internal/cloud/remote ./internal/sync`
- `go test ./internal/server/...`
- `go test ./...`
- `go test -tags e2e ./internal/server/...`
- `git diff --check`