### PR TITLE
fix(server): add GET /observations endpoint for plugin compatibility

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -133,6 +133,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 
 - `POST /observations` — Add observation. Body: `{session_id, type, title, content, tool_name?, project?, scope?, topic_key?}`
 - `GET /observations/recent` — Recent observations. Query: `?project=X&scope=project|personal&limit=N`
+- `GET /observations` — List observations. Query: `?project=X&limit=N&sort=created_at:desc`. Same behaviour as /recent; accepts sort parameter for plugin compatibility
 - `GET /observations/{id}` — Get single observation by ID
 - `PATCH /observations/{id}` — Update fields. Body: `{title?, content?, type?, project?, scope?, topic_key?}`
 - `DELETE /observations/{id}` — Delete observation (`?hard=true` for hard delete, soft delete by default)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,6 +147,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /observations", s.handleAddObservation)
 	s.mux.HandleFunc("POST /observations/passive", s.handlePassiveCapture)
 	s.mux.HandleFunc("GET /observations/recent", s.handleRecentObservations)
+	s.mux.HandleFunc("GET /observations", s.handleRecentObservations)
 	s.mux.HandleFunc("PATCH /observations/{id}", s.handleUpdateObservation)
 	s.mux.HandleFunc("DELETE /observations/{id}", s.handleDeleteObservation)
 
@@ -814,7 +815,8 @@ func (s *Server) handleListDeferred(w http.ResponseWriter, r *http.Request) {
 
 // handleScanConflicts serves POST /conflicts/scan
 // Body: {"project":"X","since":"...","apply":bool,"max_insert":int,
-//        "semantic":bool,"concurrency":int,"timeout_per_call_seconds":int,"max_semantic":int}
+//
+//	"semantic":bool,"concurrency":int,"timeout_per_call_seconds":int,"max_semantic":int}
 func (s *Server) handleScanConflicts(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Project   string `json:"project"`

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1671,3 +1671,52 @@ func TestG2_ExistingRoutes_Unaffected(t *testing.T) {
 		t.Errorf("expected /stats 200 after Phase 3, got %d", statsRec.Code)
 	}
 }
+
+// TestHandleGetObservationsWithSort verifies the new GET /observations endpoint
+// returns 200 with the same behaviour as /observations/recent,
+func TestHandleGetObservationsWithSort(t *testing.T) {
+	st := newServerTestStore(t)
+	srv := New(st, 0)
+	h := srv.Handler()
+
+	// Create session + observation to have data
+	if err := st.CreateSession("s-sort", "sortproj", "/tmp"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := st.AddObservation(store.AddObservationParams{
+		SessionID: "s-sort",
+		Type:      "decision",
+		Title:     "Sort test observation",
+		Content:   "Testing the sort parameter on GET /observations",
+		Project:   "sortproj",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	// Test 1: GET /observations with sort parameter (exactly what the plugin uses)
+	req := httptest.NewRequest(http.MethodGet, "/observations?project=sortproj&limit=1&sort=created_at:desc", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for GET /observations with sort, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var observations []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&observations); err != nil {
+		t.Fatalf("decode observations: %v", err)
+	}
+	if len(observations) == 0 {
+		t.Fatalf("expected at least 1 observation, got 0")
+	}
+
+	// Test 2: GET /observations without sort parameter - should also work
+	req2 := httptest.NewRequest(http.MethodGet, "/observations?project=sortproj&limit=1", nil)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200 for GET /observations without sort, got %d", rec2.Code)
+	}
+}


### PR DESCRIPTION
## What
Added GET /observations endpoint that reuses handleRecentObservations handler.

## Why
The save-nudge plugin sends GET /observations?project=...&limit=1&sort=created_at:desc
but the server only had POST /observations, returning 405 Method Not Allowed.
The plugin silently failed because curl -sf suppresses error output.

## How
- Registered new route `GET /observations` pointing to `handleRecentObservations`
- Updated DOCS.md with the new endpoint
- Added test coverage

## Testing
- `main`: `curl -s -w "\nHTTP_CODE: %{http_code}\n" "..."` -> **405 Method Not Allowed**  
- This branch: same curl -> **200 OK**
- All existing server tests pass
- New test `TestHandleGetObservationsWithSort` passes

Closes #288 