### PR TITLE
﻿fix(mcp): accept string-typed IDs in tool schemas and handlers

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -361,9 +362,9 @@ Examples:
 				mcp.WithDestructiveHintAnnotation(false),
 				mcp.WithIdempotentHintAnnotation(false),
 				mcp.WithOpenWorldHintAnnotation(false),
-				mcp.WithNumber("id",
-					mcp.Required(),
-					mcp.Description("Observation ID to update"),
+	mcp.WithString("id",
+			mcp.Required(),
+			mcp.Description("Observation ID to update (pass as string, e.g. \"10\")"),
 				),
 				mcp.WithString("title",
 					mcp.Description("New title"),
@@ -421,9 +422,9 @@ Examples:
 				mcp.WithDestructiveHintAnnotation(true),
 				mcp.WithIdempotentHintAnnotation(false),
 				mcp.WithOpenWorldHintAnnotation(false),
-				mcp.WithNumber("id",
-					mcp.Required(),
-					mcp.Description("Observation ID to delete"),
+	mcp.WithString("id",
+			mcp.Required(),
+			mcp.Description("Observation ID to delete (pass as string, e.g. \"10\")"),
 				),
 				mcp.WithBoolean("hard_delete",
 					mcp.Description("If true, permanently deletes the observation"),
@@ -516,9 +517,9 @@ Examples:
 				mcp.WithDestructiveHintAnnotation(false),
 				mcp.WithIdempotentHintAnnotation(true),
 				mcp.WithOpenWorldHintAnnotation(false),
-				mcp.WithNumber("observation_id",
-					mcp.Required(),
-					mcp.Description("The observation ID to center the timeline on (from mem_search results)"),
+	mcp.WithString("observation_id",
+			mcp.Required(),
+			mcp.Description("The observation ID to center the timeline on (pass as string, e.g. \"10\")"),
 				),
 				mcp.WithNumber("before",
 					mcp.Description("Number of observations to show before the focus (default: 5)"),
@@ -544,9 +545,9 @@ Examples:
 				mcp.WithDestructiveHintAnnotation(false),
 				mcp.WithIdempotentHintAnnotation(true),
 				mcp.WithOpenWorldHintAnnotation(false),
-				mcp.WithNumber("id",
-					mcp.Required(),
-					mcp.Description("The observation ID to retrieve"),
+	mcp.WithString("id",
+			mcp.Required(),
+			mcp.Description("The observation ID to retrieve (pass as string, e.g. \"10\")"),
 				),
 			),
 			handleGetObservation(s),
@@ -824,13 +825,13 @@ ERROR: Returns IsError=true if IDs are unknown, relation is invalid, or cross-pr
 				mcp.WithDestructiveHintAnnotation(false),
 				mcp.WithIdempotentHintAnnotation(true),
 				mcp.WithOpenWorldHintAnnotation(false),
-				mcp.WithNumber("memory_id_a",
-					mcp.Required(),
-					mcp.Description("Integer id of the first observation (from mem_search #id)"),
-				),
-				mcp.WithNumber("memory_id_b",
-					mcp.Required(),
-					mcp.Description("Integer id of the second observation (from mem_search #id)"),
+	mcp.WithString("memory_id_a",
+			mcp.Required(),
+			mcp.Description("Integer id of the first observation (pass as string, e.g. \"10\")"),
+		),
+		mcp.WithString("memory_id_b",
+			mcp.Required(),
+			mcp.Description("Integer id of the second observation (pass as string, e.g. \"10\")"),
 				),
 				mcp.WithString("relation",
 					mcp.Required(),
@@ -1816,17 +1817,15 @@ func handleJudge(s *store.Store, activity *SessionActivity) server.ToolHandlerFu
 // calls JudgeBySemantic. Returns the persisted relation's sync_id."
 func handleCompare(s *store.Store, _ *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// --- required numeric IDs ---
-		rawA, okA := req.GetArguments()["memory_id_a"].(float64)
-		rawB, okB := req.GetArguments()["memory_id_b"].(float64)
-		if !okA {
-			return mcp.NewToolResultError("memory_id_a is required (integer observation id)"), nil
-		}
-		if !okB {
-			return mcp.NewToolResultError("memory_id_b is required (integer observation id)"), nil
-		}
-		idA := int64(rawA)
-		idB := int64(rawB)
+	// --- required numeric IDs (accept both string and number) ---
+	idA := int64(intArg(req, "memory_id_a", 0))
+	idB := int64(intArg(req, "memory_id_b", 0))
+	if idA == 0 {
+		return mcp.NewToolResultError("memory_id_a is required (integer observation id)"), nil
+	}
+	if idB == 0 {
+		return mcp.NewToolResultError("memory_id_b is required (integer observation id)"), nil
+	}
 
 		// --- required string fields ---
 		relation, _ := req.GetArguments()["relation"].(string)
@@ -2600,11 +2599,20 @@ func defaultSessionID(project string) string {
 }
 
 func intArg(req mcp.CallToolRequest, key string, defaultVal int) int {
-	v, ok := req.GetArguments()[key].(float64)
-	if !ok {
-		return defaultVal
+	args := req.GetArguments()
+	v, ok := args[key].(float64)
+	if ok {
+		return int(v)
 	}
-	return int(v)
+	// Fallback: accept string values (LLMs sometimes send "10" instead of 10)
+	s, ok := args[key].(string)
+	if ok {
+		n, err := strconv.Atoi(s)
+		if err == nil {
+			return n
+		}
+	}
+	return defaultVal
 }
 
 func boolArg(req mcp.CallToolRequest, key string, defaultVal bool) bool {


### PR DESCRIPTION
When LLMs generate tool call arguments, they sometimes send observation IDs as strings instead of numbers. This causes OpenCode client-side Zod validation to reject the call before it reaches Engram, with the error: Expected id to be a string.

Changes:
- Changed id/observation_id/memory_id_a/memory_id_b schemas from WithNumber to WithString, matching how LLMs actually generate these
- Patched intArg() to accept both float64 and string values, using strconv.Atoi as fallback for string-typed IDs
- Fixed handleCompare to use intArg() instead of raw float64 type assertion, consistent with all other handlers

This is defense-in-depth: even if the AI provider sends IDs with the wrong type, Engram handles it gracefully instead of failing silently.

<!-- 
  ⚠️ READ BEFORE SUBMITTING
  
  Every PR must:
  1. Link an approved issue (with status:approved label)
  2. Have exactly one type:* label
  3. Pass all 5 automated checks
  
  See CONTRIBUTING.md for the full workflow.
-->

## 🔗 Linked Issue

<!-- REQUIRED: Replace the # below with the issue number. -->
<!-- Automated check: "Check Issue Reference" verifies this exists. -->
<!-- Automated check: "Check Issue Has status:approved" verifies the issue is approved. -->

Closes #

---

## 🏷️ PR Type

<!-- REQUIRED: Check exactly ONE type below, then add the matching label to the PR. -->
<!-- Automated check: "Check PR Has type:* Label" verifies the label exists. -->

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

<!-- What does this PR do? Be concise — 1-3 bullet points. -->

- 

## 📂 Changes

<!-- Key files changed and what was modified in each. -->

| File | Change |
|------|--------|
| `path/to/file` | What changed |

## 🧪 Test Plan

<!-- How did you verify this works? -->

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

<!-- Describe any manual testing steps: -->

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [ ] I linked an approved issue above (`Closes #N`)
- [ ] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] Docs updated (if behavior changed)
- [ ] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [ ] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

<!-- Optional: anything the reviewer should know — context, tradeoffs, open questions. -->
