### PR TITLE
fix(store): apply repairable cloud-upgrade mutations even when a blocker is queued

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1224,37 +1224,71 @@ func (s *Store) RepairCloudUpgrade(project string, apply bool) (CloudUpgradeRepa
 	if err != nil {
 		return CloudUpgradeRepairReport{}, fmt.Errorf("diagnose legacy cloud upgrade mutations: %w", err)
 	}
-	if legacyReport.BlockedCount > 0 {
-		first := legacyReport.Findings[0]
-		return CloudUpgradeRepairReport{
-			Class:      UpgradeRepairClassBlocked,
-			ReasonCode: UpgradeReasonBlockedLegacyMutationManual,
-			Message:    fmt.Sprintf("manual-action-required: %s (seq=%d entity=%s op=%s)", first.Message, first.Seq, first.Entity, first.Op),
-			Applied:    false,
-		}, nil
-	}
-	if legacyReport.RepairableCount > 0 {
-		report := CloudUpgradeRepairReport{
-			Class:         UpgradeRepairClassRepairable,
-			ReasonCode:    UpgradeReasonRepairableLegacyMutationPayload,
-			Message:       fmt.Sprintf("project %q has %d repairable legacy mutation payload issue(s)", project, legacyReport.RepairableCount),
-			PlannedAction: "repair_legacy_mutation_payloads",
-			Applied:       false,
-		}
-		if !apply {
-			return report, nil
-		}
+
+	// Apply the repairable subset first. Holding the entire repair pass hostage
+	// to a single unrecoverable mutation forces operators into manual SQLite
+	// surgery for the rest of the queue; instead we let recoverable findings
+	// make forward progress and surface the residual blockers afterwards.
+	appliedRepairs := false
+	if apply && legacyReport.RepairableCount > 0 {
 		if err := s.applyCloudUpgradeLegacyMutationRepairs(project); err != nil {
 			return CloudUpgradeRepairReport{}, fmt.Errorf("apply cloud upgrade legacy mutation repairs: %w", err)
 		}
-		report.Applied = true
-		report.Message = fmt.Sprintf("applied deterministic legacy mutation payload repairs for project %q", project)
+		appliedRepairs = true
+	}
+
+	if legacyReport.BlockedCount > 0 {
+		// Pick the first non-repairable finding so the user sees the actual
+		// blocker. Findings[0] is ordered by sync_mutations.seq and may be a
+		// repairable one, which previously produced misleading error messages.
+		var blocked CloudUpgradeLegacyMutationFinding
+		for _, f := range legacyReport.Findings {
+			if !f.Repairable {
+				blocked = f
+				break
+			}
+		}
+		var msg string
+		switch {
+		case appliedRepairs:
+			msg = fmt.Sprintf("applied %d repairable payload(s); %d remain blocked: manual-action-required: %s (seq=%d entity=%s entity_key=%q op=%s)",
+				legacyReport.RepairableCount, legacyReport.BlockedCount, blocked.Message, blocked.Seq, blocked.Entity, blocked.EntityKey, blocked.Op)
+		case legacyReport.RepairableCount > 0:
+			msg = fmt.Sprintf("%d repairable payload(s) would apply; %d would remain blocked: manual-action-required: %s (seq=%d entity=%s entity_key=%q op=%s)",
+				legacyReport.RepairableCount, legacyReport.BlockedCount, blocked.Message, blocked.Seq, blocked.Entity, blocked.EntityKey, blocked.Op)
+		default:
+			msg = fmt.Sprintf("manual-action-required: %s (seq=%d entity=%s entity_key=%q op=%s)",
+				blocked.Message, blocked.Seq, blocked.Entity, blocked.EntityKey, blocked.Op)
+		}
+		return CloudUpgradeRepairReport{
+			Class:      UpgradeRepairClassBlocked,
+			ReasonCode: UpgradeReasonBlockedLegacyMutationManual,
+			Message:    msg,
+			Applied:    appliedRepairs,
+		}, nil
+	}
+	if legacyReport.RepairableCount > 0 {
+		if !appliedRepairs {
+			return CloudUpgradeRepairReport{
+				Class:         UpgradeRepairClassRepairable,
+				ReasonCode:    UpgradeReasonRepairableLegacyMutationPayload,
+				Message:       fmt.Sprintf("project %q has %d repairable legacy mutation payload issue(s)", project, legacyReport.RepairableCount),
+				PlannedAction: "repair_legacy_mutation_payloads",
+				Applied:       false,
+			}, nil
+		}
 		_ = s.SaveCloudUpgradeState(CloudUpgradeState{
 			Project:     project,
 			Stage:       UpgradeStageRepairApplied,
 			RepairClass: UpgradeRepairClassRepairable,
 		})
-		return report, nil
+		return CloudUpgradeRepairReport{
+			Class:         UpgradeRepairClassRepairable,
+			ReasonCode:    UpgradeReasonRepairableLegacyMutationPayload,
+			Message:       fmt.Sprintf("applied deterministic legacy mutation payload repairs for project %q", project),
+			PlannedAction: "repair_legacy_mutation_payloads",
+			Applied:       true,
+		}, nil
 	}
 
 	requiresBackfill, err := s.projectSyncBackfillRequired(project)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1986,6 +1986,158 @@ func TestUpgradeRepairDryRunAndApply(t *testing.T) {
 			t.Fatalf("expected no remaining legacy findings after repair, got %+v", after)
 		}
 	})
+
+	t.Run("repair applies repairable mutations even when a blocker is queued ahead of them", func(t *testing.T) {
+		s := newTestStore(t)
+		// Repairable session: local row has a directory we can backfill from.
+		if err := s.CreateSession("mix-recoverable", "mix-proj", "/tmp/mix"); err != nil {
+			t.Fatalf("create recoverable session: %v", err)
+		}
+		// Enroll BEFORE the orphan row exists so EnrollProject's backfill pass
+		// does not enqueue an extra (also-blocked) session mutation for it.
+		if err := s.EnrollProject("mix-proj"); err != nil {
+			t.Fatalf("enroll project: %v", err)
+		}
+		// Unrecoverable session: local row exists but the directory is empty,
+		// so the repair pass cannot infer a value (mirrors the legacy
+		// orphan-session shape reported by users on engram <= v1.15.13).
+		if _, err := s.execHook(s.db,
+			`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, '', datetime('now'))`,
+			"mix-orphan", "mix-proj",
+		); err != nil {
+			t.Fatalf("seed orphan session row: %v", err)
+		}
+
+		// Insert the BLOCKED mutation first so it gets a lower seq than the
+		// repairable one. The pre-fix code reported Findings[0]'s details,
+		// which exposed the wrong seq when Findings[0] happened to be the
+		// repairable mutation. Here we want the orphan to legitimately be the
+		// blocker no matter the ordering.
+		if _, err := s.execHook(s.db,
+			`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			DefaultSyncTargetKey, SyncEntitySession, "mix-orphan", SyncOpUpsert,
+			`{"id":"mix-orphan","project":"mix-proj","directory":""}`,
+			SyncSourceLocal, "mix-proj",
+		); err != nil {
+			t.Fatalf("insert blocked mutation: %v", err)
+		}
+		if _, err := s.execHook(s.db,
+			`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			DefaultSyncTargetKey, SyncEntitySession, "mix-recoverable", SyncOpUpsert,
+			`{"id":"mix-recoverable","project":"mix-proj","directory":""}`,
+			SyncSourceLocal, "mix-proj",
+		); err != nil {
+			t.Fatalf("insert repairable mutation: %v", err)
+		}
+
+		// Dry-run: must surface both buckets and identify the orphan as the blocker.
+		dryRun, err := s.RepairCloudUpgrade("mix-proj", false)
+		if err != nil {
+			t.Fatalf("dry-run repair: %v", err)
+		}
+		if dryRun.Class != UpgradeRepairClassBlocked || dryRun.Applied {
+			t.Fatalf("dry-run should report blocked + applied=false, got %+v", dryRun)
+		}
+		if !strings.Contains(dryRun.Message, "1 repairable payload(s) would apply") ||
+			!strings.Contains(dryRun.Message, "1 would remain blocked") ||
+			!strings.Contains(dryRun.Message, `entity_key="mix-orphan"`) {
+			t.Fatalf("dry-run message should describe both buckets and name the orphan entity_key, got %q", dryRun.Message)
+		}
+
+		// Apply: the repairable mutation must be patched in place, the blocker
+		// must remain queued, and Applied must be true (we did do work).
+		applied, err := s.RepairCloudUpgrade("mix-proj", true)
+		if err != nil {
+			t.Fatalf("apply repair: %v", err)
+		}
+		if applied.Class != UpgradeRepairClassBlocked || !applied.Applied {
+			t.Fatalf("apply should report blocked + applied=true (partial success), got %+v", applied)
+		}
+		if !strings.Contains(applied.Message, "applied 1 repairable payload(s)") ||
+			!strings.Contains(applied.Message, "1 remain blocked") {
+			t.Fatalf("apply message should note partial success and remaining blocker, got %q", applied.Message)
+		}
+
+		var repaired, stillBroken string
+		if err := s.db.QueryRow(`SELECT payload FROM sync_mutations WHERE entity_key = ? AND acked_at IS NULL`, "mix-recoverable").Scan(&repaired); err != nil {
+			t.Fatalf("load repaired mutation payload: %v", err)
+		}
+		if strings.Contains(repaired, `"directory":""`) {
+			t.Fatalf("expected mix-recoverable payload to have directory backfilled, got %s", repaired)
+		}
+		if err := s.db.QueryRow(`SELECT payload FROM sync_mutations WHERE entity_key = ? AND acked_at IS NULL`, "mix-orphan").Scan(&stillBroken); err != nil {
+			t.Fatalf("load orphan mutation payload: %v", err)
+		}
+		if !strings.Contains(stillBroken, `"directory":""`) {
+			t.Fatalf("orphan payload should remain unchanged, got %s", stillBroken)
+		}
+
+		after, err := s.DiagnoseCloudUpgradeLegacyMutations("mix-proj")
+		if err != nil {
+			t.Fatalf("diagnose after partial repair: %v", err)
+		}
+		if after.RepairableCount != 0 || after.BlockedCount != 1 {
+			t.Fatalf("expected only the orphan to remain after partial repair, got %+v", after)
+		}
+	})
+
+	t.Run("blocker error message names the unrecoverable seq even when a lower-seq repairable exists", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.CreateSession("ord-recoverable", "ord-proj", "/tmp/ord"); err != nil {
+			t.Fatalf("create recoverable session: %v", err)
+		}
+		if err := s.EnrollProject("ord-proj"); err != nil {
+			t.Fatalf("enroll project: %v", err)
+		}
+		if _, err := s.execHook(s.db,
+			`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, '', datetime('now'))`,
+			"ord-orphan", "ord-proj",
+		); err != nil {
+			t.Fatalf("seed orphan session row: %v", err)
+		}
+
+		// Repairable goes in FIRST (lowest seq). Previously Findings[0] would
+		// be this repairable row, and the error message would report its seq
+		// even though it is not the actual blocker.
+		if _, err := s.execHook(s.db,
+			`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			DefaultSyncTargetKey, SyncEntitySession, "ord-recoverable", SyncOpUpsert,
+			`{"id":"ord-recoverable","project":"ord-proj","directory":""}`,
+			SyncSourceLocal, "ord-proj",
+		); err != nil {
+			t.Fatalf("insert repairable mutation: %v", err)
+		}
+		var repairableSeq int64
+		if err := s.db.QueryRow(`SELECT seq FROM sync_mutations WHERE entity_key = ? AND project = ?`, "ord-recoverable", "ord-proj").Scan(&repairableSeq); err != nil {
+			t.Fatalf("lookup repairable seq: %v", err)
+		}
+
+		if _, err := s.execHook(s.db,
+			`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			DefaultSyncTargetKey, SyncEntitySession, "ord-orphan", SyncOpUpsert,
+			`{"id":"ord-orphan","project":"ord-proj","directory":""}`,
+			SyncSourceLocal, "ord-proj",
+		); err != nil {
+			t.Fatalf("insert blocked mutation: %v", err)
+		}
+		var orphanSeq int64
+		if err := s.db.QueryRow(`SELECT seq FROM sync_mutations WHERE entity_key = ? AND project = ?`, "ord-orphan", "ord-proj").Scan(&orphanSeq); err != nil {
+			t.Fatalf("lookup orphan seq: %v", err)
+		}
+
+		report, err := s.RepairCloudUpgrade("ord-proj", false)
+		if err != nil {
+			t.Fatalf("dry-run repair: %v", err)
+		}
+		wantSeq := fmt.Sprintf("seq=%d", orphanSeq)
+		wrongSeq := fmt.Sprintf("seq=%d", repairableSeq)
+		if !strings.Contains(report.Message, wantSeq) {
+			t.Fatalf("error message should reference the blocked seq %d, got %q", orphanSeq, report.Message)
+		}
+		if strings.Contains(report.Message, wrongSeq) {
+			t.Fatalf("error message must NOT reference the repairable seq %d, got %q", repairableSeq, report.Message)
+		}
+	})
 }
 
 func TestRollbackCloudUpgradeSafetyBoundary(t *testing.T) {


### PR DESCRIPTION
## Context

While investigating slow Engram responses against a long-lived project, the doctor reported:

```
sync_mutation_required_fields: blocked (180 finding(s))
```

and `engram cloud upgrade repair --project X --dry-run` returned:

```
class: blocked
reason_code: upgrade_blocked_legacy_mutation_manual
message: manual-action-required: session payload is missing required fields (seq=9 entity=session op=upsert)
applied: false
```

The reported `seq=9` was misleading — that row was actually **repairable** (its local `sessions` row had a valid `directory`). The real blocker was a much later seq whose local `sessions` row had an empty `directory`, which the per-mutation evaluator at \`evaluateCloudUpgradeLegacyMutationTx\` correctly refused to infer.

The reproduction tree was:

| seq order | entity_key | local \`sessions.directory\` | evaluator verdict |
|---|---|---|---|
| 9 (lowest)  | manual-save-... | \`/Users/.../worktrees/...\`   | repairable |
| 524         | distracted-... | \`""\`                         | blocked |
| 729..1305   | many sessions   | \`/Users/.../proveido\`        | repairable |

\`DiagnoseCloudUpgradeLegacyMutations\` correctly surfaced this as \`RepairableCount=179, BlockedCount=1\`. But the gating in \`RepairCloudUpgrade\` aborted the whole pass on \`BlockedCount > 0\`, never giving the repairable 179 a chance to apply.

## Bugs fixed

1. **Repair gating** (\`store.go\` ~line 1227 before this patch): even with \`apply=true\`, the function returned \`Class=Blocked, Applied=false\` whenever a single blocked finding existed, leaving all repairable mutations queued. Operators had to perform manual SQLite surgery on the blocker before any of the recoverable mutations could be unblocked.
2. **Misleading error message**: \`first := legacyReport.Findings[0]\` picks the lowest-seq finding regardless of repairability, so users saw guidance like \"seq=9 entity=session\" pointing at a row that was actually fine. The genuine blocker (seq=524, entity_key=\"distracted-...\") was never named.
3. **No entity_key in the manual-action message**: even when the seq was right, mapping seq → entity_key required SQLite access, which is a friction step for anyone trying to do the manual repair the message asks for.

## Changes

- \`RepairCloudUpgrade\` now applies the repairable subset first when \`apply=true\` and reports residual blockers afterwards. \`Applied=true\` on partial successes. The message describes both buckets:
  - \`apply=false\` mixed: \`\"N repairable payload(s) would apply; M would remain blocked: manual-action-required: ...\"\`
  - \`apply=true\` mixed: \`\"applied N repairable payload(s); M remain blocked: manual-action-required: ...\"\`
- The manual-action finding is now selected by repairability, not by seq order — \`for _, f := range Findings { if !f.Repairable { ... } }\` — so the reported \`seq/entity/op\` always identifies an actual blocker.
- The blocker description gains \`entity_key=%q\` so users can locate the offending row directly:
  \`(seq=524 entity=session entity_key=\"distracted-antonelli-7bad05\" op=upsert)\`

## Tests

Added two subtests to \`TestUpgradeRepairDryRunAndApply\` in \`internal/store/store_test.go\`:

- \`repair applies repairable mutations even when a blocker is queued ahead of them\`: verifies dry-run reports both buckets, \`apply=true\` writes the repaired payload to disk, the orphan stays untouched, and the diagnosis after partial repair has \`RepairableCount=0, BlockedCount=1\`.
- \`blocker error message names the unrecoverable seq even when a lower-seq repairable exists\`: inserts the repairable mutation first (so it gets a lower seq), then the orphan; asserts the error message references the orphan's seq, not the repairable's.

Existing tests in the same function (including \`legacy mutation required fields are detected and repaired from authoritative local state\`) continue to pass unchanged. Full \`./internal/store/\`, \`./internal/diagnostic/\` and \`./cmd/engram/\` suites pass locally on Go 1.26.3.

## Risk

- Behavior change: a project with both repairable and blocked mutations will now have its repairable subset mutated on \`--apply\` instead of bailing. This matches what the existing \`applyCloudUpgradeLegacyMutationRepairs\` already does internally — it iterates and skips non-repairables — and prevents the previous \"all or nothing\" deadlock. The blocked finding is still surfaced (the report class remains \`Blocked\`), so downstream tooling that gates on \`Class == Blocked\` keeps working.
- Message format: the manual-action guidance now includes \`entity_key=%q\`. Any tooling that regex-matches the previous format \`(seq=X entity=Y op=Z)\` will need to accept the extended form.

## Repro / verification

To reproduce the original deadlock on \`main\`:

\`\`\`bash
# In a fresh sqlite db backing engram:
INSERT INTO sessions (id, project, directory, started_at) VALUES ('orphan', 'p', '', datetime('now'));
# Plus the matching malformed sync_mutations + one repairable row.

engram cloud upgrade repair --project p --apply
# main: applied=false, blocked. queue stuck.
# this PR: applied=true, blocked (with N remaining), repairables patched.
\`\`\`

A local DB patch (\`UPDATE sessions SET directory='...' WHERE id='orphan'\`) is still required for the orphan itself — this PR does not invent directory values out of thin air, it only stops penalizing the recoverable rows.

---

Draft because I'd like a maintainer pass on the message format change before flipping to ready.