### PR TITLE
fix(mcp): allow scope=personal to search across projects

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -893,6 +893,16 @@ func handleCurrentProject(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc 
 	}
 }
 
+// filterProjectForScope returns the project SQL filter for read paths.
+// scope=personal with no explicit project override searches across all projects.
+func filterProjectForScope(resolvedProject, projectOverride, scope string) string {
+	if strings.TrimSpace(scope) == "personal" && strings.TrimSpace(projectOverride) == "" {
+		return ""
+	}
+	p, _ := store.NormalizeProject(resolvedProject)
+	return p
+}
+
 func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		query, _ := req.GetArguments()["query"].(string)
@@ -917,12 +927,14 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		project, _ = store.NormalizeProject(project)
 		detRes.Project = project // JR2-1: keep envelope in sync with normalized query project
 
+		queryProject := filterProjectForScope(project, projectOverride, scope)
+
 		sessionID := defaultSessionID(project)
 		activity.RecordToolCall(sessionID)
 
 		results, err := s.Search(query, store.SearchOptions{
 			Type:    typ,
-			Project: project,
+			Project: queryProject,
 			Scope:   scope,
 			Limit:   limit,
 		})
@@ -1371,10 +1383,12 @@ func handleContext(s *store.Store, cfg MCPConfig, activity *SessionActivity) ser
 		project, _ = store.NormalizeProject(project)
 		detRes.Project = project // JR2-1: keep envelope in sync with normalized query project
 
+		queryProject := filterProjectForScope(project, projectOverride, scope)
+
 		sessionID := defaultSessionID(project)
 		activity.RecordToolCall(sessionID)
 
-		contextResult, err := s.FormatContext(project, scope)
+		contextResult, err := s.FormatContext(queryProject, scope)
 		if err != nil {
 			return mcp.NewToolResultError("Failed to get context: " + err.Error()), nil
 		}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -6519,3 +6519,77 @@ func TestProcessOverrideSaveHandlerWritesToDefaultProject(t *testing.T) {
 		t.Fatalf("results in trusted project = %d; want 1", len(results))
 	}
 }
+
+// Issue #391: scope=personal must not be intersected with auto-detected project.
+func TestHandleSearchPersonalScopeCrossProject(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	for _, spec := range []struct {
+		session, project, title, content string
+	}{
+		{"s-proj-a", "proj-a", "Color preference", "Always use blue syntax highlighting"},
+		{"s-proj-b", "proj-b", "Unrelated", "Database migration checklist"},
+	} {
+		if err := s.CreateSession(spec.session, spec.project, "/tmp/"+spec.project); err != nil {
+			t.Fatalf("create session %s: %v", spec.session, err)
+		}
+		if _, err := s.AddObservation(store.AddObservationParams{
+			SessionID: spec.session,
+			Type:      "preference",
+			Title:     spec.title,
+			Content:   spec.content,
+			Project:   spec.project,
+			Scope:     "personal",
+		}); err != nil {
+			t.Fatalf("add observation: %v", err)
+		}
+	}
+
+	search := handleSearch(s, MCPConfig{DefaultProject: "proj-b"}, NewSessionActivity(10*time.Minute))
+	res, err := search(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"query": "blue syntax",
+		"scope": "personal",
+	}}})
+	if err != nil {
+		t.Fatalf("search handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected search error: %s", callResultText(t, res))
+	}
+	text := callResultText(t, res)
+	if !strings.Contains(text, "Color preference") {
+		t.Fatalf("expected cross-project personal hit from proj-a, got: %s", text)
+	}
+}
+
+func TestHandleContextPersonalScopeCrossProject(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	if err := s.CreateSession("s-a", "proj-a", "/tmp/proj-a"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-a",
+		Type:      "preference",
+		Title:     "Editor font",
+		Content:   "Prefer JetBrains Mono 14pt",
+		Project:   "proj-a",
+		Scope:     "personal",
+	}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	ctx := handleContext(s, MCPConfig{DefaultProject: "proj-b"}, NewSessionActivity(10*time.Minute))
+	res, err := ctx(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"scope": "personal",
+	}}})
+	if err != nil {
+		t.Fatalf("context handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected context error: %s", callResultText(t, res))
+	}
+	if !strings.Contains(callResultText(t, res), "Editor font") {
+		t.Fatalf("expected cross-project personal context from proj-a")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #391 — `mem_search` and `mem_context` with `scope=personal` were still filtered by the auto-detected project, so personal memories from project A were invisible from project B.

## Changes

- Add `filterProjectForScope()` — when `scope=personal` and no explicit `project` argument, omit the project SQL filter
- Apply to `handleSearch` and `handleContext` only (saves still auto-fill project for authoring)
- Tests: `TestHandleSearchPersonalScopeCrossProject`, `TestHandleContextPersonalScopeCrossProject`

## Test plan

- [ ] `go test ./internal/mcp/ -run 'PersonalScopeCrossProject'`


Made with [Cursor](https://cursor.com)