### PR TITLE
fix(sync): recover legacy orphan imports

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -21,6 +21,7 @@ package sync
 
 import (
 	"compress/gzip"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -517,8 +518,10 @@ func (sy *Syncer) Import() (*ImportResult, error) {
 type importMode string
 
 const (
-	importModeLocal importMode = "local"
-	importModeCloud importMode = "cloud"
+	importModeLocal                  importMode = "local"
+	importModeCloud                  importMode = "cloud"
+	recoveredMissingSessionDirectory            = "(recovered-missing-session)"
+	recoveredMissingSessionStartedAt            = "1970-01-01 00:00:00"
 )
 
 func (sy *Syncer) importEntriesDependencySafe(entries []ChunkEntry, knownChunks map[string]bool, mode importMode) (*ImportResult, error) {
@@ -535,6 +538,14 @@ func (sy *Syncer) importEntriesDependencySafe(entries []ChunkEntry, knownChunks 
 
 	if len(pendingEntries) == 0 {
 		return result, nil
+	}
+	availableSessionIDs := map[string]struct{}{}
+	if mode == importModeLocal {
+		var err error
+		availableSessionIDs, err = sy.sessionIDsAvailableInChunks(entries, knownChunks)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	lastErrors := map[string]error{}
@@ -562,11 +573,26 @@ func (sy *Syncer) importEntriesDependencySafe(entries []ChunkEntry, knownChunks 
 			}
 
 			if err := sy.importMutationChunk(entry.ID, chunk); err != nil {
+				if mode == importModeLocal {
+					recoveredChunk, recovered, recoveryErr := sy.recoverLocalMissingSessionDependencies(chunk, availableSessionIDs)
+					if recoveryErr != nil {
+						return nil, recoveryErr
+					}
+					if recovered {
+						if retryErr := sy.importMutationChunk(entry.ID, recoveredChunk); retryErr == nil {
+							chunk = recoveredChunk
+							goto imported
+						} else {
+							err = retryErr
+						}
+					}
+				}
 				lastErrors[entry.ID] = importDependencyError(chunk, err)
 				nextPending = append(nextPending, entry)
 				continue
 			}
 
+		imported:
 			importResult := estimateMutationImportResult(chunk)
 			knownChunks[entry.ID] = true
 			delete(lastErrors, entry.ID)
@@ -610,6 +636,77 @@ func importDependencyError(chunk ChunkData, err error) error {
 	}
 	sort.Strings(sessions)
 	return fmt.Errorf("%w; pending session dependencies: %s", err, strings.Join(sessions, ", "))
+}
+
+func (sy *Syncer) sessionIDsAvailableInChunks(entries []ChunkEntry, knownChunks map[string]bool) (map[string]struct{}, error) {
+	available := make(map[string]struct{})
+	for _, entry := range entries {
+		chunkJSON, err := sy.transport.ReadChunk(entry.ID)
+		if err != nil {
+			if errors.Is(err, ErrChunkNotFound) || knownChunks[entry.ID] {
+				continue
+			}
+			return nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
+		}
+
+		var chunk ChunkData
+		if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+			if knownChunks[entry.ID] {
+				continue
+			}
+			return nil, fmt.Errorf("parse chunk %s: %w", entry.ID, err)
+		}
+		for _, mutation := range buildImportMutations(chunk) {
+			if mutation.Entity != store.SyncEntitySession || mutation.Op != store.SyncOpUpsert {
+				continue
+			}
+			sessionID := strings.TrimSpace(mutation.EntityKey)
+			if sessionID != "" {
+				available[sessionID] = struct{}{}
+			}
+		}
+	}
+	return available, nil
+}
+
+func (sy *Syncer) recoverLocalMissingSessionDependencies(chunk ChunkData, availableSessionIDs map[string]struct{}) (ChunkData, bool, error) {
+	mutations := buildImportMutations(chunk)
+	projectsBySession := referencedSessionProjectsFromNonSessionUpserts(mutations)
+	if len(projectsBySession) == 0 {
+		return chunk, false, nil
+	}
+
+	missingIDs := make([]string, 0, len(projectsBySession))
+	for sessionID := range projectsBySession {
+		if _, available := availableSessionIDs[sessionID]; available {
+			continue
+		}
+		_, err := sy.store.GetSession(sessionID)
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return chunk, false, fmt.Errorf("check recovered session dependency %s: %w", sessionID, err)
+		}
+		missingIDs = append(missingIDs, sessionID)
+	}
+	if len(missingIDs) == 0 {
+		return chunk, false, nil
+	}
+
+	sort.Strings(missingIDs)
+	recovered := chunk
+	stubSessions := make([]store.Session, 0, len(missingIDs))
+	for _, sessionID := range missingIDs {
+		stubSessions = append(stubSessions, store.Session{
+			ID:        sessionID,
+			Project:   projectsBySession[sessionID],
+			Directory: recoveredMissingSessionDirectory,
+			StartedAt: recoveredMissingSessionStartedAt,
+		})
+	}
+	recovered.Sessions = append(stubSessions, recovered.Sessions...)
+	return recovered, true, nil
 }
 
 func buildImportMutations(chunk ChunkData) []store.SyncMutation {
@@ -702,6 +799,39 @@ func referencedSessionIDsFromNonSessionUpserts(mutations []store.SyncMutation) m
 		}
 	}
 	return required
+}
+
+func referencedSessionProjectsFromNonSessionUpserts(mutations []store.SyncMutation) map[string]string {
+	projects := make(map[string]string)
+	for _, mutation := range mutations {
+		if mutation.Op != store.SyncOpUpsert {
+			continue
+		}
+		switch mutation.Entity {
+		case store.SyncEntityObservation, store.SyncEntityPrompt:
+			var payload struct {
+				SessionID string  `json:"session_id"`
+				Project   *string `json:"project"`
+			}
+			if err := decodeSyncPayloadForProject([]byte(mutation.Payload), &payload); err != nil {
+				continue
+			}
+			sessionID := strings.TrimSpace(payload.SessionID)
+			if sessionID == "" {
+				continue
+			}
+			project, _ := store.NormalizeProject(strings.TrimSpace(mutation.Project))
+			project = strings.TrimSpace(project)
+			if project == "" && payload.Project != nil {
+				project, _ = store.NormalizeProject(strings.TrimSpace(*payload.Project))
+				project = strings.TrimSpace(project)
+			}
+			if existing := strings.TrimSpace(projects[sessionID]); existing == "" || (project != "" && project < existing) {
+				projects[sessionID] = project
+			}
+		}
+	}
+	return projects
 }
 
 func mutationIdentityKey(mutation store.SyncMutation) string {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -948,15 +948,11 @@ func TestImportBranches(t *testing.T) {
 		})
 
 		chunk := ChunkData{
-			Observations: []store.Observation{{
-				ID:        1,
-				SessionID: "missing-session",
-				Type:      "bugfix",
-				Title:     "broken",
-				Content:   "missing session should violate FK",
-				Scope:     "project",
-				CreatedAt: "2025-01-01 00:00:01",
-				UpdatedAt: "2025-01-01 00:00:01",
+			Mutations: []store.SyncMutation{{
+				Entity:    "unknown",
+				EntityKey: "broken-entity",
+				Op:        store.SyncOpUpsert,
+				Payload:   `{}`,
 			}},
 		}
 		payload, err := json.Marshal(chunk)
@@ -973,7 +969,7 @@ func TestImportBranches(t *testing.T) {
 		}
 
 		sy := New(s, syncDir)
-		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "dependency-safe local import stalled") || !strings.Contains(err.Error(), "missing-session") {
+		if _, err := sy.Import(); err == nil || !strings.Contains(err.Error(), "dependency-safe local import stalled") || !strings.Contains(err.Error(), "unknown sync entity") {
 			t.Fatalf("expected dependency-safe local import error, got %v", err)
 		}
 	})
@@ -1052,8 +1048,12 @@ func TestLocalImportDependencySafeAcrossChunksRegardlessManifestOrder(t *testing
 	if res.ChunksImported != 2 || res.SessionsImported != 1 || res.ObservationsImported != 1 || res.PromptsImported != 1 {
 		t.Fatalf("unexpected import result: %+v", res)
 	}
-	if _, err := s.GetSession("sess-cross-chunk"); err != nil {
+	sess, err := s.GetSession("sess-cross-chunk")
+	if err != nil {
 		t.Fatalf("expected session imported: %v", err)
+	}
+	if sess.Directory != "/tmp/proj-a" {
+		t.Fatalf("expected real session chunk to win, got %+v", sess)
 	}
 	results, err := s.Search("cross chunk observation", store.SearchOptions{Project: project, Limit: 5})
 	if err != nil || len(results) != 1 {
@@ -1099,20 +1099,38 @@ func TestLocalImportOrdersExplicitMutationsAndDirectArraysSafely(t *testing.T) {
 	}
 }
 
-func TestLocalImportMissingSessionStallsWithUsefulError(t *testing.T) {
+func TestLocalImportRecoversLegacyChunkWithMissingSessionStub(t *testing.T) {
 	s := newTestStore(t)
 	syncDir := t.TempDir()
-	chunkID := "missing-session"
+	chunkID := "aaf7a13f"
+	project := "proj-a"
 	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2025-01-01T00:00:00Z"}}})
-	writeLocalChunkFile(t, syncDir, chunkID, ChunkData{Observations: []store.Observation{{SyncID: "obs-missing-session", SessionID: "does-not-exist", Type: "note", Title: "missing", Content: "missing dependency", Scope: "project", CreatedAt: "2025-01-01 00:00:00", UpdatedAt: "2025-01-01 00:00:00"}}})
+	writeLocalChunkFile(t, syncDir, chunkID, ChunkData{
+		Observations: []store.Observation{{SyncID: "obs-missing-session", SessionID: "does-not-exist", Type: "note", Title: "missing", Content: "missing dependency", Project: &project, Scope: "project", CreatedAt: "2025-01-01 00:00:00", UpdatedAt: "2025-01-01 00:00:00"}},
+		Prompts:      []store.Prompt{{SyncID: "prompt-missing-session", SessionID: "does-not-exist", Content: "prompt should be preserved", Project: project, CreatedAt: "2025-01-01 00:00:01"}},
+	})
 
-	_, err := New(s, syncDir).Import()
-	if err == nil {
-		t.Fatal("expected missing session dependency to stall")
+	res, err := New(s, syncDir).Import()
+	if err != nil {
+		t.Fatalf("local import should recover malformed legacy missing session chunk: %v", err)
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "dependency-safe local import stalled") || !strings.Contains(msg, chunkID) || !strings.Contains(msg, "does-not-exist") {
-		t.Fatalf("expected useful dependency-safe stall error, got %v", err)
+	if res.ChunksImported != 1 || res.SessionsImported != 1 || res.ObservationsImported != 1 || res.PromptsImported != 1 {
+		t.Fatalf("unexpected import result: %+v", res)
+	}
+	sess, err := s.GetSession("does-not-exist")
+	if err != nil {
+		t.Fatalf("expected recovered stub session: %v", err)
+	}
+	if sess.Project != project || sess.Directory != "(recovered-missing-session)" {
+		t.Fatalf("unexpected recovered session: %+v", sess)
+	}
+	results, err := s.Search("missing dependency", store.SearchOptions{Project: project, Limit: 5})
+	if err != nil || len(results) != 1 {
+		t.Fatalf("expected recovered observation, results=%d err=%v", len(results), err)
+	}
+	prompts, err := s.RecentPrompts(project, 5)
+	if err != nil || len(prompts) != 1 || prompts[0].SyncID != "prompt-missing-session" {
+		t.Fatalf("expected recovered prompt, prompts=%+v err=%v", prompts, err)
 	}
 }
 


### PR DESCRIPTION
Closes #165

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Recovers legacy malformed local sync chunks whose prompt/observation rows reference sessions missing from every chunk and the local database.
- Synthesizes deterministic recovered session stubs only after confirming no real session upsert exists elsewhere in the manifest.
- Preserves existing dependency-safe import behavior when real session chunks are available.

## Changes
| File | Change |
|------|--------|
| `internal/sync/sync.go` | Adds local-only missing-session dependency recovery with deterministic stub sessions and manifest-wide session scanning. |
| `internal/sync/sync_test.go` | Adds regression coverage for issue #165 and verifies real cross-chunk sessions still win over stubs. |

## Test Plan
- [x] `go test ./internal/sync -run 'TestLocalImport(RecoversLegacyChunkWithMissingSessionStub|DependencySafeAcrossChunksRegardlessManifestOrder|OrdersExplicitMutationsAndDirectArraysSafely)' -count=1 -v`
- [x] `go test ./internal/sync ./internal/store -count=1`
- [x] `go test ./cmd/engram ./internal/cloud/cloudserver ./internal/cloud/cloudstore ./internal/cloud/remote ./internal/sync ./internal/store -count=1`
- [x] `go test ./... -count=1`
- [x] `git diff --check`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / no scripts modified
- [x] Skills tested in at least one agent / not applicable
- [x] Docs updated if behavior changed / behavior covered by regression tests
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers