### PR TITLE
fix: escape interior double-quotes in FTS5 search to prevent 500s

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6227,8 +6227,13 @@ func stripPrivateTags(s string) string {
 func sanitizeFTS(query string) string {
 	words := strings.Fields(query)
 	for i, w := range words {
-		// Strip existing quotes to avoid double-quoting
+		// Strip surrounding quotes to avoid double-quoting
 		w = strings.Trim(w, `"`)
+		// Escape any remaining interior double-quotes by doubling them, as
+		// required for an FTS5 string literal. Without this, a token like
+		// foo"bar produces the unbalanced phrase "foo"bar" and SQLite rejects
+		// the whole query with "unterminated string", surfacing as an HTTP 500.
+		w = strings.ReplaceAll(w, `"`, `""`)
 		words[i] = `"` + w + `"`
 	}
 	return strings.Join(words, " ")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8289,3 +8289,67 @@ func TestMostRecentActiveSessionScopedByProject(t *testing.T) {
 		t.Fatalf("expected no active session for engram when only 'other' has one, got ok=%v", ok)
 	}
 }
+
+// TestSearchWithEmbeddedQuoteDoesNotCrash is a regression test for a 500 in the
+// /search endpoint. A search token containing an interior double-quote (e.g.
+// foo"bar) was wrapped by sanitizeFTS into the unbalanced FTS5 phrase
+// `"foo"bar"`, which SQLite rejected with "unterminated string", so Store.Search
+// (and the HTTP handler that wraps it) returned an error instead of results.
+// After the fix, interior quotes are escaped by doubling, the query succeeds, and
+// it still matches the literal token.
+func TestSearchWithEmbeddedQuoteDoesNotCrash(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "Config token",
+		Content:   `the value is foo"bar in the config file`,
+		Project:   "engram",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	// Inputs that previously produced an unbalanced FTS5 phrase and a 500.
+	for _, q := range []string{`foo"bar`, `a"b"c`, `"`, `he said "hi`} {
+		if _, err := s.Search(q, SearchOptions{Project: "engram", Limit: 10}); err != nil {
+			t.Fatalf("Search(%q) returned error (should be handled gracefully): %v", q, err)
+		}
+	}
+
+	// The fix must remain functional, not just non-crashing: searching the
+	// embedded-quote token still finds the observation that contains it.
+	results, err := s.Search(`foo"bar`, SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search(foo\"bar): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for embedded-quote token, got %d", len(results))
+	}
+	if results[0].Title != "Config token" {
+		t.Fatalf("expected to match \"Config token\", got %q", results[0].Title)
+	}
+}
+
+// TestSanitizeFTSPreservesPlainQueries guards backward compatibility: normal
+// multi-word queries and user-supplied surrounding quotes must keep producing
+// the same per-term quoting they did before the embedded-quote fix.
+func TestSanitizeFTSPreservesPlainQueries(t *testing.T) {
+	cases := map[string]string{
+		"fix auth bug":     `"fix" "auth" "bug"`,
+		`"quoted phrase"`:  `"quoted" "phrase"`,
+		"single":           `"single"`,
+		`foo"bar`:          `"foo""bar"`,
+		"":                 "",
+		"   ":              "",
+	}
+	for in, want := range cases {
+		if got := sanitizeFTS(in); got != want {
+			t.Errorf("sanitizeFTS(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`GET /search` (and `GET /prompts/search`) return **HTTP 500** for ordinary search input that contains a double-quote *inside* a word, e.g. `foo"bar`.

```
$ curl -s 'http://127.0.0.1:PORT/search?q=foo%22bar'
{"error":"search: SQL logic error: unterminated string (1)"}
```

## Root cause
`sanitizeFTS` (`internal/store/store.go`) wraps each whitespace-separated token in double-quotes so FTS5 treats it as a phrase. It strips *surrounding* quotes with `strings.Trim(w, "\"")` but leaves **interior** quotes untouched:

```go
w = strings.Trim(w, `"`)   // only edges
words[i] = `"` + w + `"`    // re-wrap
```

So `foo"bar` becomes the phrase `"foo"bar"`. That is an unbalanced FTS5 string literal, and SQLite aborts the whole `MATCH` query with `unterminated string`. `Store.Search` returns that error and the HTTP handler maps it to 500. Whether a given input crashes is data-dependent (an even number of interior quotes happens to balance, an odd number does not), which makes it an easy-to-hit, hard-to-explain 500.

## Fix
Escape any interior double-quotes by doubling them, which is how a literal `"` is represented inside an FTS5 string literal:

```go
w = strings.Trim(w, `"`)            // strip surrounding quotes (unchanged)
w = strings.ReplaceAll(w, `"`, `""`) // escape remaining interior quotes
words[i] = `"` + w + `"`
```

`foo"bar` now sanitizes to the valid phrase `"foo""bar"`, which both runs without error and correctly matches text containing the literal token `foo"bar`. Plain queries are unaffected: `fix auth bug` → `"fix" "auth" "bug"` and `"quoted phrase"` → `"quoted" "phrase"`, identical to before. One line of logic changed; surrounding-quote behavior preserved.

## Test (fail-before → pass-after)
Added two tests in `internal/store/store_test.go`:

- `TestSearchWithEmbeddedQuoteDoesNotCrash` — stores an observation containing `foo"bar`, then runs `Search` with several embedded-quote inputs (`foo"bar`, `a"b"c`, `"`, `he said "hi`). Asserts none error, and that searching `foo"bar` returns the matching observation.
- `TestSanitizeFTSPreservesPlainQueries` — locks in the unchanged output for plain/edge-quoted queries (backward-compat guard).

```
# with the fix reverted (fail-before):
--- FAIL: TestSearchWithEmbeddedQuoteDoesNotCrash
    store_test.go:8320: Search("foo\"bar") returned error: search: SQL logic error: unterminated string (1)
--- FAIL: TestSanitizeFTSPreservesPlainQueries
    store_test.go:8352: sanitizeFTS("foo\"bar") = "\"foo\"bar\"", want "\"foo\"\"bar\""

# with the fix (pass-after):
ok  github.com/Gentleman-Programming/engram/internal/store
```

Full `go test ./internal/store/` and `go test ./internal/server/` pass; `go vet ./internal/store/` is clean.

## Repro steps
1. Start the engram HTTP server and create at least one observation.
2. `curl -s 'http://127.0.0.1:<port>/search?q=foo%22bar'`
3. Before this change: `500` with `search: SQL logic error: unterminated string`. After: `200` with normal results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)