### PR TITLE
fix(plugin): sync plugin.json version to 0.1.1 to stop recursive cache dirs

### DIFF
--- a/plugin/assets_test.go
+++ b/plugin/assets_test.go
@@ -1,6 +1,7 @@
 package plugin_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -75,5 +76,72 @@ func TestPluginAssetsDoNotLeakSpanishTriggers(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// marketplaceJSON is the minimal structure of .claude-plugin/marketplace.json
+// needed to extract the version declared for the engram plugin entry.
+type marketplaceJSON struct {
+	Plugins []struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"plugins"`
+}
+
+// pluginJSON is the structure of plugin/claude-code/.claude-plugin/plugin.json.
+type pluginJSON struct {
+	Version string `json:"version"`
+}
+
+// TestPluginVersionsMatch asserts that the version declared in
+// .claude-plugin/marketplace.json matches the version in
+// plugin/claude-code/.claude-plugin/plugin.json.
+//
+// A mismatch between these two files causes Claude Code to silently skip
+// installation or re-download the plugin on every run because it sees the
+// cached version as stale.
+func TestPluginVersionsMatch(t *testing.T) {
+	root := repoRoot(t)
+
+	// Read marketplace.json
+	marketplacePath := filepath.Join(root, ".claude-plugin", "marketplace.json")
+	marketplaceData, err := os.ReadFile(marketplacePath)
+	if err != nil {
+		t.Fatalf("cannot read marketplace.json: %v", err)
+	}
+	var marketplace marketplaceJSON
+	if err := json.Unmarshal(marketplaceData, &marketplace); err != nil {
+		t.Fatalf("cannot parse marketplace.json: %v", err)
+	}
+
+	// Read plugin.json
+	pluginPath := filepath.Join(root, "plugin", "claude-code", ".claude-plugin", "plugin.json")
+	pluginData, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("cannot read plugin.json: %v", err)
+	}
+	var plugin pluginJSON
+	if err := json.Unmarshal(pluginData, &plugin); err != nil {
+		t.Fatalf("cannot parse plugin.json: %v", err)
+	}
+
+	// Find the engram plugin entry in marketplace.json
+	var marketplaceVersion string
+	for _, p := range marketplace.Plugins {
+		if p.Name == "engram" {
+			marketplaceVersion = p.Version
+			break
+		}
+	}
+	if marketplaceVersion == "" {
+		t.Fatal("marketplace.json contains no plugin entry named 'engram'")
+	}
+
+	if marketplaceVersion != plugin.Version {
+		t.Errorf(
+			"plugin version mismatch: marketplace.json declares %q but plugin/claude-code/.claude-plugin/plugin.json declares %q — keep them in sync",
+			marketplaceVersion,
+			plugin.Version,
+		)
 	}
 }

--- a/plugin/claude-code/.claude-plugin/plugin.json
+++ b/plugin/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "engram",
   "description": "Persistent memory for AI coding agents. Survives across sessions and compactions.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Gentleman Programming"
   },


### PR DESCRIPTION
## Summary
Closes #217 — installing the plugin created infinitely nested empty cache dirs (`~/.claude/plugins/cache/engram/0.1.0/engram/0.1.0/...`).

## Change
Sync `plugin/claude-code/.claude-plugin/plugin.json` version `0.1.0` → `0.1.1` to match `marketplace.json`. The version drift drove repeated re-downloads into versioned cache directories. Added `TestPluginVersionsMatch` to catch future drift.

## What this PR deliberately does NOT do
An earlier exploration switched `marketplace.json` `source` to the `git-subdir` object form. That was dropped: git-subdir was already reverted once in this repo (commit `54a6c52` — "Claude Code doesn't recognize it via /plugins"), and upstream [claude-plugins-official#585](https://github.com/anthropics/claude-plugins-official/issues/585) reports it breaks installs on Claude Code < v2.1.69. The `source` stays as the relative path. If sparse-clone is wanted later, it should be a separate, deliberately-scoped change with a minimum-client-version expectation.

## Test plan
`go test ./plugin/ -run TestPluginVersionsMatch` passes; both manifests parse as valid JSON.
