### PR TITLE
fix(server): add observations compatibility endpoint

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -123,6 +123,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 - `POST /sessions` — Create session. Body: `{id, project, directory}`
 - `POST /sessions/{id}/end` — End session. Body: `{summary}`
 - `GET /sessions/recent` — Recent sessions. Query: `?project=X&limit=N`
+- `GET /sessions/{id}` — Get single session by ID
 - `DELETE /sessions/{id}` — Delete session
   - `200` when deleted
   - `404` when session does not exist
@@ -132,6 +133,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 ### Observations
 
 - `POST /observations` — Add observation. Body: `{session_id, type, title, content, tool_name?, project?, scope?, topic_key?}`
+- `GET /observations` — Recent observations compatibility endpoint. Query: `?project=X&scope=project|personal&limit=N&sort=created_at:desc`
 - `GET /observations/recent` — Recent observations. Query: `?project=X&scope=project|personal&limit=N`
 - `GET /observations/{id}` — Get single observation by ID
 - `PATCH /observations/{id}` — Update fields. Body: `{title?, content?, type?, project?, scope?, topic_key?}`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -141,10 +142,12 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /sessions", s.handleCreateSession)
 	s.mux.HandleFunc("POST /sessions/{id}/end", s.handleEndSession)
 	s.mux.HandleFunc("GET /sessions/recent", s.handleRecentSessions)
+	s.mux.HandleFunc("GET /sessions/{id}", s.handleGetSession)
 	s.mux.HandleFunc("DELETE /sessions/{id}", s.handleDeleteSession)
 
 	// Observations
 	s.mux.HandleFunc("POST /observations", s.handleAddObservation)
+	s.mux.HandleFunc("GET /observations", s.handleListObservations)
 	s.mux.HandleFunc("POST /observations/passive", s.handlePassiveCapture)
 	s.mux.HandleFunc("GET /observations/recent", s.handleRecentObservations)
 	s.mux.HandleFunc("PATCH /observations/{id}", s.handleUpdateObservation)
@@ -252,6 +255,20 @@ func (s *Server) handleRecentSessions(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusOK, sessions)
 }
 
+func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
+	session, err := s.store.GetSession(r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			jsonError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, session)
+}
+
 func (s *Server) handleAddObservation(w http.ResponseWriter, r *http.Request) {
 	var body store.AddObservationParams
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -292,6 +309,16 @@ func (s *Server) handlePassiveCapture(w http.ResponseWriter, r *http.Request) {
 
 	s.notifyWrite()
 	jsonResponse(w, http.StatusOK, result)
+}
+
+func (s *Server) handleListObservations(w http.ResponseWriter, r *http.Request) {
+	sort := r.URL.Query().Get("sort")
+	if sort != "" && sort != "created_at:desc" {
+		jsonError(w, http.StatusBadRequest, "unsupported sort: use created_at:desc")
+		return
+	}
+
+	s.handleRecentObservations(w, r)
 }
 
 func (s *Server) handleRecentObservations(w http.ResponseWriter, r *http.Request) {
@@ -814,7 +841,8 @@ func (s *Server) handleListDeferred(w http.ResponseWriter, r *http.Request) {
 
 // handleScanConflicts serves POST /conflicts/scan
 // Body: {"project":"X","since":"...","apply":bool,"max_insert":int,
-//        "semantic":bool,"concurrency":int,"timeout_per_call_seconds":int,"max_semantic":int}
+//
+//	"semantic":bool,"concurrency":int,"timeout_per_call_seconds":int,"max_semantic":int}
 func (s *Server) handleScanConflicts(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Project   string `json:"project"`

--- a/internal/server/server_e2e_test.go
+++ b/internal/server/server_e2e_test.go
@@ -393,6 +393,18 @@ func TestCoreReadHandlersAndHelpersE2E(t *testing.T) {
 		t.Fatalf("expected at least one recent session")
 	}
 
+	getSessionResp, err := client.Get(ts.URL + "/sessions/s-core")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if getSessionResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 get session, got %d", getSessionResp.StatusCode)
+	}
+	getSession := decodeJSON[map[string]any](t, getSessionResp)
+	if getSession["started_at"] == "" || getSession["project"] != "engram" {
+		t.Fatalf("expected get session JSON with started_at/project, got %#v", getSession)
+	}
+
 	recentObsResp, err := client.Get(ts.URL + "/observations/recent?project=engram&scope=project&limit=bad")
 	if err != nil {
 		t.Fatalf("recent observations: %v", err)
@@ -403,6 +415,18 @@ func TestCoreReadHandlersAndHelpersE2E(t *testing.T) {
 	recentObs := decodeJSON[[]map[string]any](t, recentObsResp)
 	if len(recentObs) == 0 {
 		t.Fatalf("expected recent observations")
+	}
+
+	listObsResp, err := client.Get(ts.URL + "/observations?project=engram&limit=1&sort=created_at:desc")
+	if err != nil {
+		t.Fatalf("list observations compatibility endpoint: %v", err)
+	}
+	if listObsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 list observations compatibility endpoint, got %d", listObsResp.StatusCode)
+	}
+	listObs := decodeJSON[[]map[string]any](t, listObsResp)
+	if len(listObs) != 1 || listObs[0]["title"] != "Core test" || listObs[0]["created_at"] == "" {
+		t.Fatalf("expected latest observation with created_at, got %#v", listObs)
 	}
 
 	timelineResp, err := client.Get(ts.URL + "/timeline?observation_id=" + strconv.FormatInt(obsID, 10) + "&before=bad&after=bad")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -104,6 +104,71 @@ func TestStartUsesDefaultServeWhenServeNil(t *testing.T) {
 	}
 }
 
+func TestClaudeSaveNudgeCompatibilityRoutes(t *testing.T) {
+	st := newServerTestStore(t)
+	h := New(st, 0).Handler()
+
+	createReq := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(`{"id":"s-nudge","project":"engram","directory":"/work/engram"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	h.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("expected session create 201, got %d", createRec.Code)
+	}
+
+	getSessionReq := httptest.NewRequest(http.MethodGet, "/sessions/s-nudge", nil)
+	getSessionRec := httptest.NewRecorder()
+	h.ServeHTTP(getSessionRec, getSessionReq)
+	if getSessionRec.Code != http.StatusOK {
+		t.Fatalf("expected session get 200, got %d body=%s", getSessionRec.Code, getSessionRec.Body.String())
+	}
+	var session map[string]any
+	if err := json.Unmarshal(getSessionRec.Body.Bytes(), &session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	if session["started_at"] == "" || session["project"] != "engram" {
+		t.Fatalf("expected session JSON with started_at and project, got %#v", session)
+	}
+
+	for _, title := range []string{"Older save", "Newest save"} {
+		obsReq := httptest.NewRequest(http.MethodPost, "/observations", strings.NewReader(fmt.Sprintf(`{"session_id":"s-nudge","type":"note","title":%q,"content":"body","project":"engram"}`, title)))
+		obsReq.Header.Set("Content-Type", "application/json")
+		obsRec := httptest.NewRecorder()
+		h.ServeHTTP(obsRec, obsReq)
+		if obsRec.Code != http.StatusCreated {
+			t.Fatalf("expected observation create 201 for %q, got %d body=%s", title, obsRec.Code, obsRec.Body.String())
+		}
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/observations?project=engram&limit=1&sort=created_at:desc", nil)
+	listRec := httptest.NewRecorder()
+	h.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected observations list 200, got %d body=%s", listRec.Code, listRec.Body.String())
+	}
+	var obs []map[string]any
+	if err := json.Unmarshal(listRec.Body.Bytes(), &obs); err != nil {
+		t.Fatalf("decode observations: %v", err)
+	}
+	if len(obs) != 1 || obs[0]["title"] != "Newest save" || obs[0]["created_at"] == "" {
+		t.Fatalf("expected latest observation with created_at, got %#v", obs)
+	}
+
+	badSortReq := httptest.NewRequest(http.MethodGet, "/observations?sort=updated_at:desc", nil)
+	badSortRec := httptest.NewRecorder()
+	h.ServeHTTP(badSortRec, badSortReq)
+	if badSortRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported sort, got %d", badSortRec.Code)
+	}
+
+	missingSessionReq := httptest.NewRequest(http.MethodGet, "/sessions/missing", nil)
+	missingSessionRec := httptest.NewRecorder()
+	h.ServeHTTP(missingSessionRec, missingSessionReq)
+	if missingSessionRec.Code != http.StatusNotFound {
+		t.Fatalf("expected missing session 404, got %d", missingSessionRec.Code)
+	}
+}
+
 func TestAdditionalServerErrorBranches(t *testing.T) {
 	st := newServerTestStore(t)
 	srv := New(st, 0)


### PR DESCRIPTION
## Summary
- add `GET /sessions/{id}` for Claude hook session lookup
- add `GET /observations` compatibility endpoint for latest-observation queries
- document and test the compatibility surface, including unsupported sort handling

Fixes #288

## Tests
- `go test ./internal/server`
- `go test -tags e2e ./internal/server`
- `go test ./...`

## Review
- Fresh reviewer approved: no blockers.
