### PR TITLE
fix(plugin): remove bilingual triggers from claude-code session context

### DIFF
--- a/plugin/assets_test.go
+++ b/plugin/assets_test.go
@@ -1,4 +1,4 @@
-package claudecode_test
+package plugin_test
 
 import (
 	"os"
@@ -16,18 +16,17 @@ func repoRoot(t *testing.T) string {
 	if !ok {
 		t.Fatal("runtime.Caller failed")
 	}
-	// plugin/claude-code/assets_test.go -> up two directories
-	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
+	// plugin/assets_test.go -> up one directory
+	return filepath.Dir(filepath.Dir(file))
 }
 
-// TestPluginClaudeCodeAssetsDoNotLeakSpanishTriggers walks the plugin's
-// injected assets (scripts/*.sh and skills/*/SKILL.md) and asserts that
-// none of them contain Spanish trigger tokens. Those tokens act as register
-// cues in the model's context and cause English sessions to drift into
-// Spanish even when language-lock rules are in place elsewhere.
-func TestPluginClaudeCodeAssetsDoNotLeakSpanishTriggers(t *testing.T) {
+// TestPluginAssetsDoNotLeakSpanishTriggers walks the injected assets of all
+// three plugins (claude-code, opencode, pi) and asserts that none of them
+// contain Spanish trigger tokens. Those tokens act as register cues in the
+// model's context and cause English sessions to drift into Spanish even when
+// language-lock rules are in place elsewhere.
+func TestPluginAssetsDoNotLeakSpanishTriggers(t *testing.T) {
 	root := repoRoot(t)
-	pluginRoot := filepath.Join(root, "plugin", "claude-code")
 
 	bannedTokens := []string{
 		`"dale"`,
@@ -46,8 +45,13 @@ func TestPluginClaudeCodeAssetsDoNotLeakSpanishTriggers(t *testing.T) {
 	targets := []struct {
 		pattern string
 	}{
-		{filepath.Join(pluginRoot, "scripts", "*.sh")},
-		{filepath.Join(pluginRoot, "skills", "*", "SKILL.md")},
+		// claude-code: shell scripts and skill markdown files
+		{filepath.Join(root, "plugin", "claude-code", "scripts", "*.sh")},
+		{filepath.Join(root, "plugin", "claude-code", "skills", "*", "SKILL.md")},
+		// opencode: TypeScript plugin adapter
+		{filepath.Join(root, "plugin", "opencode", "*.ts")},
+		// pi: TypeScript plugin adapter
+		{filepath.Join(root, "plugin", "pi", "*.ts")},
 	}
 
 	for _, target := range targets {

--- a/plugin/claude-code/assets_test.go
+++ b/plugin/claude-code/assets_test.go
@@ -1,0 +1,75 @@
+package claudecode_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// repoRoot returns the absolute path to the repository root by walking up from
+// this test file's location.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// plugin/claude-code/assets_test.go -> up two directories
+	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
+}
+
+// TestPluginClaudeCodeAssetsDoNotLeakSpanishTriggers walks the plugin's
+// injected assets (scripts/*.sh and skills/*/SKILL.md) and asserts that
+// none of them contain Spanish trigger tokens. Those tokens act as register
+// cues in the model's context and cause English sessions to drift into
+// Spanish even when language-lock rules are in place elsewhere.
+func TestPluginClaudeCodeAssetsDoNotLeakSpanishTriggers(t *testing.T) {
+	root := repoRoot(t)
+	pluginRoot := filepath.Join(root, "plugin", "claude-code")
+
+	bannedTokens := []string{
+		`"dale"`,
+		`"listo"`,
+		`"acordate"`,
+		`"qué hicimos"`,
+		`"sí, esa"`,
+		`"siempre hacé`,
+		`"recordar"`,
+		`"vamos con eso"`,
+		`"me gusta más así"`,
+		`"descartemos eso"`,
+		`"quiero algo diferente"`,
+	}
+
+	targets := []struct {
+		pattern string
+	}{
+		{filepath.Join(pluginRoot, "scripts", "*.sh")},
+		{filepath.Join(pluginRoot, "skills", "*", "SKILL.md")},
+	}
+
+	for _, target := range targets {
+		matches, err := filepath.Glob(target.pattern)
+		if err != nil {
+			t.Fatalf("glob %q: %v", target.pattern, err)
+		}
+		if len(matches) == 0 {
+			t.Fatalf("glob %q matched no files — check the path", target.pattern)
+		}
+		for _, path := range matches {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			rel, _ := filepath.Rel(root, path)
+			text := string(content)
+			for _, token := range bannedTokens {
+				if strings.Contains(text, token) {
+					t.Errorf("%s contains banned Spanish trigger token %s", rel, token)
+				}
+			}
+		}
+	}
+}

--- a/plugin/claude-code/scripts/post-compaction.sh
+++ b/plugin/claude-code/scripts/post-compaction.sh
@@ -56,11 +56,11 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 **Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
 
 ### SEARCH MEMORY when:
-- User asks to recall anything ("remember", "what did we do", "acordate", "qué hicimos")
+- User asks to recall anything ("remember", "what did we do", or the equivalent in the user's language)
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
 
-### SESSION CLOSE — before saying "done"/"listo":
+### SESSION CLOSE — before saying "done":
 Call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
 
 ---

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -158,19 +158,19 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - Pattern established (naming, structure, approach)
 - User preference or constraint learned
 - Feature implemented with non-obvious approach
-- User confirms your recommendation ("dale", "go with that", "sounds good", "sí, esa")
-- User rejects an approach or expresses a preference ("no, better X", "I prefer X", "siempre hacé X")
+- User confirms your recommendation ("go with that", "sounds good", or the equivalent in the user's language)
+- User rejects an approach or expresses a preference ("no, better X", "I prefer X", or the equivalent in the user's language)
 - Discussion concludes with a clear direction chosen
 
 **Self-check after EVERY task**: "Did I or the user just make a decision, confirm a recommendation, express a preference, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
 
 ### SEARCH MEMORY when:
-- User asks to recall anything ("remember", "what did we do", "acordate", "qué hicimos")
+- User asks to recall anything ("remember", "what did we do", or the equivalent in the user's language)
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
 - User's FIRST message references the project, a feature, or a problem — call `mem_search` with keywords from their message to check for prior work before responding
 
-### SESSION CLOSE — before saying "done"/"listo":
+### SESSION CLOSE — before saying "done":
 Call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
 PROTOCOL
 

--- a/plugin/claude-code/skills/memory/SKILL.md
+++ b/plugin/claude-code/skills/memory/SKILL.md
@@ -48,9 +48,9 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 - User preference or constraint learned
 
 ### After user confirmation or rejection
-- User confirms a recommendation you made ("dale", "go with that", "sí", "perfect", "vamos con eso", "let's do that", "sounds good", "agreed")
-- User rejects an option or approach ("no, better X", "descartemos eso", "not that one", "quiero algo diferente")
-- User expresses a preference ("I prefer X over Y", "siempre hacé X", "me gusta más así", "always do it this way")
+- User confirms a recommendation you made ("go with that", "let's do that", "sounds good", "agreed", "perfect", or the equivalent in the user's language)
+- User rejects an option or approach ("no, better X", "not that one", or the equivalent in the user's language)
+- User expresses a preference ("I prefer X over Y", "always do it this way", or the equivalent in the user's language)
 - User makes a decision after you presented tradeoffs or options
 - A discussion concludes with a clear direction chosen — even if the agent proposed it
 
@@ -78,7 +78,7 @@ Format for `mem_save`:
 ## WHEN TO SEARCH MEMORY
 
 When the user asks to recall something — any variation of "remember", "recall", "what did we do",
-"how did we solve", "recordar", "acordate", "qué hicimos", or references to past work:
+"how did we solve", or the equivalent in the user's language, or references to past work:
 1. First call `mem_context` — checks recent session history (fast, cheap)
 2. If not found, call `mem_search` with relevant keywords (FTS5 full-text search)
 3. If you find a match, use `mem_get_observation` for full untruncated content
@@ -90,7 +90,7 @@ Also search memory PROACTIVELY when:
 
 ## SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", you MUST:
+Before ending a session or saying "done" / "that's it", you MUST:
 1. Call `mem_session_summary` with this structure:
 
 ## Goal

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -76,7 +76,7 @@ Topic rules:
 ### WHEN TO SEARCH MEMORY
 
 When the user asks to recall something — any variation of "remember", "recall", "what did we do",
-"how did we solve", "recordar", "acordate", "qué hicimos", or references to past work:
+"how did we solve", or the equivalent in the user's language, or references to past work:
 1. First call \`mem_context\` — checks recent session history (fast, cheap)
 2. If not found, call \`mem_search\` with relevant keywords (FTS5 full-text search)
 3. If you find a match, use \`mem_get_observation\` for full untruncated content
@@ -88,7 +88,7 @@ Also search memory PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", you MUST:
+Before ending a session or saying "done" / "that's it", you MUST:
 1. Call \`mem_session_summary\` with this structure:
 
 ## Goal

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -71,7 +71,7 @@ call \`mem_search\`, then \`mem_get_observation\` for full content.
 
 ### SESSION CLOSE PROTOCOL
 
-Before ending a session or saying "done" / "listo", call \`mem_session_summary\`
+Before ending a session or saying "done", call \`mem_session_summary\`
 with Goal, Instructions, Discoveries, Accomplished, Next Steps, and Relevant Files.
 
 ### AFTER COMPACTION


### PR DESCRIPTION
## Linked Issue

Closes #359

## PR Type

- [x] `type:bug`

## Summary

- Removes Spanish trigger examples ("dale", "listo", "acordate", "siempre hacé", etc.) from injected context across all three Claude Code / OpenCode / Pi plugin asset trees.
- Phrases triggers language-agnostically (e.g. `"remember", "what did we do", or the equivalent in the user's language`).
- Adds a Go regression test that walks plugin assets and asserts no Spanish trigger tokens.

## Changes

| File | What changed |
|------|--------------|
| `plugin/claude-code/skills/memory/SKILL.md` | Drop Spanish triggers from confirm/reject/preference/recall/close sections |
| `plugin/claude-code/scripts/session-start.sh` | Same transformation in PROTOCOL heredoc |
| `plugin/claude-code/scripts/post-compaction.sh` | Same transformation |
| `plugin/opencode/engram.ts` | Drop Spanish recall + session-close triggers |
| `plugin/pi/index.ts` | Drop "listo" from session-close phrasing |
| `plugin/assets_test.go` | Consolidated regression test asserting no Spanish trigger tokens across all three plugins (replaces `plugin/claude-code/assets_test.go`) |

## Test plan

```bash
go test ./...
```

- [x] Regression test fails on main, passes after the fix
- [x] Manually verified with `rg` that no Spanish triggers remain in any plugin asset

## Notes

This is the engram-side counterpart to gentle-ai#350. The original report (#359) was scoped to Claude Code, but the same architectural leak exists in OpenCode and Pi plugins. Expanded scope inline because the fix pattern is identical and the regression test is shared.

Closes #359