### PR TITLE
test(project): regression coverage for #312 — HOME-like config does not leak

### DIFF
--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -581,6 +581,100 @@ func TestDetectProject_MatchesFull(t *testing.T) {
 	}
 }
 
+// TestDetectProjectFull_HomeLikeConfigDoesNotLeakIntoNestedGitRepo asserts
+// that an ancestor `.engram/config.json` (e.g. one sitting at $HOME, the
+// scenario reported in #312) does NOT contaminate project detection for a
+// cwd that is inside a nested git repository several levels below.
+//
+// The repo's own root is the project lock; ancestor configs above it must be
+// ignored. This guards the multi-agent setup where each agent runs from its
+// own repo under a shared $HOME — every agent must resolve to its own repo
+// project, not the HOME-level project_name.
+func TestDetectProjectFull_HomeLikeConfigDoesNotLeakIntoNestedGitRepo(t *testing.T) {
+	homeLike := t.TempDir()
+	configDir := filepath.Join(homeLike, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"home-lock"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nested git repo a few levels below the HOME-like dir, with no config of
+	// its own. cwd is a subdirectory inside the repo (mirrors typical agent
+	// workflow: cwd is somewhere inside the repo tree, not necessarily root).
+	repoRoot := filepath.Join(homeLike, "repos", "agent-b")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, repoRoot)
+	cwd := filepath.Join(repoRoot, "src", "pkg")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res := DetectProjectFull(cwd)
+
+	if res.Error != nil {
+		t.Fatalf("unexpected detection error: %v", res.Error)
+	}
+	if res.Project == "home-lock" {
+		t.Fatalf("HOME-like ancestor config leaked into nested repo cwd: project=%q source=%q", res.Project, res.Source)
+	}
+	if res.Source != SourceGitRoot {
+		t.Fatalf("expected SourceGitRoot for nested repo without remote, got source=%q project=%q", res.Source, res.Project)
+	}
+	if res.Project != "agent-b" {
+		t.Fatalf("expected repo basename %q, got %q", "agent-b", res.Project)
+	}
+	gotPath, _ := filepath.EvalSymlinks(res.Path)
+	wantPath, _ := filepath.EvalSymlinks(repoRoot)
+	if gotPath != wantPath {
+		t.Fatalf("expected path %q, got %q", wantPath, gotPath)
+	}
+}
+
+// TestDetectProjectFull_HomeLikeConfigDoesNotLeakIntoDeeplyNestedNonGitCwd
+// asserts that an ancestor `.engram/config.json` does not contaminate a
+// deeply-nested cwd that is not inside a git repo. This is the second half
+// of the #312 scenario: agents that operate outside any git tree must still
+// resolve to their own cwd basename, not to the HOME-level project_name.
+func TestDetectProjectFull_HomeLikeConfigDoesNotLeakIntoDeeplyNestedNonGitCwd(t *testing.T) {
+	homeLike := t.TempDir()
+	configDir := filepath.Join(homeLike, ".engram")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"project_name":"home-lock"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := filepath.Join(homeLike, "workspaces", "team", "agent-c-data")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res := DetectProjectFull(cwd)
+
+	if res.Error != nil {
+		t.Fatalf("unexpected detection error: %v", res.Error)
+	}
+	if res.Project == "home-lock" {
+		t.Fatalf("HOME-like ancestor config leaked into deeply-nested non-git cwd: project=%q source=%q", res.Project, res.Source)
+	}
+	if res.Source != SourceDirBasename {
+		t.Fatalf("expected SourceDirBasename for non-git nested cwd, got source=%q project=%q", res.Source, res.Project)
+	}
+	if res.Project != "agent-c-data" {
+		t.Fatalf("expected cwd basename %q, got %q", "agent-c-data", res.Project)
+	}
+	gotPath, _ := filepath.EvalSymlinks(res.Path)
+	wantPath, _ := filepath.EvalSymlinks(cwd)
+	if gotPath != wantPath {
+		t.Fatalf("expected path %q, got %q", wantPath, gotPath)
+	}
+}
+
 // TestDetectProject_AmbiguousEmpty asserts DetectProject returns basename
 // (not empty) even on ambiguous cwd, maintaining CLI compat (REQ-307).
 func TestDetectProject_AmbiguousEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds two regression tests in \`internal/project/detect_test.go\` that pin the contract \`.engram/config.json\` is a project/repo lock — never inherited from arbitrary ancestors. They cover the multi-agent shape reported in #312, where each agent's MCP server runs from its own cwd under a shared \`\$HOME\` that contains \`~/.engram/config.json\`.

Tests-only PR — no behavior change. The actual fix that prevents \`~/.engram/config.json\` from contaminating arbitrary cwds is already in main (\`detectFromConfig\` only reads at the git-root or the input dir, never walking to ancestors). These tests blind-side regressions of that behavior.

Closes #312 if maintainers agree the issue is resolved by the existing fix + this regression coverage. Otherwise happy to keep iterating.

## Why these specific tests

\`TestDetectProjectFull_DoesNotInheritParentConfigOutsideGitRepo\` already covers the immediate-parent + plain-child case. The two shapes added here match what #312 actually reproduces in real multi-agent deployments:

1. **\`TestDetectProjectFull_HomeLikeConfigDoesNotLeakIntoNestedGitRepo\`** — config at a HOME-like ancestor, cwd inside a git repo several levels below (e.g. \`\$HOME/repos/agent-b/src/pkg\`). Asserts \`SourceGitRoot\` wins over the ancestor config; project resolves to the repo basename, not the HOME-level \`project_name\`.

2. **\`TestDetectProjectFull_HomeLikeConfigDoesNotLeakIntoDeeplyNestedNonGitCwd\`** — config at a HOME-like ancestor, cwd several levels below outside any git tree. Asserts \`SourceDirBasename\` of the leaf cwd, not the ancestor's \`project_name\`.

Both shapes are described in #312's reproduction (\"3 agents (\`agent-a\`, \`agent-b\`, \`agent-c\`) each with own engram MCP\" sharing \`/root/.engram/config.json\`).

## Test plan

- [x] \`go test ./internal/project/\` — passes (5.7s)
- [x] \`go build ./...\` — clean
- [x] New tests fail when \`detectFromConfig\` is altered to walk ancestors (verified locally by temporarily widening the lookup; both new tests fail with \`HOME-like ancestor config leaked\`, as expected)
- [x] Existing \`TestDetectProjectFull_*\` tests continue to pass

## Files changed

- \`internal/project/detect_test.go\` — +94 lines (two new test functions, no edits to existing tests)

## Notes

- Scope kept tight per Alan's note on #312 (\"Keep the implementation tight and include regression coverage where behavior changes\"). No production code touched.
- Followup option (out of scope here): a parallel test in \`internal/mcp/mcp_test.go\` that exercises the same shape end-to-end via \`resolveWriteProject()\`. Happy to add in a follow-up if useful — left out of this PR to keep the diff minimal.