### PR TITLE
chore(security): harden npm supply chain

### DIFF
--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -1,0 +1,25 @@
+name: Publish gentle-engram
+
+on:
+  push:
+    tags:
+      - "pi-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm with provenance
+        working-directory: plugin/pi
+        run: npm publish --provenance --access public

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+ignore-scripts=true
+allow-git=none
+min-release-age=3

--- a/plugin/obsidian/package.json
+++ b/plugin/obsidian/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Obsidian plugin to sync Engram persistent memory into your vault",
   "main": "main.js",
+  "private": true,
   "scripts": {
     "build": "node esbuild.config.mjs",
     "dev": "node esbuild.config.mjs --watch"

--- a/plugin/pi/package.json
+++ b/plugin/pi/package.json
@@ -44,6 +44,10 @@
     "README.md",
     "package.json"
   ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "pi-mcp-adapter": ">=2.5.0"


### PR DESCRIPTION
Closes #362

## Summary
Applies 3 fixes from a Liran Tal `npm-security-best-practices` audit.

- **`engram-brain` marked private** — prevents accidental `npm publish` from `plugin/obsidian/`. Was the highest-risk gap (a generic name on the public registry with no namespace claim).
- **Root `.npmrc`** — `ignore-scripts=true`, `allow-git=none`, `min-release-age=3`. Covers practices #1, #2, and #3 from the guide.
- **OIDC + provenance for `gentle-engram`** — new `publish-pi.yml` workflow with `id-token: write`, plus `publishConfig.provenance` in `plugin/pi/package.json`. Triggered by `pi-v*` tags.

Sibling PR: #361 (full audit coverage follow-up).

## Required follow-up (manual)
Before the next `gentle-engram` release, configure trusted publishing on npmjs.com:
1. Go to https://www.npmjs.com/package/gentle-engram/access
2. Trusted publishers → Add publisher
3. Repository: this repo, Workflow: `publish-pi.yml`, Environment: blank

Without this step, the workflow will fail on the next `pi-v*` tag.

## Test plan
- [ ] CI passes on the PR
- [ ] `npm pack --dry-run` in `plugin/pi/` still produces the expected file list
- [ ] Configure trusted publisher on npmjs.com (see above)
- [ ] On next release: tag `pi-v0.1.3` and verify provenance attestation appears on npmjs.com

Audit reference: https://github.com/lirantal/npm-security-best-practices/
