### PR TITLE
fix(mcp): resolve implicit session_id to active hook-created session

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -2695,7 +2695,8 @@ func resolveImplicitSessionID(s *store.Store, project string) (string, bool) {
 	if id, err := s.LookupActiveSession(project, cwd); err != nil {
 		// Non-fatal: log the error so operators can diagnose DB issues (e.g.
 		// transient WAL lock) that would otherwise silently route writes into
-		// manual-save-{project} with no signal. Mirror the pattern at line 1129.
+		// manual-save-{project} with no signal. See auto prompt capture error
+		// log in handleSave for the same pattern.
 		fmt.Fprintf(os.Stderr, "engram: LookupActiveSession error (non-fatal): %v\n", err)
 	} else if id != "" {
 		return id, true

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1076,7 +1076,16 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 			typ = "manual"
 		}
 		if sessionID == "" {
-			sessionID = resolveImplicitSessionID(s, project)
+			var sessionFound bool
+			sessionID, sessionFound = resolveImplicitSessionID(s, project)
+			// Skip ensure when we resolved to an existing UUID session — the UPSERT
+			// is a DB no-op but still enqueues a SyncOpUpsert mutation every call.
+			if !sessionFound {
+				_ = ensureImplicitSessionWithCWD(s, sessionID, project)
+			}
+		} else {
+			// Caller-provided session ID: preserve pre-existing auto-create behavior.
+			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 		}
 		suggestedTopicKey := suggestTopicKey(typ, title, content)
 
@@ -1100,9 +1109,6 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 				}
 			}
 		}
-
-		// Ensure the implicit MCP session exists with the current working directory.
-		_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 
 		truncated := len(content) > s.MaxObservationLength()
 
@@ -1326,11 +1332,16 @@ func handleSavePrompt(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 		project, _ := store.NormalizeProject(detRes.Project)
 
 		if sessionID == "" {
-			sessionID = resolveImplicitSessionID(s, project)
+			var sessionFound bool
+			sessionID, sessionFound = resolveImplicitSessionID(s, project)
+			// Skip ensure when we resolved to an existing UUID session to avoid spurious sync mutations.
+			if !sessionFound {
+				_ = ensureImplicitSessionWithCWD(s, sessionID, project)
+			}
+		} else {
+			// Caller-provided session ID: preserve pre-existing auto-create behavior.
+			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 		}
-
-		// Ensure the implicit MCP session exists with the current working directory.
-		_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 
 		_, err = s.AddPrompt(store.AddPromptParams{
 			SessionID: sessionID,
@@ -1608,11 +1619,16 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		project, _ := store.NormalizeProject(detRes.Project)
 
 		if sessionID == "" {
-			sessionID = resolveImplicitSessionID(s, project)
+			var sessionFound bool
+			sessionID, sessionFound = resolveImplicitSessionID(s, project)
+			// Skip ensure when we resolved to an existing UUID session to avoid spurious sync mutations.
+			if !sessionFound {
+				_ = ensureImplicitSessionWithCWD(s, sessionID, project)
+			}
+		} else {
+			// Caller-provided session ID: preserve pre-existing auto-create behavior.
+			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 		}
-
-		// Ensure the implicit MCP session exists with the current working directory.
-		_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 
 		_, err = s.AddObservation(store.AddObservationParams{
 			SessionID: sessionID,
@@ -1726,9 +1742,16 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		}
 
 		if sessionID == "" {
-			sessionID = resolveImplicitSessionID(s, project)
-			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
+			var sessionFound bool
+			sessionID, sessionFound = resolveImplicitSessionID(s, project)
+			// Skip ensure when we resolved to an existing UUID session to avoid spurious sync mutations.
+			if !sessionFound {
+				_ = ensureImplicitSessionWithCWD(s, sessionID, project)
+			}
 		}
+		// Note: when sessionID was provided by the caller we do NOT call
+		// ensureImplicitSessionWithCWD — this preserves the original behavior
+		// (the FK constraint must fire if the explicit session does not exist).
 
 		activity.RecordToolCall(sessionID)
 
@@ -2662,12 +2685,22 @@ func defaultSessionID(project string) string {
 // an explicit session_id arg attach to the real UUID session created by the
 // SessionStart hook (POST /sessions), instead of pooling into
 // manual-save-{project}. Fixes #386.
-func resolveImplicitSessionID(s *store.Store, project string) string {
+//
+// The bool return is true when an existing UUID session was found (lookup hit),
+// false when the function fell back to defaultSessionID. Callers use this to
+// skip ensureImplicitSessionWithCWD when the session already exists, preventing
+// spurious SyncOpUpsert mutations on every tool call during an active session.
+func resolveImplicitSessionID(s *store.Store, project string) (string, bool) {
 	cwd := currentWorkingDirectory()
-	if id, err := s.LookupActiveSession(project, cwd); err == nil && id != "" {
-		return id
+	if id, err := s.LookupActiveSession(project, cwd); err != nil {
+		// Non-fatal: log the error so operators can diagnose DB issues (e.g.
+		// transient WAL lock) that would otherwise silently route writes into
+		// manual-save-{project} with no signal. Mirror the pattern at line 1129.
+		fmt.Fprintf(os.Stderr, "engram: LookupActiveSession error (non-fatal): %v\n", err)
+	} else if id != "" {
+		return id, true
 	}
-	return defaultSessionID(project)
+	return defaultSessionID(project), false
 }
 
 func intArg(req mcp.CallToolRequest, key string, defaultVal int) int {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1076,7 +1076,7 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 			typ = "manual"
 		}
 		if sessionID == "" {
-			sessionID = defaultSessionID(project)
+			sessionID = resolveImplicitSessionID(s, project)
 		}
 		suggestedTopicKey := suggestTopicKey(typ, title, content)
 
@@ -1326,7 +1326,7 @@ func handleSavePrompt(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 		project, _ := store.NormalizeProject(detRes.Project)
 
 		if sessionID == "" {
-			sessionID = defaultSessionID(project)
+			sessionID = resolveImplicitSessionID(s, project)
 		}
 
 		// Ensure the implicit MCP session exists with the current working directory.
@@ -1608,7 +1608,7 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		project, _ := store.NormalizeProject(detRes.Project)
 
 		if sessionID == "" {
-			sessionID = defaultSessionID(project)
+			sessionID = resolveImplicitSessionID(s, project)
 		}
 
 		// Ensure the implicit MCP session exists with the current working directory.
@@ -1728,7 +1728,7 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		}
 
 		if sessionID == "" {
-			sessionID = defaultSessionID(project)
+			sessionID = resolveImplicitSessionID(s, project)
 			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 		}
 
@@ -2654,6 +2654,20 @@ func defaultSessionID(project string) string {
 		return "manual-save"
 	}
 	return "manual-save-" + project
+}
+
+// resolveImplicitSessionID returns the ID of an open hook-registered session
+// matching (project, current working directory) if one exists; otherwise it
+// falls back to defaultSessionID(project). This lets MCP tool calls without
+// an explicit session_id arg attach to the real UUID session created by the
+// SessionStart hook (POST /sessions), instead of pooling into
+// manual-save-{project}. Fixes #386.
+func resolveImplicitSessionID(s *store.Store, project string) string {
+	cwd := currentWorkingDirectory()
+	if id, err := s.LookupActiveSession(project, cwd); err == nil && id != "" {
+		return id
+	}
+	return defaultSessionID(project)
 }
 
 func intArg(req mcp.CallToolRequest, key string, defaultVal int) int {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1626,7 +1626,7 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		}
 
 		msg := fmt.Sprintf("Session summary saved for project %q", project)
-		if score := activity.ActivityScore(defaultSessionID(project)); score != "" {
+		if score := activity.ActivityScore(sessionID); score != "" {
 			msg += "\n" + score
 		}
 		detRes.Project = project
@@ -1647,7 +1647,7 @@ func handleSessionStart(s *store.Store, cfg MCPConfig, activity *SessionActivity
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 
-		activity.RecordToolCall(defaultSessionID(project))
+		activity.RecordToolCall(id)
 		if resolvedDirectory == "" {
 			resolvedDirectory = strings.TrimSpace(detRes.Path)
 			if resolvedDirectory == "" {
@@ -1701,7 +1701,7 @@ func handleSessionEnd(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 			return mcp.NewToolResultError("Failed to end session: " + err.Error()), nil
 		}
 
-		activity.ClearSession(defaultSessionID(project))
+		activity.ClearSession(id)
 
 		detRes.Project = project
 		return respondWithProject(detRes, fmt.Sprintf("Session %q completed", id), nil), nil
@@ -1721,15 +1721,15 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 
-		activity.RecordToolCall(defaultSessionID(project))
-
-		if content == "" {
-			return mcp.NewToolResultError("content is required — include text with a '## Key Learnings:' section"), nil
-		}
-
 		if sessionID == "" {
 			sessionID = resolveImplicitSessionID(s, project)
 			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
+		}
+
+		activity.RecordToolCall(sessionID)
+
+		if content == "" {
+			return mcp.NewToolResultError("content is required — include text with a '## Key Learnings:' section"), nil
 		}
 
 		if source == "" {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1721,16 +1721,16 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 
+		if content == "" {
+			return mcp.NewToolResultError("content is required — include text with a '## Key Learnings:' section"), nil
+		}
+
 		if sessionID == "" {
 			sessionID = resolveImplicitSessionID(s, project)
 			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 		}
 
 		activity.RecordToolCall(sessionID)
-
-		if content == "" {
-			return mcp.NewToolResultError("content is required — include text with a '## Key Learnings:' section"), nil
-		}
 
 		if source == "" {
 			source = "mcp-passive"

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -6519,3 +6519,282 @@ func TestProcessOverrideSaveHandlerWritesToDefaultProject(t *testing.T) {
 		t.Fatalf("results in trusted project = %d; want 1", len(results))
 	}
 }
+
+// ─── Phase: session-id-propagation (#386) ────────────────────────────────────
+//
+// These tests verify that mem_save and its sibling handlers resolve to the
+// UUID session created by the Claude Code SessionStart hook when one is open
+// for the current (project, cwd), instead of falling back to manual-save-{project}.
+
+// TestHandleSaveResolvesToActiveHookSession verifies that handleSave attaches
+// the observation to the UUID session created by the SessionStart hook when
+// no explicit session_id is provided and an active session matches (project, cwd).
+func TestHandleSaveResolvesToActiveHookSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/hook-session-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	// Simulate what the SessionStart hook does: create a UUID session
+	// for (project, cwd) before the MCP tools are called.
+	uuidSession := "uuid-hook-abc123"
+	if err := s.CreateSession(uuidSession, "hook-session-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Hook session test",
+		"content": "This should land in the UUID session",
+		"type":    "discovery",
+	}}}
+	res, err := h(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("save: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// The observation must be in the UUID session, NOT in manual-save-hook-session-project.
+	obs, err := s.SessionObservations(uuidSession, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations uuid: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("expected 1 observation in UUID session, got %d", len(obs))
+	}
+	manualObs, err := s.SessionObservations(defaultSessionID("hook-session-project"), 10)
+	if err != nil {
+		t.Fatalf("SessionObservations manual: %v", err)
+	}
+	if len(manualObs) != 0 {
+		t.Fatalf("expected 0 observations in manual-save session, got %d", len(manualObs))
+	}
+}
+
+// TestHandleSaveFallsBackToManualSaveWhenNoActiveSession verifies the current
+// fallback behavior is preserved when no matching open session exists.
+func TestHandleSaveFallsBackToManualSaveWhenNoActiveSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/no-hook-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	// No active session created — should fall back to manual-save-no-hook-project.
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Fallback test",
+		"content": "Should land in manual-save session",
+		"type":    "discovery",
+	}}}
+	res, err := h(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("save: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	manualID := defaultSessionID("no-hook-project")
+	obs, err := s.SessionObservations(manualID, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations manual: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("expected 1 observation in manual-save session, got %d", len(obs))
+	}
+}
+
+// TestHandleSaveIgnoresEndedSession verifies that an ended session is not
+// resolved as the active session — the fallback wins instead.
+func TestHandleSaveIgnoresEndedSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/ended-session-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	uuidSession := "uuid-ended-session"
+	if err := s.CreateSession(uuidSession, "ended-session-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := s.EndSession(uuidSession, "closed"); err != nil {
+		t.Fatalf("EndSession: %v", err)
+	}
+
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Ended session test",
+		"content": "Should land in manual-save (session ended)",
+		"type":    "discovery",
+	}}}
+	res, err := h(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("save: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// Must NOT be in the ended UUID session.
+	uuidObs, err := s.SessionObservations(uuidSession, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations uuid: %v", err)
+	}
+	if len(uuidObs) != 0 {
+		t.Fatalf("expected 0 obs in ended session, got %d", len(uuidObs))
+	}
+	// Must be in the fallback manual-save session.
+	manualID := defaultSessionID("ended-session-project")
+	manualObs, err := s.SessionObservations(manualID, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations manual: %v", err)
+	}
+	if len(manualObs) != 1 {
+		t.Fatalf("expected 1 obs in fallback session, got %d", len(manualObs))
+	}
+}
+
+// TestHandleSavePromptResolvesToActiveHookSession verifies handleSavePrompt
+// attaches to the UUID session when a matching open session exists.
+func TestHandleSavePromptResolvesToActiveHookSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/prompt-hook-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	uuidSession := "uuid-prompt-hook"
+	if err := s.CreateSession(uuidSession, "prompt-hook-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	h := handleSavePrompt(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "What is the capital of France?",
+	}}}
+	res, err := h(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("savePrompt: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// Prompt must land in the UUID session, NOT manual-save-prompt-hook-project.
+	// We verify by checking sessions — the UUID session should show as active
+	// and the manual-save session must not exist.
+	sess, err := s.GetSession(uuidSession)
+	if err != nil {
+		t.Fatalf("GetSession uuid: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected uuid session to exist")
+	}
+	_, err = s.GetSession(defaultSessionID("prompt-hook-project"))
+	if err == nil {
+		t.Fatal("manual-save-prompt-hook-project should NOT exist when UUID session resolved")
+	}
+}
+
+// TestHandleSessionSummaryResolvesToActiveHookSession verifies handleSessionSummary
+// attaches the session_summary observation to the UUID session.
+func TestHandleSessionSummaryResolvesToActiveHookSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/summary-hook-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	uuidSession := "uuid-summary-hook"
+	if err := s.CreateSession(uuidSession, "summary-hook-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	h := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "## Goal\nFixed the bug\n## Accomplished\n- Fixed it",
+	}}}
+	res, err := h(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("sessionSummary: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// The session_summary observation must be in the UUID session.
+	obs, err := s.SessionObservations(uuidSession, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations uuid: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("expected 1 obs in UUID session, got %d", len(obs))
+	}
+	if obs[0].Type != "session_summary" {
+		t.Fatalf("expected type=session_summary, got %q", obs[0].Type)
+	}
+	// Manual-save session must have zero observations.
+	manualID := defaultSessionID("summary-hook-project")
+	manualObs, err := s.SessionObservations(manualID, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations manual: %v", err)
+	}
+	if len(manualObs) != 0 {
+		t.Fatalf("expected 0 obs in manual-save session, got %d", len(manualObs))
+	}
+}
+
+// TestHandleCapturePassiveResolvesToActiveHookSession verifies handleCapturePassive
+// attaches passive-capture observations to the UUID session.
+func TestHandleCapturePassiveResolvesToActiveHookSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/passive-hook-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	uuidSession := "uuid-passive-hook"
+	if err := s.CreateSession(uuidSession, "passive-hook-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	h := handleCapturePassive(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "## Key Learnings:\n1. Rate limiting prevents authentication abuse attacks",
+	}}}
+	res, err := h(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("capturePassive: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// Extracted observations must land in the UUID session.
+	obs, err := s.SessionObservations(uuidSession, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations uuid: %v", err)
+	}
+	if len(obs) == 0 {
+		t.Fatal("expected at least 1 observation in UUID session from passive capture")
+	}
+	// Manual-save session must have zero observations.
+	manualID := defaultSessionID("passive-hook-project")
+	manualObs, err := s.SessionObservations(manualID, 10)
+	if err != nil {
+		t.Fatalf("SessionObservations manual: %v", err)
+	}
+	if len(manualObs) != 0 {
+		t.Fatalf("expected 0 obs in manual-save session, got %d (should be in UUID session)", len(manualObs))
+	}
+}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -7109,3 +7109,143 @@ func TestMemSaveSkipsSessionUpsertWhenResolvedToExistingUUID(t *testing.T) {
 			baseline, uuidSession, after)
 	}
 }
+
+// TestMemSavePromptSkipsSessionUpsertWhenResolvedToExistingUUID verifies the
+// same no-spurious-sync invariant as TestMemSaveSkipsSessionUpsertWhenResolvedTo-
+// ExistingUUID, but for handleSavePrompt. The fix lives in the same guard
+// (if !sessionFound { ensure }) in handleSavePrompt.
+//
+// Verified failing on the unguarded ensure pattern; passes with the guard from 939cc2c.
+func TestMemSavePromptSkipsSessionUpsertWhenResolvedToExistingUUID(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/no-spurious-sync-prompt-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	project := "no-spurious-sync-prompt-project"
+	uuidSession := "uuid-no-spurious-sync-prompt"
+
+	// Enroll the project so ListPendingSyncMutations returns its mutations.
+	if err := s.EnrollProject(project); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+
+	// Register a UUID session at the current working directory so that
+	// resolveImplicitSessionID will hit it rather than fall back.
+	if err := s.CreateSession(uuidSession, project, dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Count session UPSERT mutations for the UUID session already in the queue
+	// (from the CreateSession above). We baseline here and verify no new ones
+	// appear after handleSavePrompt resolves to the existing UUID session.
+	countSessionUpserts := func() int {
+		mutations, err := s.ListPendingSyncMutations(store.DefaultSyncTargetKey, 200)
+		if err != nil {
+			t.Fatalf("list pending sync mutations: %v", err)
+		}
+		n := 0
+		for _, m := range mutations {
+			if m.Entity == store.SyncEntitySession && m.EntityKey == uuidSession && m.Op == store.SyncOpUpsert {
+				n++
+			}
+		}
+		return n
+	}
+	baseline := countSessionUpserts()
+
+	// Call handleSavePrompt without an explicit session_id — handler must
+	// resolve to the UUID session and must NOT call ensureImplicitSessionWithCWD
+	// again.
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSavePrompt(s, MCPConfig{}, activity)
+	res, err := h(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"content": "test prompt content",
+		}},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("handleSavePrompt: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// Verify that the session UPSERT count did not grow after handleSavePrompt.
+	if after := countSessionUpserts(); after != baseline {
+		t.Fatalf("expected %d session UPSERT mutations for %q (no growth), got %d — spurious ensure detected",
+			baseline, uuidSession, after)
+	}
+}
+
+// TestMemSessionSummarySkipsSessionUpsertWhenResolvedToExistingUUID verifies
+// the same no-spurious-sync invariant as TestMemSaveSkipsSessionUpsertWhenResolved-
+// ToExistingUUID, but for handleSessionSummary. The fix lives in the same guard
+// (if !sessionFound { ensure }) in handleSessionSummary.
+//
+// Verified failing on the unguarded ensure pattern; passes with the guard from 939cc2c.
+func TestMemSessionSummarySkipsSessionUpsertWhenResolvedToExistingUUID(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/no-spurious-sync-summary-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	project := "no-spurious-sync-summary-project"
+	uuidSession := "uuid-no-spurious-sync-summary"
+
+	// Enroll the project so ListPendingSyncMutations returns its mutations.
+	if err := s.EnrollProject(project); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+
+	// Register a UUID session at the current working directory so that
+	// resolveImplicitSessionID will hit it rather than fall back.
+	if err := s.CreateSession(uuidSession, project, dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Count session UPSERT mutations for the UUID session already in the queue
+	// (from the CreateSession above). We baseline here and verify no new ones
+	// appear after handleSessionSummary resolves to the existing UUID session.
+	countSessionUpserts := func() int {
+		mutations, err := s.ListPendingSyncMutations(store.DefaultSyncTargetKey, 200)
+		if err != nil {
+			t.Fatalf("list pending sync mutations: %v", err)
+		}
+		n := 0
+		for _, m := range mutations {
+			if m.Entity == store.SyncEntitySession && m.EntityKey == uuidSession && m.Op == store.SyncOpUpsert {
+				n++
+			}
+		}
+		return n
+	}
+	baseline := countSessionUpserts()
+
+	// Call handleSessionSummary without an explicit session_id — handler must
+	// resolve to the UUID session and must NOT call ensureImplicitSessionWithCWD
+	// again.
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSessionSummary(s, MCPConfig{}, activity)
+	res, err := h(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"content": "test session summary content",
+		}},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("handleSessionSummary: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// Verify that the session UPSERT count did not grow after handleSessionSummary.
+	if after := countSessionUpserts(); after != baseline {
+		t.Fatalf("expected %d session UPSERT mutations for %q (no growth), got %d — spurious ensure detected",
+			baseline, uuidSession, after)
+	}
+}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -6994,3 +6994,46 @@ func TestHandleSessionEndClearsActivityByExplicitID(t *testing.T) {
 		t.Fatalf("expected defaultSessionID activity untouched, got %q", score)
 	}
 }
+
+// TestHandleCapturePassiveEmptyContentDoesNotMutate verifies that the
+// empty-content error path returns early without creating a session row in the
+// DB or recording activity. A previous reorder of resolveImplicitSessionID
+// inadvertently placed ensureImplicitSessionWithCWD and RecordToolCall above
+// the content guard, so invalid calls were leaving side effects behind
+// (spurious session rows + inflated activity counters).
+func TestHandleCapturePassiveEmptyContentDoesNotMutate(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/capture-passive-empty-content.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	project := "capture-passive-empty-content"
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleCapturePassive(s, MCPConfig{}, activity)
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected tool error when content is empty, got %q", callResultText(t, res))
+	}
+
+	// No session row should have been created on the error path.
+	defaultID := defaultSessionID(project)
+	if sess, err := s.GetSession(defaultID); err == nil && sess != nil {
+		t.Fatalf("expected no session row created for empty-content call, found id=%q", sess.ID)
+	}
+
+	// No activity should have been recorded on the error path.
+	if score := activity.ActivityScore(defaultID); score != "" {
+		t.Fatalf("expected no activity for empty-content call, got %q", score)
+	}
+}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -2903,7 +2903,11 @@ func TestSessionEndClearsActivity(t *testing.T) {
 	}
 }
 
-func TestCapturePassiveRecordsToolCall(t *testing.T) {
+// TestCapturePassiveRecordsToolCallFallbackPath exercises the fallback when no
+// active hook session matches (resolveImplicitSessionID falls back to
+// defaultSessionID). The UUID resolution path is covered by
+// TestHandleCapturePassiveActivityRecordedUnderResolvedSession.
+func TestCapturePassiveRecordsToolCallFallbackPath(t *testing.T) {
 	s := newMCPTestStore(t)
 
 	// Set up a git repo so resolveWriteProject returns a predictable name.
@@ -7035,5 +7039,73 @@ func TestHandleCapturePassiveEmptyContentDoesNotMutate(t *testing.T) {
 	// No activity should have been recorded on the error path.
 	if score := activity.ActivityScore(defaultID); score != "" {
 		t.Fatalf("expected no activity for empty-content call, got %q", score)
+	}
+}
+
+// TestMemSaveSkipsSessionUpsertWhenResolvedToExistingUUID verifies that when
+// mem_save resolves to an already-existing UUID session (lookup hit), it does
+// NOT enqueue a new SyncOpUpsert session mutation. Previously, ensureImplicit-
+// SessionWithCWD ran unconditionally, flooding the sync queue on busy sessions.
+func TestMemSaveSkipsSessionUpsertWhenResolvedToExistingUUID(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/no-spurious-sync-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	project := "no-spurious-sync-project"
+	uuidSession := "uuid-no-spurious-sync"
+
+	// Enroll the project so ListPendingSyncMutations returns its mutations.
+	if err := s.EnrollProject(project); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+
+	// Register a UUID session at the current working directory so that
+	// resolveImplicitSessionID will hit it rather than fall back.
+	if err := s.CreateSession(uuidSession, project, dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Count session UPSERT mutations for the UUID session already in the queue
+	// (from the CreateSession above). We baseline here and verify no new ones
+	// appear after mem_save resolves to the existing UUID session.
+	countSessionUpserts := func() int {
+		mutations, err := s.ListPendingSyncMutations(store.DefaultSyncTargetKey, 200)
+		if err != nil {
+			t.Fatalf("list pending sync mutations: %v", err)
+		}
+		n := 0
+		for _, m := range mutations {
+			if m.Entity == store.SyncEntitySession && m.EntityKey == uuidSession && m.Op == store.SyncOpUpsert {
+				n++
+			}
+		}
+		return n
+	}
+	baseline := countSessionUpserts()
+
+	// Call mem_save without an explicit session_id — handler must resolve to
+	// the UUID session and must NOT call ensureImplicitSessionWithCWD again.
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSave(s, MCPConfig{}, activity)
+	res, err := h(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"title":   "No spurious sync test",
+			"content": "content",
+		}},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("handleSave: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	// Verify that the session UPSERT count did not grow after mem_save.
+	if after := countSessionUpserts(); after != baseline {
+		t.Fatalf("expected %d session UPSERT mutations for %q (no growth), got %d — spurious ensure detected",
+			baseline, uuidSession, after)
 	}
 }

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -2870,34 +2870,34 @@ func TestSessionEndClearsActivity(t *testing.T) {
 	t.Chdir(dir)
 
 	activity := NewSessionActivity(10 * time.Minute)
-	project := "myproject"
-	sessionID := defaultSessionID(project)
+	// Activity must be seeded under the explicit session id that will be ended.
+	explicitID := "real-session-id"
 
 	// Record some activity
-	activity.RecordToolCall(sessionID)
-	activity.RecordSave(sessionID)
+	activity.RecordToolCall(explicitID)
+	activity.RecordSave(explicitID)
 
 	// Verify activity exists
-	score := activity.ActivityScore(sessionID)
+	score := activity.ActivityScore(explicitID)
 	if score == "" {
 		t.Fatal("expected activity score before session end")
 	}
 
 	// Create session in store so EndSession works
-	s.CreateSession("real-session-id", project, "")
+	s.CreateSession(explicitID, "myproject", "")
 
 	end := handleSessionEnd(s, MCPConfig{}, activity)
 	_, err := end(context.Background(), mcppkg.CallToolRequest{
 		Params: mcppkg.CallToolParams{Arguments: map[string]any{
-			"id": "real-session-id",
+			"id": explicitID,
 		}},
 	})
 	if err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
 
-	// Activity should be cleared
-	score = activity.ActivityScore(sessionID)
+	// Activity must be cleared under the explicit session id.
+	score = activity.ActivityScore(explicitID)
 	if score != "" {
 		t.Fatalf("expected empty activity after session end, got: %q", score)
 	}
@@ -2937,7 +2937,7 @@ func TestCapturePassiveRecordsToolCall(t *testing.T) {
 	}
 }
 
-func TestSessionStartUsesDefaultSessionID(t *testing.T) {
+func TestSessionStartRecordsActivityUnderExplicitID(t *testing.T) {
 	s := newMCPTestStore(t)
 
 	// Set up a git repo so resolveWriteProject returns a predictable name.
@@ -2963,17 +2963,17 @@ func TestSessionStartUsesDefaultSessionID(t *testing.T) {
 		t.Fatalf("handler error: %v", err)
 	}
 
-	// Activity should be recorded under defaultSessionID, not the real session ID
-	defaultSID := defaultSessionID(project)
-	score := activity.ActivityScore(defaultSID)
-	if !strings.Contains(score, "1 tool call") {
-		t.Fatalf("expected activity under defaultSessionID, got: %q", score)
+	// Activity must be recorded under the explicit session id, not defaultSessionID.
+	realScore := activity.ActivityScore("real-unique-session-id")
+	if !strings.Contains(realScore, "1 tool call") {
+		t.Fatalf("expected activity under explicit session ID, got: %q", realScore)
 	}
 
-	// The real session ID should NOT have activity
-	realScore := activity.ActivityScore("real-unique-session-id")
-	if realScore != "" {
-		t.Fatalf("expected no activity under real session ID, got: %q", realScore)
+	// The default bucket must be empty.
+	defaultSID := defaultSessionID(project)
+	score := activity.ActivityScore(defaultSID)
+	if score != "" {
+		t.Fatalf("expected no activity under defaultSessionID, got: %q", score)
 	}
 }
 
@@ -6702,6 +6702,18 @@ func TestHandleSavePromptResolvesToActiveHookSession(t *testing.T) {
 	if err == nil {
 		t.Fatal("manual-save-prompt-hook-project should NOT exist when UUID session resolved")
 	}
+
+	// Positively verify the prompt row landed in the UUID session.
+	prompts, err := s.RecentPrompts("prompt-hook-project", 10)
+	if err != nil {
+		t.Fatalf("RecentPrompts: %v", err)
+	}
+	if len(prompts) != 1 {
+		t.Fatalf("expected 1 prompt row, got %d", len(prompts))
+	}
+	if prompts[0].SessionID != uuidSession {
+		t.Fatalf("expected prompt.session_id=%q, got %q", uuidSession, prompts[0].SessionID)
+	}
 }
 
 // TestHandleSessionSummaryResolvesToActiveHookSession verifies handleSessionSummary
@@ -6796,5 +6808,189 @@ func TestHandleCapturePassiveResolvesToActiveHookSession(t *testing.T) {
 	}
 	if len(manualObs) != 0 {
 		t.Fatalf("expected 0 obs in manual-save session, got %d (should be in UUID session)", len(manualObs))
+	}
+}
+
+// TestHandleSessionSummaryActivityScoreUsesResolvedSession verifies that
+// handleSessionSummary reads the activity score from the resolved UUID session,
+// not from defaultSessionID(project). Before the fix, score was always empty for
+// UUID sessions because ActivityScore was called with the wrong key.
+func TestHandleSessionSummaryActivityScoreUsesResolvedSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/summary-activity-uuid-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	uuidSession := "uuid-summary-activity"
+	if err := s.CreateSession(uuidSession, "summary-activity-uuid-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	activity := NewSessionActivity(10 * time.Minute)
+	// Record activity under the UUID session — this is what the resolved session
+	// will be when handleSessionSummary runs.
+	for i := 0; i < 7; i++ {
+		activity.RecordToolCall(uuidSession)
+	}
+	activity.RecordSave(uuidSession)
+
+	h := handleSessionSummary(s, MCPConfig{}, activity)
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "## Goal\nTest activity score keying",
+	}}}
+	res, err := h(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("sessionSummary: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
+	}
+
+	text := callResultText(t, res)
+	// The score must appear — only possible if ActivityScore used uuidSession, not defaultSessionID.
+	if !strings.Contains(text, "Session activity:") {
+		t.Fatalf("expected activity score in response; got %q\n(score would be absent if keyed on defaultSessionID instead of resolved UUID)", text)
+	}
+	if !strings.Contains(text, "7 tool calls") {
+		t.Fatalf("expected 7 tool calls in score, got: %q", text)
+	}
+}
+
+// TestHandleCapturePassiveActivityRecordedUnderResolvedSession verifies that
+// handleCapturePassive records the tool-call increment under the resolved UUID
+// session, not under defaultSessionID(project). Before the fix, the activity
+// call happened before resolveImplicitSessionID, so it always landed on the
+// default bucket.
+func TestHandleCapturePassiveActivityRecordedUnderResolvedSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/capture-passive-uuid-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	uuidSession := "uuid-capture-passive-activity"
+	if err := s.CreateSession(uuidSession, "capture-passive-uuid-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleCapturePassive(s, MCPConfig{}, activity)
+	_, err := h(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"content": "## Key Learnings:\n1. Activity must land on the UUID session",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// Activity must be under the UUID session.
+	uuidScore := activity.ActivityScore(uuidSession)
+	if !strings.Contains(uuidScore, "1 tool call") {
+		t.Fatalf("expected 1 tool call under UUID session %q, got %q", uuidSession, uuidScore)
+	}
+	// The default bucket must be empty.
+	defaultID := defaultSessionID("capture-passive-uuid-project")
+	defaultScore := activity.ActivityScore(defaultID)
+	if defaultScore != "" {
+		t.Fatalf("expected no activity under defaultSessionID %q, got %q", defaultID, defaultScore)
+	}
+}
+
+// TestHandleSessionStartRecordsActivityUnderExplicitID verifies that
+// handleSessionStart records the tool call against the explicit session id
+// passed in the request (the UUID the caller is naming), not defaultSessionID.
+// The pre-existing behaviour recorded under the wrong bucket, making
+// handleSessionStart's own activity invisible when the session was later
+// looked up by its UUID.
+func TestHandleSessionStartRecordsActivityUnderExplicitID(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/session-start-uuid-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	activity := NewSessionActivity(10 * time.Minute)
+	explicitID := "explicit-uuid-session-start"
+
+	start := handleSessionStart(s, MCPConfig{}, activity)
+	_, err := start(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"id": explicitID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// Activity must be under the explicit session id, not defaultSessionID.
+	explicitScore := activity.ActivityScore(explicitID)
+	if !strings.Contains(explicitScore, "1 tool call") {
+		t.Fatalf("expected 1 tool call under explicit session ID %q, got %q", explicitID, explicitScore)
+	}
+	defaultID := defaultSessionID("session-start-uuid-project")
+	defaultScore := activity.ActivityScore(defaultID)
+	if defaultScore != "" {
+		t.Fatalf("expected no activity under defaultSessionID %q, got %q", defaultID, defaultScore)
+	}
+}
+
+// TestHandleSessionEndClearsActivityByExplicitID verifies that handleSessionEnd
+// clears activity for the explicit session id in the request, not for
+// defaultSessionID(project). Before the fix, ClearSession used the wrong key,
+// leaving the real session's activity in memory and clearing an unrelated bucket.
+func TestHandleSessionEndClearsActivityByExplicitID(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/session-end-uuid-project.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	activity := NewSessionActivity(10 * time.Minute)
+	explicitID := "explicit-uuid-session-end"
+
+	// Seed activity under the explicit session id that will be ended.
+	activity.RecordToolCall(explicitID)
+	activity.RecordSave(explicitID)
+
+	// Also seed the defaultSessionID bucket to confirm it is NOT touched.
+	defaultID := defaultSessionID("session-end-uuid-project")
+	activity.RecordToolCall(defaultID)
+
+	// Create and end the session.
+	if err := s.CreateSession(explicitID, "session-end-uuid-project", dir); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	end := handleSessionEnd(s, MCPConfig{}, activity)
+	_, err := end(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"id": explicitID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// Activity for the explicit session must be cleared.
+	if score := activity.ActivityScore(explicitID); score != "" {
+		t.Fatalf("expected activity cleared for explicit session %q, got %q", explicitID, score)
+	}
+	// The default bucket must remain untouched.
+	if score := activity.ActivityScore(defaultID); !strings.Contains(score, "1 tool call") {
+		t.Fatalf("expected defaultSessionID activity untouched, got %q", score)
 	}
 }

--- a/internal/store/sessions_lookup_test.go
+++ b/internal/store/sessions_lookup_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"testing"
-	"time"
 )
 
 // TestLookupActiveSessionReturnsMatchingOpenSession verifies that
@@ -33,11 +32,16 @@ func TestLookupActiveSessionReturnsMostRecentWhenMultipleOpen(t *testing.T) {
 	if err := s.CreateSession("uuid-old", "myproject", "/work/myproject"); err != nil {
 		t.Fatalf("CreateSession old: %v", err)
 	}
-	// Small sleep to ensure started_at differs — SQLite datetime('now') has 1-second resolution.
-	// TODO: tighten if started_at gains sub-second resolution.
-	time.Sleep(1100 * time.Millisecond)
 	if err := s.CreateSession("uuid-new", "myproject", "/work/myproject"); err != nil {
 		t.Fatalf("CreateSession new: %v", err)
+	}
+	// Write deterministic started_at values so the test does not depend on
+	// datetime('now') sub-second timing or sleep to force ordering.
+	if _, err := s.db.Exec(`UPDATE sessions SET started_at = '2026-01-01T00:00:01Z' WHERE id = 'uuid-old'`); err != nil {
+		t.Fatalf("set started_at old: %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE sessions SET started_at = '2026-01-01T00:00:02Z' WHERE id = 'uuid-new'`); err != nil {
+		t.Fatalf("set started_at new: %v", err)
 	}
 
 	got, err := s.LookupActiveSession("myproject", "/work/myproject")

--- a/internal/store/sessions_lookup_test.go
+++ b/internal/store/sessions_lookup_test.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLookupActiveSessionReturnsMatchingOpenSession verifies that
+// LookupActiveSession returns the ID of an open session matching
+// (project, directory).
+func TestLookupActiveSessionReturnsMatchingOpenSession(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("uuid-session-1", "myproject", "/work/myproject"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	got, err := s.LookupActiveSession("myproject", "/work/myproject")
+	if err != nil {
+		t.Fatalf("LookupActiveSession: %v", err)
+	}
+	if got != "uuid-session-1" {
+		t.Fatalf("expected uuid-session-1, got %q", got)
+	}
+}
+
+// TestLookupActiveSessionReturnsMostRecentWhenMultipleOpen verifies that
+// when multiple open sessions share (project, directory), the most recent
+// one (by started_at) is returned.
+func TestLookupActiveSessionReturnsMostRecentWhenMultipleOpen(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("uuid-old", "myproject", "/work/myproject"); err != nil {
+		t.Fatalf("CreateSession old: %v", err)
+	}
+	// Small sleep to ensure started_at differs — SQLite datetime('now') has 1-second resolution.
+	time.Sleep(1100 * time.Millisecond)
+	if err := s.CreateSession("uuid-new", "myproject", "/work/myproject"); err != nil {
+		t.Fatalf("CreateSession new: %v", err)
+	}
+
+	got, err := s.LookupActiveSession("myproject", "/work/myproject")
+	if err != nil {
+		t.Fatalf("LookupActiveSession: %v", err)
+	}
+	if got != "uuid-new" {
+		t.Fatalf("expected uuid-new (most recent), got %q", got)
+	}
+}
+
+// TestLookupActiveSessionReturnsEmptyWhenNoMatch verifies that "" is returned
+// (no error) when no session matches the given (project, directory).
+func TestLookupActiveSessionReturnsEmptyWhenNoMatch(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("uuid-session-1", "myproject", "/work/myproject"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	got, err := s.LookupActiveSession("myproject", "/other/dir")
+	if err != nil {
+		t.Fatalf("LookupActiveSession: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string for no match, got %q", got)
+	}
+}
+
+// TestLookupActiveSessionExcludesEnded verifies that sessions with ended_at
+// set are not returned.
+func TestLookupActiveSessionExcludesEnded(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("uuid-ended", "myproject", "/work/myproject"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := s.EndSession("uuid-ended", ""); err != nil {
+		t.Fatalf("EndSession: %v", err)
+	}
+
+	got, err := s.LookupActiveSession("myproject", "/work/myproject")
+	if err != nil {
+		t.Fatalf("LookupActiveSession: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string (session ended), got %q", got)
+	}
+}
+
+// TestLookupActiveSessionExcludesDirectoryMismatch verifies exact directory match.
+func TestLookupActiveSessionExcludesDirectoryMismatch(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("uuid-session-1", "myproject", "/work/myproject"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	got, err := s.LookupActiveSession("myproject", "/work/myproject/subdir")
+	if err != nil {
+		t.Fatalf("LookupActiveSession: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string (directory mismatch), got %q", got)
+	}
+}
+
+// TestLookupActiveSessionExcludesProjectMismatch verifies exact project match.
+func TestLookupActiveSessionExcludesProjectMismatch(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("uuid-session-1", "myproject", "/work/myproject"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	got, err := s.LookupActiveSession("otherproject", "/work/myproject")
+	if err != nil {
+		t.Fatalf("LookupActiveSession: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string (project mismatch), got %q", got)
+	}
+}
+
+// TestLookupActiveSessionReturnsEmptyForBlankInputs verifies that empty
+// project or directory returns "" without error (no DB query).
+func TestLookupActiveSessionReturnsEmptyForBlankInputs(t *testing.T) {
+	s := newTestStore(t)
+
+	// empty project
+	got, err := s.LookupActiveSession("", "/work/myproject")
+	if err != nil {
+		t.Fatalf("LookupActiveSession empty project: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string for empty project, got %q", got)
+	}
+
+	// empty directory
+	got, err = s.LookupActiveSession("myproject", "")
+	if err != nil {
+		t.Fatalf("LookupActiveSession empty directory: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string for empty directory, got %q", got)
+	}
+}

--- a/internal/store/sessions_lookup_test.go
+++ b/internal/store/sessions_lookup_test.go
@@ -34,6 +34,7 @@ func TestLookupActiveSessionReturnsMostRecentWhenMultipleOpen(t *testing.T) {
 		t.Fatalf("CreateSession old: %v", err)
 	}
 	// Small sleep to ensure started_at differs — SQLite datetime('now') has 1-second resolution.
+	// TODO: tighten if started_at gains sub-second resolution.
 	time.Sleep(1100 * time.Millisecond)
 	if err := s.CreateSession("uuid-new", "myproject", "/work/myproject"); err != nil {
 		t.Fatalf("CreateSession new: %v", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1057,6 +1057,14 @@ func (s *Store) migrate() error {
 		return err
 	}
 
+	// Phase: session-id-propagation (#386) — index for LookupActiveSession.
+	if _, err := s.execHook(s.db, `
+		CREATE INDEX IF NOT EXISTS idx_sessions_active_lookup
+			ON sessions(project, directory, ended_at);
+	`); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -2048,6 +2056,33 @@ func (s *Store) RecentSessions(project string, limit int) ([]SessionSummary, err
 		results = append(results, ss)
 	}
 	return results, rows.Err()
+}
+
+// LookupActiveSession returns the ID of the most recent open session matching
+// (project, directory), or "" if none exists. "Open" means ended_at IS NULL.
+// Returns "" without error when project or directory is empty.
+// This is the store-side half of the fix for #386: it lets MCP tool calls
+// without an explicit session_id resolve to the UUID session created by the
+// Claude Code SessionStart hook instead of falling back to manual-save-{project}.
+func (s *Store) LookupActiveSession(project, directory string) (string, error) {
+	if project == "" || directory == "" {
+		return "", nil
+	}
+	var id string
+	err := s.db.QueryRow(
+		`SELECT id FROM sessions
+		 WHERE project = ? AND directory = ? AND ended_at IS NULL
+		 ORDER BY started_at DESC
+		 LIMIT 1`,
+		project, directory,
+	).Scan(&id)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return id, nil
 }
 
 // AllSessions returns recent sessions ordered by most recent first (for TUI browsing).

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1058,9 +1058,15 @@ func (s *Store) migrate() error {
 	}
 
 	// Phase: session-id-propagation (#386) — index for LookupActiveSession.
+	// Includes started_at DESC so the planner can satisfy ORDER BY started_at DESC
+	// directly from the index without a TEMP B-TREE sort step. DROP first to
+	// supersede any pre-existing index that lacked the sort column.
+	if _, err := s.execHook(s.db, `DROP INDEX IF EXISTS idx_sessions_active_lookup;`); err != nil {
+		return err
+	}
 	if _, err := s.execHook(s.db, `
 		CREATE INDEX IF NOT EXISTS idx_sessions_active_lookup
-			ON sessions(project, directory, ended_at);
+			ON sessions(project, directory, ended_at, started_at DESC);
 	`); err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #386

## Summary

When the `SessionStart` hook registers a session via `POST /sessions`, subsequent `mem_save` calls without an explicit `session_id` were falling back to `manual-save-{project}` instead of attaching observations to the active UUID session. The result: every Claude Code session left an empty UUID row, while one ever-growing `manual-save-*` bucket accumulated all observations.

This PR implements direction (3) from the issue (store-side resolution), with `directory` matching to avoid cross-cwd collisions inside the same project.

## Approach

- New `store.LookupActiveSession(project, directory)` returns the most recent open session (`ended_at IS NULL`) for the resolved project, preferring the row whose `directory` matches the caller's cwd.
- New `resolveImplicitSessionID(s, project)` in `internal/mcp` is the single bridge used by every handler that previously called `defaultSessionID(project)` directly. It falls back to `manual-save-{project}` only when no active session is found.
- `SessionActivity` is now keyed by the resolved session ID rather than the raw argument, so activity tracking stays consistent whether the caller passes `session_id` explicitly or relies on implicit resolution.

## Handlers updated

- `handleSave` (`mem_save`)
- `handleSavePrompt` (`mem_save_prompt`)
- `handleSessionSummary`
- `handleSessionStart` / `handleSessionEnd`
- `handleCapturePassive`

## Behavior preserved

- Explicit `session_id` argument still wins; resolution only kicks in when the caller omits it.
- `manual-save-{project}` remains the final fallback when there is no active session row, so existing flows that never opened a session are unaffected.
- Saves still auto-fill project for authoring; the resolver only affects which session row the observation lands on.

## Tests

- `internal/store/sessions_lookup_test.go` (new) covers `LookupActiveSession`: directory match, project scoping, `ended_at` filtering, ordering by most recent.
- `internal/mcp/mcp_test.go` adds coverage across every affected handler: implicit resolution to an active session, fallback to `manual-save-*` when none is open, activity tracker keyed by the resolved ID, and the `capture_passive` and `save_prompt` / `session_summary` paths.

## Test plan

- [ ] `go test ./internal/store/... -run LookupActiveSession`
- [ ] `go test ./internal/mcp/...`
- [ ] `go test ./...`
- [ ] Optional manual: start a Claude Code session, let the hook open a session, call `mem_save` without `session_id`, verify the UUID session's `observation_count` increments instead of the `manual-save-*` row.