### PR TITLE
fix(cloudstore): invalidate dashboard cache after every InsertMutationBatch commit

### DIFF
--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -779,9 +779,7 @@ func (cs *CloudStore) InsertMutationBatch(ctx context.Context, batch []MutationE
 		return nil, fmt.Errorf("cloudstore: commit mutation batch: %w", err)
 	}
 	tx = nil // mark committed so deferred Rollback is a no-op
-	if len(chunks) > 0 {
-		cs.invalidateDashboardReadModel()
-	}
+	cs.invalidateDashboardReadModel()
 	return seqs, nil
 }
 

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -1096,3 +1096,49 @@ func TestSetDashboardAllowedProjectsInvalidatesCachedReadModel(t *testing.T) {
 		t.Fatalf("expected allowlist update to invalidate read-model cache, got load count %d", loadCalls)
 	}
 }
+
+// TestInsertMutationBatchInvalidatesDashboardReadModel verifies that
+// InsertMutationBatch invalidates the dashboard read model cache even when no
+// materialized chunks are produced (e.g. relation-only batches).
+// Regression test for https://github.com/Gentleman-Programming/engram/issues/251
+func TestInsertMutationBatchInvalidatesDashboardReadModel(t *testing.T) {
+	// Reuse the partial-fail driver with a high failAfter so all INSERTs succeed.
+	resetPartialFailDriver(100)
+	db, err := sql.Open("cloudstore-partial-fail-driver", "dsn")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	loadCalls := 0
+	cs := &CloudStore{db: db}
+	cs.dashboardReadModelLoad = func() (dashboardReadModel, error) {
+		loadCalls++
+		return dashboardReadModel{}, nil
+	}
+
+	// Populate the cache by calling a dashboard query.
+	if _, err := cs.ListProjects(""); err != nil {
+		t.Fatalf("initial ListProjects: %v", err)
+	}
+	if loadCalls != 1 {
+		t.Fatalf("expected initial load count=1, got %d", loadCalls)
+	}
+
+	// Insert a batch containing ONLY non-materializable entities (relation).
+	// This produces zero chunks, so before the fix the cache was NOT invalidated.
+	batch := []MutationEntry{
+		{Project: "proj-a", Entity: "relation", EntityKey: "r1", Op: "upsert", Payload: json.RawMessage(`{"source_id":1,"target_id":2,"relation":"related"}`)},
+	}
+	if _, err := cs.InsertMutationBatch(context.Background(), batch); err != nil {
+		t.Fatalf("InsertMutationBatch: %v", err)
+	}
+
+	// After InsertMutationBatch, the cache must be invalidated.
+	// A new dashboard query should trigger a reload (loadCalls=2).
+	if _, err := cs.ListProjects(""); err != nil {
+		t.Fatalf("post-mutation ListProjects: %v", err)
+	}
+	if loadCalls != 2 {
+		t.Fatalf("expected InsertMutationBatch to invalidate dashboard cache (load count 2), got %d", loadCalls)
+	}
+}

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -1108,6 +1108,7 @@ func TestInsertMutationBatchInvalidatesDashboardReadModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
+	t.Cleanup(func() { db.Close() })
 
 	loadCalls := 0
 	cs := &CloudStore{db: db}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #251

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

---

## 📝 Summary

- `InsertMutationBatch` now unconditionally invalidates the dashboard read model cache after every successful commit, aligning its behavior with `WriteChunk`.
- Before this fix, only batches that produced materialized chunks (session/observation/prompt entities) triggered cache invalidation. Batches containing only non-materializable entities (e.g. `relation`) left the cache stale, causing 404s on the dashboard until a manual restart.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudstore/cloudstore.go` | Moved `invalidateDashboardReadModel()` outside the `if len(chunks) > 0` conditional so it always runs after commit |
| `internal/cloud/cloudstore/cloudstore_test.go` | Added `TestInsertMutationBatchInvalidatesDashboardReadModel` regression test using a relation-only batch (zero chunks) |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./internal/cloud/cloudstore/` — all pass (47 tests, 0 failures)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — skipped (no local Postgres)
- [x] Manually verified that `InsertMutationBatch` with a relation-only batch triggers cache invalidation

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #251`)
- [x] I added exactly **one** `type:*` label to this PR (`type:bug`)
- [x] I ran unit tests locally: `go test ./internal/cloud/cloudstore/`
- [ ] I ran e2e tests locally: no local Postgres available
- [x] Docs updated (if behavior changed) — no docs change needed, internal cache behavior
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The root cause is that `InsertMutationBatch` guarded the cache invalidation behind `if len(chunks) > 0`, but `WriteChunk` (the other write path) invalidates unconditionally. This meant that mutations arriving via autosync that contained only non-materializable entities (like `relation`) never invalidated the cache, making the dashboard stale until a server restart. The fix is a one-line change that matches the proven pattern from `WriteChunk`.