### PR TITLE
docs(mcp): align server instructions with Claude Code plugin behavior

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -167,11 +167,15 @@ func NewServer(s *store.Store) *server.MCPServer {
 }
 
 // serverInstructions tells MCP clients when to use Engram's tools.
-// 7 core tools are eager (always in context). The rest are deferred
-// and require ToolSearch to load.
+// Tools are split into two pools via the defer_loading annotation:
+//   - eager  (defer_loading=false): clients should keep them in context
+//   - deferred (defer_loading=true): clients load them via Tool Search on demand
+// NOTE: Claude Code currently ignores defer_loading for tools that arrive
+// through a plugin (prefix mcp__plugin_*) and treats all of them as deferred.
+// The CLAUDE CODE PLUGIN USERS block below documents the workaround.
 const serverInstructions = `Engram provides persistent memory that survives across sessions and compactions.
 
-CORE TOOLS (always available — use without ToolSearch):
+EAGER TOOLS (defer_loading=false — keep in context by default):
   mem_save — save decisions, bugs, discoveries, conventions PROACTIVELY (do not wait to be asked)
   mem_search — find past work, decisions, or context from previous sessions
   mem_context — get recent session history (call at session start or after compaction)
@@ -180,9 +184,16 @@ CORE TOOLS (always available — use without ToolSearch):
   mem_save_prompt — save user prompt for context
   mem_current_project — detect current project from cwd (recommended first call)
 
-DEFERRED TOOLS (use ToolSearch when needed):
+DEFERRED TOOLS (defer_loading=true — load via Tool Search when needed):
   mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end,
   mem_stats, mem_delete, mem_timeline, mem_capture_passive, mem_merge_projects
+
+CLAUDE CODE PLUGIN USERS — IMPORTANT: When Engram runs as a Claude Code plugin
+(tools arrive with the prefix mcp__plugin_engram_engram__*), Claude Code
+currently treats ALL tools as deferred regardless of the defer_loading flag.
+Before calling any engram tool, load its schema first:
+  ToolSearch(query: "select:mcp__plugin_engram_engram__<tool_name>")
+Once a tool's schema is loaded it stays callable for the rest of the session.
 
 PROACTIVE SAVE RULE: Call mem_save immediately after ANY decision, bug fix, discovery, or convention — not just when asked.
 

--- a/plugin/claude-code/scripts/post-compaction.sh
+++ b/plugin/claude-code/scripts/post-compaction.sh
@@ -37,10 +37,13 @@ cat <<'PROTOCOL'
 
 You have engram memory tools. This protocol is MANDATORY and ALWAYS ACTIVE.
 
-### CORE TOOLS — always available, no ToolSearch needed
-mem_save, mem_search, mem_context, mem_session_summary, mem_get_observation, mem_save_prompt
+### MEMORY TOOLS — load via ToolSearch before first call
+Claude Code currently treats ALL Engram plugin tools as deferred (prefix `mcp__plugin_engram_engram__*`) regardless of the server's `defer_loading` flag. Before calling any engram tool, load its schema with:
+  ToolSearch(query: "select:mcp__plugin_engram_engram__<tool_name>")
+Once loaded, the tool stays callable for the rest of the session.
 
-Use ToolSearch for other tools: mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end, mem_stats, mem_delete, mem_timeline, mem_capture_passive
+Load early (used the most): mem_save, mem_search, mem_context, mem_session_summary, mem_get_observation, mem_save_prompt, mem_current_project
+Load on demand: mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end, mem_stats, mem_delete, mem_timeline, mem_capture_passive
 
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -143,10 +143,13 @@ cat <<'PROTOCOL'
 
 You have engram memory tools. This protocol is MANDATORY and ALWAYS ACTIVE.
 
-### CORE TOOLS — always available, no ToolSearch needed
-mem_save, mem_search, mem_context, mem_session_summary, mem_get_observation, mem_save_prompt
+### MEMORY TOOLS — load via ToolSearch before first call
+Claude Code currently treats ALL Engram plugin tools as deferred (prefix `mcp__plugin_engram_engram__*`) regardless of the server's `defer_loading` flag. Before calling any engram tool, load its schema with:
+  ToolSearch(query: "select:mcp__plugin_engram_engram__<tool_name>")
+Once loaded, the tool stays callable for the rest of the session.
 
-Use ToolSearch for other tools: mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end, mem_stats, mem_delete, mem_timeline, mem_capture_passive
+Load early (used the most): mem_save, mem_search, mem_context, mem_session_summary, mem_get_observation, mem_save_prompt, mem_current_project
+Load on demand: mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end, mem_stats, mem_delete, mem_timeline, mem_capture_passive
 
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:


### PR DESCRIPTION
## Summary
- Realigns `serverInstructions` and the two Claude Code hooks (`session-start.sh`, `post-compaction.sh`) so they no longer promise "always available — use without ToolSearch" for core memory tools.
- Documents the underlying Claude Code behavior: tools from plugin-loaded MCP servers (prefix `mcp__plugin_*`) are currently treated as deferred regardless of the server-emitted `defer_loading` flag.
- The plugin already declares core tools with `defer_loading: false`; this PR only changes user-facing copy so the contract matches what Claude Code actually does today.

## Repro of the underlying behavior
1. Probe the MCP server's `tools/list` directly — `mem_get_observation` and the other 6 core tools are emitted without `defer_loading` (which is `false` per the JSON contract; verified with raw stdio probe to `engram mcp --tools=agent`).
2. In a fresh Claude Code session, calling `mcp__plugin_engram_engram__mem_get_observation` fails with `id is required` — the tool schema is not loaded.
3. After `ToolSearch(query: "select:mcp__plugin_engram_engram__mem_get_observation")`, the same call succeeds and stays callable for the rest of the session.

The root fix lives in the Claude Code harness, not in Engram. This PR only makes the user-facing docs honest while that's pending upstream.

## Test plan
- [ ] `TestCoreToolsAreNotDeferred` / `TestNonCoreToolsAreDeferred` — annotations not touched, expected unchanged.
- [ ] `TestServerInstructionsConstantIsNonEmpty` — keywords preserved (`mem_save`, `mem_search`, `mem_context`, `mem_session_summary`).
- [ ] `TestServerInstructions_ConflictSurfacingBlock` — phrases preserved (`judgment_required`, `candidates[]`, `mem_judge`, `0.7`, `supersedes`, `conflicts_with`, `architecture`, `conversationally`, `evidence`).
- [ ] Hook scripts dry-run produce the new `MEMORY TOOLS` block (verified locally with `bash session-start.sh < <(echo '{"session_id":"x","cwd":"."}')`).