### PR TITLE
feat(tui): copy observation content to clipboard via OSC 52

### DIFF
--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ─── Messages ─────────────────────────────────────────────────────────────────
+
+// clipboardCopiedMsg is sent after building the OSC 52 sequence to copy.
+// The sequence field carries the raw escape sequence so Update can emit it.
+type clipboardCopiedMsg struct {
+	sequence string
+}
+
+// clipboardClearMsg is sent after the 2-second feedback timer expires.
+type clipboardClearMsg struct{}
+
+// ─── OSC 52 helpers ──────────────────────────────────────────────────────────
+
+// osc52Sequence returns the OSC 52 terminal escape sequence that asks the
+// terminal to write content to the system clipboard.
+//
+// Format: ESC ] 52 ; c ; <base64> BEL
+func osc52Sequence(content string) string {
+	b64 := base64.StdEncoding.EncodeToString([]byte(content))
+	return fmt.Sprintf("\x1b]52;c;%s\x07", b64)
+}
+
+// copyToClipboard returns a Cmd that builds the OSC 52 sequence for content
+// and wraps it in a clipboardCopiedMsg.
+func copyToClipboard(content string) tea.Cmd {
+	return func() tea.Msg {
+		return clipboardCopiedMsg{sequence: osc52Sequence(content)}
+	}
+}
+
+// clearFeedbackAfter returns a Cmd that sends clipboardClearMsg after d.
+func clearFeedbackAfter(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(_ time.Time) tea.Msg {
+		return clipboardClearMsg{}
+	})
+}

--- a/internal/tui/clipboard_test.go
+++ b/internal/tui/clipboard_test.go
@@ -1,0 +1,373 @@
+package tui
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gentleman-Programming/engram/internal/store"
+)
+
+// ─── OSC 52 sequence generation ──────────────────────────────────────────────
+
+func TestOSC52SequenceForContent(t *testing.T) {
+	content := "hello world"
+	seq := osc52Sequence(content)
+
+	wantPrefix := "\x1b]52;c;"
+	wantSuffix := "\x07"
+	wantB64 := base64.StdEncoding.EncodeToString([]byte(content))
+
+	if !strings.HasPrefix(seq, wantPrefix) {
+		t.Fatalf("sequence does not start with OSC 52 prefix: %q", seq)
+	}
+	if !strings.HasSuffix(seq, wantSuffix) {
+		t.Fatalf("sequence does not end with BEL: %q", seq)
+	}
+	middle := strings.TrimPrefix(strings.TrimSuffix(seq, wantSuffix), wantPrefix)
+	if middle != wantB64 {
+		t.Fatalf("base64 payload = %q, want %q", middle, wantB64)
+	}
+}
+
+func TestOSC52SequenceEmptyContent(t *testing.T) {
+	seq := osc52Sequence("")
+	wantB64 := base64.StdEncoding.EncodeToString([]byte(""))
+	if !strings.Contains(seq, wantB64) {
+		t.Fatalf("empty content sequence should still contain valid base64: %q", seq)
+	}
+}
+
+func TestOSC52SequenceUnicodeContent(t *testing.T) {
+	content := "Decisión de arquitectura 🐘"
+	seq := osc52Sequence(content)
+	wantB64 := base64.StdEncoding.EncodeToString([]byte(content))
+	if !strings.Contains(seq, wantB64) {
+		t.Fatalf("unicode content not properly encoded: %q", seq)
+	}
+}
+
+// ─── copyToClipboard command ─────────────────────────────────────────────────
+
+func TestCopyToClipboardReturnsClipboardCopiedMsg(t *testing.T) {
+	cmd := copyToClipboard("test content")
+	if cmd == nil {
+		t.Fatal("copyToClipboard should return a non-nil command")
+	}
+	msg := cmd()
+	_, ok := msg.(clipboardCopiedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want clipboardCopiedMsg", msg)
+	}
+}
+
+func TestCopyToClipboardMsgContainsSequence(t *testing.T) {
+	content := "observation content"
+	cmd := copyToClipboard(content)
+	msg := cmd()
+	cm, ok := msg.(clipboardCopiedMsg)
+	if !ok {
+		t.Fatalf("message type = %T", msg)
+	}
+	wantB64 := base64.StdEncoding.EncodeToString([]byte(content))
+	if !strings.Contains(cm.sequence, wantB64) {
+		t.Fatalf("clipboardCopiedMsg.sequence does not contain encoded content: %q", cm.sequence)
+	}
+}
+
+// ─── clipboardClearMsg timer ─────────────────────────────────────────────────
+
+func TestClearFeedbackAfterReturnsCmd(t *testing.T) {
+	cmd := clearFeedbackAfter(1 * time.Millisecond)
+	if cmd == nil {
+		t.Fatal("clearFeedbackAfter should return a non-nil command")
+	}
+	msg := cmd()
+	_, ok := msg.(clipboardClearMsg)
+	if !ok {
+		t.Fatalf("message type = %T, want clipboardClearMsg", msg)
+	}
+}
+
+// ─── Update: clipboardCopiedMsg sets CopyFeedback ────────────────────────────
+
+func TestUpdateClipboardCopiedMsgSetsFeedback(t *testing.T) {
+	m := New(nil, "")
+	m.CopyFeedback = ""
+
+	updatedModel, cmd := m.Update(clipboardCopiedMsg{sequence: "\x1b]52;c;aGVsbG8=\x07"})
+	updated := updatedModel.(Model)
+
+	if updated.CopyFeedback != "✓ Copied!" {
+		t.Fatalf("CopyFeedback = %q, want %q", updated.CopyFeedback, "✓ Copied!")
+	}
+	if cmd == nil {
+		t.Fatal("clipboardCopiedMsg should return a clear-feedback command")
+	}
+}
+
+// ─── Update: clipboardClearMsg clears CopyFeedback ───────────────────────────
+
+func TestUpdateClipboardClearMsgClearsFeedback(t *testing.T) {
+	m := New(nil, "")
+	m.CopyFeedback = "✓ Copied!"
+
+	updatedModel, cmd := m.Update(clipboardClearMsg{})
+	updated := updatedModel.(Model)
+
+	if updated.CopyFeedback != "" {
+		t.Fatalf("CopyFeedback = %q, want empty string after clear", updated.CopyFeedback)
+	}
+	if cmd != nil {
+		t.Fatal("clipboardClearMsg should not return a command")
+	}
+}
+
+// ─── 'c' key on ScreenRecent copies selected observation ─────────────────────
+
+func TestRecentScreenCKeyCopiesToClipboard(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenRecent
+	m.RecentObservations = []store.Observation{
+		{ID: 1, Content: "first observation content"},
+		{ID: 2, Content: "second observation content"},
+	}
+	m.Cursor = 1
+
+	updatedModel, cmd := m.handleRecentKeys("c")
+	updated := updatedModel.(Model)
+	_ = updated
+
+	if cmd == nil {
+		t.Fatal("'c' on recent screen should return a clipboard command")
+	}
+	msg := cmd()
+	cm, ok := msg.(clipboardCopiedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want clipboardCopiedMsg", msg)
+	}
+	wantB64 := base64.StdEncoding.EncodeToString([]byte("second observation content"))
+	if !strings.Contains(cm.sequence, wantB64) {
+		t.Fatalf("sequence does not contain expected content encoding")
+	}
+}
+
+func TestRecentScreenCKeyWithNoObservationsIsNoop(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenRecent
+	m.RecentObservations = nil
+
+	_, cmd := m.handleRecentKeys("c")
+	if cmd != nil {
+		t.Fatal("'c' with no observations should not return command")
+	}
+}
+
+// ─── 'c' key on ScreenSearchResults copies selected result ───────────────────
+
+func TestSearchResultsScreenCKeyCopiesToClipboard(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenSearchResults
+	m.SearchResults = []store.SearchResult{
+		{Observation: store.Observation{ID: 1, Content: "search result one"}},
+		{Observation: store.Observation{ID: 2, Content: "search result two"}},
+	}
+	m.Cursor = 0
+
+	_, cmd := m.handleSearchResultsKeys("c")
+	if cmd == nil {
+		t.Fatal("'c' on search results screen should return a clipboard command")
+	}
+	msg := cmd()
+	cm, ok := msg.(clipboardCopiedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want clipboardCopiedMsg", msg)
+	}
+	wantB64 := base64.StdEncoding.EncodeToString([]byte("search result one"))
+	if !strings.Contains(cm.sequence, wantB64) {
+		t.Fatalf("sequence does not contain expected content encoding")
+	}
+}
+
+func TestSearchResultsScreenCKeyWithNoResultsIsNoop(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenSearchResults
+	m.SearchResults = nil
+
+	_, cmd := m.handleSearchResultsKeys("c")
+	if cmd != nil {
+		t.Fatal("'c' with no search results should not return command")
+	}
+}
+
+// ─── 'c' key on ScreenObservationDetail copies full content ──────────────────
+
+func TestObservationDetailScreenCKeyCopiesToClipboard(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenObservationDetail
+	m.SelectedObservation = &store.Observation{
+		ID:      42,
+		Content: "full observation content for copy",
+	}
+
+	_, cmd := m.handleObservationDetailKeys("c")
+	if cmd == nil {
+		t.Fatal("'c' on observation detail screen should return a clipboard command")
+	}
+	msg := cmd()
+	cm, ok := msg.(clipboardCopiedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want clipboardCopiedMsg", msg)
+	}
+	wantB64 := base64.StdEncoding.EncodeToString([]byte("full observation content for copy"))
+	if !strings.Contains(cm.sequence, wantB64) {
+		t.Fatalf("sequence does not contain expected content encoding")
+	}
+}
+
+func TestObservationDetailScreenCKeyWithNoObservationIsNoop(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenObservationDetail
+	m.SelectedObservation = nil
+
+	_, cmd := m.handleObservationDetailKeys("c")
+	if cmd != nil {
+		t.Fatal("'c' with nil observation should not return command")
+	}
+}
+
+// ─── 'c' key on ScreenSessionDetail copies selected observation ───────────────
+
+func TestSessionDetailScreenCKeyCopiesToClipboard(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenSessionDetail
+	m.SessionObservations = []store.Observation{
+		{ID: 10, Content: "session obs one"},
+		{ID: 11, Content: "session obs two"},
+	}
+	m.Cursor = 1
+
+	_, cmd := m.handleSessionDetailKeys("c")
+	if cmd == nil {
+		t.Fatal("'c' on session detail screen should return a clipboard command")
+	}
+	msg := cmd()
+	cm, ok := msg.(clipboardCopiedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want clipboardCopiedMsg", msg)
+	}
+	wantB64 := base64.StdEncoding.EncodeToString([]byte("session obs two"))
+	if !strings.Contains(cm.sequence, wantB64) {
+		t.Fatalf("sequence does not contain expected content encoding")
+	}
+}
+
+func TestSessionDetailScreenCKeyWithNoObservationsIsNoop(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenSessionDetail
+	m.SessionObservations = nil
+
+	_, cmd := m.handleSessionDetailKeys("c")
+	if cmd != nil {
+		t.Fatal("'c' with no session observations should not return command")
+	}
+}
+
+// ─── View: CopyFeedback appears in rendered output ───────────────────────────
+
+func TestViewShowsCopyFeedback(t *testing.T) {
+	m := New(nil, "")
+	m.Width = 80
+	m.Height = 24
+	m.Screen = ScreenObservationDetail
+	m.SelectedObservation = &store.Observation{
+		ID:      1,
+		Type:    "decision",
+		Title:   "Test",
+		Content: "content",
+	}
+	m.CopyFeedback = "✓ Copied!"
+
+	view := m.View()
+	if !strings.Contains(view, "✓ Copied!") {
+		t.Fatal("view should display CopyFeedback when set")
+	}
+}
+
+func TestViewDoesNotShowCopyFeedbackWhenEmpty(t *testing.T) {
+	m := New(nil, "")
+	m.Width = 80
+	m.Height = 24
+	m.Screen = ScreenObservationDetail
+	m.SelectedObservation = &store.Observation{
+		ID:      1,
+		Type:    "decision",
+		Title:   "Test",
+		Content: "content",
+	}
+	m.CopyFeedback = ""
+
+	view := m.View()
+	if strings.Contains(view, "✓ Copied!") {
+		t.Fatal("view should not show copy feedback when CopyFeedback is empty")
+	}
+}
+
+// ─── View: help text includes 'c copy' on relevant screens ───────────────────
+
+func TestViewRecentHelpTextIncludesCopy(t *testing.T) {
+	m := New(nil, "")
+	m.Width = 80
+	m.Height = 24
+	m.Screen = ScreenRecent
+	m.RecentObservations = []store.Observation{{ID: 1, Type: "decision", Title: "t", Content: "c"}}
+
+	view := m.viewRecent()
+	if !strings.Contains(view, "c copy") {
+		t.Fatalf("recent screen help text should include 'c copy', got: %q", view[strings.LastIndex(view, "\n")-100:])
+	}
+}
+
+func TestViewSearchResultsHelpTextIncludesCopy(t *testing.T) {
+	m := New(nil, "")
+	m.Width = 80
+	m.Height = 24
+	m.Screen = ScreenSearchResults
+	m.SearchResults = []store.SearchResult{{Observation: store.Observation{ID: 1}}}
+
+	view := m.viewSearchResults()
+	if !strings.Contains(view, "c copy") {
+		t.Fatalf("search results help text should include 'c copy'")
+	}
+}
+
+func TestViewObservationDetailHelpTextIncludesCopy(t *testing.T) {
+	m := New(nil, "")
+	m.Width = 80
+	m.Height = 24
+	m.Screen = ScreenObservationDetail
+	m.SelectedObservation = &store.Observation{
+		ID: 1, Type: "decision", Title: "t", Content: "content",
+	}
+
+	view := m.viewObservationDetail()
+	if !strings.Contains(view, "c copy") {
+		t.Fatalf("observation detail help text should include 'c copy'")
+	}
+}
+
+func TestViewSessionDetailHelpTextIncludesCopy(t *testing.T) {
+	m := New(nil, "")
+	m.Width = 80
+	m.Height = 24
+	m.Screen = ScreenSessionDetail
+	m.Sessions = []store.SessionSummary{{ID: "s1", Project: "engram"}}
+	m.SelectedSessionIdx = 0
+	m.SessionObservations = []store.Observation{{ID: 1, Type: "decision", Title: "t", Content: "c"}}
+
+	view := m.viewSessionDetail()
+	if !strings.Contains(view, "c copy") {
+		t.Fatalf("session detail help text should include 'c copy'")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -126,6 +126,9 @@ type Model struct {
 	SessionObservations []store.Observation
 	SessionDetailScroll int
 
+	// Clipboard feedback
+	CopyFeedback string // "✓ Copied!" or "" — shown for 2 s after copy
+
 	// Setup
 	SetupAgents           []setup.Agent
 	SetupResult           *setup.Result

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -49,6 +49,12 @@ var (
 			Bold(true).
 			Padding(0, 1)
 
+	// Clipboard copy feedback ("✓ Copied!")
+	copyFeedbackStyle = lipgloss.NewStyle().
+				Foreground(colorGreen).
+				Bold(true).
+				Padding(0, 1)
+
 	// Update available banner
 	updateBannerStyle = lipgloss.NewStyle().
 				Foreground(colorYellow).

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"time"
+
 	"github.com/Gentleman-Programming/engram/internal/setup"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -115,6 +117,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.SetupDone = true
+		return m, nil
+
+	case clipboardCopiedMsg:
+		// Emit the OSC 52 sequence to stdout so the terminal copies the content,
+		// set the feedback label, and schedule its removal after 2 seconds.
+		m.CopyFeedback = "✓ Copied!"
+		return m, tea.Batch(
+			tea.Println(msg.sequence),
+			clearFeedbackAfter(2*time.Second),
+		)
+
+	case clipboardClearMsg:
+		m.CopyFeedback = ""
 		return m, nil
 
 	case spinner.TickMsg:
@@ -300,6 +315,10 @@ func (m Model) handleSearchResultsKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevScreen = ScreenSearchResults
 			return m, loadObservationDetail(m.store, obsID)
 		}
+	case "c":
+		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
+			return m, copyToClipboard(m.SearchResults[m.Cursor].Content)
+		}
 	case "t":
 		// Timeline for selected result
 		if len(m.SearchResults) > 0 && m.Cursor < len(m.SearchResults) {
@@ -352,6 +371,10 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 			m.PrevScreen = ScreenRecent
 			return m, loadObservationDetail(m.store, obsID)
 		}
+	case "c":
+		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
+			return m, copyToClipboard(m.RecentObservations[m.Cursor].Content)
+		}
 	case "t":
 		if len(m.RecentObservations) > 0 && m.Cursor < len(m.RecentObservations) {
 			obsID := m.RecentObservations[m.Cursor].ID
@@ -377,6 +400,10 @@ func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
 		}
 	case "down", "j":
 		m.DetailScroll++
+	case "c":
+		if m.SelectedObservation != nil {
+			return m, copyToClipboard(m.SelectedObservation.Content)
+		}
 	case "t":
 		// View timeline for this observation
 		if m.SelectedObservation != nil {
@@ -477,6 +504,10 @@ func (m Model) handleSessionDetailKeys(key string) (tea.Model, tea.Cmd) {
 			obsID := m.SessionObservations[m.Cursor].ID
 			m.PrevScreen = ScreenSessionDetail
 			return m, loadObservationDetail(m.store, obsID)
+		}
+	case "c":
+		if len(m.SessionObservations) > 0 && m.Cursor < len(m.SessionObservations) {
+			return m, copyToClipboard(m.SessionObservations[m.Cursor].Content)
 		}
 	case "t":
 		if len(m.SessionObservations) > 0 && m.Cursor < len(m.SessionObservations) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -88,6 +88,11 @@ func (m Model) View() string {
 		content += "\n" + errorStyle.Render("Error: "+m.ErrorMsg)
 	}
 
+	// Show clipboard copy feedback if present
+	if m.CopyFeedback != "" {
+		content += "\n" + copyFeedbackStyle.Render(m.CopyFeedback)
+	}
+
 	return appStyle.Render(content)
 }
 
@@ -226,7 +231,7 @@ func (m Model) viewSearchResults() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, resultCount))))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • / search • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • c copy • t timeline • / search • esc back"))
 
 	return b.String()
 }
@@ -268,7 +273,7 @@ func (m Model) viewRecent() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.Scroll+1, end, count))))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • c copy • t timeline • esc back"))
 
 	return b.String()
 }
@@ -363,7 +368,7 @@ func (m Model) viewObservationDetail() string {
 			timestampStyle.Render(fmt.Sprintf("line %d-%d of %d", m.DetailScroll+1, end, len(contentLines)))))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k scroll • t timeline • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k scroll • c copy • t timeline • esc back"))
 
 	return b.String()
 }
@@ -553,7 +558,7 @@ func (m Model) viewSessionDetail() string {
 			timestampStyle.Render(fmt.Sprintf("showing %d-%d of %d", m.SessionDetailScroll+1, end, count))))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • t timeline • esc back"))
+	b.WriteString(helpStyle.Render("\n  j/k navigate • enter detail • c copy • t timeline • esc back"))
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary

- Adds a `c` keybinding to copy observation content to the clipboard on the Recent Observations, Search Results, Observation Detail, and Session Detail screens.
- Uses the OSC 52 terminal escape sequence: works over SSH, no system deps (xclip/pbcopy), no new Go dependencies.
- Shows a "✓ Copied!" feedback for ~2 seconds. Graceful no-op if the terminal ignores OSC 52.

## Test plan
- 18 new tests in `internal/tui/clipboard_test.go` (OSC52 encoding, command dispatch, 4 screen handlers, feedback view, help text)
- `go test ./... && go vet ./... && go build ./...` clean

Closes #141
