### PR TITLE
fix(mcp): preserve mem_save observation content

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -697,7 +697,8 @@ Save structured observations. The tool description teaches agents the format:
 - **scope**: `project` (default) | `personal`
 - **topic_key**: optional canonical topic id (e.g. `architecture/auth-model`) used to upsert evolving memories
 - **capture_prompt**: optional boolean, default `true`; when current prompt context is available in the same MCP process for the same project/session, Engram best-effort records it alongside the observation. If that process-local context is unavailable or prompt capture fails, `mem_save` still succeeds. Automated pipeline saves such as SDD artifacts should pass `false`.
-- **content**: Structured with `**What**`, `**Why**`, `**Where**`, `**Learned**`
+- **content**: Structured with `**What**`, `**Why**`, `**Where**`, `**Learned**`; required unless the legacy `observation` alias is provided
+- **observation**: backward-compatible alias for `content` for older/raw MCP clients; prefer `content` for new integrations
 
 Exact duplicate saves are deduplicated in a rolling time window using a normalized content hash + project + scope + type + title.
 When `topic_key` is provided, `mem_save` upserts the latest observation in the same `project + scope + topic_key`, incrementing `revision_count`.

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -318,8 +318,10 @@ Examples:
 					mcp.Description("Short, searchable title (e.g. 'JWT auth middleware', 'Fixed N+1 query')"),
 				),
 				mcp.WithString("content",
-					mcp.Required(),
-					mcp.Description("Structured content using **What**, **Why**, **Where**, **Learned** format"),
+					mcp.Description("Structured content using **What**, **Why**, **Where**, **Learned** format. Required unless observation alias is provided."),
+				),
+				mcp.WithString("observation",
+					mcp.Description("Backward-compatible alias for content. Prefer content for new clients."),
 				),
 				mcp.WithString("type",
 					mcp.Description("Category: decision, architecture, bugfix, pattern, config, discovery, learning (default: manual)"),
@@ -1021,6 +1023,14 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		title, _ := req.GetArguments()["title"].(string)
 		content, _ := req.GetArguments()["content"].(string)
+		if strings.TrimSpace(content) == "" {
+			if observation, _ := req.GetArguments()["observation"].(string); strings.TrimSpace(observation) != "" {
+				content = observation
+			}
+		}
+		if strings.TrimSpace(content) == "" {
+			return mcp.NewToolResultError("content is required for mem_save (use content, or observation for backward-compatible clients)"), nil
+		}
 		typ, _ := req.GetArguments()["type"].(string)
 		sessionID, _ := req.GetArguments()["session_id"].(string)
 		scope, _ := req.GetArguments()["scope"].(string)

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -154,6 +154,90 @@ func TestHandleSaveSuggestsTopicKeyWhenMissing(t *testing.T) {
 	if !strings.Contains(text, "Suggested topic_key: architecture/auth-architecture") {
 		t.Fatalf("expected suggestion in save response, got %q", text)
 	}
+
+	obs, err := s.RecentObservations("engram", "project", 5)
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if len(obs) != 1 || obs[0].Content != "Define boundaries for auth middleware" {
+		t.Fatalf("expected persisted content, got %#v", obs)
+	}
+}
+
+func TestHandleSaveAcceptsObservationAliasForContent(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":       "Alias save",
+		"observation": "Body sent by older MCP clients",
+		"type":        "bugfix",
+		"project":     "engram",
+	}}})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected save error: %s", callResultText(t, res))
+	}
+
+	obs, err := s.RecentObservations("engram", "project", 5)
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if len(obs) != 1 || obs[0].Content != "Body sent by older MCP clients" {
+		t.Fatalf("expected observation alias to persist content, got %#v", obs)
+	}
+
+	mutations, err := s.ListPendingSyncMutations(store.DefaultSyncTargetKey, 100)
+	if err != nil {
+		t.Fatalf("list pending sync mutations: %v", err)
+	}
+	for _, mutation := range mutations {
+		if mutation.Entity != store.SyncEntityObservation || mutation.Op != store.SyncOpUpsert {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(mutation.Payload), &payload); err != nil {
+			t.Fatalf("decode observation sync payload: %v", err)
+		}
+		if payload["content"] != "Body sent by older MCP clients" {
+			t.Fatalf("expected sync payload content to be preserved, got %s", mutation.Payload)
+		}
+		return
+	}
+	t.Fatalf("expected pending observation upsert sync mutation, got %#v", mutations)
+}
+
+func TestHandleSaveRejectsMissingContent(t *testing.T) {
+	s := newMCPTestStore(t)
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Missing body",
+		"type":    "bugfix",
+		"project": "engram",
+	}}})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected missing content to fail")
+	}
+	if !strings.Contains(callResultText(t, res), "content is required") {
+		t.Fatalf("expected content validation error, got %q", callResultText(t, res))
+	}
+
+	obs, err := s.RecentObservations("engram", "project", 5)
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Fatalf("expected no observation to be written, got %#v", obs)
+	}
 }
 
 func TestHandleSaveAutoCapturesCurrentPromptByDefault(t *testing.T) {
@@ -5241,6 +5325,14 @@ func TestMemSaveSchemaIncludesCapturePrompt(t *testing.T) {
 	props := st.Tool.InputSchema.Properties
 	if _, ok := props["capture_prompt"]; !ok {
 		t.Fatal("mem_save schema must include capture_prompt")
+	}
+	if _, ok := props["observation"]; !ok {
+		t.Fatal("mem_save schema must include backward-compatible observation alias")
+	}
+	for _, required := range st.Tool.InputSchema.Required {
+		if required == "content" {
+			t.Fatal("mem_save schema must not require content when observation alias is accepted")
+		}
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #363

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Accept `observation` as a backward-compatible alias for `mem_save` body content.
- Fail loudly when neither `content` nor `observation` is provided, preventing empty observation rows.
- Add regression coverage for persisted content, sync mutation payloads, validation, schema, and docs.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/mcp/mcp.go` | Adds `observation` alias and explicit body validation before saving. |
| `internal/mcp/mcp_test.go` | Covers content persistence, alias behavior, sync payload content, missing body rejection, and schema. |
| `DOCS.md` | Documents the legacy `observation` alias and `content OR observation` requirement. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Targeted MCP tests pass locally: `go test ./internal/mcp -count=1`
- [x] Judgment Day dual review passed after re-judgment

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This preserves compatibility for older/raw MCP clients sending `observation`, while keeping `content` as the preferred field for new integrations.
