### PR TITLE
feat(sync): add --dir flag for custom sync directory

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1262,6 +1262,7 @@ func cmdSync(cfg store.Config) {
 	doCloud := false
 	project := ""
 	projectProvided := false
+	customDir := ""
 	for i := 2; i < len(os.Args); i++ {
 		switch os.Args[i] {
 		case "--help", "-h", "help":
@@ -1279,6 +1280,11 @@ func cmdSync(cfg store.Config) {
 			if i+1 < len(os.Args) {
 				project = os.Args[i+1]
 				projectProvided = true
+				i++
+			}
+		case "--dir":
+			if i+1 < len(os.Args) {
+				customDir = os.Args[i+1]
 				i++
 			}
 		}
@@ -1301,6 +1307,12 @@ func cmdSync(cfg store.Config) {
 	}
 
 	syncDir := ".engram"
+	if envDir := os.Getenv("ENGRAM_SYNC_DIR"); envDir != "" {
+		syncDir = envDir
+	}
+	if customDir != "" {
+		syncDir = customDir
+	}
 
 	s, err := storeNew(cfg)
 	if err != nil {
@@ -1472,7 +1484,11 @@ func cmdSync(cfg store.Config) {
 }
 
 func printSyncUsage() {
-	fmt.Println("usage: engram sync [--import | --status] [--all] [--cloud --project PROJECT]")
+	fmt.Println("usage: engram sync [--import | --status] [--all] [--dir DIR] [--cloud --project PROJECT]")
+	fmt.Println()
+	fmt.Println("  --dir DIR    Use DIR instead of .engram/ for chunk storage.")
+	fmt.Println("               Also configurable via ENGRAM_SYNC_DIR env var.")
+	fmt.Println()
 	fmt.Println("Local sync exports project-scoped chunks to .engram/ by default.")
 	fmt.Println("Cloud sync requires an explicit --project and never runs from --help.")
 }

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1456,3 +1456,108 @@ func TestObsidianExportWatchModeCallsInjectedWatcher(t *testing.T) {
 		t.Fatalf("expected non-nil Logf in WatcherConfig")
 	}
 }
+
+func TestCmdSyncDirFlag(t *testing.T) {
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+
+	customDir := filepath.Join(workDir, "custom-sync-dir")
+
+	exportCfg := testConfig(t)
+	importCfg := testConfig(t)
+
+	mustSeedObservation(t, exportCfg, "s-dir", "dir-project", "note", "dir test", "dir content", "project")
+
+	// Export with --dir flag
+	withArgs(t, "engram", "sync", "--all", "--dir", customDir)
+	exportOut, exportErr := captureOutput(t, func() { cmdSync(exportCfg) })
+	if exportErr != "" {
+		t.Fatalf("expected no stderr from export with --dir, got: %q", exportErr)
+	}
+	if !strings.Contains(exportOut, "Created chunk") {
+		t.Fatalf("unexpected export output: %q", exportOut)
+	}
+
+	// Verify chunk was created in custom directory
+	if _, err := os.Stat(filepath.Join(customDir, "manifest.json")); err != nil {
+		t.Fatalf("manifest.json not found in custom dir: %v", err)
+	}
+	chunksDir := filepath.Join(customDir, "chunks")
+	entries, err := os.ReadDir(chunksDir)
+	if err != nil {
+		t.Fatalf("failed to read chunks dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 chunk file, got %d", len(entries))
+	}
+
+	// Verify default .engram/ was NOT created
+	if _, err := os.Stat(filepath.Join(workDir, ".engram", "manifest.json")); err == nil {
+		t.Fatalf(".engram/manifest.json should not exist when --dir is used")
+	}
+
+	// Import from custom dir into a different store
+	withArgs(t, "engram", "sync", "--import", "--dir", customDir)
+	importOut, importErr := captureOutput(t, func() { cmdSync(importCfg) })
+	if importErr != "" {
+		t.Fatalf("expected no stderr from import with --dir, got: %q", importErr)
+	}
+	if !strings.Contains(importOut, "Imported 1 new chunk(s)") {
+		t.Fatalf("unexpected import output: %q", importOut)
+	}
+}
+
+func TestCmdSyncDirEnvVar(t *testing.T) {
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+
+	customDir := filepath.Join(workDir, "env-sync-dir")
+
+	cfg := testConfig(t)
+	mustSeedObservation(t, cfg, "s-env", "env-project", "note", "env test", "env content", "project")
+
+	// Set env var
+	t.Setenv("ENGRAM_SYNC_DIR", customDir)
+
+	// Export using env var (no --dir flag)
+	withArgs(t, "engram", "sync", "--all")
+	exportOut, _ := captureOutput(t, func() { cmdSync(cfg) })
+	if !strings.Contains(exportOut, "Created chunk") {
+		t.Fatalf("unexpected export output with env var: %q", exportOut)
+	}
+
+	// Verify chunk was created in env var directory
+	if _, err := os.Stat(filepath.Join(customDir, "manifest.json")); err != nil {
+		t.Fatalf("manifest.json not found in env var dir: %v", err)
+	}
+}
+
+func TestCmdSyncDirFlagOverridesEnvVar(t *testing.T) {
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+
+	envDir := filepath.Join(workDir, "env-dir")
+	flagDir := filepath.Join(workDir, "flag-dir")
+
+	cfg := testConfig(t)
+	mustSeedObservation(t, cfg, "s-override", "override-project", "note", "override test", "override content", "project")
+
+	// Set env var AND --dir flag — flag should win
+	t.Setenv("ENGRAM_SYNC_DIR", envDir)
+
+	withArgs(t, "engram", "sync", "--all", "--dir", flagDir)
+	exportOut, _ := captureOutput(t, func() { cmdSync(cfg) })
+	if !strings.Contains(exportOut, "Created chunk") {
+		t.Fatalf("unexpected export output: %q", exportOut)
+	}
+
+	// Flag dir should have the chunk
+	if _, err := os.Stat(filepath.Join(flagDir, "manifest.json")); err != nil {
+		t.Fatalf("manifest.json not found in flag dir: %v", err)
+	}
+
+	// Env dir should NOT have the chunk
+	if _, err := os.Stat(filepath.Join(envDir, "manifest.json")); err == nil {
+		t.Fatalf("manifest.json should not exist in env dir when --dir flag is used")
+	}
+}

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -50,7 +50,14 @@ if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
 fi
 
 # Auto-import git-synced chunks
+# Check both .engram/ (default) and .atl/engram/ (team convention)
+SYNC_DIR=""
 if [ -f "${CWD}/.engram/manifest.json" ]; then
+  SYNC_DIR="${CWD}/.engram"
+elif [ -f "${CWD}/.atl/engram/manifest.json" ]; then
+  SYNC_DIR="${CWD}/.atl/engram"
+fi
+if [ -n "$SYNC_DIR" ]; then
   (
     cd "$CWD" 2>/dev/null || exit 0
     IMPORT_LOCK="/tmp/engram-sync-import-$(printf '%s' "$CWD" | cksum | cut -d ' ' -f 1).lock"
@@ -121,9 +128,9 @@ if [ -f "${CWD}/.engram/manifest.json" ]; then
     fi
     trap 'rm -f "$IMPORT_LOCK/info" 2>/dev/null || true; rmdir "$IMPORT_LOCK" 2>/dev/null || true' EXIT
     if command -v timeout >/dev/null 2>&1; then
-      timeout "${IMPORT_TIMEOUT_SECS}s" engram sync --import >/dev/null 2>&1 || true
+      timeout "${IMPORT_TIMEOUT_SECS}s" engram sync --import --dir "$SYNC_DIR" >/dev/null 2>&1 || true
     else
-      engram sync --import >/dev/null 2>&1 &
+      engram sync --import --dir "$SYNC_DIR" >/dev/null 2>&1 &
       IMPORT_PID=$!
       (sleep "$IMPORT_TIMEOUT_SECS"; kill "$IMPORT_PID" 2>/dev/null || true) &
       WAITER_PID=$!

--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Engram — Stop hook for Claude Code (async)
 #
-# Marks the session as ended via the HTTP API.
+# 1. Exports new memories to git-synced chunks (if sync dir exists)
+# 2. Marks the session as ended via the HTTP API.
 # Runs async so it doesn't block Claude's response.
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
@@ -9,9 +10,22 @@ ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 if [ -z "$SESSION_ID" ]; then
   exit 0
+fi
+
+# Auto-export memories to git-synced chunks
+# Check both .engram/ (default) and .atl/engram/ (team convention)
+SYNC_DIR=""
+if [ -f "${CWD}/.engram/manifest.json" ]; then
+  SYNC_DIR="${CWD}/.engram"
+elif [ -f "${CWD}/.atl/engram/manifest.json" ]; then
+  SYNC_DIR="${CWD}/.atl/engram"
+fi
+if [ -n "$SYNC_DIR" ]; then
+  engram sync --dir "$SYNC_DIR" >/dev/null 2>&1 &
 fi
 
 curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}/end" \


### PR DESCRIPTION
## Summary

- Add `--dir` CLI flag to `engram sync` for custom sync directory (overrides default `.engram/`)
- Add `ENGRAM_SYNC_DIR` environment variable as fallback (flag takes precedence)
- Update session-start/stop hooks to auto-detect `.atl/engram/` alongside `.engram/`
- Add 3 tests: flag usage, env var usage, flag-overrides-env-var

## Motivation

Enables team workflows where chunks are stored in a repo-relative directory (e.g., `.atl/engram/`) and shared via Git. This way multiple developers can share memory context through their existing Git workflow with zero token overhead — sync happens entirely in shell hooks, not in the agent.

## Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Parse `--dir` flag + `ENGRAM_SYNC_DIR` env var in `cmdSync()`, update `printSyncUsage()` |
| `cmd/engram/main_test.go` | 3 new tests covering flag, env var, and precedence |
| `plugin/claude-code/scripts/session-start.sh` | Auto-detect `.atl/engram/` dir, pass `--dir` to import |
| `plugin/claude-code/scripts/session-stop.sh` | Add auto-export with `--dir` on session end |

## Test plan

- [x] `TestCmdSyncDirFlag` — export/import with `--dir` works, default `.engram/` not created
- [x] `TestCmdSyncDirEnvVar` — export uses `ENGRAM_SYNC_DIR` when no flag
- [x] `TestCmdSyncDirFlagOverridesEnvVar` — `--dir` takes precedence over env var
- [x] All existing `TestCmdSync*` tests pass (0 regressions)