### PR TITLE
feat(setup): add antigravity agent support

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -255,6 +255,11 @@ func SupportedAgents() []Agent {
 			InstallDir:  geminiConfigPath(),
 		},
 		{
+			Name:        "antigravity",
+			Description: "Antigravity — MCP registration for Antigravity CLI and IDE plus system rules",
+			InstallDir:  antigravityConfigPath(),
+		},
+		{
 			Name:        "codex",
 			Description: "Codex — MCP registration plus model/compaction instruction files",
 			InstallDir:  codexConfigPath(),
@@ -273,10 +278,12 @@ func Install(agentName string) (*Result, error) {
 		return installClaudeCode()
 	case "gemini-cli":
 		return installGeminiCLI()
+	case "antigravity":
+		return installAntigravity()
 	case "codex":
 		return installCodex()
 	default:
-		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, gemini-cli, codex)", agentName)
+		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, gemini-cli, antigravity, codex)", agentName)
 	}
 }
 
@@ -1261,3 +1268,105 @@ func codexInstructionsPath() string {
 func codexCompactPromptPath() string {
 	return filepath.Join(filepath.Dir(codexConfigPath()), "engram-compact-prompt.md")
 }
+
+func installAntigravity() (*Result, error) {
+	path := antigravityConfigPath()
+	if err := injectAntigravityMCP(path); err != nil {
+		return nil, err
+	}
+
+	if err := writeAntigravitySystemPrompt(); err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Agent:       "antigravity",
+		Destination: filepath.Dir(path),
+		Files:       2,
+	}, nil
+}
+
+func antigravityConfigPath() string {
+	home, _ := userHomeDir()
+
+	switch runtimeGOOS {
+	case "windows":
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			return filepath.Join(appData, "gemini", "config", "mcp_config.json")
+		}
+		return filepath.Join(home, "AppData", "Roaming", "gemini", "config", "mcp_config.json")
+	default:
+		return filepath.Join(home, ".gemini", "config", "mcp_config.json")
+	}
+}
+
+func injectAntigravityMCP(configPath string) error {
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	var config map[string]json.RawMessage
+	data, err := readFileFn(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			config = make(map[string]json.RawMessage)
+		} else {
+			return fmt.Errorf("read config: %w", err)
+		}
+	} else {
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("parse config: %w", err)
+		}
+	}
+
+	var mcpServers map[string]json.RawMessage
+	if raw, exists := config["mcpServers"]; exists {
+		if err := json.Unmarshal(raw, &mcpServers); err != nil {
+			return fmt.Errorf("parse mcpServers block: %w", err)
+		}
+	} else {
+		mcpServers = make(map[string]json.RawMessage)
+	}
+
+	engramEntry := map[string]any{
+		"command": resolveEngramCommand(),
+		"args":    []string{"mcp", "--tools=agent"},
+	}
+	entryJSON, err := jsonMarshalFn(engramEntry)
+	if err != nil {
+		return fmt.Errorf("marshal engram entry: %w", err)
+	}
+	mcpServers["engram"] = json.RawMessage(entryJSON)
+
+	mcpJSON, err := jsonMarshalFn(mcpServers)
+	if err != nil {
+		return fmt.Errorf("marshal mcpServers block: %w", err)
+	}
+	config["mcpServers"] = json.RawMessage(mcpJSON)
+
+	output, err := jsonMarshalIndentFn(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	if err := writeFileFn(configPath, output, 0644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	return nil
+}
+
+func writeAntigravitySystemPrompt() error {
+	home, _ := userHomeDir()
+	systemPath := filepath.Join(home, ".gemini", "GEMINI.md")
+	if err := os.MkdirAll(filepath.Dir(systemPath), 0755); err != nil {
+		return fmt.Errorf("create gemini system prompt dir: %w", err)
+	}
+
+	if err := writeFileFn(systemPath, []byte(memoryProtocolMarkdown), 0644); err != nil {
+		return fmt.Errorf("write gemini system prompt: %w", err)
+	}
+
+	return nil
+}
+

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -256,7 +256,7 @@ func SupportedAgents() []Agent {
 		},
 		{
 			Name:        "antigravity",
-			Description: "Antigravity — MCP registration for Antigravity CLI and IDE plus system rules",
+			Description: "Antigravity — MCP registration for Antigravity CLI and Desktop plus system rules",
 			InstallDir:  antigravityConfigPath(),
 		},
 		{
@@ -1289,15 +1289,11 @@ func installAntigravity() (*Result, error) {
 func antigravityConfigPath() string {
 	home, _ := userHomeDir()
 
-	switch runtimeGOOS {
-	case "windows":
-		if appData := os.Getenv("APPDATA"); appData != "" {
-			return filepath.Join(appData, "gemini", "config", "mcp_config.json")
-		}
-		return filepath.Join(home, "AppData", "Roaming", "gemini", "config", "mcp_config.json")
-	default:
-		return filepath.Join(home, ".gemini", "config", "mcp_config.json")
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+	if _, err := os.Stat(desktopDir); err == nil {
+		return filepath.Join(desktopDir, "mcp_config.json")
 	}
+	return filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json")
 }
 
 func injectAntigravityMCP(configPath string) error {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3022,3 +3022,60 @@ func TestPluginSubAgentFiltering(t *testing.T) {
 		t.Fatalf("session.deleted handler must clean up subAgentSessions set")
 	}
 }
+
+// ─── Antigravity setup tests ──────────────────────────────────────────────────
+
+func TestInstallAntigravity(t *testing.T) {
+	t.Run("installAntigravity resolves desktop variant first", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		
+		// Create the desktop folder to simulate its existence
+		desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+		if err := os.MkdirAll(desktopDir, 0755); err != nil {
+			t.Fatalf("mkdir desktop: %v", err)
+		}
+		
+		// Set executable fallback
+		osExecutable = func() (string, error) { return "/usr/local/bin/engram", nil }
+		
+		res, err := installAntigravity()
+		if err != nil {
+			t.Fatalf("installAntigravity failed: %v", err)
+		}
+		
+		if res.Destination != desktopDir {
+			t.Fatalf("expected destination %q, got %q", desktopDir, res.Destination)
+		}
+		
+		// Check that mcp_config.json was written to the desktop folder
+		configPath := filepath.Join(desktopDir, "mcp_config.json")
+		if _, err := os.Stat(configPath); err != nil {
+			t.Fatalf("mcp_config.json not found at %s: %v", configPath, err)
+		}
+	})
+
+	t.Run("installAntigravity falls back to cli variant", func(t *testing.T) {
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		
+		// Set executable fallback
+		osExecutable = func() (string, error) { return "/usr/local/bin/engram", nil }
+		
+		res, err := installAntigravity()
+		if err != nil {
+			t.Fatalf("installAntigravity failed: %v", err)
+		}
+		
+		cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+		if res.Destination != cliDir {
+			t.Fatalf("expected destination %q, got %q", cliDir, res.Destination)
+		}
+		
+		configPath := filepath.Join(cliDir, "mcp_config.json")
+		if _, err := os.Stat(configPath); err != nil {
+			t.Fatalf("mcp_config.json not found at %s: %v", configPath, err)
+		}
+	})
+}
+


### PR DESCRIPTION
This PR implements native automated setup support for the Google Antigravity agent in the `engram setup` pipeline, addressing Issue #120.

### What this PR does:

1. Adds `"antigravity"` to the list of supported agents in `SupportedAgents()`, with description updated to reflect Antigravity CLI and Desktop support.
2. Registers a new `installAntigravity()` configuration routine that:
   - Dynamically resolves configuration paths, scanning for the existence of `~/.gemini/antigravity-desktop` (Desktop path) and falling back to `~/.gemini/antigravity-cli` (CLI path).
   - Configures the MCP server configuration in `mcp_config.json` inside the resolved variant folder with the absolute path of the `engram` binary and correct `--tools=agent` arguments.
   - Writes the Memory Protocol rules and compaction instructions file `~/.gemini/GEMINI.md` to restore context after model compactions.
3. Adds comprehensive unit tests in `setup_test.go` (`TestInstallAntigravity`) to assert successful setup across both scenarios: Desktop folder exists (preferred) and CLI fallback.
4. Successfully passes all Go unit tests for setup loading and config validation.

Fixes #120