### PR TITLE
docs: clarify install-from-source version stamp and Claude Code schema fallback

### DIFF
--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -244,6 +244,17 @@ claude plugin install engram
 
 That's it. The plugin registers the MCP server, hooks, and Memory Protocol skill automatically.
 
+> **If the marketplace command fails with a schema error**
+>
+> Older Claude Code CLI versions cannot parse some plugin manifest fields and will reject `claude plugin marketplace add` with messages like `Invalid schema: plugins.0.source: Invalid input`. The fix is to update the CLI:
+>
+> ```bash
+> claude --version  # check what you have
+> claude update     # upgrade to the latest
+> ```
+>
+> Then re-run the marketplace command. If you cannot update for some reason, **Option C (Bare MCP)** below works on any Claude Code version because it does not go through the marketplace.
+
 **Option B: Plugin via `engram setup`** — same plugin, installed from the embedded binary:
 
 ```bash

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,11 +51,28 @@ git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
 go install ./cmd/engram
 # Binary goes to %GOPATH%\bin\engram.exe (typically %USERPROFILE%\go\bin\)
-
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
-$v = git describe --tags --always
-go build -ldflags="-X main.version=local-$v" -o engram.exe ./cmd/engram
 ```
+
+> **Want a real version string instead of `dev`?**
+>
+> `go install` always stamps the binary as `dev`. To get a meaningful version, pick one of these — not both. Running them both leaves two binaries on disk and `engram version` keeps reporting `dev` because PATH still resolves to the `go install` build.
+>
+> **Option B1 — version-stamped `go install` (binary stays on PATH):**
+>
+> ```powershell
+> $v = git describe --tags --always
+> go install -ldflags="-X main.version=local-$v" ./cmd/engram
+> ```
+>
+> **Option B2 — `go build` and move the result onto PATH:**
+>
+> ```powershell
+> $v = git describe --tags --always
+> go build -ldflags="-X main.version=local-$v" -o engram.exe ./cmd/engram
+> Move-Item -Force engram.exe "$env:USERPROFILE\go\bin\engram.exe"
+> ```
+>
+> After either option, `engram version` should print `local-<git-describe>` instead of `dev`.
 
 **Option C: Download the prebuilt binary**
 
@@ -104,10 +121,27 @@ Expand-Archive engram_*_windows_amd64.zip -DestinationPath "$env:USERPROFILE\bin
 git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
 go install ./cmd/engram
-
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
-go build -ldflags="-X main.version=local-$(git describe --tags --always)" -o engram ./cmd/engram
+# Binary goes to $GOPATH/bin (typically ~/go/bin/)
 ```
+
+> **Want a real version string instead of `dev`?**
+>
+> `go install` always stamps the binary as `dev`. To get a meaningful version, pick one of these — not both. Running them both leaves two binaries on disk and `engram version` keeps reporting `dev` because PATH still resolves to the `go install` build.
+>
+> **Option 1 — version-stamped `go install` (binary stays on PATH):**
+>
+> ```bash
+> go install -ldflags="-X main.version=local-$(git describe --tags --always)" ./cmd/engram
+> ```
+>
+> **Option 2 — `go build` and move the result onto PATH:**
+>
+> ```bash
+> go build -ldflags="-X main.version=local-$(git describe --tags --always)" -o engram ./cmd/engram
+> mv engram "$(go env GOPATH)/bin/engram"
+> ```
+>
+> After either option, `engram version` should print `local-<git-describe>` instead of `dev`.
 
 ---
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #67

---

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

---

## 📝 Summary

- Rewrites the version-stamp tip in `docs/INSTALLATION.md` (Windows and macOS/Linux) so it is no longer two consecutive commands that leave the user with two binaries and `engram version` still printing `dev`. The new tip presents two explicit, mutually exclusive options.
- Adds a focused troubleshooting callout in `docs/AGENT-SETUP.md` for the Claude Code marketplace schema error, pointing at `claude update` and naming Bare MCP as the fallback.

## 📂 Changes

| File | Change |
|------|--------|
| `docs/INSTALLATION.md` | Replaces the inline "Optional: build with version stamp" block in both Windows and macOS/Linux sections with a callout that shows Option 1 (`go install -ldflags`) and Option 2 (`go build` + move) as separate alternatives. Warns the reader not to run both. |
| `docs/AGENT-SETUP.md` | Adds an "If the marketplace command fails with a schema error" callout right under the marketplace command in the Claude Code section. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...` (no code changes; ran as a sanity check)
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (no code changes; ran as a sanity check)
- [x] Manually verified that `go install -ldflags="-X main.version=local-$(git describe --tags --always)" ./cmd/engram` produces a binary whose `engram version` reports the stamped value instead of `dev`. The new instructions match observed behavior.

---

## ✅ Contributor Checklist

- [x] Linked an approved issue (`Closes #67`)
- [x] Added exactly one `type:*` label (`type:docs`)
- [x] Ran unit tests locally
- [x] Ran e2e tests locally
- [x] Docs updated (this PR is the doc update)
- [x] Commit follows conventional commits format
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The current `.claude-plugin/marketplace.json` uses `"source": "./plugin/claude-code"`, not `"source": "git-subdir"`, so the exact failure mode the issue cites is not reproducible against `main` today. I kept the troubleshooting callout intentionally generic ("schema errors on some manifest fields") and named the `Invalid schema: plugins.0.source: Invalid input` text only as one example, so the guidance still helps users on older CLIs who hit any related schema issue (including any future change to the manifest).
- I deliberately did NOT invent a "minimum Claude Code version" number. The original issue admitted the exact minimum was not precisely known, so the callout points at `claude update` (which always upgrades to the latest) instead of a specific version that might be wrong.
- Both `INSTALLATION.md` blocks already had a one-line version-stamp tip. The rewrite preserves the same intent but resolves the PATH gotcha the issue described.
