### PR TITLE
fix(mcp): harden handleSessionSummary with process override and empty-content guard

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1600,8 +1600,15 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		sessionID, _ := req.GetArguments()["session_id"].(string)
 		// project field intentionally not read — auto-detect only (REQ-308 write-tool contract)
 
-		// Auto-detect project from cwd; fail fast on ambiguous (REQ-308, REQ-309)
-		detRes, err := resolveWriteProject()
+		// Reject empty/whitespace-only content before any project resolution (#393).
+		if strings.TrimSpace(content) == "" {
+			return mcp.NewToolResultError("content is required for mem_session_summary"), nil
+		}
+
+		// Honour process-level project override (cfg.DefaultProject) set via
+		// ENGRAM_PROJECT or `engram mcp --project` (#403/#413). Falls back to cwd
+		// detection when no override is configured.
+		detRes, err := resolveWriteProjectWithProcessOverride(cfg.DefaultProject)
 		if err != nil {
 			return writeProjectErrorResult(nil, "", detRes, err), nil
 		}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -6519,3 +6519,132 @@ func TestProcessOverrideSaveHandlerWritesToDefaultProject(t *testing.T) {
 		t.Fatalf("results in trusted project = %d; want 1", len(results))
 	}
 }
+
+// ─── #403/#413: handleSessionSummary process-override tests ──────────────────
+
+// TestSessionSummary_ProcessOverrideWritesToDefaultProject verifies that when
+// cfg.DefaultProject is set (process-level override via ENGRAM_PROJECT / --project),
+// handleSessionSummary writes under that project instead of falling back to cwd
+// detection. Mirrors TestProcessOverrideSaveHandlerWritesToDefaultProject for save.
+func TestSessionSummary_ProcessOverrideWritesToDefaultProject(t *testing.T) {
+	// Use a temp dir that has no git repo — without the fix, resolveWriteProject()
+	// would return an error or a wrong project; with the fix it uses the override.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	h := handleSessionSummary(s, MCPConfig{DefaultProject: "Trusted Project"}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "## Goal\nProcess override session summary",
+	}}})
+	if err != nil || res.IsError {
+		t.Fatalf("session summary error: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+
+	obs, err := s.RecentObservations("trusted project", "project", 5)
+	if err != nil {
+		t.Fatalf("RecentObservations: %v", err)
+	}
+	if len(obs) == 0 {
+		t.Fatal("expected session_summary observation under 'trusted project' (process override); got none")
+	}
+
+	m := callResultJSON(t, res)
+	if got := m["project"]; got != "trusted project" {
+		t.Errorf("response envelope project = %v; want 'trusted project'", got)
+	}
+	if got := m["project_source"]; got != sourceProcessOverride {
+		t.Errorf("response envelope project_source = %v; want %s", got, sourceProcessOverride)
+	}
+}
+
+// TestSessionSummary_ProcessOverrideBypassesAmbiguousCWD verifies that an
+// ambiguous cwd (parent dir with multiple git repos) is bypassed when
+// cfg.DefaultProject is set.
+func TestSessionSummary_ProcessOverrideBypassesAmbiguousCWD(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"repo-ss-1", "repo-ss-2"} {
+		child := filepath.Join(parent, name)
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initTestGitRepo(t, child)
+	}
+	t.Chdir(parent)
+
+	s := newMCPTestStore(t)
+	h := handleSessionSummary(s, MCPConfig{DefaultProject: "override-project"}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "## Goal\nAmbiguous override test",
+	}}})
+	if err != nil || res.IsError {
+		t.Fatalf("expected success via process override; err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+
+	obs, err := s.RecentObservations("override-project", "project", 5)
+	if err != nil {
+		t.Fatalf("RecentObservations: %v", err)
+	}
+	if len(obs) == 0 {
+		t.Fatal("expected session_summary under 'override-project'; got none")
+	}
+}
+
+// ─── #393: handleSessionSummary empty-content guard tests ────────────────────
+
+// TestSessionSummary_EmptyContentRejected verifies that an empty content string
+// is rejected before AddObservation is called, mirroring the guard in handleSave.
+func TestSessionSummary_EmptyContentRejected(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	h := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "",
+	}}})
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected tool error for empty content; got success")
+	}
+	text := callResultText(t, res)
+	if !strings.Contains(text, "content") {
+		t.Errorf("error message should mention 'content'; got: %q", text)
+	}
+
+	// No observation must have been persisted.
+	obs, err := s.RecentObservations("", "project", 10)
+	if err != nil {
+		t.Fatalf("RecentObservations: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Fatalf("expected 0 observations after empty-content rejection; got %d", len(obs))
+	}
+}
+
+// TestSessionSummary_WhitespaceOnlyContentRejected verifies that whitespace-only
+// content is also rejected (mirrors handleSave behaviour).
+func TestSessionSummary_WhitespaceOnlyContentRejected(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	h := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "   \n\t  ",
+	}}})
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected tool error for whitespace-only content; got success")
+	}
+}


### PR DESCRIPTION
## Summary

- `handleSessionSummary` was the sole write tool still calling bare `resolveWriteProject()` after commit `b094052` hardened every other write tool. The process-level project override (`ENGRAM_PROJECT` / `engram mcp --project`) was silently ignored, causing wrong-project writes and an OpenCode timeout in ambiguous-cwd environments.
- An empty `mem_session_summary` had no content guard, so it persisted a blank observation that created a stuck `sync_mutation` blocking `cloud upgrade`.

## Changes
- Use `resolveWriteProjectWithProcessOverride(cfg.DefaultProject)`, consistent with all other write tools.
- Add a `strings.TrimSpace(content) == ""` guard before `AddObservation`, mirroring `handleSave` (#374).

## Test plan
4 new tests in `internal/mcp/mcp_test.go`: process override writes to default project, override bypasses ambiguous cwd, empty content rejected, whitespace-only rejected. `go test ./... && go vet ./... && go build ./...` clean.

Closes #403
Closes #413
Closes #393
