### PR TITLE
fix(release): adhoc re-sign darwin binaries to prevent AMFI SIGKILL on macOS 26.4

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,9 @@ builds:
       - arm64
     ldflags:
       - -s -w -X main.version={{.Version}}
+    hooks:
+      post:
+        - cmd: sh -c 'if [ "{{ .Os }}" = "darwin" ] && command -v codesign >/dev/null 2>&1; then codesign --force --sign - "{{ .Path }}"; fi'
 
 archives:
   - formats:


### PR DESCRIPTION
## Summary
Closes #402 — the released `darwin_arm64` binary got SIGKILL (exit 137) on macOS 26.4 because it carried only a Go-linker adhoc signature (`flags=0x20002 adhoc,linker-signed`), which AMFI on recent macOS rejects.

## Change
`.goreleaser.yaml`: add a post-build hook that adhoc-re-signs darwin binaries with `codesign --force --sign -` (produces `flags=0x2 adhoc`, which AMFI accepts). Free — no Apple Developer certificate required.

Note: goreleaser v2 has no `filter: goos` field, so the hook uses a shell conditional gated on `{{ .Os }}` plus `command -v codesign`, which no-ops safely on Linux CI runners.

## Test plan
`goreleaser check` passes. Cannot exercise macOS signing in CI; manual verification on a macOS 26.4 arm64 host: `codesign -dvv ./engram` must NOT show `linker-signed`, and `./engram --version` must exit 0 (not 137).

## Notes
Passed adversarial review — `{{ .Os }}` and `{{ .Path }}` verified against goreleaser v2 source; hook fires per-binary for both darwin archs; fails safe on Linux.
