### PR TITLE
fix(mcp): resolve project from session to fix global CWD detection bug in Antigravity

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -726,6 +726,12 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 				mcp.WithDestructiveHintAnnotation(false),
 				mcp.WithIdempotentHintAnnotation(true),
 				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("cwd",
+					mcp.Description("Optional working directory path of the client"),
+				),
+				mcp.WithString("directory",
+					mcp.Description("Optional working directory path of the client (alias for cwd)"),
+				),
 			),
 			handleCurrentProject(s, cfg),
 		)
@@ -868,7 +874,13 @@ ERROR: Returns IsError=true if IDs are unknown, relation is invalid, or cross-pr
 // detection info is available (REQ-313).
 func handleCurrentProject(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		cwd, _ := os.Getwd()
+		cwd, _ := req.GetArguments()["cwd"].(string)
+		if cwd == "" {
+			cwd, _ = req.GetArguments()["directory"].(string)
+		}
+		if cwd == "" {
+			cwd, _ = os.Getwd()
+		}
 		res := projectpkg.DetectProjectFull(cwd)
 		if processRes, ok := processProjectResult(cfg.DefaultProject); ok {
 			res = processRes
@@ -1600,12 +1612,29 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		sessionID, _ := req.GetArguments()["session_id"].(string)
 		// project field intentionally not read — auto-detect only (REQ-308 write-tool contract)
 
-		// Auto-detect project from cwd; fail fast on ambiguous (REQ-308, REQ-309)
-		detRes, err := resolveWriteProject()
-		if err != nil {
-			return writeProjectErrorResult(nil, "", detRes, err), nil
+		var project string
+		var detRes projectpkg.DetectionResult
+		var err error
+
+		if sessionID != "" {
+			if sess, errSess := s.GetSession(sessionID); errSess == nil {
+				project = sess.Project
+				detRes = projectpkg.DetectionResult{
+					Project: project,
+					Source:  projectpkg.SourceSessionProject,
+					Path:    sess.Directory,
+				}
+			}
 		}
-		project, _ := store.NormalizeProject(detRes.Project)
+
+		if project == "" {
+			detRes, err = resolveWriteProject()
+			if err != nil {
+				return writeProjectErrorResult(nil, "", detRes, err), nil
+			}
+			project = detRes.Project
+		}
+		project, _ = store.NormalizeProject(project)
 
 		if sessionID == "" {
 			sessionID = defaultSessionID(project)
@@ -1681,21 +1710,39 @@ func handleSessionEnd(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 		summary, _ := req.GetArguments()["summary"].(string)
 		// project field intentionally not read — auto-detect only (REQ-308)
 
-		detRes, err := resolveWriteProject()
-		if err != nil {
-			if errors.Is(err, projectpkg.ErrInvalidConfig) {
-				return writeProjectErrorResult(nil, "", detRes, err), nil
-			}
-			// For session end, still complete the operation even if project resolution fails.
-			// Use basename fallback.
-			cwd, _ := os.Getwd()
-			detRes = projectpkg.DetectionResult{
-				Project: projectpkg.DetectProject(cwd),
-				Source:  "dir_basename",
-				Path:    cwd,
+		var project string
+		var detRes projectpkg.DetectionResult
+		var err error
+
+		if id != "" {
+			if sess, errSess := s.GetSession(id); errSess == nil {
+				project = sess.Project
+				detRes = projectpkg.DetectionResult{
+					Project: project,
+					Source:  projectpkg.SourceSessionProject,
+					Path:    sess.Directory,
+				}
 			}
 		}
-		project, _ := store.NormalizeProject(detRes.Project)
+
+		if project == "" {
+			detRes, err = resolveWriteProject()
+			if err != nil {
+				if errors.Is(err, projectpkg.ErrInvalidConfig) {
+					return writeProjectErrorResult(nil, "", detRes, err), nil
+				}
+				// For session end, still complete the operation even if project resolution fails.
+				// Use basename fallback.
+				cwd, _ := os.Getwd()
+				detRes = projectpkg.DetectionResult{
+					Project: projectpkg.DetectProject(cwd),
+					Source:  "dir_basename",
+					Path:    cwd,
+				}
+			}
+			project = detRes.Project
+		}
+		project, _ = store.NormalizeProject(project)
 
 		if err := s.EndSession(id, summary); err != nil {
 			return mcp.NewToolResultError("Failed to end session: " + err.Error()), nil

--- a/internal/mcp/mcp_session_project_test.go
+++ b/internal/mcp/mcp_session_project_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mcppkg "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestHandleCurrentProjectWithCwd(t *testing.T) {
+	s := newMCPTestStore(t)
+	h := handleCurrentProject(s, MCPConfig{})
+
+	// Create a temp directory that mimics a project structure
+	tmpDir := t.TempDir()
+	projDir := filepath.Join(tmpDir, "custom-project-name")
+	if err := os.Mkdir(projDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// We pass cwd as argument
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"cwd": projDir,
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected handler error: %s", callResultText(t, res))
+	}
+
+	text := callResultText(t, res)
+	if !strings.Contains(text, "custom-project-name") {
+		t.Fatalf("expected project name 'custom-project-name' in output, got: %q", text)
+	}
+}
+
+func TestHandleCurrentProjectWithDirectory(t *testing.T) {
+	s := newMCPTestStore(t)
+	h := handleCurrentProject(s, MCPConfig{})
+
+	// Create a temp directory that mimics a project structure
+	tmpDir := t.TempDir()
+	projDir := filepath.Join(tmpDir, "another-custom-project")
+	if err := os.Mkdir(projDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// We pass directory as argument
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"directory": projDir,
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected handler error: %s", callResultText(t, res))
+	}
+
+	text := callResultText(t, res)
+	if !strings.Contains(text, "another-custom-project") {
+		t.Fatalf("expected project name 'another-custom-project' in output, got: %q", text)
+	}
+}
+
+func TestHandleSessionSummaryResolvesFromSession(t *testing.T) {
+	s := newMCPTestStore(t)
+	// Create session for "my-real-project"
+	sessionID := "sess-xyz-123"
+	if err := s.CreateSession(sessionID, "my-real-project", "/tmp/my-real-project"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSessionSummary(s, MCPConfig{}, activity)
+
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"session_id": sessionID,
+		"content":    "## Goal\nTest\n## Accomplished\nDone\n",
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected handler error: %s", callResultText(t, res))
+	}
+
+	// Verify that summary observation was created under project "my-real-project"
+	obs, err := s.RecentObservations("my-real-project", "project", 5)
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("expected 1 summary observation under project 'my-real-project', got: %d", len(obs))
+	}
+	if obs[0].SessionID != sessionID {
+		t.Fatalf("expected observation session ID to be %q, got: %q", sessionID, obs[0].SessionID)
+	}
+}
+
+func TestHandleSessionEndResolvesFromSession(t *testing.T) {
+	s := newMCPTestStore(t)
+	// Create session for "my-ended-project"
+	sessionID := "sess-end-999"
+	if err := s.CreateSession(sessionID, "my-ended-project", "/tmp/my-ended-project"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSessionEnd(s, MCPConfig{}, activity)
+
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":      sessionID,
+		"summary": "This session is done",
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected handler error: %s", callResultText(t, res))
+	}
+
+	// Verify the session is ended in store
+	sess, err := s.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if sess.EndedAt == nil {
+		t.Fatalf("expected session to be marked as ended")
+	}
+	if sess.Summary == nil || *sess.Summary != "This session is done" {
+		t.Fatalf("expected session summary 'This session is done', got: %v", sess.Summary)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #413 

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Added optional `cwd` and `directory` string parameters to `mem_current_project` tool to allow clients to send their actual workspace path.
- Decoupled `handleSessionSummary` and `handleSessionEnd` project resolution from the server's working directory (`os.Getwd()`) by querying the session record directly from the SQLite database.
- Fixes incorrect project detection mapping all global agent sessions to a fallback directory ("antigravity").

---

## 📂 Changes

| File | Change |
|------|--------|
| `internal/mcp/mcp.go` | Registered client working directory arguments in `mem_current_project` and fetched project from DB sessions in summary/end handlers. |
| `internal/mcp/mcp_session_project_test.go` | Created unit tests verifying project detection through parameter arguments and DB session records. |

---

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

### Manual Testing Steps
1. Ran the specific MCP tests locally (`go test github.com/Gentleman-Programming/engram/internal/mcp -run "TestHandleCurrentProject|TestHandleSessionSummaryResolves|TestHandleSessionEndResolves"`), which passed in `0.788s`.
2. Verified that when a session ID is provided, the database-linked project path is chosen instead of the process working directory.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This is a critical patch for users on global agent hosts like Google Antigravity or global IDE extensions. When running globally, `os.Getwd()` returns the installation path (e.g. `C:\Users\...\AppData\Local\Programs\Antigravity`), forcing all session summaries and closed sessions to overwrite memories in a default "antigravity" workspace instead of the user's actual project folder.