### PR TITLE
feat(pi): add compaction recovery redaction

### DIFF
--- a/plugin/pi/README.md
+++ b/plugin/pi/README.md
@@ -110,6 +110,26 @@ HTTP event capture and MCP tools are separate paths. Engram currently exposes MC
 - Prompt context tied to meaningful saved observations
 - Cross-machine/team memory once a project is enrolled in Engram Cloud
 
+## Private blocks
+
+`gentle-engram` redacts explicit private blocks before sending captured prompts, passive observations, or compaction summaries to Engram:
+
+```text
+<private>
+this should not be persisted verbatim
+</private>
+```
+
+The persisted payload keeps the surrounding text but replaces the private block with `[REDACTED]`. Redaction is applied recursively to string values in outgoing JSON payloads and to query values in Engram HTTP requests.
+
+This is a lightweight convenience convention, not a full secret-scanning system. Do not rely on it to detect credentials automatically.
+
+## Compaction recovery
+
+When Pi emits a compaction lifecycle event, `gentle-engram` best-effort extracts a compacted summary from supported event fields and saves it as a `session_summary` observation with topic key `session/compaction-recovery`.
+
+Unsupported event shapes fail gracefully. The extension still injects a manual recovery instruction containing `FIRST ACTION REQUIRED`, so the next agent turn can call `mem_session_summary` if the Engram MCP tools are installed and active. If the tools are unavailable, save the compacted summary manually after Engram is available again.
+
 ## Local, sync, or cloud
 
 Engram can grow with your workflow:

--- a/plugin/pi/compaction-recovery.js
+++ b/plugin/pi/compaction-recovery.js
@@ -1,0 +1,64 @@
+const SUMMARY_FIELD_PATHS = [
+  ["summary"],
+  ["compactedSummary"],
+  ["compacted_summary"],
+  ["compactSummary"],
+  ["compact_summary"],
+  ["content"],
+  ["text"],
+  ["message"],
+  ["compacted", "summary"],
+  ["compacted", "content"],
+  ["compaction", "summary"],
+  ["compaction", "content"],
+  ["output", "summary"],
+  ["output", "content"],
+  ["payload", "summary"],
+  ["payload", "content"],
+  ["data", "summary"],
+  ["data", "content"],
+];
+
+function getPath(root, path) {
+  let current = root;
+  for (const key of path) {
+    if (!current || typeof current !== "object" || !(key in current)) return undefined;
+    current = current[key];
+  }
+  return current;
+}
+
+function normalizeSummary(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Best-effort extraction for Pi compaction event shapes. Unsupported shapes
+ * intentionally return undefined instead of throwing.
+ */
+export function extractCompactedSummary(event) {
+  if (!event || typeof event !== "object") return undefined;
+  for (const path of SUMMARY_FIELD_PATHS) {
+    const summary = normalizeSummary(getPath(event, path));
+    if (summary) return summary;
+  }
+  return undefined;
+}
+
+export function recoveryInstruction(project) {
+  return (
+    `CRITICAL INSTRUCTION FOR COMPACTED SUMMARY:\n` +
+    `The agent has access to Engram persistent memory via MCP tools when gentle-engram and the Engram MCP tools are installed and active.\n` +
+    `FIRST ACTION REQUIRED: Call mem_session_summary with the content of this compacted summary. ` +
+    `Use project: '${project}'. This preserves what was accomplished before compaction. Do this BEFORE any other work.\n` +
+    `If mem_session_summary is unavailable, manually save this compacted summary once Engram tools are available.`
+  );
+}
+
+export function buildRecoveryNotice(project, context) {
+  const instruction = recoveryInstruction(project);
+  const trimmedContext = typeof context === "string" ? context.trim() : "";
+  return trimmedContext ? `${trimmedContext}\n\n${instruction}` : instruction;
+}

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -10,6 +10,8 @@ import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { buildRecoveryNotice, extractCompactedSummary } from "./compaction-recovery.js";
+import { redactPrivateTags, redactUrlPath, redactValue } from "./private-redaction.js";
 
 const ENGRAM_PORT = Number.parseInt(process.env.ENGRAM_PORT ?? "7437", 10);
 const CONFIGURED_ENGRAM_URL = process.env.ENGRAM_URL?.trim() || undefined;
@@ -131,10 +133,10 @@ interface ToolEndEvent {
 
 async function engramFetch<TResponse = unknown>(path: string, opts: FetchOptions = {}): Promise<TResponse | null> {
   try {
-    const res = await fetch(`${ENGRAM_URL}${path}`, {
+    const res = await fetch(`${ENGRAM_URL}${redactUrlPath(path)}`, {
       method: opts.method ?? "GET",
       headers: opts.body ? { "Content-Type": "application/json" } : undefined,
-      body: opts.body ? JSON.stringify(opts.body) : undefined,
+      body: opts.body ? JSON.stringify(redactValue(opts.body)) : undefined,
     });
     return (await res.json()) as TResponse;
   } catch {
@@ -257,7 +259,7 @@ function truncate(str: string, max: number): string {
 }
 
 function stripPrivateTags(str: string): string {
-  return str.replace(/<private>[\s\S]*?<\/private>/gi, "[REDACTED]").trim();
+  return redactPrivateTags(str).trim();
 }
 
 function wait(ms: number): Promise<void> {
@@ -349,18 +351,28 @@ export default function registerEngram(pi: ExtensionAPI) {
     knownSessions.delete(sessionId);
   });
 
-  pi.on("session_compact", async (_event: unknown, ctx: SessionContext) => {
+  pi.on("session_compact", async (event: unknown, ctx: SessionContext) => {
     const sessionId = getSessionId(ctx);
     if (sessionId) await ensureSession(sessionId);
 
-    const data = await engramFetch<ContextResponse>(`/context?project=${encodeURIComponent(project)}`);
-    const recovery =
-      `CRITICAL INSTRUCTION FOR COMPACTED SUMMARY:\n` +
-      `The agent has access to Engram persistent memory via MCP tools.\n` +
-      `FIRST ACTION REQUIRED: Call mem_session_summary with the content of this compacted summary. ` +
-      `Use project: '${project}'. This preserves what was accomplished before compaction. Do this BEFORE any other work.`;
+    const summary = extractCompactedSummary(event);
+    if (sessionId && summary) {
+      await engramFetch("/observations", {
+        method: "POST",
+        body: {
+          session_id: sessionId,
+          type: "session_summary",
+          title: "Compaction recovery summary",
+          content: summary,
+          project,
+          scope: "project",
+          topic_key: "session/compaction-recovery",
+        },
+      });
+    }
 
-    pendingRecoveryNotice = data?.context ? `${data.context}\n\n${recovery}` : recovery;
+    const data = await engramFetch<ContextResponse>(`/context?project=${encodeURIComponent(project)}`);
+    pendingRecoveryNotice = buildRecoveryNotice(project, data?.context);
   });
 
   pi.on("before_agent_start", async (event: AgentStartEvent, ctx: SessionContext) => {

--- a/plugin/pi/package.json
+++ b/plugin/pi/package.json
@@ -14,6 +14,9 @@
   "bin": {
     "pi-engram": "cli.js"
   },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
   "keywords": [
     "pi-package",
     "pi",
@@ -39,8 +42,11 @@
   "files": [
     "assets/",
     "cli.js",
+    "compaction-recovery.js",
     "index.ts",
     "mcp-template.json",
+    "private-redaction.js",
+    "test/",
     "README.md",
     "package.json"
   ],

--- a/plugin/pi/private-redaction.js
+++ b/plugin/pi/private-redaction.js
@@ -1,0 +1,44 @@
+const PRIVATE_TAG_PATTERN = /<private>[\s\S]*?<\/private>/gi;
+
+/**
+ * Redact explicit private blocks before content leaves the Pi session.
+ * This is a convenience convention, not a general-purpose secret scanner.
+ */
+export function redactPrivateTags(value) {
+  return value.replace(PRIVATE_TAG_PATTERN, "[REDACTED]");
+}
+
+/**
+ * Redact private blocks in a relative URL path, including decoded query values.
+ */
+export function redactUrlPath(path) {
+  const redactedPath = redactPrivateTags(path);
+  try {
+    const url = new URL(redactedPath, "http://engram.local");
+    const redactedParams = new URLSearchParams();
+    for (const [key, value] of url.searchParams.entries()) {
+      redactedParams.append(key, redactPrivateTags(value));
+    }
+    const query = redactedParams.toString();
+    return `${url.pathname}${query ? `?${query}` : ""}${url.hash}`;
+  } catch {
+    return redactedPath;
+  }
+}
+
+/**
+ * Recursively redact strings in payloads sent to Engram.
+ * Preserves object/array shape and leaves non-string primitives unchanged.
+ */
+export function redactValue(value) {
+  if (typeof value === "string") return redactPrivateTags(value);
+  if (Array.isArray(value)) return value.map((entry) => redactValue(entry));
+  if (value && typeof value === "object") {
+    const redacted = {};
+    for (const [key, entry] of Object.entries(value)) {
+      redacted[key] = redactValue(entry);
+    }
+    return redacted;
+  }
+  return value;
+}

--- a/plugin/pi/test/compaction-recovery.test.mjs
+++ b/plugin/pi/test/compaction-recovery.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildRecoveryNotice, extractCompactedSummary, recoveryInstruction } from "../compaction-recovery.js";
+
+test("extractCompactedSummary returns undefined for unsupported event shapes", () => {
+  assert.equal(extractCompactedSummary(null), undefined);
+  assert.equal(extractCompactedSummary({}), undefined);
+  assert.equal(extractCompactedSummary({ payload: { unrelated: "value" } }), undefined);
+  assert.equal(extractCompactedSummary({ summary: "   " }), undefined);
+});
+
+test("extractCompactedSummary supports top-level and nested summary fields", () => {
+  assert.equal(extractCompactedSummary({ compactedSummary: "summary text" }), "summary text");
+  assert.equal(extractCompactedSummary({ payload: { summary: " nested summary " } }), "nested summary");
+  assert.equal(extractCompactedSummary({ compaction: { content: "content summary" } }), "content summary");
+});
+
+test("recoveryInstruction keeps manual FIRST ACTION REQUIRED fallback", () => {
+  const notice = recoveryInstruction("engram");
+  assert.match(notice, /FIRST ACTION REQUIRED/);
+  assert.match(notice, /mem_session_summary/);
+  assert.match(notice, /gentle-engram and the Engram MCP tools are installed and active/);
+  assert.match(notice, /If mem_session_summary is unavailable/);
+});
+
+test("buildRecoveryNotice prefixes context when available", () => {
+  assert.equal(buildRecoveryNotice("engram", "existing context").startsWith("existing context\n\nCRITICAL"), true);
+  assert.equal(buildRecoveryNotice("engram", "").startsWith("CRITICAL"), true);
+});

--- a/plugin/pi/test/private-redaction.test.mjs
+++ b/plugin/pi/test/private-redaction.test.mjs
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { redactPrivateTags, redactUrlPath, redactValue } from "../private-redaction.js";
+
+test("redactPrivateTags redacts multiline private blocks", () => {
+  const input = "keep <private>secret\nline two</private> visible";
+  assert.equal(redactPrivateTags(input), "keep [REDACTED] visible");
+});
+
+test("redactUrlPath redacts private query values", () => {
+  const path = "/context?project=safe&note=%3Cprivate%3Esecret%3C%2Fprivate%3E";
+  assert.equal(redactUrlPath(path), "/context?project=safe&note=%5BREDACTED%5D");
+});
+
+test("redactUrlPath preserves duplicate query keys", () => {
+  const path = "/context?tag=safe&tag=%3Cprivate%3Esecret%3C%2Fprivate%3E#section";
+  assert.equal(redactUrlPath(path), "/context?tag=safe&tag=%5BREDACTED%5D#section");
+});
+
+test("redactValue recursively redacts strings in objects and arrays", () => {
+  const input = {
+    title: "safe",
+    content: "before <private>token</private> after",
+    nested: {
+      values: ["ok", "<private>array secret</private>", 42, false, null],
+    },
+  };
+
+  assert.deepEqual(redactValue(input), {
+    title: "safe",
+    content: "before [REDACTED] after",
+    nested: {
+      values: ["ok", "[REDACTED]", 42, false, null],
+    },
+  });
+});


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #367

Related Gentle Pi tracking issues: Gentleman-Programming/gentle-pi#11, Gentleman-Programming/gentle-pi#13

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds reusable private-block redaction for `gentle-engram` outgoing HTTP payloads and query values.
- Adds best-effort Pi compaction summary extraction and automatic `session_summary` persistence when supported.
- Documents private blocks and compaction recovery fallback behavior.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Redacts outgoing Engram requests and persists supported compaction summaries. |
| `plugin/pi/private-redaction.js` | Adds multiline private-tag redaction, recursive payload redaction, and query-value redaction. |
| `plugin/pi/compaction-recovery.js` | Adds compaction summary extraction and recovery notice helpers. |
| `plugin/pi/test/*.test.mjs` | Adds deterministic Node tests for redaction and compaction recovery helpers. |
| `plugin/pi/package.json` | Adds plugin-local test script and publishes helper/test files. |
| `plugin/pi/README.md` | Documents private blocks and compaction recovery/manual fallback. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Plugin tests pass locally: `npm test --prefix plugin/pi`
- [x] Package contents verified: `cd plugin/pi && npm pack --dry-run --json`

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This stays in the `gentle-engram` companion package. It does not move persistent memory into `gentle-pi` core and does not claim memory is available unless the companion/MCP tools are installed and active.

Private blocks are a convenience redaction mechanism, not a full secret scanner.
