### PR TITLE
fix(mcp): apply process-level project override in handleSessionSummary

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1600,8 +1600,8 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		sessionID, _ := req.GetArguments()["session_id"].(string)
 		// project field intentionally not read — auto-detect only (REQ-308 write-tool contract)
 
-		// Auto-detect project from cwd; fail fast on ambiguous (REQ-308, REQ-309)
-		detRes, err := resolveWriteProject()
+		// Auto-detect project from cwd; process-level override (--project / ENGRAM_PROJECT) takes precedence.
+		detRes, err := resolveWriteProjectWithProcessOverride(cfg.DefaultProject)
 		if err != nil {
 			return writeProjectErrorResult(nil, "", detRes, err), nil
 		}


### PR DESCRIPTION
## Problem

Closes #403

`mem_session_summary` calls `resolveWriteProject()` directly, which ignores the process-level project override set via `--project` flag or `ENGRAM_PROJECT` env var (`cfg.DefaultProject`).

All other write-tool handlers in this file use `resolveWriteProjectWithProcessOverride(cfg.DefaultProject)`, but `handleSessionSummary` was calling the bare variant — so even when the MCP server is started as `engram mcp --project claudestat`, `mem_session_summary` would still auto-detect from cwd and write to the wrong project.

## Fix

One-line change: replace `resolveWriteProject()` with `resolveWriteProjectWithProcessOverride(cfg.DefaultProject)` in `handleSessionSummary`.

This aligns the handler with the pattern used by every other write-tool and respects REQ-308 (no per-call `project` parameter is added back).

## Testing

`go test ./internal/mcp/...` passes with no changes to existing tests.