### PR TITLE
fix(store): match ANY term in multi-word FTS queries (OR, not implicit AND)

### DIFF
--- a/internal/store/sanitize_fts_test.go
+++ b/internal/store/sanitize_fts_test.go
@@ -1,0 +1,64 @@
+package store
+
+import "testing"
+
+// TestSanitizeFTS verifies multi-word queries are joined with OR (not an
+// implicit AND), while each term stays quoted to survive FTS5 special chars.
+func TestSanitizeFTS(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"blank", "   ", ""},
+		{"single", "auth", `"auth"`},
+		{"multi", "fix auth bug", `"fix" OR "auth" OR "bug"`},
+		{"strips existing quotes", `"fix" auth`, `"fix" OR "auth"`},
+		{"collapses whitespace", "a   b", `"a" OR "b"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeFTS(tc.in); got != tc.want {
+				t.Fatalf("sanitizeFTS(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSearchMatchesAnyTermInMultiWordQuery is a regression test for the
+// implicit-AND bug: a natural-language query whose terms are spread across a
+// document (and include terms absent from it) must still match. Under the old
+// space-join (implicit AND) this returned 0 results.
+func TestSearchMatchesAnyTermInMultiWordQuery(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "Auth middleware",
+		Content:   "Keep auth middleware in project memory",
+		Project:   "engram",
+		Scope:     "personal",
+	}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	// Only "auth" appears in the document; "database" and "migration" do not.
+	// Implicit AND would require all three terms → 0 results.
+	results, err := s.Search("auth database migration", SearchOptions{
+		Project: "engram",
+		Scope:   "personal",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for partial multi-word match, got %d", len(results))
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6145,8 +6145,15 @@ func stripPrivateTags(s string) string {
 	return result
 }
 
-// sanitizeFTS wraps each word in quotes so FTS5 doesn't choke on special chars.
-// "fix auth bug" → `"fix" "auth" "bug"`
+// sanitizeFTS wraps each word in quotes so FTS5 doesn't choke on special chars,
+// then joins them with OR so the query matches documents containing ANY term.
+// "fix auth bug" → `"fix" OR "auth" OR "bug"`
+//
+// Joining with OR (instead of a space, which FTS5 treats as an implicit AND)
+// is what makes multi-word / natural-language queries usable: an AND query
+// requires EVERY term to appear in a single document and returns 0 hits for
+// almost all real queries. Relevance is preserved by the callers' ORDER BY
+// fts.rank (bm25): documents matching more — and rarer — terms still rank highest.
 func sanitizeFTS(query string) string {
 	words := strings.Fields(query)
 	for i, w := range words {
@@ -6154,7 +6161,7 @@ func sanitizeFTS(query string) string {
 		w = strings.Trim(w, `"`)
 		words[i] = `"` + w + `"`
 	}
-	return strings.Join(words, " ")
+	return strings.Join(words, " OR ")
 }
 
 // ─── Passive Capture ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`sanitizeFTS` wraps each query word in quotes and joins them with a **space**. FTS5 treats a space between terms as an **implicit AND**, so a multi-word query only matches documents that contain **every** term.

For natural-language / multi-word searches this means near-zero recall — the query returns 0 hits unless one single document happens to contain all the words.

Reproducible at the SQL level on any populated DB:

```sql
-- implicit AND (current behaviour): every term required
SELECT count(*) FROM observations_fts
WHERE observations_fts MATCH '"email" "pipeline" "stalled" "leads"';   -- 0

-- OR: matches any term
SELECT count(*) FROM observations_fts
WHERE observations_fts MATCH '"email" OR "pipeline" OR "stalled" OR "leads"'; -- many
```

In practice `mem_search` (and the HTTP `/search` + context-injection hook, which share this helper) return nothing for typical multi-word queries while the data is clearly present and findable by single-term search.

## Fix

Join the quoted terms with `OR` instead of a space.

Relevance is preserved by the callers' existing `ORDER BY fts.rank` (bm25): documents matching **more** — and rarer — terms still rank highest. So the previous "best" matches stay on top, and partial matches simply become reachable instead of being dropped entirely. Each term stays quoted, so the original special-char protection is unchanged.

Diff is 3 lines of logic (plus an updated doc comment).

## Alternative considered

A hybrid "AND first, fall back to OR if 0 results" would also work and keeps strict-AND precision when it happens to match. I went with plain `OR` + bm25 because it's a one-line change, matches how FTS engines are normally queried, and the rank ordering already delivers the precision benefit (all-term matches float to the top) without a second query.

## Tests

- `TestSanitizeFTS` — table-driven unit test for the OR join, quote-stripping, empty/blank, single term.
- `TestSearchMatchesAnyTermInMultiWordQuery` — regression test: a query whose terms are only partially present now returns the document (0 results before this change).

```
ok  github.com/Gentleman-Programming/engram/internal/store
```

Verified locally end-to-end: rebuilt the binary, and `mem_search` / `engram search` / the `/search` HTTP endpoint now return ranked results for previously-empty multi-word queries.
