### PR TITLE
docs: document recent env vars, CLI commands, scopes, and TUI keybindings

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -133,8 +133,8 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 ### Observations
 
 - `POST /observations` — Add observation. Body: `{session_id, type, title, content, tool_name?, project?, scope?, topic_key?}`
-- `GET /observations` — Recent observations compatibility endpoint. Query: `?project=X&scope=project|personal&limit=N&sort=created_at:desc`
-- `GET /observations/recent` — Recent observations. Query: `?project=X&scope=project|personal&limit=N`
+- `GET /observations` — Recent observations compatibility endpoint. Query: `?project=X&scope=project|personal|global&limit=N&sort=created_at:desc`
+- `GET /observations/recent` — Recent observations. Query: `?project=X&scope=project|personal|global&limit=N`
 - `GET /observations/{id}` — Get single observation by ID
 - `PATCH /observations/{id}` — Update fields. Body: `{title?, content?, type?, project?, scope?, topic_key?}`
 - `DELETE /observations/{id}` — Delete observation (`?hard=true` for hard delete, soft delete by default)
@@ -161,7 +161,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 
 ### Context
 
-- `GET /context` — Formatted context. Query: `?project=X&scope=project|personal`
+- `GET /context` — Formatted context. Query: `?project=X&scope=project|personal|global`
 
 ### Passive Capture
 
@@ -453,11 +453,24 @@ Response:
 
 ### Environment Variables
 
-| Variable          | Description                                                                                                                                         | Default              |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `ENGRAM_DATA_DIR` | Override data directory                                                                                                                             | `~/.engram`          |
-| `ENGRAM_PORT`     | Override HTTP server port                                                                                                                           | `7437`               |
-| `ENGRAM_PROJECT`  | Default project for `engram serve` `GET /sync/status` when no `project` query param is supplied. When unset, cwd detection is used as the fallback. | cwd-detected project |
+| Variable                        | Description                                                                                                                                                                                                                                               | Default              |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `ENGRAM_DATA_DIR`               | Override data directory                                                                                                                                                                                                                                   | `~/.engram`          |
+| `ENGRAM_PORT`                   | Override HTTP server port                                                                                                                                                                                                                                 | `7437`               |
+| `ENGRAM_PROJECT`                | Default project for `engram serve` `GET /sync/status` when no `project` query param is supplied. When unset, cwd detection is used as the fallback.                                                                                                       | cwd-detected project |
+| `ENGRAM_HTTP_TOKEN`             | Optional Bearer auth for the local HTTP server. When set, the following routes require `Authorization: Bearer <token>`: `DELETE /sessions/{id}`, `DELETE /observations/{id}`, `DELETE /prompts/{id}`, `GET /export`, `POST /import`, `POST /projects/migrate`. Comparison is constant-time. Token is read at request time (no restart needed). When unset, all routes are open (zero-config default). | (unset — open) |
+| `ENGRAM_TIMEZONE`               | Timezone for timestamp display in the TUI and cloud dashboard. Accepts any IANA zone name (e.g. `America/New_York`, `Europe/Berlin`). Falls back to system local time when unset or invalid.                                                               | system local         |
+| `ENGRAM_AGENT_CLI`              | LLM runner name used by `engram conflicts scan --semantic` and the HTTP `/conflicts/scan` endpoint. Accepted values: `claude`, `opencode`.                                                                                                                | (unset)              |
+| `ENGRAM_CLOUD_AUTOSYNC`         | Set to `1` to enable background autosync. Requires `ENGRAM_CLOUD_TOKEN` and `ENGRAM_CLOUD_SERVER` to also be set.                                                                                                                                         | (unset — disabled)   |
+| `ENGRAM_CLOUD_SERVER`           | Cloud server URL used by the autosync manager and `engram sync --cloud`.                                                                                                                                                                                  | (unset)              |
+| `ENGRAM_DATABASE_URL`           | Postgres DSN for `engram cloud serve`.                                                                                                                                                                                                                    | (unset)              |
+| `ENGRAM_CLOUD_HOST`             | Bind host for `engram cloud serve`.                                                                                                                                                                                                                       | `127.0.0.1`          |
+| `ENGRAM_CLOUD_MAX_PUSH_BYTES`   | Max cloud push payload bytes.                                                                                                                                                                                                                             | `8388608`            |
+| `ENGRAM_CLOUD_TOKEN`            | Bearer token required in authenticated `engram cloud serve` mode.                                                                                                                                                                                         | (unset)              |
+| `ENGRAM_CLOUD_INSECURE_NO_AUTH` | Set to `1` for local insecure cloud serve (no auth). Cannot be combined with `ENGRAM_CLOUD_TOKEN`.                                                                                                                                                        | (unset)              |
+| `ENGRAM_CLOUD_ALLOWED_PROJECTS` | Comma-separated project allowlist enforced by `engram cloud serve`. Required in both token-auth and insecure modes. Use `*` to allow all projects (dev/internal deploys) — bypasses per-project name enforcement while still requiring a non-empty project on each request. | (unset) |
+| `ENGRAM_JWT_SECRET`             | Required in authenticated cloud serve mode. Must be explicitly set to a non-default value.                                                                                                                                                                | (unset)              |
+| `ENGRAM_CLOUD_ADMIN`            | Optional admin-only dashboard token in authenticated cloud serve mode. Ignored/rejected in insecure mode.                                                                                                                                                 | (unset)              |
 
 ### Conflict Audit CLI (admin)
 
@@ -549,7 +562,7 @@ Cloud runtime envs for `engram cloud serve`:
 | `ENGRAM_PORT`                   | no                       | Runtime port (default `8080`)                                                         |
 | `ENGRAM_CLOUD_HOST`             | no                       | Bind host (default `127.0.0.1`; use `0.0.0.0` for containers)                         |
 | `ENGRAM_CLOUD_MAX_PUSH_BYTES`   | no                       | Max chunk/mutation push request body bytes (default `8388608`)                        |
-| `ENGRAM_CLOUD_ALLOWED_PROJECTS` | yes                      | Comma-separated allowlist; always required (authenticated + insecure modes)           |
+| `ENGRAM_CLOUD_ALLOWED_PROJECTS` | yes                      | Comma-separated allowlist; always required (authenticated + insecure modes). Use `*` to allow all projects (dev/internal deploys) — bypasses per-project name enforcement while still requiring a non-empty project on each request. |
 | `ENGRAM_CLOUD_TOKEN`            | yes (authenticated mode) | Enables bearer auth mode                                                              |
 | `ENGRAM_JWT_SECRET`             | yes (authenticated mode) | Must be explicitly set and non-default when token mode is enabled                     |
 | `ENGRAM_CLOUD_INSECURE_NO_AUTH` | no                       | Set to `1` only for local insecure mode; cannot be combined with `ENGRAM_CLOUD_TOKEN` |
@@ -762,6 +775,8 @@ Search persistent memory across all sessions. Supports FTS5 full-text search wit
 
 Set `all_projects: true` to search across every project instead of the resolved one. This bypasses project detection entirely and ignores the `project` argument, so an agent can recall a decision logged elsewhere without knowing the project key. The response envelope reports `project_source: "all_projects"` and an empty `project` to reflect the cross-project scope.
 
+Scope values accepted by the `scope` parameter: `project` (default), `personal`, `global`. When `scope: personal` is passed without an explicit `project` override, the project filter is cleared and personal observations are searched across all projects (cross-project personal scope).
+
 When an observation has judged relations in `memory_relations`, the result entry includes annotation lines immediately after the title/content block:
 
 ```
@@ -781,7 +796,7 @@ Save structured observations. The tool description teaches agents the format:
 
 - **title**: Short, searchable (e.g. "JWT auth middleware")
 - **type**: `decision` | `architecture` | `bugfix` | `pattern` | `config` | `discovery` | `learning`
-- **scope**: `project` (default) | `personal`
+- **scope**: `project` (default) | `personal` | `global`
 - **topic_key**: optional canonical topic id (e.g. `architecture/auth-model`) used to upsert evolving memories
 - **capture_prompt**: optional boolean, default `true`; when current prompt context is available in the same MCP process for the same project/session, Engram best-effort records it alongside the observation. If that process-local context is unavailable or prompt capture fails, `mem_save` still succeeds. Automated pipeline saves such as SDD artifacts should pass `false`.
 - **content**: Structured with `**What**`, `**Why**`, `**Where**`, `**Learned**`; required unless the legacy `observation` alias is provided
@@ -810,6 +825,8 @@ When called in the same MCP process, this also feeds process-local current promp
 ### mem_context
 
 Get recent memory context from previous sessions — shows sessions, prompts, and observations, with optional scope filtering for observations.
+
+Scope values accepted by the `scope` parameter: `project` (default), `personal`, `global`. When `scope: personal` is passed without an explicit `project` override, the project filter is cleared and personal observations are returned across all projects (cross-project personal scope).
 
 ### mem_stats
 
@@ -919,7 +936,7 @@ Format for `mem_save`:
 
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList", "Chose Zustand over Redux")
 - **type**: `bugfix` | `decision` | `architecture` | `discovery` | `pattern` | `config` | `preference`
-- **scope**: `project` (default) | `personal`
+- **scope**: `project` (default) | `personal` | `global`
 - **topic_key** (optional, recommended for evolving decisions): stable key like `architecture/auth-model`
 - **content**:
   ```
@@ -1136,6 +1153,7 @@ Interactive Bubbletea-based terminal UI. Launch with `engram tui`.
 
 - `j/k` or arrow keys — Navigate lists
 - `Enter` — Select / drill into detail
+- `c` — Copy observation content to clipboard (OSC 52; works in search results, recent list, detail, and session views)
 - `t` — View timeline for selected observation
 - `s` or `/` — Quick search from any screen
 - `Esc` or `q` — Go back / quit

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ engram tui
   <img src="assets/tui-search.png" alt="TUI Search Results" width="400" />
 </p>
 
-**Navigation**: `j/k` vim keys, `Enter` to drill in, `/` to search, `Esc` back. Catppuccin Mocha theme.
+**Navigation**: `j/k` vim keys, `Enter` to drill in, `c` to copy content to clipboard (OSC 52), `/` to search, `Esc` back. Catppuccin Mocha theme.
 
 ## Git Sync
 
@@ -137,6 +137,7 @@ engram sync --cloud --project smoke-project
 ```
 
 Cloud mode is always project-scoped (`--project` is required; `engram sync --cloud --all` is intentionally blocked).
+`ENGRAM_CLOUD_ALLOWED_PROJECTS` is required for `engram cloud serve` in both token-auth and insecure modes. Set it to `*` to allow all projects (useful for dev/internal deploys) — this bypasses per-project name enforcement while still requiring a non-empty project on each request.
 Known repairable cloud sync/upsert/canonicalization failures keep the original error visible and recommend the explicit `doctor`/`repair` flow below; Engram never auto-applies repair from sync or autosync.
 For blocked cloud sync, `transport_failed`, or legacy session directory repair, see [Engram Cloud Troubleshooting](docs/engram-cloud/troubleshooting.md).
 If cloud sync stays blocked after `doctor`/`repair`, download the rescue helper and run the recommended exported-row repair:
@@ -306,18 +307,34 @@ Your production engram is fully untouched throughout.
 | `engram tui`                               | Launch terminal UI                                              |
 | `engram search <query>`                    | Search memories                                                 |
 | `engram save <title> <msg>`                | Save a memory                                                   |
+| `engram delete <obs_id>`                   | Delete an observation (soft by default; `--hard` removes permanently) |
 | `engram timeline <obs_id>`                 | Chronological context                                           |
 | `engram context [project]`                 | Recent session context                                          |
 | `engram stats`                             | Memory statistics                                               |
 | `engram export [file]`                     | Export to JSON                                                  |
 | `engram import <file>`                     | Import from JSON                                                |
 | `engram sync`                              | Git sync export/import                                          |
+| `engram conflicts <sub>`                   | Inspect and manage memory conflict relations                    |
+| `engram doctor`                            | Run read-only operational diagnostics                           |
 | `engram cloud <subcommand>`                | Opt-in cloud config/status/enrollment + cloud runtime (`serve`) |
 | `engram projects list\|consolidate\|prune` | Manage project names                                            |
 | `engram obsidian-export`                   | Export to Obsidian vault (beta)                                 |
 | `engram version`                           | Show version                                                    |
 
 Full CLI with all flags → [docs/ARCHITECTURE.md#cli-reference](docs/ARCHITECTURE.md#cli-reference)
+
+### Key Environment Variables
+
+| Variable                        | Description                                                                                                            | Default        |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `ENGRAM_DATA_DIR`               | Override data directory                                                                                                | `~/.engram`    |
+| `ENGRAM_PORT`                   | Override HTTP server port                                                                                              | `7437`         |
+| `ENGRAM_HTTP_TOKEN`             | Optional Bearer auth for local HTTP server. When set, destructive and export routes require `Authorization: Bearer <token>`. Unset = open (zero-config default). | (unset) |
+| `ENGRAM_TIMEZONE`               | Timezone for timestamp display in TUI and cloud dashboard (e.g. `America/New_York`). Falls back to system local when unset or invalid. | system local |
+| `ENGRAM_CLOUD_AUTOSYNC`         | Set to `1` to enable background autosync (also requires `ENGRAM_CLOUD_TOKEN` + `ENGRAM_CLOUD_SERVER`).                 | (unset)        |
+| `ENGRAM_CLOUD_ALLOWED_PROJECTS` | Comma-separated project allowlist for `engram cloud serve`. Use `*` to allow all projects.                             | (unset)        |
+
+Full environment variable reference → [DOCS.md#environment-variables](DOCS.md#environment-variables)
 
 ## Documentation
 

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2378,6 +2378,21 @@ Environment:
   ENGRAM_DATA_DIR    Override data directory (default: ~/.engram)
   ENGRAM_PORT        Override HTTP server port (default: 7437)
   ENGRAM_PROJECT     Default project hint for serve sync status fallback
+  ENGRAM_HTTP_TOKEN  Optional Bearer auth for local HTTP server (engram serve).
+                     When set, the following routes require Authorization: Bearer <token>:
+                       DELETE /sessions/{id}, DELETE /observations/{id}, DELETE /prompts/{id},
+                       GET /export, POST /import, POST /projects/migrate
+                     Comparison is constant-time. Token is read per-request (no restart needed).
+                     When unset, all routes are open (zero-config default).
+  ENGRAM_TIMEZONE    Timezone for timestamp display in TUI and cloud dashboard.
+                     Accepts any IANA zone name (e.g. America/New_York, Europe/Berlin).
+                     Falls back to system local time when unset or invalid.
+  ENGRAM_AGENT_CLI   LLM runner for conflicts scan --semantic (claude or opencode)
+  ENGRAM_CLOUD_AUTOSYNC
+                     Set to 1 to enable background autosync; also requires
+                     ENGRAM_CLOUD_TOKEN and ENGRAM_CLOUD_SERVER
+  ENGRAM_CLOUD_SERVER
+                     Cloud server URL used by autosync and engram sync --cloud
   ENGRAM_DATABASE_URL
                      Postgres DSN for engram cloud serve
   ENGRAM_CLOUD_HOST  Bind host for engram cloud serve (default: 127.0.0.1)
@@ -2389,12 +2404,13 @@ Environment:
                      Cannot be combined with ENGRAM_CLOUD_TOKEN
                      Cannot be combined with ENGRAM_CLOUD_ADMIN
   ENGRAM_CLOUD_ALLOWED_PROJECTS
-	                     Comma-separated project allowlist enforced by cloud server
-	                     Required for cloud serve in BOTH token auth and insecure no-auth mode
-	ENGRAM_JWT_SECRET   Required in authenticated cloud serve mode (ENGRAM_CLOUD_TOKEN set);
-	                     must be explicitly set to a non-default value
-	ENGRAM_CLOUD_ADMIN  Optional admin-only dashboard token in authenticated mode
-	                     Ignored/rejected in insecure mode (ENGRAM_CLOUD_INSECURE_NO_AUTH=1)
+                     Comma-separated project allowlist enforced by cloud server.
+                     Required for cloud serve in BOTH token auth and insecure no-auth mode.
+                     Use * to allow all projects (dev/internal deploys).
+  ENGRAM_JWT_SECRET  Required in authenticated cloud serve mode (ENGRAM_CLOUD_TOKEN set);
+                     must be explicitly set to a non-default value
+  ENGRAM_CLOUD_ADMIN Optional admin-only dashboard token in authenticated mode
+                     Ignored/rejected in insecure mode (ENGRAM_CLOUD_INSECURE_NO_AUTH=1)
 
 MCP Configuration (add to your agent's config):
   {

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -37,6 +37,8 @@ engram setup pi
 
 `engram setup pi` runs `pi install npm:gentle-engram@0.1.7` and `pi install npm:pi-mcp-adapter`, then ensures Pi settings contain both packages and writes `mcpServers.engram` in the Pi agent MCP config when no Engram server is already configured. Existing `mcpServers.engram` entries are preserved.
 
+When [mise](https://mise.jdx.dev/) is detected in `PATH`, `engram setup pi` also auto-pins `npmCommand` in Pi's `settings.json` to `["mise", "exec", "node@<version>", "--", "npm"]`, preventing Node version drift from silently changing which npm root Pi uses. If `npmCommand` already exists in `settings.json`, the existing value is preserved. This step is a no-op when mise is not installed.
+
 Manual equivalent:
 
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,7 +89,7 @@ Token-efficient memory retrieval — don't dump everything, drill in:
 
 ## Memory Hygiene
 
-- `mem_save` now supports `scope` (`project` default, `personal` optional)
+- `mem_save` now supports `scope` (`project` default, `personal` and `global` also accepted)
 - `mem_save` also supports `topic_key`; with a topic key, saves become upserts (same project+scope+topic updates the existing memory)
 - `mem_save` supports `capture_prompt` (`true` by default). When the same MCP process lifecycle has current prompt context for the same project and session, it best-effort records that prompt alongside the observation. The prompt context must be fed before the later `mem_save` (typically via `mem_save_prompt`); `mem_save` still succeeds if context is unavailable or prompt capture fails. Automated saves such as SDD artifacts should pass `capture_prompt=false`.
 - Exact dedupe prevents repeated inserts in a rolling window (hash + project + scope + type + title)
@@ -172,6 +172,7 @@ engram mcp                Start MCP server (stdio transport)
 engram tui                Launch interactive terminal UI
 engram search <query>     Search memories
 engram save <title> <msg> Save a memory
+engram delete <obs_id>    Delete an observation [--hard] (soft-delete by default; --hard removes permanently)
 engram timeline <obs_id>  Chronological context around an observation
 engram context [project]  Recent context from previous sessions
 engram stats              Memory statistics
@@ -181,6 +182,9 @@ engram sync               Export new memories as compressed chunk to .engram/
 engram sync --all         Export ALL projects (ignore directory-based filter)
 engram sync --cloud --project <name>
                           Sync against configured cloud endpoint (project-scoped)
+engram conflicts <sub>    Inspect and manage memory conflict relations
+                            list, show, stats, scan, deferred
+engram doctor             Run read-only operational diagnostics [--json] [--project P] [--check CODE]
 engram cloud status       Show cloud runtime/config status
 engram cloud config --server <url>
                           Configure cloud server URL
@@ -196,10 +200,15 @@ engram obsidian-export    Export memories to Obsidian vault (beta)
 engram version            Show version
 ```
 
+Local server auth:
+
+- `ENGRAM_HTTP_TOKEN`: optional Bearer auth for `engram serve`. When set, the following routes require `Authorization: Bearer <token>`: `DELETE /sessions/{id}`, `DELETE /observations/{id}`, `DELETE /prompts/{id}`, `GET /export`, `POST /import`, `POST /projects/migrate`. Comparison is constant-time; token is read per-request. When unset, all routes are open (zero-config default).
+- `ENGRAM_TIMEZONE`: IANA zone name for timestamp display in TUI and cloud dashboard (e.g. `America/New_York`). Falls back to system local when unset or invalid.
+
 Cloud constraints (current behavior):
 
 - Cloud is opt-in replication/shared access; local SQLite remains source of truth.
-- `engram cloud serve` requires `ENGRAM_CLOUD_ALLOWED_PROJECTS` in both token-auth and insecure no-auth mode.
+- `engram cloud serve` requires `ENGRAM_CLOUD_ALLOWED_PROJECTS` in both token-auth and insecure no-auth mode. Use `*` to allow all projects (dev/internal deploys) — bypasses per-project name enforcement while still requiring a non-empty project on each request.
 - Authenticated cloud serve requires `ENGRAM_CLOUD_TOKEN` + explicit non-default `ENGRAM_JWT_SECRET`.
 - Insecure local-dev mode (`ENGRAM_CLOUD_INSECURE_NO_AUTH=1`) still requires the project allowlist and must not be used in production.
 

--- a/plugin/pi/README.md
+++ b/plugin/pi/README.md
@@ -192,6 +192,8 @@ If the binary is missing, Pi keeps running and memory degrades instead of crashi
 - `settings.json`: ensures `npm:pi-mcp-adapter` and `npm:gentle-engram@0.1.7` are declared.
 - `mcp.json`: adds an `engram` MCP server that launches `engram mcp --tools=agent` through a safe Node wrapper with `directTools: false`, so MCP remains available through the gateway without duplicating Pi-native `mem_*` tools.
 
+`engram setup pi` also auto-pins `npmCommand` in Pi's `settings.json` when [mise](https://mise.jdx.dev/) is detected in `PATH`. It sets `npmCommand` to `["mise", "exec", "node@<version>", "--", "npm"]` so Pi always uses the mise-managed Node version. Existing `npmCommand` values are never overwritten; if mise is not found, this step is a no-op.
+
 Existing `mcpServers.engram` entries are preserved unless you pass `--force`:
 
 ```bash


### PR DESCRIPTION
## Summary

Brings the docs up to date after the 2026-05-27 fix/feature batches. Documentation only (plus `printUsage()` help text), no runtime behavior changes. All entries were sourced by reading the actual implementation.

### Today's features documented
- `ENGRAM_HTTP_TOKEN` — optional Bearer auth for destructive HTTP endpoints (DELETE sessions/observations/prompts, GET /export, POST /import, POST /projects/migrate); unset = open (zero-config); constant-time compare.
- `scope=personal` without an explicit project searches across all projects (`mem_search`, `mem_context`).
- `global` is a valid scope value (alongside `project`, `personal`).
- `ENGRAM_TIMEZONE` — timezone for timestamp display (TUI + cloud dashboard). Note: falls back to **system local** (`t.Local()`), not UTC.
- `engram delete <id> [--hard]` — added to the CLI reference tables.
- TUI `c` — copy observation content to clipboard (OSC 52).
- `ENGRAM_CLOUD_ALLOWED_PROJECTS` accepts `*` to allow all projects.
- `engram setup pi` pins `npmCommand` via mise when detected (existing values preserved).

### Prior debt fixed
- `DOCS.md` env-var table expanded from 3 → 17 rows, synced with `printUsage()`.
- `printUsage()` env block: 5 missing vars added, indentation fixed.
- CLI reference tables in `README.md` and `docs/ARCHITECTURE.md` now include `doctor`, `conflicts`, `delete`, `projects prune`.

## Files
`DOCS.md`, `README.md`, `cmd/engram/main.go` (printUsage), `docs/ARCHITECTURE.md`, `docs/AGENT-SETUP.md`, `plugin/pi/README.md`

## Test plan
- `go build ./... && go vet ./...` clean
- Spot-check the env-var tables, scope enums, CLI tables, and TUI navigation entries against the implementation

Closes #435
