### PR TITLE
feat(cloud): make push payload limit configurable (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Breaking changes are always marked with a `type:breaking-change` label and docum
 
 <!-- Changes that are merged but not yet released are tracked here until the next tag. -->
 
+- feat(cloud): make push payload limit configurable via `ENGRAM_CLOUD_MAX_PUSH_BYTES` env var (#316)
+
 ### Cloud dashboard visual parity (`cloud-dashboard-visual-parity`)
 
 New and updated routes registered in `internal/cloud/dashboard/dashboard.go`:

--- a/docs/engram-cloud/quickstart.md
+++ b/docs/engram-cloud/quickstart.md
@@ -83,6 +83,9 @@ Required runtime env vars:
 - `ENGRAM_CLOUD_HOST=0.0.0.0`
 - `ENGRAM_PORT=18080`
 
+Optional runtime env vars:
+- `ENGRAM_CLOUD_MAX_PUSH_BYTES` — maximum cloud push payload size in bytes. Default: `8388608` (8 MiB). Increase this if your initial project bootstrap or sync chunks exceed the default limit (e.g. set to `33554432` for 32 MiB). Must be between 1 MiB and 1 GiB; values outside that range fall back to the default with a warning logged.
+
 Dokploy guidance:
 1. Create a managed Postgres service.
 2. Create an app from image `ghcr.io/gentleman-programming/engram:latest`.

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,20 +48,45 @@ type staticStatusProvider struct{ status dashboard.SyncStatus }
 func (s staticStatusProvider) Status() dashboard.SyncStatus { return s.status }
 
 type CloudServer struct {
-	store          ChunkStore
-	auth           Authenticator
-	projectAuth    ProjectAuthorizer
-	dashboardAdmin string
-	port           int
-	host           string
-	mux            *http.ServeMux
-	syncStatus     dashboard.SyncStatusProvider
-	listenAndServe func(addr string, handler http.Handler) error
+	store            ChunkStore
+	auth             Authenticator
+	projectAuth      ProjectAuthorizer
+	dashboardAdmin   string
+	port             int
+	host             string
+	mux              *http.ServeMux
+	syncStatus       dashboard.SyncStatusProvider
+	listenAndServe   func(addr string, handler http.Handler) error
+	maxPushBodyBytes int64
 }
 
 const defaultHost = "127.0.0.1"
-const maxPushBodyBytes int64 = 8 * 1024 * 1024
+const defaultMaxPushBodyBytes int64 = 8 * 1024 * 1024
+const minPushBodyBytes int64 = 1 * 1024 * 1024   // 1 MiB
+const maxPushBodyBytesLimit int64 = 1024 * 1024 * 1024 // 1 GiB
 const maxDashboardLoginBodyBytes int64 = 16 * 1024
+
+// resolveMaxPushBodyBytes reads ENGRAM_CLOUD_MAX_PUSH_BYTES from the environment
+// and returns the configured limit. If the variable is unset, empty, or invalid
+// (non-numeric or out of the [1 MiB, 1 GiB] range), it logs a warning and
+// returns defaultMaxPushBodyBytes (8 MiB) so existing deployments are unaffected.
+func resolveMaxPushBodyBytes() int64 {
+	raw := strings.TrimSpace(os.Getenv("ENGRAM_CLOUD_MAX_PUSH_BYTES"))
+	if raw == "" {
+		return defaultMaxPushBodyBytes
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		log.Printf("[engram-cloud] ENGRAM_CLOUD_MAX_PUSH_BYTES=%q is not a valid integer; using default %d bytes", raw, defaultMaxPushBodyBytes)
+		return defaultMaxPushBodyBytes
+	}
+	if v < minPushBodyBytes || v > maxPushBodyBytesLimit {
+		log.Printf("[engram-cloud] ENGRAM_CLOUD_MAX_PUSH_BYTES=%d is out of range [%d, %d]; using default %d bytes", v, minPushBodyBytes, maxPushBodyBytesLimit, defaultMaxPushBodyBytes)
+		return defaultMaxPushBodyBytes
+	}
+	return v
+}
+
 const dashboardSessionCookieName = "engram_dashboard_token"
 
 var ErrDashboardSessionCodecRequired = errors.New("dashboard session codec is required for dashboard auth")
@@ -99,7 +126,8 @@ func New(store ChunkStore, authSvc Authenticator, port int, opts ...Option) *Clo
 			ReasonCode:    constants.ReasonTransportFailed,
 			ReasonMessage: "sync status provider is unavailable",
 		}},
-		listenAndServe: http.ListenAndServe,
+		listenAndServe:   http.ListenAndServe,
+		maxPushBodyBytes: resolveMaxPushBodyBytes(),
 	}
 	if projectAuthorizer, ok := authSvc.(ProjectAuthorizer); ok {
 		s.projectAuth = projectAuthorizer
@@ -346,7 +374,7 @@ func (s *CloudServer) handlePullChunk(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxPushBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxPushBodyBytes)
 	var req struct {
 		ChunkID         string          `json:"chunk_id"`
 		CreatedBy       string          `json:"created_by"`
@@ -357,7 +385,7 @@ func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			writeActionableError(w, http.StatusRequestEntityTooLarge, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadTooLarge, fmt.Sprintf("push payload too large (max %d bytes)", maxPushBodyBytes))
+			writeActionableError(w, http.StatusRequestEntityTooLarge, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadTooLarge, fmt.Sprintf("push payload too large (max %d bytes)", s.maxPushBodyBytes))
 			return
 		}
 		writeActionableError(w, http.StatusBadRequest, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadInvalid, fmt.Sprintf("invalid push payload: %v", err))

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -776,7 +777,7 @@ func TestHandlerProjectScopeForbiddenReturnsPolicyClassPayload(t *testing.T) {
 
 func TestHandlerPushRejectsOversizedPayload(t *testing.T) {
 	srv := New(&fakeStore{}, fakeAuth{}, 0)
-	tooLarge := strings.Repeat("x", int(maxPushBodyBytes)+1)
+	tooLarge := strings.Repeat("x", int(defaultMaxPushBodyBytes)+1)
 	body := bytes.NewBufferString(`{"project":"proj-a","created_by":"tester","data":"` + tooLarge + `"}`)
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/sync/push", body))
@@ -1519,5 +1520,63 @@ func TestInsecureModeLoginRedirects(t *testing.T) {
 	}
 	if loc := rec.Header().Get("Location"); loc != "/dashboard/" {
 		t.Fatalf("expected redirect to /dashboard/, got %q", loc)
+	}
+}
+
+func TestResolveMaxPushBodyBytes_Default(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", "")
+	got := resolveMaxPushBodyBytes()
+	if got != defaultMaxPushBodyBytes {
+		t.Fatalf("expected default %d, got %d", defaultMaxPushBodyBytes, got)
+	}
+}
+
+func TestResolveMaxPushBodyBytes_ValidOverride(t *testing.T) {
+	want := int64(32 * 1024 * 1024) // 32 MiB
+	t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", strconv.FormatInt(want, 10))
+	got := resolveMaxPushBodyBytes()
+	if got != want {
+		t.Fatalf("expected %d, got %d", want, got)
+	}
+}
+
+func TestResolveMaxPushBodyBytes_InvalidNonNumeric(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", "not-a-number")
+	got := resolveMaxPushBodyBytes()
+	if got != defaultMaxPushBodyBytes {
+		t.Fatalf("expected default %d on invalid value, got %d", defaultMaxPushBodyBytes, got)
+	}
+}
+
+func TestResolveMaxPushBodyBytes_TooSmall(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", "0")
+	got := resolveMaxPushBodyBytes()
+	if got != defaultMaxPushBodyBytes {
+		t.Fatalf("expected default %d when below min, got %d", defaultMaxPushBodyBytes, got)
+	}
+}
+
+func TestResolveMaxPushBodyBytes_TooLarge(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", "9999999999999")
+	got := resolveMaxPushBodyBytes()
+	if got != defaultMaxPushBodyBytes {
+		t.Fatalf("expected default %d when above max, got %d", defaultMaxPushBodyBytes, got)
+	}
+}
+
+func TestHandlerPushRespectsEnvConfiguredLimit(t *testing.T) {
+	const customLimit = 2 * 1024 * 1024 // 2 MiB
+	t.Setenv("ENGRAM_CLOUD_MAX_PUSH_BYTES", strconv.FormatInt(customLimit, 10))
+	srv := New(&fakeStore{}, fakeAuth{}, 0)
+	if srv.maxPushBodyBytes != customLimit {
+		t.Fatalf("expected server.maxPushBodyBytes=%d, got %d", customLimit, srv.maxPushBodyBytes)
+	}
+	// A body just over the custom limit must be rejected with 413.
+	tooLarge := strings.Repeat("x", customLimit+1)
+	body := bytes.NewBufferString(`{"project":"proj-a","created_by":"tester","data":"` + tooLarge + `"}`)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/sync/push", body))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 with custom limit, got %d body=%q", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -61,7 +61,7 @@ const defaultPullLimit = 100
 // BC2: project authorization is enforced for every distinct project in the batch.
 // BW9: 409 pause response uses writeActionableError for structured error envelope.
 func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxPushBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxPushBodyBytes)
 
 	var req mutationPushEnvelope
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {


### PR DESCRIPTION
## Summary
Closes #316.

Replaces the hardcoded 8 MiB cloud push body limit with a configurable
value sourced from `ENGRAM_CLOUD_MAX_PUSH_BYTES`. Default remains 8 MiB
when the env var is unset, so existing deployments are unaffected.

## Why
Real-world deployments accumulate enough mutations that a single sync
chunk exceeds 8 MiB. In our production case (engram cloud running on a
self-hosted VPS), one project (1080 observations, ~9.28 MB chunk) was
blocked behind this limit, which currently has no operator escape hatch.

## Changes
- `internal/cloud/cloudserver/cloudserver.go`: replace constant with
  `resolveMaxPushBodyBytes()` helper that reads the env var, validates
  bounds (1 MiB ≤ N ≤ 1 GiB), and falls back to default on parse error
  or out-of-bounds value. Resolved limit is stored in
  `CloudServer.maxPushBodyBytes` at `New()` time — not re-read per request.
- `internal/cloud/cloudserver/mutations.go`: updated `handleMutationPush`
  to use `s.maxPushBodyBytes` (the constant was shared by both push
  handlers — both now benefit).
- Tests: 6 new cases covering default, valid override, invalid (non-numeric),
  and out-of-bounds (too small / too large) — plus an integration test that
  verifies the server actually rejects at the configured custom limit.
- `docs/engram-cloud/quickstart.md`: documents the new optional env var.
- `CHANGELOG.md`: added entry under Unreleased.

## Behavior matrix
| Env value | Effective limit |
|-----------|-----------------|
| unset | 8 MiB (default) |
| `33554432` (32 MiB) | 32 MiB |
| `0` or non-numeric | 8 MiB (logs warning) |
| `9999999999999` (out of bounds) | 8 MiB (logs warning) |

## Tested
### Local
- `go build ./...`
- `go test ./internal/cloud/cloudserver/...`
- `go vet ./...`

### Production
Deployed as a custom image on a self-hosted VPS (running upstream `1.15.8`
prior). With `ENGRAM_CLOUD_MAX_PUSH_BYTES=33554432`:
- Successfully synced a project with 1080 observations / 1404 mutations
  (chunk size ~9.28 MB — previously rejected with HTTP 413)
- Other 25 projects (smaller chunks) continued syncing normally
- No regressions in startup time, memory footprint, or healthcheck behavior
- Server logs show the configured limit being applied at startup

## Notes
- Bounds chosen conservatively: 1 MiB minimum to prevent footguns,
  1 GiB maximum to prevent OOM. Open to adjusting if you'd prefer
  different limits.
- Both chunk push (`POST /sync/push`) and mutation push (`POST /sync/mutations/push`)
  share the same resolved limit — they shared the old constant, so both benefit.
- Did not change `chunkcodec` or remote transport — limit is enforced only at the
  server's `MaxBytesReader`. Client behavior is unchanged.
- Log warnings on invalid/out-of-bounds values use the existing logger;
  format follows the surrounding code style.