### PR TITLE
fix(mcp): trust process project override

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -830,13 +830,27 @@ func tryStartAutosync(ctx context.Context, s *store.Store, cfg store.Config) (au
 }
 
 func cmdMCP(cfg store.Config) {
-	// Parse --tools flag. Project is always auto-detected from cwd at call time (JR2-4).
 	toolsFilter := ""
+	projectOverride := strings.TrimSpace(os.Getenv("ENGRAM_PROJECT"))
 	for i := 2; i < len(os.Args); i++ {
 		if strings.HasPrefix(os.Args[i], "--tools=") {
 			toolsFilter = strings.TrimPrefix(os.Args[i], "--tools=")
 		} else if os.Args[i] == "--tools" && i+1 < len(os.Args) {
 			toolsFilter = os.Args[i+1]
+			i++
+		} else if strings.HasPrefix(os.Args[i], "--project=") {
+			projectOverride = strings.TrimSpace(strings.TrimPrefix(os.Args[i], "--project="))
+			if projectOverride == "" {
+				fatal(fmt.Errorf("--project requires a value"))
+			}
+		} else if os.Args[i] == "--project" {
+			if i+1 >= len(os.Args) {
+				fatal(fmt.Errorf("--project requires a value"))
+			}
+			projectOverride = strings.TrimSpace(os.Args[i+1])
+			if projectOverride == "" {
+				fatal(fmt.Errorf("--project requires a value"))
+			}
 			i++
 		}
 	}
@@ -865,7 +879,7 @@ func cmdMCP(cfg store.Config) {
 	}
 	defer stopAutosync()
 
-	mcpCfg := mcp.MCPConfig{}
+	mcpCfg := mcp.MCPConfig{DefaultProject: projectOverride}
 	allowlist := resolveMCPTools(toolsFilter)
 	mcpSrv := newMCPServerWithConfig(s, mcpCfg, allowlist)
 

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -974,9 +974,6 @@ func TestCmdProjectsAllNoGroups(t *testing.T) {
 }
 
 func TestCmdMCPDetectsProjectFromFlag(t *testing.T) {
-	// JR2-4: --project flag is no longer used (dead code removed). The --project flag
-	// is now silently ignored; project is auto-detected from cwd at each MCP call.
-	// This test verifies cmdMCP still starts correctly when an unknown flag is passed.
 	cfg := testConfig(t)
 
 	var capturedCfg mcp.MCPConfig
@@ -998,9 +995,9 @@ func TestCmdMCPDetectsProjectFromFlag(t *testing.T) {
 	withArgs(t, "engram", "mcp", "--project=myproject")
 	_, _ = captureOutput(t, func() { cmdMCP(cfg) })
 
-	// JW6: MCPConfig.DefaultProject removed — verify cmdMCP still calls newMCPServerWithConfig.
-	// The project flag is parsed but project is now auto-detected per call, not stored in config.
-	_ = capturedCfg // MCPConfig{} — no fields to assert
+	if capturedCfg.DefaultProject != "myproject" {
+		t.Fatalf("DefaultProject = %q; want myproject", capturedCfg.DefaultProject)
+	}
 }
 
 func TestCmdMCPDetectsProjectFromEnv(t *testing.T) {
@@ -1025,8 +1022,9 @@ func TestCmdMCPDetectsProjectFromEnv(t *testing.T) {
 	withArgs(t, "engram", "mcp")
 	_, _ = captureOutput(t, func() { cmdMCP(cfg) })
 
-	// JW6: MCPConfig.DefaultProject removed — just verify cmdMCP completes without panic.
-	_ = capturedCfg
+	if capturedCfg.DefaultProject != "env-project" {
+		t.Fatalf("DefaultProject = %q; want env-project", capturedCfg.DefaultProject)
+	}
 }
 
 func TestCmdMCPDetectsProjectFromGit(t *testing.T) {
@@ -1054,8 +1052,9 @@ func TestCmdMCPDetectsProjectFromGit(t *testing.T) {
 	withArgs(t, "engram", "mcp")
 	_, _ = captureOutput(t, func() { cmdMCP(cfg) })
 
-	// JW6: MCPConfig.DefaultProject removed — just verify cmdMCP completes without panic.
-	_ = capturedCfg
+	if capturedCfg.DefaultProject != "" {
+		t.Fatalf("DefaultProject = %q; want empty without flag/env", capturedCfg.DefaultProject)
+	}
 }
 
 func TestCmdSyncUsesDetectProject(t *testing.T) {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -30,10 +30,16 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+const sourceProcessOverride = "process_override"
+
 // MCPConfig holds configuration for the MCP server.
-// JW6: DefaultProject removed — it was populated but never read (dead code).
-// Project is always auto-detected from cwd at call time via resolveWriteProject/resolveReadProject.
 type MCPConfig struct {
+	// DefaultProject is a trusted process-level project override supplied by
+	// long-lived MCP hosts (for example, `engram mcp --project NAME` or
+	// ENGRAM_PROJECT). When set, it is used before cwd detection for MCP
+	// auto-resolution; per-call project arguments remain separately validated.
+	DefaultProject string
+
 	// BM25Floor overrides the default BM25 score floor used by FindCandidates
 	// during conflict candidate detection (REQ-001). The floor is the minimum
 	// acceptable BM25 rank (negative; closer to 0 = better match). Candidates
@@ -503,7 +509,7 @@ Examples:
 					mcp.Description("Project to echo in envelope context (omit for auto-detect; stats themselves are global aggregates)"),
 				),
 			),
-			handleStats(s),
+			handleStats(s, cfg),
 		)
 	}
 
@@ -532,7 +538,7 @@ Examples:
 					mcp.Description("Filter by project name (omit for auto-detect)"),
 				),
 			),
-			handleTimeline(s),
+			handleTimeline(s, cfg),
 		)
 	}
 
@@ -551,7 +557,7 @@ Examples:
 					mcp.Description("The observation ID to retrieve"),
 				),
 			),
-			handleGetObservation(s),
+			handleGetObservation(s, cfg),
 		)
 	}
 
@@ -721,7 +727,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 				mcp.WithIdempotentHintAnnotation(true),
 				mcp.WithOpenWorldHintAnnotation(false),
 			),
-			handleCurrentProject(s),
+			handleCurrentProject(s, cfg),
 		)
 	}
 
@@ -739,7 +745,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 				mcp.WithString("project", mcp.Description("Project to diagnose (omit for auto-detect)")),
 				mcp.WithString("check", mcp.Description("Optional diagnostic check code to run")),
 			),
-			handleDoctor(s),
+			handleDoctor(s, cfg),
 		)
 	}
 
@@ -860,10 +866,13 @@ ERROR: Returns IsError=true if IDs are unknown, relation is invalid, or cross-pr
 // handleCurrentProject implements mem_current_project. It NEVER returns an error
 // even on ambiguous cwd — it always returns a success result with whatever
 // detection info is available (REQ-313).
-func handleCurrentProject(s *store.Store) server.ToolHandlerFunc {
+func handleCurrentProject(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		cwd, _ := os.Getwd()
 		res := projectpkg.DetectProjectFull(cwd)
+		if processRes, ok := processProjectResult(cfg.DefaultProject); ok {
+			res = processRes
+		}
 
 		envelope := map[string]any{
 			"project":            res.Project,
@@ -893,7 +902,7 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		limit := intArg(req, "limit", 10)
 
 		// Resolve project: validate override or auto-detect (REQ-310, REQ-311)
-		detRes, err := resolveReadProject(s, projectOverride)
+		detRes, err := resolveReadProjectWithProcessOverride(s, projectOverride, cfg.DefaultProject)
 		if err != nil {
 			var upe *unknownProjectError
 			if errors.As(err, &upe) {
@@ -1052,8 +1061,8 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 		}
 
 		// Resolve write project using the full MCP precedence: explicit request,
-		// existing session association, repo config/directory detection, then cwd fallback.
-		detRes, err := resolveSaveWriteProject(s, projectChoice, explicitProjectProvided, projectChoiceReason, sessionID, validateRecoveryToken)
+		// existing session association, process override, repo config/directory detection, then cwd fallback.
+		detRes, err := resolveSaveWriteProjectWithProcessOverride(s, projectChoice, explicitProjectProvided, projectChoiceReason, sessionID, validateRecoveryToken, cfg.DefaultProject)
 		if err != nil {
 			return writeProjectErrorResult(activity, recoverySessionID, detRes, err), nil
 		}
@@ -1310,7 +1319,7 @@ func handleSavePrompt(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 			return true, activity.ValidateAmbiguousProjectRecoveryToken(recoverySessionID, recoveryToken, strings.TrimSpace(choice), res.AvailableProjects, res.Path)
 		}
 
-		detRes, err := resolveWriteProjectWithChoice(projectChoice, projectChoiceReason, validateRecoveryToken)
+		detRes, err := resolveWriteProjectWithChoiceAndProcessOverride(projectChoice, projectChoiceReason, validateRecoveryToken, cfg.DefaultProject)
 		if err != nil {
 			return writeProjectErrorResult(activity, recoverySessionID, detRes, err), nil
 		}
@@ -1347,7 +1356,7 @@ func handleContext(s *store.Store, cfg MCPConfig, activity *SessionActivity) ser
 		scope, _ := req.GetArguments()["scope"].(string)
 
 		// Resolve project: validate override or auto-detect (REQ-310, REQ-311)
-		detRes, err := resolveReadProject(s, projectOverride)
+		detRes, err := resolveReadProjectWithProcessOverride(s, projectOverride, cfg.DefaultProject)
 		if err != nil {
 			var upe *unknownProjectError
 			if errors.As(err, &upe) {
@@ -1393,12 +1402,12 @@ func handleContext(s *store.Store, cfg MCPConfig, activity *SessionActivity) ser
 	}
 }
 
-func handleStats(s *store.Store) server.ToolHandlerFunc {
+func handleStats(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		projectOverride, _ := req.GetArguments()["project"].(string)
 
 		// Resolve project: validate override or auto-detect (REQ-310, REQ-311, REQ-314)
-		detRes, err := resolveReadProject(s, projectOverride)
+		detRes, err := resolveReadProjectWithProcessOverride(s, projectOverride, cfg.DefaultProject)
 		if err != nil {
 			var upe *unknownProjectError
 			if errors.As(err, &upe) {
@@ -1430,14 +1439,14 @@ func handleStats(s *store.Store) server.ToolHandlerFunc {
 }
 
 func DoctorToolHandler(s *store.Store) server.ToolHandlerFunc {
-	return handleDoctor(s)
+	return handleDoctor(s, MCPConfig{})
 }
 
-func handleDoctor(s *store.Store) server.ToolHandlerFunc {
+func handleDoctor(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		projectOverride, _ := req.GetArguments()["project"].(string)
 		check, _ := req.GetArguments()["check"].(string)
-		detRes, err := resolveReadProject(s, projectOverride)
+		detRes, err := resolveReadProjectWithProcessOverride(s, projectOverride, cfg.DefaultProject)
 		if err != nil {
 			var upe *unknownProjectError
 			if errors.As(err, &upe) {
@@ -1470,7 +1479,7 @@ func handleDoctor(s *store.Store) server.ToolHandlerFunc {
 	}
 }
 
-func handleTimeline(s *store.Store) server.ToolHandlerFunc {
+func handleTimeline(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		observationID := int64(intArg(req, "observation_id", 0))
 		if observationID == 0 {
@@ -1481,7 +1490,7 @@ func handleTimeline(s *store.Store) server.ToolHandlerFunc {
 		projectOverride, _ := req.GetArguments()["project"].(string)
 
 		// Resolve project: validate override or auto-detect (REQ-310, REQ-311, REQ-314)
-		detRes, err := resolveReadProject(s, projectOverride)
+		detRes, err := resolveReadProjectWithProcessOverride(s, projectOverride, cfg.DefaultProject)
 		if err != nil {
 			var upe *unknownProjectError
 			if errors.As(err, &upe) {
@@ -1536,7 +1545,7 @@ func handleTimeline(s *store.Store) server.ToolHandlerFunc {
 	}
 }
 
-func handleGetObservation(s *store.Store) server.ToolHandlerFunc {
+func handleGetObservation(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id := int64(intArg(req, "id", 0))
 		if id == 0 {
@@ -1548,10 +1557,10 @@ func handleGetObservation(s *store.Store) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("Observation #%d not found", id)), nil
 		}
 
-		// Resolve project from cwd (REQ-310, REQ-314). No override possible for
-		// get-by-ID — always auto-detect. JW5: use resolveReadProject (read semantics).
-		// Tolerant: don't fail the fetch on resolution error; degrade to plain text.
-		detRes, detErr := resolveReadProject(s, "")
+		// Resolve project from process override/cwd (REQ-310, REQ-314). No per-call
+		// override possible for get-by-ID. Tolerant: don't fail the fetch on
+		// resolution error; degrade to plain text.
+		detRes, detErr := resolveReadProjectWithProcessOverride(s, "", cfg.DefaultProject)
 
 		obsProject := ""
 		if obs.Project != nil {
@@ -2024,7 +2033,35 @@ func resolveWriteProject() (projectpkg.DetectionResult, error) {
 	return res, nil
 }
 
+func processProjectResult(project string) (projectpkg.DetectionResult, bool) {
+	project = strings.TrimSpace(project)
+	if project == "" {
+		return projectpkg.DetectionResult{}, false
+	}
+	normalized, warning := store.NormalizeProject(project)
+	return projectpkg.DetectionResult{
+		Project: normalized,
+		Source:  sourceProcessOverride,
+		Path:    "",
+		Warning: warning,
+	}, true
+}
+
+func resolveWriteProjectWithProcessOverride(defaultProject string) (projectpkg.DetectionResult, error) {
+	if res, ok := processProjectResult(defaultProject); ok {
+		return res, nil
+	}
+	return resolveWriteProject()
+}
+
 type ambiguousRecoveryTokenValidator func(projectpkg.DetectionResult, string) (provided bool, valid bool)
+
+func resolveWriteProjectWithChoiceAndProcessOverride(projectChoice, reason string, validateToken ambiguousRecoveryTokenValidator, defaultProject string) (projectpkg.DetectionResult, error) {
+	if strings.TrimSpace(projectChoice) == "" {
+		return resolveWriteProjectWithProcessOverride(defaultProject)
+	}
+	return resolveWriteProjectWithChoice(projectChoice, reason, validateToken)
+}
 
 // resolveWriteProjectWithChoice preserves normal write resolution authority and
 // only uses an explicit project choice as a recovery path from ErrAmbiguousProject.
@@ -2079,6 +2116,15 @@ func resolveWriteProjectWithChoice(projectChoice, reason string, validateToken a
 	res.Path = resolveAmbiguousChoicePath(res.Path, choice)
 	res.Warning = "project selected by user after ambiguous_project recovery"
 	return res, nil
+}
+
+func resolveSaveWriteProjectWithProcessOverride(s *store.Store, projectChoice string, explicitProjectProvided bool, reason, sessionID string, validateToken ambiguousRecoveryTokenValidator, defaultProject string) (projectpkg.DetectionResult, error) {
+	if !explicitProjectProvided && strings.TrimSpace(projectChoice) == "" && strings.TrimSpace(sessionID) == "" && strings.TrimSpace(reason) == "" {
+		if processRes, ok := processProjectResult(defaultProject); ok {
+			return processRes, nil
+		}
+	}
+	return resolveSaveWriteProject(s, projectChoice, explicitProjectProvided, reason, sessionID, validateToken)
 }
 
 func resolveSaveWriteProject(s *store.Store, projectChoice string, explicitProjectProvided bool, reason, sessionID string, validateToken ambiguousRecoveryTokenValidator) (projectpkg.DetectionResult, error) {
@@ -2408,6 +2454,15 @@ func resolveAmbiguousChoicePath(ambiguousParent, choice string) string {
 // If override is empty, falls back to auto-detection from cwd.
 // JW2: normalizes the override (lowercase+trim) before ProjectExists lookup so
 // that e.g. "MyApp" and "  myapp  " both resolve to the stored "myapp".
+func resolveReadProjectWithProcessOverride(s *store.Store, override, defaultProject string) (projectpkg.DetectionResult, error) {
+	if strings.TrimSpace(override) == "" {
+		if res, ok := processProjectResult(defaultProject); ok {
+			return res, nil
+		}
+	}
+	return resolveReadProject(s, override)
+}
+
 func resolveReadProject(s *store.Store, override string) (projectpkg.DetectionResult, error) {
 	override = strings.TrimSpace(override)
 	if override == "" {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -699,7 +699,7 @@ func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 		t.Fatalf("unexpected update error: %s", callResultText(t, updateRes))
 	}
 
-	getObs := handleGetObservation(s)
+	getObs := handleGetObservation(s, MCPConfig{})
 	getReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"id": float64(obsID),
 	}}}
@@ -774,7 +774,7 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 		t.Fatalf("expected context output with memory stats")
 	}
 
-	statsHandler := handleStats(s)
+	statsHandler := handleStats(s, MCPConfig{})
 	statsRes, err := statsHandler(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("stats handler error: %v", err)
@@ -788,7 +788,7 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 		t.Fatalf("recent observations for timeline: %v len=%d", err, len(recent))
 	}
 
-	timelineHandler := handleTimeline(s)
+	timelineHandler := handleTimeline(s, MCPConfig{})
 	timelineReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"observation_id": float64(recent[0].ID),
 		"before":         2.0,
@@ -886,7 +886,7 @@ func TestMCPHandlersErrorBranches(t *testing.T) {
 		t.Fatalf("expected delete missing id to return tool error")
 	}
 
-	timeline := handleTimeline(s)
+	timeline := handleTimeline(s, MCPConfig{})
 	timelineMissingIDRes, err := timeline(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{}}})
 	if err != nil {
 		t.Fatalf("timeline missing id error: %v", err)
@@ -895,7 +895,7 @@ func TestMCPHandlersErrorBranches(t *testing.T) {
 		t.Fatalf("expected timeline missing id to return tool error")
 	}
 
-	getObs := handleGetObservation(s)
+	getObs := handleGetObservation(s, MCPConfig{})
 	getMissingIDRes, err := getObs(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{}}})
 	if err != nil {
 		t.Fatalf("get observation missing id error: %v", err)
@@ -975,7 +975,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("expected context to return tool error when store is closed")
 	}
 
-	statsRes, err := handleStats(s)(context.Background(), mcppkg.CallToolRequest{})
+	statsRes, err := handleStats(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("closed store stats call: %v", err)
 	}
@@ -983,7 +983,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("expected stats fallback result even when store is closed")
 	}
 
-	timelineRes, err := handleTimeline(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"observation_id": 1.0}}})
+	timelineRes, err := handleTimeline(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"observation_id": 1.0}}})
 	if err != nil {
 		t.Fatalf("closed store timeline call: %v", err)
 	}
@@ -991,7 +991,7 @@ func TestMCPHandlersReturnErrorsWhenStoreClosed(t *testing.T) {
 		t.Fatalf("expected timeline to return tool error when store is closed")
 	}
 
-	getObsRes, err := handleGetObservation(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": 1.0}}})
+	getObsRes, err := handleGetObservation(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": 1.0}}})
 	if err != nil {
 		t.Fatalf("closed store get observation call: %v", err)
 	}
@@ -1038,7 +1038,7 @@ func TestMCPAdditionalCoverageBranches(t *testing.T) {
 		t.Fatalf("expected empty context message")
 	}
 
-	statsRes, err := handleStats(s)(context.Background(), mcppkg.CallToolRequest{})
+	statsRes, err := handleStats(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("stats empty store: %v", err)
 	}
@@ -1062,7 +1062,7 @@ func TestMCPAdditionalCoverageBranches(t *testing.T) {
 	}
 
 	timelineReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"observation_id": float64(firstID), "before": 1.0, "after": 2.0}}}
-	timelineRes, err := handleTimeline(s)(context.Background(), timelineReq)
+	timelineRes, err := handleTimeline(s, MCPConfig{})(context.Background(), timelineReq)
 	if err != nil {
 		t.Fatalf("timeline with header branches: %v", err)
 	}
@@ -1187,7 +1187,7 @@ func TestHandleStatsReturnsErrorWhenLoaderFails(t *testing.T) {
 	})
 
 	s := newMCPTestStore(t)
-	res, err := handleStats(s)(context.Background(), mcppkg.CallToolRequest{})
+	res, err := handleStats(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("stats handler error: %v", err)
 	}
@@ -1217,7 +1217,7 @@ func TestHandleTimelineBeforeSectionAndSummaryBranches(t *testing.T) {
 		t.Fatalf("end session: %v", err)
 	}
 
-	res, err := handleTimeline(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+	res, err := handleTimeline(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"observation_id": float64(focusID),
 		"before":         2.0,
 		"after":          1.0,
@@ -1252,7 +1252,7 @@ func TestHandleGetObservationIncludesTopicAndToolMetadata(t *testing.T) {
 		t.Fatalf("add observation: %v", err)
 	}
 
-	res, err := handleGetObservation(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+	res, err := handleGetObservation(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"id": float64(id),
 	}}})
 	if err != nil {
@@ -1975,7 +1975,7 @@ func TestMemDoctorRegisteredAndReturnsEnvelope(t *testing.T) {
 	if srv.ListTools()["mem_doctor"] == nil {
 		t.Fatal("expected mem_doctor in agent profile")
 	}
-	res, err := handleDoctor(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "engram", "check": "manual_session_name_project_mismatch"}}})
+	res, err := handleDoctor(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "engram", "check": "manual_session_name_project_mismatch"}}})
 	if err != nil {
 		t.Fatalf("handleDoctor: %v", err)
 	}
@@ -2001,7 +2001,7 @@ func TestMemDoctorOmittedProjectUsesAutoDetectedScope(t *testing.T) {
 	if err := s.CreateSession("manual-save-"+detected.Project, detected.Project, dir); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	res, err := handleDoctor(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"check": "manual_session_name_project_mismatch"}}})
+	res, err := handleDoctor(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"check": "manual_session_name_project_mismatch"}}})
 	if err != nil {
 		t.Fatalf("handleDoctor: %v", err)
 	}
@@ -2019,7 +2019,7 @@ func TestMemDoctorUnknownProjectReturnsStructuredError(t *testing.T) {
 	if err := s.CreateSession("manual-save-engram", "engram", "/work/engram"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	res, err := handleDoctor(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "missing"}}})
+	res, err := handleDoctor(s, MCPConfig{})(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "missing"}}})
 	if err != nil {
 		t.Fatalf("handleDoctor: %v", err)
 	}
@@ -4735,7 +4735,7 @@ func TestAllTools_ReadResponseEnvelope(t *testing.T) {
 	}
 
 	// mem_get_observation envelope
-	hGet := handleGetObservation(s)
+	hGet := handleGetObservation(s, MCPConfig{})
 	resGet, err := hGet(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"id": float64(obsID),
@@ -4761,7 +4761,7 @@ func TestMemCurrentProject_NormalResult(t *testing.T) {
 	t.Chdir(dir)
 
 	s := newMCPTestStore(t)
-	h := handleCurrentProject(s)
+	h := handleCurrentProject(s, MCPConfig{})
 
 	res, err := h(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
@@ -4796,7 +4796,7 @@ func TestMemCurrentProject_AmbiguousNoError(t *testing.T) {
 	t.Chdir(parent)
 
 	s := newMCPTestStore(t)
-	h := handleCurrentProject(s)
+	h := handleCurrentProject(s, MCPConfig{})
 
 	res, err := h(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil {
@@ -4828,7 +4828,7 @@ func TestMemCurrentProject_WarningCase3(t *testing.T) {
 	t.Chdir(parent)
 
 	s := newMCPTestStore(t)
-	h := handleCurrentProject(s)
+	h := handleCurrentProject(s, MCPConfig{})
 
 	res, err := h(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil || res.IsError {
@@ -5137,7 +5137,7 @@ func TestHandleGetObservation_ResponseEnvelopeIncludesProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := handleGetObservation(s)
+	h := handleGetObservation(s, MCPConfig{})
 	res, err := h(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"id": float64(id),
@@ -5171,7 +5171,7 @@ func TestHandleStats_AutoDetectsProject(t *testing.T) {
 	t.Chdir(dir)
 
 	s := newMCPTestStore(t)
-	h := handleStats(s)
+	h := handleStats(s, MCPConfig{})
 	res, err := h(context.Background(), mcppkg.CallToolRequest{})
 	if err != nil || res.IsError {
 		t.Fatalf("stats: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
@@ -5193,7 +5193,7 @@ func TestHandleStats_ExplicitUnknownProjectError(t *testing.T) {
 	t.Chdir(dir)
 
 	s := newMCPTestStore(t)
-	h := handleStats(s)
+	h := handleStats(s, MCPConfig{})
 	res, err := h(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"project": "nonexistent-stats-project",
@@ -5237,7 +5237,7 @@ func TestHandleTimeline_AutoDetectsProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := handleTimeline(s)
+	h := handleTimeline(s, MCPConfig{})
 	res, err := h(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"observation_id": float64(obsID),
@@ -5277,7 +5277,7 @@ func TestHandleTimeline_ExplicitUnknownProjectError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := handleTimeline(s)
+	h := handleTimeline(s, MCPConfig{})
 	res, err := h(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"observation_id": float64(obsID),
@@ -5652,7 +5652,7 @@ func TestHandleGetObservation_DegradedPathNoEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := handleGetObservation(s)
+	h := handleGetObservation(s, MCPConfig{})
 	res, err := h(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"id": float64(obsID),
@@ -5700,7 +5700,7 @@ func TestHandleGetObservation_EnvelopePresent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := handleGetObservation(s)
+	h := handleGetObservation(s, MCPConfig{})
 	res, err := h(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"id": float64(obsID),
@@ -5718,18 +5718,11 @@ func TestHandleGetObservation_EnvelopePresent(t *testing.T) {
 	}
 }
 
-// JW6: TestMCPConfig_DefaultProjectFieldRemoved — DefaultProject must not appear in MCPConfig.
-// This test is a compile-time guard; accessing a removed field causes a compile error.
-// We assert it by confirming MCPConfig can be constructed without DefaultProject.
-// (No runtime check possible for a removed field — this test passes post-removal.)
-func TestMCPConfig_CanConstructWithoutDefaultProject(t *testing.T) {
-	// If MCPConfig.DefaultProject exists, this test compiles fine but is a no-op.
-	// The real guard is removing the field and verifying the only populate site in main.go
-	// is also removed. The test below verifies the struct has the expected shape post-fix.
-	cfg := MCPConfig{}
-	_ = cfg
-	// After fix: MCPConfig has no DefaultProject field; this function body is unchanged.
-	// The REAL enforcement is that main.go no longer sets cfg.DefaultProject.
+func TestMCPConfig_CanConstructWithDefaultProject(t *testing.T) {
+	cfg := MCPConfig{DefaultProject: "trusted-project"}
+	if cfg.DefaultProject != "trusted-project" {
+		t.Fatalf("DefaultProject = %q", cfg.DefaultProject)
+	}
 }
 
 // JW7: TestMemContext_SchemaNoLimitParam — mem_context schema must NOT advertise limit.
@@ -5801,7 +5794,7 @@ func TestAllTools_ReadResponseEnvelope_WithAssertions(t *testing.T) {
 	assertEnvelope(t, "mem_search", resSearch)
 
 	// mem_get_observation envelope
-	hGet := handleGetObservation(s)
+	hGet := handleGetObservation(s, MCPConfig{})
 	resGet, err := hGet(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
 			"id": float64(obsID),
@@ -6405,5 +6398,124 @@ func TestMemSearch_AllThreeTypes_FormatExact(t *testing.T) {
 	}
 	if !strings.Contains(text, wantSupersededBy) {
 		t.Fatalf("expected %q, got:\n%s", wantSupersededBy, text)
+	}
+}
+
+func TestProcessOverrideCurrentProjectBeatsAmbiguousCWD(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"repo-a", "repo-b"} {
+		child := filepath.Join(parent, name)
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initTestGitRepo(t, child)
+	}
+	t.Chdir(parent)
+
+	s := newMCPTestStore(t)
+	h := handleCurrentProject(s, MCPConfig{DefaultProject: "Trusted Project"})
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil || res.IsError {
+		t.Fatalf("handler error: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(callResultText(t, res)), &envelope); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if envelope["project"] != "trusted project" {
+		t.Fatalf("project = %v; want trusted project", envelope["project"])
+	}
+	if envelope["project_source"] != sourceProcessOverride {
+		t.Fatalf("project_source = %v; want %s", envelope["project_source"], sourceProcessOverride)
+	}
+}
+
+func TestProcessOverrideReadResolutionBeforeCWD(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"repo-a", "repo-b"} {
+		child := filepath.Join(parent, name)
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initTestGitRepo(t, child)
+	}
+	t.Chdir(parent)
+
+	s := newMCPTestStore(t)
+	res, err := resolveReadProjectWithProcessOverride(s, "", "Trusted Project")
+	if err != nil {
+		t.Fatalf("resolve read with process override: %v", err)
+	}
+	if res.Project != "trusted project" || res.Source != sourceProcessOverride {
+		t.Fatalf("resolution = %+v; want trusted project from process override", res)
+	}
+}
+
+func TestProcessOverrideReadKeepsPerCallValidation(t *testing.T) {
+	s := newMCPTestStore(t)
+	_, err := resolveReadProjectWithProcessOverride(s, "missing-project", "trusted-project")
+	if err == nil {
+		t.Fatal("expected unknown project error for per-call override")
+	}
+	var upe *unknownProjectError
+	if !errors.As(err, &upe) {
+		t.Fatalf("error = %T %v; want unknownProjectError", err, err)
+	}
+}
+
+func TestProcessOverrideSaveWriteKeepsExplicitEmptyProjectInvalid(t *testing.T) {
+	s := newMCPTestStore(t)
+	_, err := resolveSaveWriteProjectWithProcessOverride(s, "", true, "", "", nil, "Trusted Project")
+	if err == nil {
+		t.Fatal("expected invalid explicit project error")
+	}
+	var ipe *invalidExplicitProjectError
+	if !errors.As(err, &ipe) {
+		t.Fatalf("error = %T %v; want invalidExplicitProjectError", err, err)
+	}
+}
+
+func TestProcessOverrideSaveWriteResolutionBeforeCWD(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"repo-a", "repo-b"} {
+		child := filepath.Join(parent, name)
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initTestGitRepo(t, child)
+	}
+	t.Chdir(parent)
+
+	s := newMCPTestStore(t)
+	detRes, err := resolveSaveWriteProjectWithProcessOverride(s, "", false, "", "", nil, "Trusted Project")
+	if err != nil {
+		t.Fatalf("resolve save write with process override: %v", err)
+	}
+	if detRes.Project != "trusted project" || detRes.Source != sourceProcessOverride {
+		t.Fatalf("resolution = %+v; want trusted project from process override", detRes)
+	}
+}
+
+func TestProcessOverrideSaveHandlerWritesToDefaultProject(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	s := newMCPTestStore(t)
+	h := handleSave(s, MCPConfig{DefaultProject: "Trusted Project"}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "process override write",
+		"content": "saved through process override",
+		"type":    "decision",
+	}}})
+	if err != nil || res.IsError {
+		t.Fatalf("save error: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+	results, err := s.Search("process override write", store.SearchOptions{Project: "trusted project", Limit: 10})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results in trusted project = %d; want 1", len(results))
 	}
 }


### PR DESCRIPTION
## Summary
- wire `engram mcp --project` and `ENGRAM_PROJECT` into MCP process config
- use the trusted process project before cwd detection for current project, read resolution, and write resolution
- keep explicit per-call project validation strict, including explicit empty project errors

Fixes #312
Fixes #248
Fixes #347

## Non-goals
- no legacy case-folding or project consolidation work for #146/#229/#283

## Tests
- `go test ./internal/mcp ./cmd/engram`
- `go test ./...`

## Review
- Fresh reviewer found one strict-validation blocker; fixed and re-reviewed approved.
