### PR TITLE
chore: update go toolchain to 1.25.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.10"
 
       - name: Run unit tests
         run: go test ./...
@@ -33,9 +33,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.10"
 
       - name: Run e2e tests
         run: go test -tags e2e ./internal/server/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.10"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Gentleman-Programming/engram
 
-go 1.25.0
+go 1.25.10
 
 require (
 	github.com/a-h/templ v0.3.1001


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #205

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Pins Engram's Go directive and GitHub Actions workflows to Go 1.25.10.
- Updates CI and release workflows from `actions/setup-go@v5` to `actions/setup-go@v6`.
- Aligns the cloud Docker builder image with the same Go patch version.

## 📂 Changes

| File | Change |
|------|--------|
| `go.mod` | Updates the Go directive from `1.25.0` to `1.25.10`. |
| `.github/workflows/ci.yml` | Uses `actions/setup-go@v6` and pins both test jobs to Go `1.25.10`. |
| `.github/workflows/release.yml` | Uses `actions/setup-go@v6` and pins GoReleaser to Go `1.25.10`. |
| `docker/cloud/Dockerfile` | Pins the cloud builder image to `golang:1.25.10-alpine`. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Manual verification:

- `git diff --check`
- `docker manifest inspect golang:1.25.10-alpine`
- fresh review confirmed only the four intended files should be committed

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The original issue claim about `setup-go@v5` failing for Go 1.25 no longer reproduces in recent Actions runs. This PR treats the issue as a narrow maintenance update: explicit Go 1.25.10 pins plus setup-go v6.