### PR TITLE
ci: route workflows through runner variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CI_RUNS_ON_JSON || '"ubuntu-latest"') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CI_RUNS_ON_JSON || '"ubuntu-latest"') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cloud-image.yml
+++ b/.github/workflows/cloud-image.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   publish-ghcr:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CI_RUNS_ON_JSON || '"ubuntu-latest"') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-issue-reference:
     name: Check Issue Reference
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CONTROL_RUNS_ON_JSON || '"ubuntu-slim"') }}
     steps:
       - name: Verify PR links an issue
         uses: actions/github-script@v7
@@ -30,7 +30,7 @@ jobs:
 
   check-issue-approved:
     name: Check Issue Has status:approved
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CONTROL_RUNS_ON_JSON || '"ubuntu-slim"') }}
     needs: check-issue-reference
     steps:
       - name: Verify linked issue is approved
@@ -85,7 +85,7 @@ jobs:
 
   check-type-label:
     name: Check PR Has type:* Label
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CONTROL_RUNS_ON_JSON || '"ubuntu-slim"') }}
     steps:
       - name: Verify PR has a type label
         uses: actions/github-script@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CI_RUNS_ON_JSON || '"ubuntu-latest"') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   stale:
     name: Mark and close stale items
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.JOJO_CONTROL_RUNS_ON_JSON || '"ubuntu-slim"') }}
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- route Engram CI, release, image, stale, and PR validation workflows through the shared JOJO runner variables
- keep lightweight workflows on the control runner variable and heavier jobs on the CI runner variable

## Traceability
- Tools used: OpenCode