### PR TITLE
fix(sync): harden cloud mutation backfill

### DIFF
--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -547,14 +547,42 @@ func (cs *CloudStore) migrate(ctx context.Context) error {
 		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS sessions_count INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS observations_count INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE cloud_chunks ADD COLUMN IF NOT EXISTS prompts_count INTEGER NOT NULL DEFAULT 0`,
-		`UPDATE cloud_chunks SET created_at = imported_at WHERE imported_at IS NOT NULL AND created_at IS NULL`,
-		`UPDATE cloud_chunks SET sessions_count = sessions WHERE sessions_count = 0 AND sessions IS NOT NULL`,
-		`UPDATE cloud_chunks SET observations_count = memories WHERE observations_count = 0 AND memories IS NOT NULL`,
-		`UPDATE cloud_chunks SET prompts_count = prompts WHERE prompts_count = 0 AND prompts IS NOT NULL`,
 		`DO $$ BEGIN
 			IF EXISTS (
 				SELECT 1 FROM information_schema.columns
-				WHERE table_name = 'cloud_chunks' AND column_name = 'user_id'
+				WHERE table_schema = current_schema() AND table_name = 'cloud_chunks' AND column_name = 'imported_at'
+			) THEN
+				EXECUTE 'UPDATE cloud_chunks SET created_at = imported_at WHERE imported_at IS NOT NULL AND created_at IS NULL';
+			END IF;
+		END $$`,
+		`DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = current_schema() AND table_name = 'cloud_chunks' AND column_name = 'sessions'
+			) THEN
+				EXECUTE 'UPDATE cloud_chunks SET sessions_count = sessions WHERE sessions_count = 0 AND sessions IS NOT NULL';
+			END IF;
+		END $$`,
+		`DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = current_schema() AND table_name = 'cloud_chunks' AND column_name = 'memories'
+			) THEN
+				EXECUTE 'UPDATE cloud_chunks SET observations_count = memories WHERE observations_count = 0 AND memories IS NOT NULL';
+			END IF;
+		END $$`,
+		`DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = current_schema() AND table_name = 'cloud_chunks' AND column_name = 'prompts'
+			) THEN
+				EXECUTE 'UPDATE cloud_chunks SET prompts_count = prompts WHERE prompts_count = 0 AND prompts IS NOT NULL';
+			END IF;
+		END $$`,
+		`DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = current_schema() AND table_name = 'cloud_chunks' AND column_name = 'user_id'
 			) THEN
 				ALTER TABLE cloud_chunks ALTER COLUMN user_id DROP NOT NULL;
 			END IF;
@@ -592,7 +620,8 @@ func (cs *CloudStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN
 			IF EXISTS (
 				SELECT 1 FROM information_schema.columns
-				WHERE table_name = 'cloud_project_controls'
+				WHERE table_schema = current_schema()
+				  AND table_name = 'cloud_project_controls'
 				  AND column_name = 'updated_by'
 				  AND udt_name = 'uuid'
 			) THEN
@@ -617,7 +646,7 @@ func (cs *CloudStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN
 			IF EXISTS (
 				SELECT 1 FROM information_schema.columns
-				WHERE table_name = 'cloud_mutations' AND column_name = 'user_id'
+				WHERE table_schema = current_schema() AND table_name = 'cloud_mutations' AND column_name = 'user_id'
 			) THEN
 				ALTER TABLE cloud_mutations ALTER COLUMN user_id DROP NOT NULL;
 			END IF;
@@ -678,6 +707,7 @@ type MutationChunkBackfillReport struct {
 	Applied             bool   `json:"applied"`
 	CandidateMutations  int    `json:"candidate_mutations"`
 	AlreadyMaterialized int    `json:"already_materialized"`
+	InvalidMutations    int    `json:"invalid_mutations"`
 	ChunksPlanned       int    `json:"chunks_planned"`
 	ChunksInserted      int    `json:"chunks_inserted"`
 }
@@ -796,7 +826,8 @@ func (cs *CloudStore) BackfillMutationChunks(ctx context.Context, project string
 		report.CandidateMutations++
 		sig, err := mutationEntrySignature(entry)
 		if err != nil {
-			return MutationChunkBackfillReport{}, fmt.Errorf("cloudstore: sign mutation chunk backfill candidate %s/%s/%s: %w", entry.Project, entry.Entity, entry.EntityKey, err)
+			report.InvalidMutations++
+			continue
 		}
 		if _, ok := materialized[sig]; ok {
 			report.AlreadyMaterialized++

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -2,8 +2,11 @@ package cloudstore
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -40,6 +43,57 @@ func TestChunkIDFromPayloadStable(t *testing.T) {
 	if got := chunkIDFromPayload(payload); got == "" || len(got) != 8 {
 		t.Fatalf("expected 8-char chunk id, got %q", got)
 	}
+}
+
+func TestMigrateAcceptsModernCloudChunksWithoutLegacyColumns(t *testing.T) {
+	dsn := os.Getenv("CLOUDSTORE_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CLOUDSTORE_TEST_DSN not set — skipping integration test (requires Postgres)")
+	}
+	if !strings.HasPrefix(dsn, "postgres://") && !strings.HasPrefix(dsn, "postgresql://") {
+		t.Skip("test requires URL-style CLOUDSTORE_TEST_DSN so a per-test search_path can be attached")
+	}
+
+	schema := fmt.Sprintf("cloudstore_modern_%d", time.Now().UnixNano())
+	adminDB, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open admin db: %v", err)
+	}
+	defer adminDB.Close()
+	if _, err := adminDB.ExecContext(context.Background(), `CREATE SCHEMA `+schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() { _, _ = adminDB.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`) })
+
+	testDSN := dsn + "?search_path=" + schema
+	if strings.Contains(dsn, "?") {
+		testDSN = dsn + "&search_path=" + schema
+	}
+	db, err := sql.Open("pgx", testDSN)
+	if err != nil {
+		t.Fatalf("open schema db: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE cloud_chunks (
+		project_name TEXT NOT NULL DEFAULT 'default',
+		chunk_id TEXT NOT NULL,
+		created_by TEXT NOT NULL,
+		client_created_at TIMESTAMPTZ,
+		created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		payload JSONB NOT NULL,
+		sessions_count INTEGER NOT NULL DEFAULT 0,
+		observations_count INTEGER NOT NULL DEFAULT 0,
+		prompts_count INTEGER NOT NULL DEFAULT 0
+	)`); err != nil {
+		db.Close()
+		t.Fatalf("create modern cloud_chunks: %v", err)
+	}
+	db.Close()
+
+	cs, err := New(cloud.Config{DSN: testDSN})
+	if err != nil {
+		t.Fatalf("New should migrate modern cloud_chunks without imported_at/sessions/memories/prompts: %v", err)
+	}
+	cs.Close()
 }
 
 func TestMaterializedMutationBatchChunkIncludesObservationAlongsidePromptAndSession(t *testing.T) {
@@ -509,6 +563,38 @@ func TestBackfillMutationChunksIsIdempotent(t *testing.T) {
 	}
 	if got := countCloudChunksForProject(t, cs, project); got != 1 {
 		t.Fatalf("expected no duplicate chunks after rerun, got %d", got)
+	}
+}
+
+func TestBackfillMutationChunksSkipsInvalidLegacyMutationPayloads(t *testing.T) {
+	cs := openTestCloudStore(t)
+	ctx := context.Background()
+	project := uniqueCloudstoreTestProject("mutation-backfill-invalid")
+	cleanupCloudstoreProject(t, cs, project)
+
+	insertLegacyCloudMutation(t, cs, project, store.SyncEntitySession, "manual-save-engram", store.SyncOpUpsert, `{"id":"manual-save-engram"}`)
+	insertLegacyCloudMutation(t, cs, project, store.SyncEntityObservation, "obs-valid", store.SyncOpUpsert, `{"sync_id":"obs-valid","session_id":"sess-valid","type":"decision","title":"Valid observation","content":"materialize this one","scope":"project","created_at":"2026-05-04T01:49:52Z"}`)
+
+	report, err := cs.BackfillMutationChunks(ctx, project, true)
+	if err != nil {
+		t.Fatalf("BackfillMutationChunks must skip invalid legacy payloads instead of failing: %v", err)
+	}
+	if !report.Applied || report.CandidateMutations != 2 || report.InvalidMutations != 1 || report.ChunksPlanned != 1 || report.ChunksInserted != 1 {
+		t.Fatalf("unexpected report for invalid legacy payload skip: %+v", report)
+	}
+	chunks := readCloudChunksForProject(t, cs, project)
+	if len(chunks) != 1 {
+		t.Fatalf("expected valid mutation to still materialize into one chunk, got %d", len(chunks))
+	}
+	var chunk engramsync.ChunkData
+	if err := json.Unmarshal(chunks[0], &chunk); err != nil {
+		t.Fatalf("decode repair chunk: %v", err)
+	}
+	if len(chunk.Sessions) != 0 {
+		t.Fatalf("invalid legacy session without directory must not be materialized, got %+v", chunk.Sessions)
+	}
+	if len(chunk.Observations) != 1 || chunk.Observations[0].SyncID != "obs-valid" {
+		t.Fatalf("expected valid observation to materialize, got %+v", chunk.Observations)
 	}
 }
 


### PR DESCRIPTION
Closes #323

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Guards legacy cloud chunk migration backfills so modern production schemas without old columns still migrate cleanly.
- Makes mutation chunk backfill skip invalid legacy mutation payloads and report `invalid_mutations` instead of crashing `engram cloud serve`.
- Adds Postgres-backed regressions for the production schema and invalid legacy payload cases.

## Changes
| File | Change |
|------|--------|
| `internal/cloud/cloudstore/cloudstore.go` | Guard legacy column references by current schema and report invalid mutation backfill candidates. |
| `internal/cloud/cloudstore/cloudstore_test.go` | Add production-schema migration and invalid legacy mutation regression tests. |

## Test Plan
- [x] `go test ./internal/cloud/cloudstore`
- [x] `CLOUDSTORE_TEST_DSN='postgres://engram:engram_dev@localhost:5433/engram_cloud?sslmode=disable' go test ./internal/cloud/cloudstore`
- [x] `go test ./cmd/engram ./internal/cloud/cloudserver ./internal/cloud/remote ./internal/sync`
- [x] `go test ./internal/server/...`
- [x] `go test ./...`
- [x] `git diff --check`
- [x] Validated on HostGator VPS: cloud service healthy, dashboard 200, startup backfill completed, post-repair dry-runs planned zero chunks.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / no scripts modified
- [x] Skills tested in at least one agent / not applicable
- [x] Docs updated if behavior changed / operator-visible report field covered by CLI JSON output
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers