### PR TITLE
feat(setup): add pi integration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Windows, Linux, and other install methods → [docs/INSTALLATION.md](docs/INSTAL
 | Agent                       | One-liner                                                                                    |
 | --------------------------- | -------------------------------------------------------------------------------------------- |
 | Claude Code                 | `claude plugin marketplace add Gentleman-Programming/engram && claude plugin install engram` |
-| Pi                          | `pi install npm:gentle-engram && pi install npm:pi-mcp-adapter && pi-engram init`            |
+| Pi                          | `engram setup pi`                                                                            |
 | OpenCode                    | `engram setup opencode`                                                                      |
 | Gemini CLI                  | `engram setup gemini-cli`                                                                    |
 | Codex                       | `engram setup codex`                                                                         |
@@ -65,9 +65,7 @@ That's it. No Node.js, no Python, no Docker. **One binary, one SQLite file.**
 Engram has a first-class Pi package: [`gentle-engram`](plugin/pi/README.md).
 
 ```bash
-pi install npm:gentle-engram
-pi install npm:pi-mcp-adapter
-pi-engram init
+engram setup pi
 ```
 
 It gives Pi persistent project memory, compaction recovery, and shared memory with other MCP agents through the same local-or-cloud Engram brain. The package is part of the Gentleman Programming agentic-coding ecosystem alongside Gentle-AI, SDD, skills, and Engram Cloud.

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2207,10 +2207,14 @@ func printPostInstall(result *setup.Result) {
 	case "opencode":
 		fmt.Println("\nNext steps:")
 		fmt.Println("  1. Restart OpenCode — plugin + MCP server are ready")
-		fmt.Println("  2. Run 'engram serve &' for session tracking (HTTP API)")
+		fmt.Println("  2. The plugin auto-starts the Engram HTTP server when needed")
 		if result.TUIPluginEnabled {
 			fmt.Println("\nAlso enabled: opencode-subagent-statusline in tui.json — sub-agent activity in the sidebar/footer.")
 		}
+	case "pi":
+		fmt.Println("\nNext steps:")
+		fmt.Println("  1. Restart Pi so packages and MCP config are reloaded")
+		fmt.Println("  2. Verify with: pi list")
 	case "claude-code":
 		// Offer to add engram tools to the permissions allowlist
 		fmt.Print("\nAdd engram tools to ~/.claude/settings.json allowlist?\n")
@@ -2285,7 +2289,7 @@ Commands:
                      Merge similar project names into one canonical name
                        --all      Scan ALL projects for similar name groups
                        --dry-run  Preview what would be merged (no changes)
-  setup [agent]      Install/setup agent integration (opencode, claude-code, gemini-cli, codex)
+  setup [agent]      Install/setup agent integration (opencode, pi, claude-code, gemini-cli, codex)
   sync               Export new memories as compressed chunk to .engram/
                          --import   Import new chunks from .engram/ into local DB
                          --status   Show sync status

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -166,6 +166,9 @@ func TestPrintUsage(t *testing.T) {
 	if !strings.Contains(stdout, "search <query>") || !strings.Contains(stdout, "setup [agent]") {
 		t.Fatalf("usage missing expected commands: %q", stdout)
 	}
+	if !strings.Contains(stdout, "opencode, pi, claude-code, gemini-cli, codex") {
+		t.Fatalf("usage missing pi setup agent: %q", stdout)
+	}
 	if !strings.Contains(stdout, "cloud <subcommand>") {
 		t.Fatalf("usage missing cloud command tree: %q", stdout)
 	}
@@ -198,15 +201,22 @@ func TestPrintPostInstall(t *testing.T) {
 		notExpects []string
 	}{
 		{
-			name:    "opencode with subagent monitor enabled",
-			result:  &setup.Result{Agent: "opencode", TUIPluginEnabled: true},
-			expects: []string{"Restart OpenCode", "opencode-subagent-statusline", "engram serve &"},
+			name:       "opencode with subagent monitor enabled",
+			result:     &setup.Result{Agent: "opencode", TUIPluginEnabled: true},
+			expects:    []string{"Restart OpenCode", "opencode-subagent-statusline", "auto-starts"},
+			notExpects: []string{"engram serve &"},
 		},
 		{
 			name:       "opencode with subagent monitor not enabled",
 			result:     &setup.Result{Agent: "opencode", TUIPluginEnabled: false},
-			expects:    []string{"Restart OpenCode", "engram serve &"},
-			notExpects: []string{"opencode-subagent-statusline"},
+			expects:    []string{"Restart OpenCode", "auto-starts"},
+			notExpects: []string{"opencode-subagent-statusline", "engram serve &"},
+		},
+		{
+			name:       "pi",
+			result:     &setup.Result{Agent: "pi"},
+			expects:    []string{"Restart Pi", "pi list"},
+			notExpects: []string{"ENGRAM_BIN"},
 		},
 		{
 			name:    "gemini-cli",

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -7,28 +7,37 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 > Cloud bootstrap automation in agent scripts/plugins is intentionally deferred in this rollout. Use `engram cloud ...` manually for now.
 >
 > Deferred validation scope for this rollout:
+>
 > - Setup/plugin scripts are **not** yet validated as cloud enrollment/login orchestrators.
 > - `engram setup ...` installs MCP/plugin integrations only; it does **not** auto-run `engram cloud config/enroll/upgrade`.
 > - Cloud onboarding contract remains CLI-first until script-level cloud flows are explicitly implemented.
 
 ## Quick Reference
 
-| Agent | One-liner | Manual Config |
-|-------|-----------|---------------|
-| Claude Code | `claude plugin marketplace add Gentleman-Programming/engram && claude plugin install engram` | [Details](#claude-code) |
-| Pi | `pi install npm:gentle-engram && pi install npm:pi-mcp-adapter && pi-engram init` | [Details](#pi) |
-| OpenCode | `engram setup opencode` | [Details](#opencode) |
-| Gemini CLI | `engram setup gemini-cli` | [Details](#gemini-cli) |
-| Codex | `engram setup codex` | [Details](#codex) |
-| VS Code | `code --add-mcp '{"name":"engram","command":"engram","args":["mcp"]}'` | [Details](#vs-code-copilot--claude-code-extension) |
-| Antigravity | Manual JSON config | [Details](#antigravity) |
-| Cursor | Manual JSON config | [Details](#cursor) |
-| Windsurf | Manual JSON config | [Details](#windsurf) |
-| Any MCP agent | `engram mcp` (stdio) | [Details](#any-other-mcp-agent) |
+| Agent         | One-liner                                                                                    | Manual Config                                      |
+| ------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Claude Code   | `claude plugin marketplace add Gentleman-Programming/engram && claude plugin install engram` | [Details](#claude-code)                            |
+| Pi            | `engram setup pi`                                                                            | [Details](#pi)                                     |
+| OpenCode      | `engram setup opencode`                                                                      | [Details](#opencode)                               |
+| Gemini CLI    | `engram setup gemini-cli`                                                                    | [Details](#gemini-cli)                             |
+| Codex         | `engram setup codex`                                                                         | [Details](#codex)                                  |
+| VS Code       | `code --add-mcp '{"name":"engram","command":"engram","args":["mcp"]}'`                       | [Details](#vs-code-copilot--claude-code-extension) |
+| Antigravity   | Manual JSON config                                                                           | [Details](#antigravity)                            |
+| Cursor        | Manual JSON config                                                                           | [Details](#cursor)                                 |
+| Windsurf      | Manual JSON config                                                                           | [Details](#windsurf)                               |
+| Any MCP agent | `engram mcp` (stdio)                                                                         | [Details](#any-other-mcp-agent)                    |
 
 ## Pi
 
-Install Engram's Pi package and the MCP adapter:
+Install Engram's Pi package, the MCP adapter, and Pi MCP config:
+
+```bash
+engram setup pi
+```
+
+`engram setup pi` runs `pi install npm:gentle-engram` and `pi install npm:pi-mcp-adapter`, then ensures Pi settings contain both packages and writes `mcpServers.engram` in the Pi agent MCP config when no Engram server is already configured. Existing `mcpServers.engram` entries are preserved.
+
+Manual equivalent:
 
 ```bash
 pi install npm:gentle-engram
@@ -189,6 +198,7 @@ engram setup opencode
 ```
 
 This does three things:
+
 1. Copies the plugin to `~/.config/opencode/plugins/engram.ts` (session tracking, Memory Protocol, compaction recovery)
 2. Adds the `engram` MCP server entry to your `opencode.json` with `--tools=agent` (15 agent-facing tools)
 3. Adds `opencode-subagent-statusline` to your `tui.json` or `tui.jsonc` so OpenCode shows sub-agent activity in the sidebar/home footer
@@ -298,6 +308,7 @@ engram setup gemini-cli
 ```
 
 `engram setup gemini-cli` now does three things:
+
 - Registers `mcpServers.engram` in `~/.gemini/settings.json` (Windows: `%APPDATA%\gemini\settings.json`)
 - Writes `~/.gemini/system.md` with the Engram Memory Protocol (includes post-compaction recovery)
 - Ensures `~/.gemini/.env` contains `GEMINI_SYSTEM_MD=1` so Gemini actually loads that system prompt
@@ -334,6 +345,7 @@ engram setup codex
 ```
 
 `engram setup codex` now does three things:
+
 - Registers `[mcp_servers.engram]` in `~/.codex/config.toml` (Windows: `%APPDATA%\codex\config.toml`)
 - Writes `~/.codex/engram-instructions.md` with the Engram Memory Protocol
 - Writes `~/.codex/engram-compact-prompt.md` and points `experimental_compact_prompt_file` to it, so compaction output includes a required memory-save instruction
@@ -398,6 +410,7 @@ Without the Memory Protocol, the agent has the tools but doesn't know WHEN to us
 **For Copilot:** Create a `.instructions.md` file in the VS Code User `prompts/` folder and paste the Memory Protocol from [DOCS.md](../DOCS.md#memory-protocol-full-text).
 
 Recommended file path:
+
 - macOS: `~/Library/Application Support/Code/User/prompts/engram-memory.instructions.md`
 - Linux: `~/.config/Code/User/prompts/engram-memory.instructions.md`
 - Windows: `%APPDATA%\Code\User\prompts\engram-memory.instructions.md`
@@ -405,6 +418,7 @@ Recommended file path:
 **For any VS Code chat extension:** Add the Memory Protocol text to your extension's custom instructions or system prompt configuration.
 
 The Memory Protocol tells the agent:
+
 - **When to save** — after bugfixes, decisions, discoveries, config changes, patterns
 - **When to search** — reactive ("remember", "recall") + proactive (overlapping past work)
 - **Session close** — mandatory `mem_session_summary` before ending
@@ -457,6 +471,7 @@ Add to your `.cursor/mcp.json` (same path on all platforms — it's project-rela
 > **Windows**: Make sure `engram.exe` is in your `PATH`. Cursor resolves MCP commands from the system PATH.
 
 > **Memory Protocol:** Cursor uses `.mdc` rule files stored in `.cursor/rules/` (Cursor 0.43+). Create an `engram.mdc` file (any name works — the `.mdc` extension is what matters) and place it in one of:
+>
 > - **Project-specific:** `.cursor/rules/engram.mdc` — commit to git so your whole team gets it
 > - **Global (all projects):** `~/.cursor/rules/engram.mdc` (Windows: `%USERPROFILE%\.cursor\rules\engram.mdc`) — create the directory if it doesn't exist
 >
@@ -496,39 +511,52 @@ The pattern is always the same — point your agent's MCP config to `engram mcp`
 When your agent compacts (summarizes long conversations to free context), it starts fresh — and might forget about Engram. To make memory truly resilient, add this to your agent's system prompt or config file:
 
 **For Claude Code** (`CLAUDE.md`):
+
 ```markdown
 ## Memory
+
 You have access to Engram persistent memory via MCP tools (mem_save, mem_search, mem_session_summary, etc.).
+
 - Save proactively after significant work — don't wait to be asked.
 - After any compaction or context reset, call `mem_context` to recover session state before continuing.
 ```
 
 **For OpenCode** (agent prompt in `opencode.json`):
+
 ```
 After any compaction or context reset, call mem_context to recover session state before continuing.
 Save memories proactively with mem_save after significant work.
 ```
 
 **For Gemini CLI** (`GEMINI.md`):
+
 ```markdown
 ## Memory
+
 You have access to Engram persistent memory via MCP tools (mem_save, mem_search, mem_session_summary, etc.).
+
 - Save proactively after significant work — don't wait to be asked.
 - After any compaction or context reset, call `mem_context` to recover session state before continuing.
 ```
 
 **For VS Code** (`Code/User/prompts/*.instructions.md` or custom instructions):
+
 ```markdown
 ## Memory
+
 You have access to Engram persistent memory via MCP tools (mem_save, mem_search, mem_session_summary, etc.).
+
 - Save proactively after significant work — don't wait to be asked.
 - After any compaction or context reset, call `mem_context` to recover session state before continuing.
 ```
 
 **For Antigravity** (`~/.gemini/GEMINI.md` or `.agent/rules/`):
+
 ```markdown
 ## Memory
+
 You have access to Engram persistent memory via MCP tools (mem_save, mem_search, mem_session_summary, etc.).
+
 - Save proactively after significant work — don't wait to be asked.
 - After any compaction or context reset, call `mem_context` to recover session state before continuing.
 ```
@@ -547,6 +575,7 @@ Save proactively after significant work. After context resets, call mem_context 
 ```
 
 **For Windsurf** (`.windsurfrules`):
+
 ```
 You have access to Engram persistent memory (mem_save, mem_search, mem_context).
 Save proactively after significant work. After context resets, call mem_context to recover state.
@@ -609,6 +638,7 @@ There is no separate dashboard or conflict list in Phase 1.
 ### What happens after judgment
 
 Once the agent calls `mem_judge` with a verdict:
+
 - The relation row is persisted with `judgment_status: "judged"` and the chosen `relation`.
 - If the relation is `supersedes`, future `mem_search` results show `supersedes: #<id> (<title>)` and `superseded_by: #<id> (<title>)` annotations on the affected observations, including the related memory's title.
 - If the relation is `conflicts_with`, future `mem_search` results show `conflicts: #<id> (<title>)` on both observations.

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -10,6 +10,7 @@
 //     absolute binary path so the subprocess never needs PATH resolution.
 //   - Gemini CLI: injects MCP registration in ~/.gemini/settings.json
 //   - Codex: injects MCP registration in ~/.codex/config.toml
+//   - Pi: installs gentle-engram/pi-mcp-adapter packages and writes Pi MCP config
 package setup
 
 import (
@@ -75,6 +76,9 @@ type Result struct {
 const claudeCodeMarketplace = "Gentleman-Programming/engram"
 
 const openCodeSubagentStatuslinePlugin = "opencode-subagent-statusline"
+
+const piGentleEngramPackage = "npm:gentle-engram"
+const piMCPAdapterPackage = "npm:pi-mcp-adapter"
 
 // claudeCodeMCPTools are the MCP tool permission names for the agent profile
 // registered by the engram Claude Code plugin and durable user-level MCP config.
@@ -236,6 +240,11 @@ func SupportedAgents() []Agent {
 			InstallDir:  openCodePluginDir(),
 		},
 		{
+			Name:        "pi",
+			Description: "Pi — gentle-engram package plus pi-mcp-adapter MCP tools",
+			InstallDir:  piAgentDir(),
+		},
+		{
 			Name:        "claude-code",
 			Description: "Claude Code — Native plugin via marketplace (hooks, skills, MCP, compaction recovery)",
 			InstallDir:  "managed by claude plugin system",
@@ -258,6 +267,8 @@ func Install(agentName string) (*Result, error) {
 	switch agentName {
 	case "opencode":
 		return installOpenCode()
+	case "pi":
+		return installPi()
 	case "claude-code":
 		return installClaudeCode()
 	case "gemini-cli":
@@ -265,8 +276,162 @@ func Install(agentName string) (*Result, error) {
 	case "codex":
 		return installCodex()
 	default:
-		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, claude-code, gemini-cli, codex)", agentName)
+		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, gemini-cli, codex)", agentName)
 	}
+}
+
+// ─── Pi ──────────────────────────────────────────────────────────────────────
+
+func piAgentDir() string {
+	if dir := strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR")); dir != "" {
+		return dir
+	}
+	home, err := userHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return filepath.Join(".pi", "agent")
+	}
+	return filepath.Join(home, ".pi", "agent")
+}
+
+func installPi() (*Result, error) {
+	if _, err := runCommand("pi", "install", piGentleEngramPackage); err != nil {
+		return nil, fmt.Errorf("install %s: %w", piGentleEngramPackage, err)
+	}
+	if _, err := runCommand("pi", "install", piMCPAdapterPackage); err != nil {
+		return nil, fmt.Errorf("install %s: %w", piMCPAdapterPackage, err)
+	}
+
+	agentDir := piAgentDir()
+	files := 0
+	settingsChanged, err := ensurePiPackageSettings(filepath.Join(agentDir, "settings.json"))
+	if err != nil {
+		return nil, err
+	}
+	if settingsChanged {
+		files++
+	}
+	mcpChanged, err := ensurePiMCPConfig(filepath.Join(agentDir, "mcp.json"))
+	if err != nil {
+		return nil, err
+	}
+	if mcpChanged {
+		files++
+	}
+
+	return &Result{Agent: "pi", Destination: agentDir, Files: files}, nil
+}
+
+func ensurePiPackageSettings(settingsPath string) (bool, error) {
+	config, err := readJSONConfig(settingsPath)
+	if err != nil {
+		return false, fmt.Errorf("read Pi settings: %w", err)
+	}
+	packages, err := readRawArrayField(config, "packages", settingsPath)
+	if err != nil {
+		return false, err
+	}
+	changed := false
+	for _, pkg := range []string{piGentleEngramPackage, piMCPAdapterPackage} {
+		if !rawArrayContainsString(packages, pkg) {
+			raw, err := jsonMarshalFn(pkg)
+			if err != nil {
+				return false, fmt.Errorf("marshal Pi package %q: %w", pkg, err)
+			}
+			packages = append(packages, raw)
+			changed = true
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	config["packages"], err = jsonMarshalFn(packages)
+	if err != nil {
+		return false, fmt.Errorf("marshal Pi packages: %w", err)
+	}
+	return true, writeJSONConfig(settingsPath, config)
+}
+
+func ensurePiMCPConfig(mcpPath string) (bool, error) {
+	config, err := readJSONConfig(mcpPath)
+	if err != nil {
+		return false, fmt.Errorf("read Pi MCP config: %w", err)
+	}
+	servers := make(map[string]json.RawMessage)
+	if raw, ok := config["mcpServers"]; ok {
+		if err := json.Unmarshal(raw, &servers); err != nil {
+			return false, fmt.Errorf("parse Pi mcpServers: %w", err)
+		}
+	}
+	if _, exists := servers["engram"]; exists {
+		return false, nil
+	}
+	server := map[string]any{
+		"command":     resolveEngramCommand(),
+		"args":        []string{"mcp", "--tools=agent"},
+		"lifecycle":   "lazy",
+		"directTools": true,
+	}
+	raw, err := jsonMarshalFn(server)
+	if err != nil {
+		return false, fmt.Errorf("marshal Pi Engram MCP server: %w", err)
+	}
+	servers["engram"] = raw
+	config["mcpServers"], err = jsonMarshalFn(servers)
+	if err != nil {
+		return false, fmt.Errorf("marshal Pi mcpServers: %w", err)
+	}
+	return true, writeJSONConfig(mcpPath, config)
+}
+
+func readJSONConfig(path string) (map[string]json.RawMessage, error) {
+	data, err := readFileFn(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]json.RawMessage), nil
+		}
+		return nil, err
+	}
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, fmt.Errorf("%s must contain a JSON object", path)
+	}
+	return config, nil
+}
+
+func writeJSONConfig(path string, config map[string]json.RawMessage) error {
+	output, err := jsonMarshalIndentFn(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	return writeFileFn(path, append(output, '\n'), 0644)
+}
+
+func readRawArrayField(config map[string]json.RawMessage, key, path string) ([]json.RawMessage, error) {
+	raw, ok := config[key]
+	if !ok {
+		return nil, nil
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("parse %s %q: %w", path, key, err)
+	}
+	return values, nil
+}
+
+func rawArrayContainsString(values []json.RawMessage, target string) bool {
+	for _, value := range values {
+		var decoded string
+		if err := json.Unmarshal(value, &decoded); err == nil && decoded == target {
+			return true
+		}
+	}
+	return false
 }
 
 // ─── OpenCode ────────────────────────────────────────────────────────────────

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -296,6 +296,124 @@ func TestInstallCodexInjectsTOMLAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestInstallPiInstallsPackagesAndWritesConfig(t *testing.T) {
+	resetSetupSeams(t)
+	agentDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", agentDir)
+	osExecutable = func() (string, error) { return "/opt/engram/bin/engram", nil }
+
+	var commands []string
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return []byte("ok"), nil
+	}
+
+	result, err := Install("pi")
+	if err != nil {
+		t.Fatalf("Install(pi) failed: %v", err)
+	}
+	if result.Agent != "pi" || result.Destination != agentDir || result.Files != 2 {
+		t.Fatalf("unexpected install result: %#v", result)
+	}
+	wantCommands := []string{"pi install npm:gentle-engram", "pi install npm:pi-mcp-adapter"}
+	if !reflect.DeepEqual(commands, wantCommands) {
+		t.Fatalf("unexpected pi install commands: got %#v want %#v", commands, wantCommands)
+	}
+
+	settingsRaw, err := os.ReadFile(filepath.Join(agentDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings struct {
+		Packages []string `json:"packages"`
+	}
+	if err := json.Unmarshal(settingsRaw, &settings); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	for _, pkg := range []string{"npm:gentle-engram", "npm:pi-mcp-adapter"} {
+		if !slices.Contains(settings.Packages, pkg) {
+			t.Fatalf("expected settings packages to include %q, got %#v", pkg, settings.Packages)
+		}
+	}
+
+	mcpRaw, err := os.ReadFile(filepath.Join(agentDir, "mcp.json"))
+	if err != nil {
+		t.Fatalf("read mcp: %v", err)
+	}
+	var mcpConfig struct {
+		MCPServers map[string]struct {
+			Command     string   `json:"command"`
+			Args        []string `json:"args"`
+			Lifecycle   string   `json:"lifecycle"`
+			DirectTools bool     `json:"directTools"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(mcpRaw, &mcpConfig); err != nil {
+		t.Fatalf("parse mcp: %v", err)
+	}
+	server, ok := mcpConfig.MCPServers["engram"]
+	if !ok {
+		t.Fatalf("expected mcpServers.engram in %#v", mcpConfig.MCPServers)
+	}
+	if server.Command != "/opt/engram/bin/engram" || !reflect.DeepEqual(server.Args, []string{"mcp", "--tools=agent"}) || server.Lifecycle != "lazy" || !server.DirectTools {
+		t.Fatalf("unexpected engram MCP server: %#v", server)
+	}
+}
+
+func TestInstallPiPreservesExistingEngramMCPServer(t *testing.T) {
+	resetSetupSeams(t)
+	agentDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", agentDir)
+	runCommand = func(string, ...string) ([]byte, error) { return []byte("ok"), nil }
+
+	settingsPath := filepath.Join(agentDir, "settings.json")
+	mcpPath := filepath.Join(agentDir, "mcp.json")
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatalf("mkdir agent dir: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"packages":["npm:existing"]}`), 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	originalMCP := `{"mcpServers":{"engram":{"command":"custom-engram","args":["mcp"],"lifecycle":"eager"},"other":{"command":"other"}}}`
+	if err := os.WriteFile(mcpPath, []byte(originalMCP), 0644); err != nil {
+		t.Fatalf("write mcp: %v", err)
+	}
+
+	result, err := Install("pi")
+	if err != nil {
+		t.Fatalf("Install(pi) failed: %v", err)
+	}
+	if result.Files != 1 {
+		t.Fatalf("expected only settings to change, got files=%d", result.Files)
+	}
+	mcpAfter, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("read mcp after install: %v", err)
+	}
+	if string(mcpAfter) != originalMCP {
+		t.Fatalf("expected existing mcp server to be preserved, got %s", mcpAfter)
+	}
+
+	settingsRaw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings after install: %v", err)
+	}
+	if !strings.Contains(string(settingsRaw), "npm:existing") || !strings.Contains(string(settingsRaw), "npm:gentle-engram") || !strings.Contains(string(settingsRaw), "npm:pi-mcp-adapter") {
+		t.Fatalf("expected settings packages to be preserved and extended, got %s", settingsRaw)
+	}
+}
+
+func TestInstallPiCommandFailure(t *testing.T) {
+	resetSetupSeams(t)
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("boom"), errors.New("exit 1")
+	}
+	_, err := Install("pi")
+	if err == nil || !strings.Contains(err.Error(), "install npm:gentle-engram") {
+		t.Fatalf("expected pi install error, got %v", err)
+	}
+}
+
 func TestInstallUnknownAgent(t *testing.T) {
 	resetSetupSeams(t)
 	_, err := Install("unknown")


### PR DESCRIPTION
## Summary
- add `engram setup pi` to install `gentle-engram` and `pi-mcp-adapter`
- write Pi package settings and lazy/direct Engram MCP config while preserving existing config
- update README/agent setup docs and remove stale OpenCode manual `engram serve &` next step

Fixes #127
Fixes #300

## Tests
- `go test ./cmd/engram ./internal/setup`
- `go test ./...`

## Review
- Fresh reviewer approved after post-install ENGRAM_BIN wording cleanup.
