### PR TITLE
refactor(internal): replace log.Printf with structured slog logging

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"github.com/Gentleman-Programming/engram/internal/cloud/remote"
 	"github.com/Gentleman-Programming/engram/internal/cloud/syncguidance"
 	"github.com/Gentleman-Programming/engram/internal/diagnostic"
+	"github.com/Gentleman-Programming/engram/internal/logging"
 	"github.com/Gentleman-Programming/engram/internal/mcp"
 	"github.com/Gentleman-Programming/engram/internal/obsidian"
 	"github.com/Gentleman-Programming/engram/internal/project"
@@ -581,6 +583,8 @@ func cloudSyncFailureMessage(project string, syncErr error) string {
 }
 
 func main() {
+	logging.Init()
+
 	if len(os.Args) < 2 {
 		printUsage()
 		exitFunc(1)
@@ -599,7 +603,7 @@ func main() {
 		// that os.UserHomeDir() might have missed (e.g. MCP subprocesses on
 		// Windows where %USERPROFILE% is not propagated).
 		if home := resolveHomeFallback(); home != "" {
-			log.Printf("[engram] UserHomeDir failed, using fallback: %s", home)
+			slog.Warn("UserHomeDir failed, using fallback", "dir", home)
 			cfg = store.FallbackConfig(filepath.Join(home, ".engram"))
 		} else {
 			fatal(cfgErr)
@@ -757,7 +761,7 @@ func cmdServe(cfg store.Config) {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCh
-		log.Println("[engram] shutting down...")
+		slog.Info("shutting down")
 		cancel()
 		if mgrStop != nil {
 			mgrStop() // BW7: wait for Manager to release lease before exiting
@@ -795,7 +799,7 @@ func tryStartAutosync(ctx context.Context, s *store.Store, cfg store.Config) (au
 
 	cc, err := resolveCloudRuntimeConfig(cfg)
 	if err != nil {
-		log.Printf("[autosync] ERROR: cannot read cloud config: %v", err)
+		slog.Error("cannot read cloud config", "error", err)
 		return nil, nil
 	}
 
@@ -804,18 +808,18 @@ func tryStartAutosync(ctx context.Context, s *store.Store, cfg store.Config) (au
 
 	// REQ-211: token required.
 	if token == "" {
-		log.Printf("[autosync] ERROR: ENGRAM_CLOUD_TOKEN is required when ENGRAM_CLOUD_AUTOSYNC=1; autosync disabled")
+		slog.Error("ENGRAM_CLOUD_TOKEN required; autosync disabled")
 		return nil, nil
 	}
 	// REQ-211: server URL required.
 	if serverURL == "" {
-		log.Printf("[autosync] ERROR: ENGRAM_CLOUD_SERVER is required when ENGRAM_CLOUD_AUTOSYNC=1; autosync disabled")
+		slog.Error("ENGRAM_CLOUD_SERVER required; autosync disabled")
 		return nil, nil
 	}
 
 	remoteMT, err := remote.NewMutationTransport(serverURL, token)
 	if err != nil {
-		log.Printf("[autosync] ERROR: invalid server URL %q: %v; autosync disabled", serverURL, err)
+		slog.Error("invalid server URL", "url", serverURL, "error", err)
 		return nil, nil
 	}
 	transport := &mutationTransportAdapter{remote: remoteMT}
@@ -825,7 +829,7 @@ func tryStartAutosync(ctx context.Context, s *store.Store, cfg store.Config) (au
 	mgr := newAutosyncManager(s, transport, mgrCfg)
 
 	go mgr.Run(ctx)
-	log.Printf("[autosync] started (server=%s)", serverURL)
+	slog.Info("autosync started", "server", serverURL)
 	return mgr, mgr.Stop
 }
 
@@ -1630,9 +1634,9 @@ func cmdObsidianExport(cfg store.Config) {
 
 		if w != nil {
 			if runErr := w.Run(ctx); runErr != nil {
-				log.Printf("[engram] shutting down watch mode: %v", runErr)
+				slog.Info("shutting down watch mode", "error", runErr)
 			} else {
-				log.Printf("[engram] shutting down watch mode")
+				slog.Info("shutting down watch mode")
 			}
 		}
 		exitFunc(0)
@@ -2432,10 +2436,10 @@ func migrateOrphanedDB(correctDir string) {
 		}
 
 		// Found an orphaned DB — migrate it.
-		log.Printf("[engram] found orphaned database at %s, migrating to %s", candidate, correctDB)
+		slog.Info("found orphaned database, migrating", "from", candidate, "to", correctDB)
 
 		if err := os.MkdirAll(correctDir, 0755); err != nil {
-			log.Printf("[engram] migration failed (create dir): %v", err)
+			slog.Error("migration failed (create dir)", "error", err)
 			return
 		}
 
@@ -2447,7 +2451,7 @@ func migrateOrphanedDB(correctDir string) {
 				continue
 			}
 			if renameErr := os.Rename(src, dst); renameErr != nil {
-				log.Printf("[engram] migration failed (move %s): %v", filepath.Base(src), renameErr)
+				slog.Error("migration failed (move)", "path", filepath.Base(src), "error", renameErr)
 				return
 			}
 		}
@@ -2459,7 +2463,7 @@ func migrateOrphanedDB(correctDir string) {
 			os.Remove(orphanDir)
 		}
 
-		log.Printf("[engram] migration complete — memories recovered")
+		slog.Info("migration complete — memories recovered")
 		return
 	}
 }

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"math/rand"
 	"runtime/debug"
@@ -356,7 +356,7 @@ func (m *Manager) safeRun(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
 			stack := string(debug.Stack())
-			log.Printf("[autosync] PANIC in cycle: %v\n%s", r, stack)
+			slog.Error("PANIC in autosync cycle", "recover", r, "stack", stack)
 			m.mu.Lock()
 			m.status.Phase = PhaseBackoff
 			m.status.ReasonCode = "internal_error"
@@ -553,11 +553,9 @@ func (m *Manager) pull(ctx context.Context) error {
 	// This gives previously-deferred rows a chance to apply now that their
 	// referenced observations may have arrived.
 	if res, err := m.store.ReplayDeferred(); err != nil {
-		log.Printf("[autosync] replayDeferred error: %v", err)
-		// Non-fatal: log and continue — deferred replay failures must not halt pulls.
+		slog.Error("replayDeferred error", "error", err)
 	} else if res.Retried > 0 {
-		log.Printf("[autosync] replayDeferred: retried=%d succeeded=%d failed=%d dead=%d",
-			res.Retried, res.Succeeded, res.Failed, res.Dead)
+		slog.Info("replayDeferred", "retried", res.Retried, "succeeded", res.Succeeded, "failed", res.Failed, "dead", res.Dead)
 	}
 
 	state, err := m.store.GetSyncState(m.cfg.TargetKey)

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -127,7 +127,7 @@ func (s *CloudServer) Start() error {
 		host = defaultHost
 	}
 	addr := fmt.Sprintf("%s:%d", host, s.port)
-	log.Printf("[engram-cloud] listening on %s", addr)
+	slog.Info("cloud server listening", "addr", addr)
 	return s.listenAndServe(addr, s.Handler())
 }
 
@@ -434,10 +434,10 @@ func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
 					Outcome:     cloudstore.AuditOutcomeRejectedProjectPaused,
 					ReasonCode:  "sync-paused",
 				}); aerr != nil {
-					log.Printf("cloudserver: audit insert failed (chunk push): %v", aerr)
+					slog.Error("audit insert failed", "error", aerr)
 				}
 			} else {
-				log.Printf("cloudserver: store (%T) does not implement InsertAuditEntry; audit skipped", s.store)
+				slog.Warn("store does not implement InsertAuditEntry; audit skipped")
 			}
 			// JW4: include project envelope fields in 409 response, consistent
 			// with the mutation push 409 envelope (REQ-414 parity for chunk path).
@@ -476,7 +476,7 @@ func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
 	computedChunkID := chunkIDFromPayload(normalizedData)
 	providedChunkID := strings.TrimSpace(req.ChunkID)
 	if providedChunkID != "" && providedChunkID != computedChunkID {
-		log.Printf("cloudserver: chunk_id mismatch for project %q: client=%q server=%q; accepting server-canonicalized payload", project, providedChunkID, computedChunkID)
+		slog.Warn("chunk_id mismatch, accepting canonicalized", "provided", providedChunkID, "computed", computedChunkID)
 	}
 	clientCreatedAt := strings.TrimSpace(req.ClientCreatedAt)
 	if clientCreatedAt != "" {

--- a/internal/cloud/remote/transport.go
+++ b/internal/cloud/remote/transport.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -408,7 +408,7 @@ func newMutationHTTPStatusError(operation string, statusCode int, body []byte) e
 	errorCode := strings.TrimSpace(payload.ErrorCode)
 	if statusCode == http.StatusNotFound {
 		errorCode = "server_unsupported"
-		log.Printf("[autosync] cloud mutation endpoint returned 404 (server_unsupported); deploy the new server first before enabling ENGRAM_CLOUD_AUTOSYNC=1")
+		slog.Warn("cloud mutation endpoint returned 404 (server_unsupported)")
 	}
 
 	return &HTTPStatusError{

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,41 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func Init() {
+	level := parseLevel()
+	opts := &slog.HandlerOptions{Level: level}
+
+	var handler slog.Handler
+	if parseFormat() == "json" {
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	}
+
+	slog.SetDefault(slog.New(handler))
+}
+
+func parseLevel() slog.Level {
+	switch strings.ToLower(os.Getenv("ENGRAM_LOG_LEVEL")) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func parseFormat() string {
+	if strings.EqualFold(os.Getenv("ENGRAM_LOG_FORMAT"), "json") {
+		return "json"
+	}
+	return "text"
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestInitDefaults(t *testing.T) {
+	os.Unsetenv("ENGRAM_LOG_LEVEL")
+	os.Unsetenv("ENGRAM_LOG_FORMAT")
+
+	Init()
+
+	l := slog.Default()
+	h := l.Handler()
+	if _, ok := h.(*slog.TextHandler); !ok {
+		t.Errorf("default handler = %T, want *slog.TextHandler", h)
+	}
+}
+
+func TestInitJSON(t *testing.T) {
+	os.Setenv("ENGRAM_LOG_FORMAT", "json")
+	defer os.Unsetenv("ENGRAM_LOG_FORMAT")
+
+	Init()
+
+	l := slog.Default()
+	h := l.Handler()
+	if _, ok := h.(*slog.JSONHandler); !ok {
+		t.Errorf("handler = %T, want *slog.JSONHandler", h)
+	}
+}
+
+func TestInitLevelDebug(t *testing.T) {
+	os.Setenv("ENGRAM_LOG_LEVEL", "debug")
+	defer os.Unsetenv("ENGRAM_LOG_LEVEL")
+	os.Unsetenv("ENGRAM_LOG_FORMAT")
+
+	Init()
+
+	l := slog.Default()
+	h := l.Handler()
+	th, ok := h.(*slog.TextHandler)
+	if !ok {
+		t.Fatalf("handler = %T, want *slog.TextHandler", h)
+	}
+	_ = th
+	if !th.Enabled(nil, slog.LevelDebug) {
+		t.Error("handler should be enabled at LevelDebug")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -129,7 +129,7 @@ func (s *Server) Start() error {
 	if err != nil {
 		return fmt.Errorf("engram server: listen %s: %w", addr, err)
 	}
-	log.Printf("[engram] HTTP server listening on %s", addr)
+	slog.Info("HTTP server listening", "addr", addr)
 	return serveFn(ln, s.mux)
 }
 
@@ -801,7 +801,7 @@ func (s *Server) handleMigrateProject(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.store.MigrateProject(body.OldProject, body.NewProject)
 	if err != nil {
-		log.Printf("[engram] project migration failed: %v", err)
+		slog.Error("project migration failed", "error", err)
 		jsonError(w, http.StatusInternalServerError, "migration failed")
 		return
 	}
@@ -811,9 +811,11 @@ func (s *Server) handleMigrateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[engram] migrated project %q → %q (obs: %d, sessions: %d, prompts: %d)",
-		body.OldProject, body.NewProject,
-		result.ObservationsUpdated, result.SessionsUpdated, result.PromptsUpdated)
+	slog.Info("project migrated",
+		"from", body.OldProject, "to", body.NewProject,
+		"observations", result.ObservationsUpdated,
+		"sessions", result.SessionsUpdated,
+		"prompts", result.PromptsUpdated)
 
 	jsonResponse(w, http.StatusOK, map[string]any{
 		"status":       "migrated",


### PR DESCRIPTION
Closes #411

## Summary

Replace ad-hoc `log.Printf` calls across the server and cloud packages with structured logging via Go's standard `log/slog` package. Adds a new `internal/logging` package that reads `ENGRAM_LOG_LEVEL` and `ENGRAM_LOG_FORMAT` environment variables, making output format (text vs JSON) and verbosity configurable without recompilation.

## Why This Matters

- **Observability**: JSON output is parseable by log aggregators (Datadog, Loki, Grafana, etc.). Operators can filter on structured fields like `"error"`, `"server"`, `"addr"`, `"observations"` instead of grepping unstructured text.
- **Consistency**: Removes 5 different ad-hoc prefix styles (`[engram]`, `[autosync]`, `[engram-cloud]`, `cloudserver:`, `[engram]`) in favor of standard `slog.Info/Error/Warn` with key=value pairs.
- **Configurability**: `ENGRAM_LOG_FORMAT=json` for structured output, `ENGRAM_LOG_LEVEL=debug` for verbose diagnostics — no recompile needed.
- **Zero new dependencies**: `log/slog` is in Go 1.21+ standard library.
- **MCP-safe**: Outputs to `os.Stderr` (same as slog default), so it never interferes with the MCP stdout protocol.

## Changes

| File | Change |
|------|--------|
| `internal/logging/logging.go` (new) | New package with `Init()`, `parseLevel()`, `parseFormat()` — reads env vars, configures handler to `os.Stderr` |
| `internal/logging/logging_test.go` (new) | 3 tests covering defaults, JSON format toggle, and debug level |
| `cmd/engram/main.go` | Added `logging.Init()` as first call in `main()`; converted 13 `log.Printf` → `slog.Warn/Info/Error` with structured attributes |
| `internal/server/server.go` | Converted 3 `log.Printf` → `slog.Info/Error` |
| `internal/cloud/autosync/manager.go` | Converted 3 `log.Printf` → `slog.Error/Info` |
| `internal/cloud/cloudserver/cloudserver.go` | Converted 4 `log.Printf` → `slog.Info/Warn/Error` |
| `internal/cloud/remote/transport.go` | Converted 1 `log.Printf` → `slog.Warn` |

## Test Plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./internal/logging/...` — 3/3 pass (defaults, JSON, debug)
- [x] `go test ./internal/server/...` — existing tests still pass
- [x] `ENGRAM_LOG_FORMAT=json go run ./cmd/engram serve` — produces valid JSON on stderr

## Not Converted (Deferred)

- `internal/store/*.go` (13 logs) — internal debugging, less user-facing
- `internal/cloud/dashboard/*.go` (~22 logs) — template rendering errors
- `internal/obsidian/watcher.go` — uses injectable `Logf` pattern (keep it)

## Checklist

- [x] Linked an approved issue (#411)
- [x] Unit tests pass locally
- [x] Manually tested the affected functionality
