### PR TITLE
feat(cloud): detect dead local daemon in cloud status and document launchd unit

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -514,7 +514,7 @@ Inspect or replay the `sync_apply_deferred` queue.
 
 ### Cloud CLI (opt-in)
 
-- `engram cloud status` — show current cloud config state plus auth/sync readiness without mutating local state
+- `engram cloud status` — show current cloud config state plus auth/sync readiness without mutating local state. When cloud is configured, also probes the local `engram serve` daemon at `127.0.0.1:7437` (respects `ENGRAM_PORT`) and prints a `Local daemon:` line (`running` / `not running` / `unreachable`) so you can detect a silently dead autosync. Exit code is unaffected; the line is informational
 - `engram cloud enroll <project>` — enroll one project for cloud replication
 - `engram cloud config --server <url>` — persist cloud server URL to `~/.engram/cloud.json`
 - `engram cloud serve` — run cloud backend API + dashboard (`/dashboard`) using Postgres config from env
@@ -1150,7 +1150,9 @@ Interactive Bubbletea-based terminal UI. Launch with `engram tui`.
 
 ## Running as a Service
 
-### Using systemd
+Without a service supervisor, `engram serve` dies whenever the binary is replaced (e.g. on `brew upgrade engram`) or the host reboots, and autosync stops silently. The templates below restart it automatically. Use `engram cloud status` afterwards to confirm — the `Local daemon:` line should report `running on port 7437`.
+
+### Using systemd (Linux)
 
 1. Move binary to `~/.local/bin` (ensure it's in your `$PATH`)
 2. Create directories: `mkdir -p ~/.engram ~/.config/systemd/user`
@@ -1175,6 +1177,59 @@ Environment=ENGRAM_DATA_DIR=%h/.engram
 [Install]
 WantedBy=default.target
 ```
+
+### Using launchd (macOS)
+
+This is the recommended setup for Homebrew users on macOS. With `KeepAlive=true`, launchd relaunches `engram serve` automatically after `brew upgrade engram` replaces the binary, so autosync survives upgrades.
+
+1. Find your binary path: `which engram` (typically `/opt/homebrew/bin/engram` on Apple Silicon or `/usr/local/bin/engram` on Intel)
+2. Create the data dir if missing: `mkdir -p ~/.engram`
+3. Create `~/Library/LaunchAgents/com.gentleman-programming.engram.plist` with the contents below — replace `<HOME>` with the absolute path of your home directory (`echo $HOME`) and adjust the binary path if `which engram` returned something different
+4. Load it: `launchctl load ~/Library/LaunchAgents/com.gentleman-programming.engram.plist`
+5. Verify: `launchctl list | grep engram` and `engram cloud status` (the `Local daemon:` line should report `running on port 7437`)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.gentleman-programming.engram</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/engram</string>
+        <string>serve</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string><HOME></string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ENGRAM_DATA_DIR</key>
+        <string><HOME>/.engram</string>
+        <!-- Uncomment and fill these to enable cloud autosync:
+        <key>ENGRAM_CLOUD_AUTOSYNC</key>
+        <string>1</string>
+        <key>ENGRAM_CLOUD_SERVER</key>
+        <string>https://your-cloud-host</string>
+        <key>ENGRAM_CLOUD_TOKEN</key>
+        <string>your-cloud-token</string>
+        -->
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string><HOME>/.engram/serve.out.log</string>
+    <key>StandardErrorPath</key>
+    <string><HOME>/.engram/serve.err.log</string>
+</dict>
+</plist>
+```
+
+To unload (stop and disable): `launchctl unload ~/Library/LaunchAgents/com.gentleman-programming.engram.plist`. To reload after editing the plist: unload, then load again.
+
+> **Note on `brew upgrade`:** launchd does not expand `$HOME` or `~` inside plist values, which is why the template uses literal absolute paths.
 
 ---
 

--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -623,17 +623,20 @@ func cmdCloudStatus(cfg store.Config) {
 			fmt.Println("Auth status: ready (insecure local-dev mode: ENGRAM_CLOUD_INSECURE_NO_AUTH=1)")
 			fmt.Println("Sync readiness: ready for explicit --project sync (project must be enrolled)")
 			fmt.Println("Warning: bearer auth is disabled in insecure mode; do not use in production")
+			printCloudStatusDaemonProbe()
 			printCloudStatusSyncDiagnostic(cfg)
 			return
 		}
 		fmt.Println("Auth status: token not configured (client token is optional at preflight)")
 		fmt.Println("Sync readiness: ready to attempt explicit --project sync (project must be enrolled)")
 		fmt.Println("Hint: if the remote server enforces bearer auth, set ENGRAM_CLOUD_TOKEN")
+		printCloudStatusDaemonProbe()
 		printCloudStatusSyncDiagnostic(cfg)
 		return
 	}
 	fmt.Println("Auth status: ready (token provided via runtime cloud config)")
 	fmt.Println("Sync readiness: ready for explicit --project sync (project must be enrolled)")
+	printCloudStatusDaemonProbe()
 	printCloudStatusSyncDiagnostic(cfg)
 }
 

--- a/cmd/engram/cloud_daemon_probe.go
+++ b/cmd/engram/cloud_daemon_probe.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// daemonProbeStatus describes the outcome of probing the local engram daemon.
+type daemonProbeStatus string
+
+const (
+	daemonProbeRunning     daemonProbeStatus = "running"
+	daemonProbeNotRunning  daemonProbeStatus = "not_running"
+	daemonProbeUnreachable daemonProbeStatus = "unreachable"
+)
+
+// daemonProbeResult captures the outcome of a single probe.
+type daemonProbeResult struct {
+	Status daemonProbeStatus
+	Port   int
+	Err    error
+}
+
+const defaultDaemonProbePort = 7437
+
+// daemonProbeTimeout is a var (not const) so tests can shorten it when
+// exercising the "server accepts but never replies" path.
+var daemonProbeTimeout = time.Second
+
+// cloudDaemonProbe issues a short timeout GET to /health on the local engram
+// HTTP server. Exposed as a variable so tests can stub it.
+var cloudDaemonProbe = defaultCloudDaemonProbe
+
+// defaultCloudDaemonProbe performs a real HTTP GET against the local daemon.
+// A dial error to 127.0.0.1 is interpreted as "not running"; any other error
+// (timeout, non-2xx response, malformed reply) maps to "unreachable" so the
+// user can distinguish "the daemon is gone" from "the daemon is misbehaving".
+func defaultCloudDaemonProbe(ctx context.Context, port int) daemonProbeResult {
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	client := &http.Client{Timeout: daemonProbeTimeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return daemonProbeResult{Status: daemonProbeUnreachable, Port: port, Err: err}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		var opErr *net.OpError
+		if errors.As(err, &opErr) && opErr.Op == "dial" {
+			return daemonProbeResult{Status: daemonProbeNotRunning, Port: port, Err: err}
+		}
+		return daemonProbeResult{Status: daemonProbeUnreachable, Port: port, Err: err}
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return daemonProbeResult{Status: daemonProbeRunning, Port: port}
+	}
+	return daemonProbeResult{Status: daemonProbeUnreachable, Port: port}
+}
+
+// resolveDaemonProbePort mirrors the port resolution used by cmdServe so the
+// probe targets the same address the user's serve process is bound to.
+func resolveDaemonProbePort() int {
+	if p := strings.TrimSpace(os.Getenv("ENGRAM_PORT")); p != "" {
+		if n, err := strconv.Atoi(p); err == nil && n > 0 && n < 65536 {
+			return n
+		}
+	}
+	return defaultDaemonProbePort
+}
+
+// printCloudStatusDaemonProbe prints a single line describing whether the
+// local engram daemon answers /health, plus a short hint when it is down.
+// Exit code is unchanged: this is informational so cloud status remains a
+// non-failing diagnostic surface.
+func printCloudStatusDaemonProbe() {
+	port := resolveDaemonProbePort()
+	ctx, cancel := context.WithTimeout(context.Background(), daemonProbeTimeout)
+	defer cancel()
+	res := cloudDaemonProbe(ctx, port)
+	switch res.Status {
+	case daemonProbeRunning:
+		fmt.Printf("Local daemon: running on port %d\n", res.Port)
+	case daemonProbeNotRunning:
+		fmt.Printf("Local daemon: not running on port %d\n", res.Port)
+		fmt.Println("Hint: run `engram serve` to resume autosync; on macOS see DOCS.md launchd template to keep it alive across upgrades")
+	default:
+		if res.Err != nil {
+			fmt.Printf("Local daemon: unreachable on port %d (probe error: %v)\n", res.Port, res.Err)
+		} else {
+			fmt.Printf("Local daemon: unreachable on port %d\n", res.Port)
+		}
+	}
+}

--- a/cmd/engram/cloud_daemon_probe_test.go
+++ b/cmd/engram/cloud_daemon_probe_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultCloudDaemonProbeReturnsRunningOn200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	port := portFromTestServer(t, srv)
+	res := defaultCloudDaemonProbe(context.Background(), port)
+	if res.Status != daemonProbeRunning {
+		t.Fatalf("expected daemonProbeRunning, got %q (err=%v)", res.Status, res.Err)
+	}
+	if res.Port != port {
+		t.Fatalf("expected port %d, got %d", port, res.Port)
+	}
+}
+
+func TestDefaultCloudDaemonProbeReturnsNotRunningOnRefused(t *testing.T) {
+	port := allocateClosedPort(t)
+	res := defaultCloudDaemonProbe(context.Background(), port)
+	if res.Status != daemonProbeNotRunning {
+		t.Fatalf("expected daemonProbeNotRunning on refused, got %q (err=%v)", res.Status, res.Err)
+	}
+	if res.Err == nil {
+		t.Fatalf("expected non-nil err for refused dial")
+	}
+}
+
+func TestDefaultCloudDaemonProbeReturnsUnreachableOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	port := portFromTestServer(t, srv)
+	res := defaultCloudDaemonProbe(context.Background(), port)
+	if res.Status != daemonProbeUnreachable {
+		t.Fatalf("expected daemonProbeUnreachable on 500, got %q", res.Status)
+	}
+}
+
+func TestDefaultCloudDaemonProbeReturnsUnreachableOnTimeout(t *testing.T) {
+	prev := daemonProbeTimeout
+	daemonProbeTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { daemonProbeTimeout = prev })
+
+	// Listener accepts but never reads/writes, forcing the client to time out.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		// Hold the connection until the listener closes; never write a response.
+		<-done
+		_ = conn.Close()
+	}()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	res := defaultCloudDaemonProbe(context.Background(), port)
+	if res.Status != daemonProbeUnreachable {
+		t.Fatalf("expected daemonProbeUnreachable on timeout, got %q (err=%v)", res.Status, res.Err)
+	}
+}
+
+func TestResolveDaemonProbePortHonorsEnvAndDefaults(t *testing.T) {
+	t.Run("defaults to 7437 when ENGRAM_PORT unset", func(t *testing.T) {
+		t.Setenv("ENGRAM_PORT", "")
+		if got := resolveDaemonProbePort(); got != defaultDaemonProbePort {
+			t.Fatalf("expected default %d, got %d", defaultDaemonProbePort, got)
+		}
+	})
+	t.Run("honors valid ENGRAM_PORT", func(t *testing.T) {
+		t.Setenv("ENGRAM_PORT", "9999")
+		if got := resolveDaemonProbePort(); got != 9999 {
+			t.Fatalf("expected 9999, got %d", got)
+		}
+	})
+	t.Run("falls back to default on invalid ENGRAM_PORT", func(t *testing.T) {
+		t.Setenv("ENGRAM_PORT", "not-a-number")
+		if got := resolveDaemonProbePort(); got != defaultDaemonProbePort {
+			t.Fatalf("expected default %d, got %d", defaultDaemonProbePort, got)
+		}
+	})
+	t.Run("falls back to default on out-of-range ENGRAM_PORT", func(t *testing.T) {
+		t.Setenv("ENGRAM_PORT", "0")
+		if got := resolveDaemonProbePort(); got != defaultDaemonProbePort {
+			t.Fatalf("expected default %d, got %d", defaultDaemonProbePort, got)
+		}
+		t.Setenv("ENGRAM_PORT", "70000")
+		if got := resolveDaemonProbePort(); got != defaultDaemonProbePort {
+			t.Fatalf("expected default %d, got %d", defaultDaemonProbePort, got)
+		}
+	})
+}
+
+func TestPrintCloudStatusDaemonProbeFormatsEachState(t *testing.T) {
+	cases := []struct {
+		name      string
+		stub      func(context.Context, int) daemonProbeResult
+		wantLines []string
+	}{
+		{
+			name: "running",
+			stub: func(_ context.Context, port int) daemonProbeResult {
+				return daemonProbeResult{Status: daemonProbeRunning, Port: port}
+			},
+			wantLines: []string{"Local daemon: running on port"},
+		},
+		{
+			name: "not_running prints recovery hint",
+			stub: func(_ context.Context, port int) daemonProbeResult {
+				return daemonProbeResult{Status: daemonProbeNotRunning, Port: port}
+			},
+			wantLines: []string{
+				"Local daemon: not running on port",
+				"Hint: run `engram serve`",
+				"launchd",
+			},
+		},
+		{
+			name: "unreachable surfaces probe error",
+			stub: func(_ context.Context, port int) daemonProbeResult {
+				return daemonProbeResult{Status: daemonProbeUnreachable, Port: port, Err: fmt.Errorf("simulated boom")}
+			},
+			wantLines: []string{
+				"Local daemon: unreachable on port",
+				"probe error: simulated boom",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			prev := cloudDaemonProbe
+			cloudDaemonProbe = tc.stub
+			t.Cleanup(func() { cloudDaemonProbe = prev })
+
+			stdout, _, recovered := captureOutputAndRecover(t, func() { printCloudStatusDaemonProbe() })
+			if recovered != nil {
+				t.Fatalf("unexpected panic: %v", recovered)
+			}
+			for _, want := range tc.wantLines {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("expected stdout to contain %q, got %q", want, stdout)
+				}
+			}
+		})
+	}
+}
+
+// portFromTestServer extracts the TCP port a httptest.Server is bound to.
+func portFromTestServer(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	parsed, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	return port
+}
+
+// allocateClosedPort returns a TCP port number that is guaranteed to be
+// closed: it binds, reads the assigned port, then closes the listener.
+// On loopback this reliably surfaces "connection refused" on dial.
+func allocateClosedPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return port
+}

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -155,6 +155,7 @@ func stubRuntimeHooks(t *testing.T) {
 	oldSyncExport := syncExport
 	oldNewCloudAutosyncManager := newCloudAutosyncManager
 	oldCheckForUpdates := checkForUpdates
+	oldCloudDaemonProbe := cloudDaemonProbe
 
 	storeNew = store.New
 	newHTTPServer = func(s *store.Store, _ int) *engramsrv.Server { return engramsrv.New(s, 0) }
@@ -198,6 +199,9 @@ func stubRuntimeHooks(t *testing.T) {
 	checkForUpdates = func(string) versioncheck.CheckResult {
 		return versioncheck.CheckResult{Status: versioncheck.StatusUpToDate}
 	}
+	cloudDaemonProbe = func(_ context.Context, port int) daemonProbeResult {
+		return daemonProbeResult{Status: daemonProbeRunning, Port: port}
+	}
 
 	t.Cleanup(func() {
 		storeNew = oldStoreNew
@@ -224,6 +228,7 @@ func stubRuntimeHooks(t *testing.T) {
 		syncExport = oldSyncExport
 		newCloudAutosyncManager = oldNewCloudAutosyncManager
 		checkForUpdates = oldCheckForUpdates
+		cloudDaemonProbe = oldCloudDaemonProbe
 	})
 }
 
@@ -728,6 +733,114 @@ func TestCmdCloudStatusDistinguishesAuthAndSyncReadiness(t *testing.T) {
 		}
 		if !strings.Contains(stdout, "Auth status: ready") || !strings.Contains(stdout, "Sync readiness: ready") {
 			t.Fatalf("expected ready readiness output, got %q", stdout)
+		}
+	})
+}
+
+func TestCmdCloudStatusEmitsLocalDaemonLine(t *testing.T) {
+	stubExitWithPanic(t)
+	stubRuntimeHooks(t)
+
+	cfg := testConfig(t)
+
+	t.Run("not configured suppresses daemon probe", func(t *testing.T) {
+		t.Setenv("ENGRAM_CLOUD_TOKEN", "")
+		t.Setenv("ENGRAM_CLOUD_SERVER", "")
+		t.Setenv("ENGRAM_CLOUD_INSECURE_NO_AUTH", "")
+
+		// Override the probe with a sentinel so we can detect any accidental call.
+		probed := false
+		prev := cloudDaemonProbe
+		cloudDaemonProbe = func(_ context.Context, port int) daemonProbeResult {
+			probed = true
+			return daemonProbeResult{Status: daemonProbeRunning, Port: port}
+		}
+		t.Cleanup(func() { cloudDaemonProbe = prev })
+
+		notConfiguredCfg := testConfig(t)
+		withArgs(t, "engram", "cloud", "status")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(notConfiguredCfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("cloud status should succeed, panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "not configured") {
+			t.Fatalf("expected not-configured output, got %q", stdout)
+		}
+		if probed {
+			t.Fatalf("daemon probe must not run when cloud is not configured")
+		}
+		if strings.Contains(stdout, "Local daemon:") {
+			t.Fatalf("expected no daemon line in not-configured output, got %q", stdout)
+		}
+	})
+
+	if err := saveCloudConfig(cfg, &cloudConfig{ServerURL: "https://cloud.example.test"}); err != nil {
+		t.Fatalf("save cloud config: %v", err)
+	}
+
+	t.Run("configured prints running daemon line", func(t *testing.T) {
+		t.Setenv("ENGRAM_CLOUD_TOKEN", "token-abc")
+		t.Setenv("ENGRAM_CLOUD_INSECURE_NO_AUTH", "")
+
+		prev := cloudDaemonProbe
+		cloudDaemonProbe = func(_ context.Context, port int) daemonProbeResult {
+			return daemonProbeResult{Status: daemonProbeRunning, Port: port}
+		}
+		t.Cleanup(func() { cloudDaemonProbe = prev })
+
+		withArgs(t, "engram", "cloud", "status")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("cloud status should succeed, panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "Local daemon: running on port") {
+			t.Fatalf("expected running daemon line, got %q", stdout)
+		}
+	})
+
+	t.Run("configured prints recovery hint when daemon is down", func(t *testing.T) {
+		t.Setenv("ENGRAM_CLOUD_TOKEN", "token-abc")
+		t.Setenv("ENGRAM_CLOUD_INSECURE_NO_AUTH", "")
+
+		prev := cloudDaemonProbe
+		cloudDaemonProbe = func(_ context.Context, port int) daemonProbeResult {
+			return daemonProbeResult{Status: daemonProbeNotRunning, Port: port}
+		}
+		t.Cleanup(func() { cloudDaemonProbe = prev })
+
+		withArgs(t, "engram", "cloud", "status")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("cloud status should succeed when daemon is down, panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "Local daemon: not running on port") {
+			t.Fatalf("expected not-running daemon line, got %q", stdout)
+		}
+		if !strings.Contains(stdout, "engram serve") {
+			t.Fatalf("expected recovery hint mentioning `engram serve`, got %q", stdout)
+		}
+	})
+
+	t.Run("insecure mode also prints daemon line", func(t *testing.T) {
+		t.Setenv("ENGRAM_CLOUD_TOKEN", "")
+		t.Setenv("ENGRAM_CLOUD_INSECURE_NO_AUTH", "1")
+
+		prev := cloudDaemonProbe
+		cloudDaemonProbe = func(_ context.Context, port int) daemonProbeResult {
+			return daemonProbeResult{Status: daemonProbeRunning, Port: port}
+		}
+		t.Cleanup(func() { cloudDaemonProbe = prev })
+
+		withArgs(t, "engram", "cloud", "status")
+		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
+		if recovered != nil || stderr != "" {
+			t.Fatalf("cloud status should succeed, panic=%v stderr=%q", recovered, stderr)
+		}
+		if !strings.Contains(stdout, "insecure local-dev mode") {
+			t.Fatalf("expected insecure-mode banner, got %q", stdout)
+		}
+		if !strings.Contains(stdout, "Local daemon: running on port") {
+			t.Fatalf("expected running daemon line in insecure mode, got %q", stdout)
 		}
 	})
 }

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -29,6 +29,8 @@ brew update && brew upgrade engram
 > brew uninstall --cask engram 2>/dev/null; brew install gentleman-programming/tap/engram
 > ```
 
+> **Keep `engram serve` running across `brew upgrade`?** On macOS, `brew upgrade engram` replaces the binary and kills any running `engram serve` process — autosync stops silently until you relaunch it. To make autosync survive upgrades and reboots, use the launchd template in [Running as a Service → Using launchd (macOS)](../DOCS.md#using-launchd-macos). Run `engram cloud status` afterwards: the `Local daemon:` line should report `running`.
+
 ---
 
 ## Windows


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #279

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- `engram cloud status` now probes the local `engram serve` daemon at `127.0.0.1:7437` (respects `ENGRAM_PORT`) with a 1s timeout and prints a `Local daemon: running | not running | unreachable` line so users can detect a silently dead autosync after `brew upgrade engram` or any other binary replacement.
- Adds a launchd template to `DOCS.md "Running as a Service"` so macOS users can supervise `engram serve` the same way Linux users do with systemd. With `KeepAlive=true`, autosync now survives `brew upgrade` automatically.
- Probe is informational: exit code is unchanged. Probe is suppressed when cloud is not configured to avoid noisy output for users who don't use cloud sync.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/cloud_daemon_probe.go` | New: `cloudDaemonProbe` variable function (1s timeout `GET /health`), port resolution (`ENGRAM_PORT` → 7437), and `printCloudStatusDaemonProbe` writer with recovery hint when the daemon is down. |
| `cmd/engram/cloud_daemon_probe_test.go` | New: unit tests covering all four probe outcomes (running, refused, non-2xx, timeout) and the three printer states. |
| `cmd/engram/cloud.go` | `cmdCloudStatus` calls `printCloudStatusDaemonProbe` in each cloud-configured branch (token, token+insecure, no-token) before the existing sync diagnostic. No behavior change in the "not configured" branch. |
| `cmd/engram/main_extra_test.go` | `stubRuntimeHooks` now stubs `cloudDaemonProbe` so existing tests stay deterministic; new `TestCmdCloudStatusEmitsLocalDaemonLine` verifies the line is printed when configured (and suppressed when not). |
| `DOCS.md` | Renames `Using systemd` → `Using systemd (Linux)`. Adds `Using launchd (macOS)` with full plist template (KeepAlive=true so brew upgrade does not break autosync), load/unload steps, and verification via `engram cloud status`. Updates the `engram cloud status` reference bullet to describe the new `Local daemon:` line. |
| `docs/INSTALLATION.md` | Homebrew section gains a tip pointing macOS users at the launchd template so autosync survives `brew upgrade`. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...` (passes with the standard CI environment; my local env had `ENGRAM_CLOUD_SERVER` set which leaks into pre-existing tests — repro by `unset ENGRAM_CLOUD_SERVER ENGRAM_CLOUD_TOKEN ENGRAM_CLOUD_INSECURE_NO_AUTH ENGRAM_CLOUD_AUTOSYNC ENGRAM_PORT` before running, same isolation as CI).
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`.
- [x] Manually verified all three states with `cloud config --server ...`:
  - daemon down on port 7777 → `Local daemon: not running on port 7777` + recovery hint mentioning `engram serve` and the launchd template
  - daemon up on port 7777 → `Local daemon: running on port 7777`
  - `ENGRAM_PORT=9000` while daemon stays on 7777 → probe targets 9000 and reports `not running on port 9000` (env override honored)

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #279`)
- [x] I added exactly **one** `type:*` label to this PR (`type:feature`)
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (DOCS.md service section + cloud status reference + INSTALLATION.md tip)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

- The Homebrew formula post-install hook approach mentioned in the issue lives in `homebrew-tap`, so it is intentionally **out of scope** for this PR. The two in-repo mitigations (status probe + launchd template) close the gap on this side.
- The probe deliberately distinguishes `not_running` (TCP dial error to 127.0.0.1) from `unreachable` (timeout / non-2xx / unexpected error) so the recovery hint only fires when restarting `engram serve` is the right action.
- Probe timeout is exposed as a `var daemonProbeTimeout` so tests can shorten it; default in production stays at 1s.
- Plist uses literal `<HOME>` placeholders because launchd does not expand `$HOME`/`~` inside plist values; the docs explicitly call this out.