### PR TITLE
fix(store): handle global scope in normalizeScope

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5807,10 +5807,12 @@ func truncate(s string, max int) string {
 
 func normalizeScope(scope string) string {
 	v := strings.TrimSpace(strings.ToLower(scope))
-	if v == "personal" {
-		return "personal"
+	switch v {
+	case "personal", "global":
+		return v
+	default:
+		return "project"
 	}
-	return "project"
 }
 
 // NormalizeProject applies canonical project name normalization:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7715,3 +7715,29 @@ func TestGetDeferred_NotFound(t *testing.T) {
 		t.Errorf("expected error to contain 'not found'; got %q", err.Error())
 	}
 }
+
+func TestNormalizeScopeHandlesGlobal(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"global", "global"},
+		{"Global", "global"},
+		{"GLOBAL", "global"},
+		{"  global  ", "global"},
+		{"personal", "personal"},
+		{"Personal", "personal"},
+		{"project", "project"},
+		{"Project", "project"},
+		{"", "project"},
+		{"unknown", "project"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := normalizeScope(tc.input)
+			if got != tc.want {
+				t.Errorf("normalizeScope(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `normalizeScope()` in `internal/store/store.go` had no `case` for `global`, silently coercing it to `project` via the fallthrough default.
- Any `mem_save` / `mem_update` / CLI / HTTP call with `scope: "global"` stored `project` instead, making global observations impossible to create or upsert.
- Fix: extend the switch to `case "personal", "global": return v`, accepting `global` as a third valid scope.

## Test plan
- `TestNormalizeScopeHandlesGlobal` — 10 table-driven subtests covering case/whitespace variants of `global`, plus unchanged behavior for `personal`, `project`, empty, and unknown inputs
- `go test ./... && go vet ./... && go build ./...` clean

Closes #122
