### PR TITLE
fix(sync): defer orphan observations on pull, reject sessions without directory on push

### DIFF
--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -589,9 +589,11 @@ func (m *Manager) pull(ctx context.Context) error {
 				OccurredAt: rm.OccurredAt,
 			}
 			// Phase E: per-entity error policy (design §9).
-			// ApplyPulledMutation handles relation FK misses internally by writing
-			// to sync_apply_deferred and returning nil — the cursor advances normally.
-			// All other errors (legacy entities, decode errors) propagate and halt the pull.
+			// ApplyPulledMutation handles FK misses by writing to sync_apply_deferred
+			// and returning nil — the cursor advances normally. This covers both
+			// relation FK misses and legacy entities (observation/session/prompt) whose
+			// parent session is not yet present locally; both defer instead of halting.
+			// Decode errors and other unrecoverable failures propagate and halt the pull.
 			if err := m.store.ApplyPulledMutation(m.cfg.TargetKey, localMut); err != nil {
 				return fmt.Errorf("apply pulled mutation seq=%d: %w", rm.Seq, err)
 			}

--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -333,17 +333,47 @@ func validateRelationPayload(payload json.RawMessage) (string, bool) {
 	return "", true
 }
 
-// validateLegacyPayload is a no-op for legacy entities (session, observation,
-// prompt). REQ-008: these entities have no new required payload fields — their
-// push/pull behavior is UNCHANGED from before Phase 2. Any tightening of legacy
-// payload validation is a breaking change and must not be done here.
-func validateLegacyPayload(_ string, _ json.RawMessage) (string, bool) {
+// validateLegacyPayload validates legacy entity payloads (session, observation,
+// prompt). For a session upsert, directory is required unless the session is
+// being deleted. Delete forms are: deleted=true, hard_delete=true, or a
+// non-empty deleted_at value — matching the server-side isSessionDeletePayload
+// semantics. All other legacy entities pass unconditionally — their pull/push
+// behavior is UNCHANGED from before Phase 2.
+func validateLegacyPayload(entity string, payload json.RawMessage) (string, bool) {
+	if entity != "session" {
+		return "", true
+	}
+	var p struct {
+		Deleted    bool    `json:"deleted"`
+		HardDelete bool    `json:"hard_delete"`
+		DeletedAt  *string `json:"deleted_at"`
+		Directory  string  `json:"directory"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		// Malformed JSON: pass through; other validators surface decode errors.
+		return "", true
+	}
+	// Any delete form exempts the directory requirement.
+	if p.Deleted || p.HardDelete {
+		return "", true
+	}
+	if p.DeletedAt != nil && strings.TrimSpace(*p.DeletedAt) != "" {
+		return "", true
+	}
+	if strings.TrimSpace(p.Directory) == "" {
+		return "directory", false
+	}
 	return "", true
 }
 
 // validateMutationEntry dispatches to the correct validator for the entry's
 // entity type. Returns (missingField, false) on validation failure.
+// Delete operations (op=="delete") bypass payload validation entirely — the
+// payload may be minimal or empty for tombstone deletes.
 func validateMutationEntry(entry MutationEntry) (string, bool) {
+	if entry.Op == "delete" {
+		return "", true
+	}
 	switch entry.Entity {
 	case "relation":
 		return validateRelationPayload(entry.Payload)

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -1271,6 +1271,175 @@ func TestHandleMutationPush_LegacyObsMissingOptional_Returns200(t *testing.T) {
 	}
 }
 
+// ─── Bug A: validateLegacyPayload rejects sessions without directory ──────────
+
+// TestHandleMutationPush_SessionMissingDirectory_Returns400 (Bug A) verifies
+// that a session mutation without a directory field is rejected with 400 and
+// the "directory" field name in the error response.
+func TestHandleMutationPush_SessionMissingDirectory_Returns400(t *testing.T) {
+	ms := newFakeMutationStore()
+	srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
+
+	// Session payload with no directory field — must be rejected.
+	payloadNone := json.RawMessage(`{"id":"ses-001"}`)
+	// Session payload with empty directory — must also be rejected.
+	payloadEmpty := json.RawMessage(`{"id":"ses-002","directory":""}`)
+
+	cases := []struct {
+		name    string
+		payload json.RawMessage
+	}{
+		{"no directory field", payloadNone},
+		{"empty directory", payloadEmpty},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := []MutationEntry{
+				{Project: "proj-a", Entity: "session", EntityKey: "ses-001", Op: "upsert", Payload: tc.payload},
+			}
+			body := marshalPushRequest(t, entries)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", body)
+			req.Header.Set("Authorization", "Bearer secret")
+			req.Header.Set("Content-Type", "application/json")
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("Bug A %s: expected 400, got %d body=%q", tc.name, rec.Code, rec.Body.String())
+			}
+			// The error response must name the missing field.
+			var resp struct {
+				Invalid []struct {
+					Field string `json:"field"`
+				} `json:"invalid"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("Bug A %s: decode response: %v", tc.name, err)
+			}
+			if len(resp.Invalid) == 0 || resp.Invalid[0].Field != "directory" {
+				t.Errorf("Bug A %s: expected field='directory' in invalid[0], got %+v", tc.name, resp.Invalid)
+			}
+			// Nothing must be stored.
+			if len(ms.mutations) != 0 {
+				t.Errorf("Bug A %s: expected 0 mutations stored, got %d", tc.name, len(ms.mutations))
+			}
+		})
+	}
+}
+
+// TestHandleMutationPush_SessionWithDirectory_Returns200 (Bug A happy-path)
+// verifies that a session mutation WITH a directory still passes through.
+func TestHandleMutationPush_SessionWithDirectory_Returns200(t *testing.T) {
+	ms := newFakeMutationStore()
+	srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
+
+	entries := []MutationEntry{
+		{
+			Project:   "proj-a",
+			Entity:    "session",
+			EntityKey: "ses-ok",
+			Op:        "upsert",
+			Payload:   json.RawMessage(`{"id":"ses-ok","directory":"/home/user/proj"}`),
+		},
+	}
+	body := marshalPushRequest(t, entries)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Bug A happy path: expected 200 for session with directory, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(ms.mutations) != 1 {
+		t.Fatalf("Bug A happy path: expected 1 mutation stored, got %d", len(ms.mutations))
+	}
+}
+
+// TestHandleMutationPush_DeletedSessionWithoutDirectory_Returns200 verifies
+// that a deleted session without a directory is NOT rejected (deleted=true exemption).
+func TestHandleMutationPush_DeletedSessionWithoutDirectory_Returns200(t *testing.T) {
+	ms := newFakeMutationStore()
+	srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
+
+	entries := []MutationEntry{
+		{
+			Project:   "proj-a",
+			Entity:    "session",
+			EntityKey: "ses-del",
+			Op:        "upsert",
+			Payload:   json.RawMessage(`{"id":"ses-del","deleted":true}`),
+		},
+	}
+	body := marshalPushRequest(t, entries)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", body)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Bug A deleted session: expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleMutationPush_SessionDeleteVariants_Returns200 verifies that all
+// delete forms (hard_delete=true, deleted_at set, op=="delete") bypass the
+// directory requirement — matching the server-side isSessionDeletePayload
+// semantics exactly (CRITICAL-1).
+func TestHandleMutationPush_SessionDeleteVariants_Returns200(t *testing.T) {
+	cases := []struct {
+		name    string
+		op      string
+		payload json.RawMessage
+	}{
+		{
+			name:    "hard_delete=true without directory",
+			op:      "upsert",
+			payload: json.RawMessage(`{"id":"ses-hd","hard_delete":true}`),
+		},
+		{
+			name:    "deleted_at set without directory",
+			op:      "upsert",
+			payload: json.RawMessage(`{"id":"ses-da","deleted_at":"2026-01-01T00:00:00Z"}`),
+		},
+		{
+			name:    "op=delete without directory",
+			op:      "delete",
+			payload: json.RawMessage(`{"id":"ses-op"}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := newFakeMutationStore()
+			srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
+
+			entries := []MutationEntry{
+				{
+					Project:   "proj-a",
+					Entity:    "session",
+					EntityKey: "ses-del-variant",
+					Op:        tc.op,
+					Payload:   tc.payload,
+				},
+			}
+			body := marshalPushRequest(t, entries)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", body)
+			req.Header.Set("Authorization", "Bearer secret")
+			req.Header.Set("Content-Type", "application/json")
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("CRITICAL-1 %s: expected 200, got %d body=%q",
+					tc.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 func newMutationTestServer(ms *fakeMutationStore, token string, projects []string) *CloudServer {

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -129,6 +129,7 @@ type RelationStats struct {
 type DeferredRow struct {
 	SyncID          string         `json:"sync_id"`
 	Entity          string         `json:"entity"`
+	Op              string         `json:"op"`
 	Payload         map[string]any `json:"payload,omitempty"`
 	PayloadRaw      string         `json:"payload_raw"`
 	PayloadValid    bool           `json:"payload_valid"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1056,6 +1056,15 @@ func (s *Store) migrate() error {
 		return err
 	}
 
+	// Phase 3 — CRITICAL-2: preserve the sync op (upsert vs delete) so that a
+	// deferred delete is replayed as a delete, not silently converted to an upsert.
+	// addColumnIfNotExists is idempotent: a no-op when the column already exists.
+	if err := s.addColumnIfNotExists(
+		"sync_apply_deferred", "op", "TEXT NOT NULL DEFAULT 'upsert'",
+	); err != nil {
+		return err
+	}
+
 	// Phase 3b: composite index for conflict-audit list/count queries.
 	if _, err := s.execHook(s.db, `
 		CREATE INDEX IF NOT EXISTS idx_memrel_status_created
@@ -3982,17 +3991,21 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 			// Phase E: per-entity skip+log policy (design §9).
 			// For relation FK misses, write to sync_apply_deferred and ACK the seq
 			// so the cursor can advance. All other errors propagate and halt the pull.
+			isLegacyEntity := mutation.Entity == SyncEntityObservation ||
+				mutation.Entity == SyncEntitySession ||
+				mutation.Entity == SyncEntityPrompt
 			if mutation.Entity == SyncEntityRelation && errors.Is(applyErr, ErrRelationFKMissing) {
 				log.Printf("[store] ApplyPulledMutation: relation FK miss seq=%d entity_key=%s — deferring",
 					mutation.Seq, mutation.EntityKey)
 				if _, deferErr := s.execHook(tx, `
 					INSERT INTO sync_apply_deferred
-						(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
-					VALUES (?, ?, ?, 'deferred', 0, datetime('now'))
+						(sync_id, entity, op, payload, apply_status, retry_count, first_seen_at)
+					VALUES (?, ?, ?, ?, 'deferred', 0, datetime('now'))
 					ON CONFLICT(sync_id) DO UPDATE SET
+						op                 = excluded.op,
 						payload            = excluded.payload,
 						last_attempted_at  = datetime('now')
-				`, mutation.EntityKey, mutation.Entity, mutation.Payload); deferErr != nil {
+				`, mutation.EntityKey, mutation.Entity, mutation.Op, mutation.Payload); deferErr != nil {
 					return fmt.Errorf("ApplyPulledMutation: write deferred row: %w", deferErr)
 				}
 				// Fall through to advance the cursor (ACK the seq).
@@ -4003,14 +4016,32 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 					mutation.Seq, mutation.EntityKey, applyErr)
 				if _, deferErr := s.execHook(tx, `
 					INSERT INTO sync_apply_deferred
-						(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
-					VALUES (?, ?, ?, 'dead', 0, datetime('now'))
+						(sync_id, entity, op, payload, apply_status, retry_count, first_seen_at)
+					VALUES (?, ?, ?, ?, 'dead', 0, datetime('now'))
 					ON CONFLICT(sync_id) DO UPDATE SET
+						op                = excluded.op,
 						payload           = excluded.payload,
 						apply_status      = 'dead',
 						last_attempted_at = datetime('now')
-				`, mutation.EntityKey, mutation.Entity, mutation.Payload); deferErr != nil {
+				`, mutation.EntityKey, mutation.Entity, mutation.Op, mutation.Payload); deferErr != nil {
 					return fmt.Errorf("ApplyPulledMutation: write dead row: %w", deferErr)
+				}
+				// Fall through to advance the cursor (ACK the seq).
+			} else if isLegacyEntity && isSQLiteFKConstraintError(applyErr) {
+				// Legacy entity (observation/session/prompt) arrived before its parent
+				// session exists locally. Defer instead of halting the pull stream.
+				log.Printf("[store] ApplyPulledMutation: legacy FK miss seq=%d entity=%s entity_key=%s — deferring",
+					mutation.Seq, mutation.Entity, mutation.EntityKey)
+				if _, deferErr := s.execHook(tx, `
+					INSERT INTO sync_apply_deferred
+						(sync_id, entity, op, payload, apply_status, retry_count, first_seen_at)
+					VALUES (?, ?, ?, ?, 'deferred', 0, datetime('now'))
+					ON CONFLICT(sync_id) DO UPDATE SET
+						op                = excluded.op,
+						payload           = excluded.payload,
+						last_attempted_at = datetime('now')
+				`, mutation.EntityKey, mutation.Entity, mutation.Op, mutation.Payload); deferErr != nil {
+					return fmt.Errorf("ApplyPulledMutation: write deferred legacy row: %w", deferErr)
 				}
 				// Fall through to advance the cursor (ACK the seq).
 			} else {
@@ -4063,9 +4094,34 @@ func (s *Store) ApplyPulledChunk(targetKey, chunkID string, mutations []SyncMuta
 			mutation.Seq = seq
 			mutation.TargetKey = targetKey
 			mutation.Source = SyncSourceRemote
-			if err := s.applyPulledMutationTx(tx, mutation); err != nil {
-				return fmt.Errorf("apply chunk mutation %d: %w", i, err)
+			applyErr := s.applyPulledMutationTx(tx, mutation)
+			if applyErr == nil {
+				continue
 			}
+			// WARNING-3: legacy entities (observation/session/prompt) with an FK
+			// miss in a chunk must be deferred — not returned as an error — so the
+			// rest of the chunk can be applied.  This mirrors the per-mutation
+			// deferral logic in ApplyPulledMutation (design §9).
+			isLegacyEntity := mutation.Entity == SyncEntityObservation ||
+				mutation.Entity == SyncEntitySession ||
+				mutation.Entity == SyncEntityPrompt
+			if isLegacyEntity && isSQLiteFKConstraintError(applyErr) {
+				log.Printf("[store] ApplyPulledChunk: legacy FK miss chunk=%s entity=%s entity_key=%s — deferring",
+					chunkID, mutation.Entity, mutation.EntityKey)
+				if _, deferErr := s.execHook(tx, `
+					INSERT INTO sync_apply_deferred
+						(sync_id, entity, op, payload, apply_status, retry_count, first_seen_at)
+					VALUES (?, ?, ?, ?, 'deferred', 0, datetime('now'))
+					ON CONFLICT(sync_id) DO UPDATE SET
+						op                = excluded.op,
+						payload           = excluded.payload,
+						last_attempted_at = datetime('now')
+				`, mutation.EntityKey, mutation.Entity, mutation.Op, mutation.Payload); deferErr != nil {
+					return fmt.Errorf("ApplyPulledChunk: write deferred legacy row: %w", deferErr)
+				}
+				continue // ACK this mutation; move on to the next in the chunk.
+			}
+			return fmt.Errorf("apply chunk mutation %d: %w", i, applyErr)
 		}
 
 		if _, err := s.execHook(tx,
@@ -4719,6 +4775,21 @@ func withSQLiteWriteRetry(fn func() error) error {
 		return nil
 	}
 	return lastErr
+}
+
+// isSQLiteFKConstraintError returns true when err is a SQLite foreign-key
+// constraint violation (extended result code 787 / SQLITE_CONSTRAINT_FOREIGNKEY).
+// Falls back to a string check for robustness in test environments where the
+// driver may wrap the error differently.
+func isSQLiteFKConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.Code() == sqliteConstraintForeignKey
+	}
+	return strings.Contains(err.Error(), "FOREIGN KEY constraint failed")
 }
 
 func isRetryableSQLiteLockError(err error) bool {
@@ -6451,7 +6522,7 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 	const deadThreshold = 5
 
 	rows, err := s.db.Query(`
-		SELECT sync_id, entity, payload, retry_count
+		SELECT sync_id, entity, COALESCE(op, 'upsert'), payload, retry_count
 		FROM sync_apply_deferred
 		WHERE apply_status = 'deferred'
 		ORDER BY first_seen_at
@@ -6464,6 +6535,7 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 	type deferredRow struct {
 		syncID     string
 		entity     string
+		op         string
 		payload    string
 		retryCount int
 	}
@@ -6471,7 +6543,7 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 	var pending []deferredRow
 	for rows.Next() {
 		var r deferredRow
-		if err := rows.Scan(&r.syncID, &r.entity, &r.payload, &r.retryCount); err != nil {
+		if err := rows.Scan(&r.syncID, &r.entity, &r.op, &r.payload, &r.retryCount); err != nil {
 			rows.Close()
 			return result, fmt.Errorf("ReplayDeferred: scan: %w", err)
 		}
@@ -6486,17 +6558,33 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 		result.Retried++
 		mut := SyncMutation{
 			Entity:  row.entity,
-			Op:      SyncOpUpsert,
+			Op:      row.op, // CRITICAL-2: preserve original op (delete vs upsert)
 			Payload: row.payload,
 			Source:  SyncSourceRemote,
 		}
 
+		// WARNING-2: apply and deferred-row cleanup run in the SAME transaction.
+		// If the process dies between apply and cleanup, the row would be retried
+		// unnecessarily. Moving the DELETE inside withTx makes them atomic.
+		// For relations, applyRelationUpsertTx already deletes the deferred row
+		// inside the tx; the extra DELETE here is a no-op for those.
 		applyErr := s.withTx(func(tx *sql.Tx) error {
-			return s.applyPulledMutationTx(tx, mut)
+			if err := s.applyPulledMutationTx(tx, mut); err != nil {
+				return err
+			}
+			// Delete the deferred row inside the same transaction so the apply
+			// and the cleanup are atomic — no double-retry if the process crashes
+			// between commit and a separate DELETE statement.
+			if _, delErr := s.execHook(tx,
+				`DELETE FROM sync_apply_deferred WHERE sync_id = ?`, row.syncID,
+			); delErr != nil {
+				// Non-fatal: the apply succeeded; log and carry on.
+				log.Printf("[store] replayDeferred: cleanup deferred row sync_id=%s: %v", row.syncID, delErr)
+			}
+			return nil
 		})
 
 		if applyErr == nil {
-			// Success: applyRelationUpsertTx already deleted the deferred row.
 			result.Succeeded++
 			log.Printf("[store] replayDeferred: applied sync_id=%s", row.syncID)
 			continue
@@ -6505,7 +6593,9 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 		// Classify the error and update the deferred row.
 		newRetry := row.retryCount + 1
 		var newStatus string
-		if errors.Is(applyErr, ErrRelationFKMissing) && newRetry < deadThreshold {
+		isRetryableFKMiss := errors.Is(applyErr, ErrRelationFKMissing) ||
+			isSQLiteFKConstraintError(applyErr)
+		if isRetryableFKMiss && newRetry < deadThreshold {
 			// Still retryable.
 			newStatus = "deferred"
 			result.Failed++
@@ -6570,7 +6660,7 @@ func (s *Store) CountDeferredAndDead() (deferred, dead int, err error) {
 // JSON, PayloadValid is false and PayloadRaw is preserved.
 func (s *Store) ListDeferred(opts ListDeferredOptions) ([]DeferredRow, error) {
 	query := `
-		SELECT sync_id, entity, payload, apply_status, retry_count,
+		SELECT sync_id, entity, COALESCE(op, 'upsert'), payload, apply_status, retry_count,
 		       last_error, last_attempted_at, first_seen_at
 		FROM sync_apply_deferred
 		WHERE 1=1`
@@ -6617,7 +6707,7 @@ func (s *Store) ListDeferred(opts ListDeferredOptions) ([]DeferredRow, error) {
 // Returns an error wrapping "not found" when no row exists (matches FindCandidates style).
 func (s *Store) GetDeferred(syncID string) (DeferredRow, error) {
 	row := s.db.QueryRow(`
-		SELECT sync_id, entity, payload, apply_status, retry_count,
+		SELECT sync_id, entity, COALESCE(op, 'upsert'), payload, apply_status, retry_count,
 		       last_error, last_attempted_at, first_seen_at
 		FROM sync_apply_deferred
 		WHERE sync_id = ?
@@ -6643,7 +6733,7 @@ func scanDeferredRow(row scannable) (DeferredRow, error) {
 	var r DeferredRow
 	var rawPayload string
 	if err := row.Scan(
-		&r.SyncID, &r.Entity, &rawPayload, &r.ApplyStatus, &r.RetryCount,
+		&r.SyncID, &r.Entity, &r.Op, &rawPayload, &r.ApplyStatus, &r.RetryCount,
 		&r.LastError, &r.LastAttemptedAt, &r.FirstSeenAt,
 	); err != nil {
 		return r, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2679,6 +2679,9 @@ func TestApplyPulledObservationPreservesChronologyAndRevisionMetadata(t *testing
 func TestApplyPulledChunkIsAtomicAndRetrySafe(t *testing.T) {
 	s := newTestStore(t)
 
+	// A chunk with an unrecoverable (non-FK-miss) error: an unknown entity type
+	// triggers the "unknown sync entity" path and is NOT a deferrable FK miss,
+	// so it must roll back the entire chunk (true atomicity test).
 	badChunk := []SyncMutation{
 		{
 			Entity:    SyncEntitySession,
@@ -2687,16 +2690,17 @@ func TestApplyPulledChunkIsAtomicAndRetrySafe(t *testing.T) {
 			Payload:   `{"id":"chunk-session","project":"engram","directory":"/remote"}`,
 		},
 		{
-			Entity:    SyncEntityObservation,
-			EntityKey: "chunk-obs-bad",
+			Entity:    "unknown_entity_type", // triggers an unrecoverable error
+			EntityKey: "chunk-bad-entity",
 			Op:        SyncOpUpsert,
-			Payload:   `{"sync_id":"chunk-obs-bad","session_id":"missing-session","type":"note","title":"bad","content":"fails fk","project":"engram","scope":"project"}`,
+			Payload:   `{}`,
 		},
 	}
 
 	if err := s.ApplyPulledChunk(DefaultSyncTargetKey, "chunk-retry-safe", badChunk); err == nil {
-		t.Fatal("expected chunk apply error for invalid observation payload")
+		t.Fatal("expected chunk apply error for unrecoverable mutation")
 	}
+	// Atomicity: the session in the same chunk must have been rolled back.
 	if _, err := s.GetSession("chunk-session"); err == nil {
 		t.Fatal("expected chunk session upsert to roll back after failed chunk apply")
 	}

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -578,3 +578,332 @@ func TestApplyPulledRelation_MultiActorSamePair(t *testing.T) {
 		t.Errorf("actor-2 sync_id: expected 1 row, got %d", n2)
 	}
 }
+
+// ─── CRITICAL-2: sync_apply_deferred must preserve Op ────────────────────────
+
+// TestReplayDeferred_PreservesDeleteOp verifies that a deferred row with
+// op='delete' is replayed as a delete (not an upsert) — so a delete that was
+// queued while its target was missing is correctly applied once it arrives.
+//
+// Strategy: create a session + observation locally, insert a deferred row with
+// op='delete' for that observation (simulating a delete that arrived before a
+// dependency was ready), then call ReplayDeferred and verify the observation is
+// soft-deleted, not re-upserted.
+func TestReplayDeferred_PreservesDeleteOp(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.ensureSyncState(DefaultSyncTargetKey); err != nil {
+		t.Fatalf("ensureSyncState: %v", err)
+	}
+
+	// Set up: session + observation exist locally.
+	if err := s.CreateSession("ses-del-op", "proj-del", "/tmp/delop"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	obsID, obsSyncID := addTestObsSession(t, s, "ses-del-op", "Delete-op obs", "decision", "proj-del", "project")
+
+	// Confirm observation exists and is not deleted.
+	obs, err := s.GetObservationBySyncID(obsSyncID)
+	if err != nil || obs == nil {
+		t.Fatalf("setup: observation not found by sync_id %s: %v", obsSyncID, err)
+	}
+	if obs.DeletedAt != nil {
+		t.Fatalf("setup: observation already deleted before test, id=%d", obsID)
+	}
+
+	// Build a minimal delete payload (matches what the sync protocol sends).
+	delPayload, err := json.Marshal(syncObservationPayload{
+		SyncID:    obsSyncID,
+		SessionID: "ses-del-op",
+		Type:      "decision",
+		Title:     "Delete-op obs",
+		Content:   "",
+		Deleted:   true,
+		CreatedAt: "2026-01-01T00:00:00Z",
+		UpdatedAt: "2026-01-01T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal delete payload: %v", err)
+	}
+
+	// Manually insert a deferred row with op='delete'.
+	// (Before the fix, the op column doesn't exist — this insert will fail if
+	// the migration hasn't added the column.)
+	if _, dbErr := s.db.Exec(`
+		INSERT INTO sync_apply_deferred
+			(sync_id, entity, op, payload, apply_status, retry_count, first_seen_at)
+		VALUES (?, 'observation', 'delete', ?, 'deferred', 0, datetime('now'))
+	`, obsSyncID, string(delPayload)); dbErr != nil {
+		t.Fatalf("CRITICAL-2 pre-condition: insert deferred row with op='delete': %v — "+
+			"op column missing from sync_apply_deferred (migration not applied)", dbErr)
+	}
+
+	// ReplayDeferred must replay it as a delete.
+	res, err := s.ReplayDeferred()
+	if err != nil {
+		t.Fatalf("ReplayDeferred: %v", err)
+	}
+	if res.Succeeded != 1 {
+		t.Errorf("ReplayDeferred: want succeeded=1, got %d (failed=%d dead=%d)",
+			res.Succeeded, res.Failed, res.Dead)
+	}
+
+	// Deferred row must be gone.
+	if n := countDeferredRows(t, s, obsSyncID); n != 0 {
+		t.Errorf("deferred row still present after replay; got %d", n)
+	}
+
+	// Observation must now be soft-deleted (deleted_at set), not alive.
+	// GetObservationBySyncID filters deleted_at IS NULL, so it should return error.
+	got, err2 := s.GetObservationBySyncID(obsSyncID)
+	if err2 == nil && got != nil {
+		t.Errorf("CRITICAL-2: observation was re-upserted instead of deleted (op not preserved); got %+v", got)
+	}
+	// Verify deleted_at IS set in the raw table.
+	var deletedAt *string
+	if scanErr := s.db.QueryRow(
+		`SELECT deleted_at FROM observations WHERE sync_id = ? ORDER BY id DESC LIMIT 1`, obsSyncID,
+	).Scan(&deletedAt); scanErr != nil {
+		t.Fatalf("scan deleted_at: %v", scanErr)
+	}
+	if deletedAt == nil {
+		t.Errorf("CRITICAL-2: observation deleted_at is NULL — delete op was not applied (replayed as upsert)")
+	}
+}
+
+// ─── Bug B: observation/session/prompt FK miss deferral ───────────────────────
+
+// ptrStr returns a pointer to s, for use with *string struct fields.
+func ptrStr(s string) *string { return &s }
+
+// buildObservationMutation builds a SyncMutation for entity='observation'.
+func buildObservationMutation(t *testing.T, p syncObservationPayload) SyncMutation {
+	t.Helper()
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("buildObservationMutation: marshal: %v", err)
+	}
+	proj := ""
+	if p.Project != nil {
+		proj = *p.Project
+	}
+	return SyncMutation{
+		Entity:    SyncEntityObservation,
+		EntityKey: p.SyncID,
+		Op:        SyncOpUpsert,
+		Payload:   string(raw),
+		Source:    SyncSourceRemote,
+		Project:   proj,
+	}
+}
+
+// countObservationRows returns the count of observations with the given sync_id.
+func countObservationRows(t *testing.T, s *Store, syncID string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(
+		`SELECT count(*) FROM observations WHERE sync_id = ?`, syncID,
+	).Scan(&n); err != nil {
+		t.Fatalf("countObservationRows: %v", err)
+	}
+	return n
+}
+
+// TestApplyPulledObservation_DefersOnSessionFKMiss: applying an observation
+// whose session does NOT exist locally must:
+//   (a) NOT return an error from ApplyPulledMutation (cursor can advance),
+//   (b) advance the cursor (last_pulled_seq updated),
+//   (c) create a row in sync_apply_deferred with apply_status='deferred'.
+func TestApplyPulledObservation_DefersOnSessionFKMiss(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.ensureSyncState(DefaultSyncTargetKey); err != nil {
+		t.Fatalf("ensureSyncState: %v", err)
+	}
+
+	obsSyncID := newSyncID("obs")
+	m := buildObservationMutation(t, syncObservationPayload{
+		SyncID:    obsSyncID,
+		SessionID: "session-does-not-exist",
+		Type:      "decision",
+		Title:     "Orphan observation",
+		Content:   "content",
+		Project:   ptrStr("proj-obs-fk"),
+		Scope:     "project",
+		CreatedAt: "2026-04-26T10:00:00Z",
+		UpdatedAt: "2026-04-26T10:00:00Z",
+	})
+	m.Seq = 10
+	m.TargetKey = DefaultSyncTargetKey
+
+	// (a) Must NOT return an error — FK miss must be deferred, not propagated.
+	if err := s.ApplyPulledMutation(DefaultSyncTargetKey, m); err != nil {
+		t.Fatalf("ApplyPulledMutation: expected nil for observation FK miss (deferred), got %v", err)
+	}
+
+	// (b) Cursor must have advanced to seq=10.
+	state, err := s.GetSyncState(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("GetSyncState: %v", err)
+	}
+	if state.LastPulledSeq != 10 {
+		t.Errorf("last_pulled_seq: want 10, got %d", state.LastPulledSeq)
+	}
+
+	// (c) A deferred row must exist for this sync_id.
+	d := countDeferredRows(t, s, obsSyncID)
+	if d != 1 {
+		t.Errorf("expected 1 deferred row in sync_apply_deferred; got %d", d)
+	}
+
+	// The observations table must NOT contain the row.
+	o := countObservationRows(t, s, obsSyncID)
+	if o != 0 {
+		t.Errorf("expected 0 rows in observations for deferred obs; got %d", o)
+	}
+}
+
+// TestApplyPulledObservation_ReplayAfterSessionArrives: after an observation is
+// deferred due to a missing session, once the session arrives and ReplayDeferred
+// is called, the observation must be applied and the deferred row removed.
+func TestApplyPulledObservation_ReplayAfterSessionArrives(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.ensureSyncState(DefaultSyncTargetKey); err != nil {
+		t.Fatalf("ensureSyncState: %v", err)
+	}
+
+	sessionID := "ses-replay-obs"
+	obsSyncID := newSyncID("obs-replay")
+
+	obsPayload, err := json.Marshal(syncObservationPayload{
+		SyncID:    obsSyncID,
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "Replay me",
+		Content:   "content",
+		Project:   ptrStr("proj-replay"),
+		Scope:     "project",
+		CreatedAt: "2026-04-26T10:00:00Z",
+		UpdatedAt: "2026-04-26T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal obs payload: %v", err)
+	}
+
+	m := SyncMutation{
+		Entity:    SyncEntityObservation,
+		EntityKey: obsSyncID,
+		Op:        SyncOpUpsert,
+		Payload:   string(obsPayload),
+		Source:    SyncSourceRemote,
+		Seq:       5,
+		TargetKey: DefaultSyncTargetKey,
+	}
+
+	// First attempt: session missing → must be deferred, no error.
+	if err := s.ApplyPulledMutation(DefaultSyncTargetKey, m); err != nil {
+		t.Fatalf("first ApplyPulledMutation: expected nil, got %v", err)
+	}
+	if d := countDeferredRows(t, s, obsSyncID); d != 1 {
+		t.Fatalf("expected 1 deferred row after FK miss; got %d", d)
+	}
+
+	// Session arrives.
+	if err := s.CreateSession(sessionID, "proj-replay", "/tmp/replay"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// ReplayDeferred must now apply the observation.
+	res, err := s.ReplayDeferred()
+	if err != nil {
+		t.Fatalf("ReplayDeferred: %v", err)
+	}
+	if res.Succeeded != 1 {
+		t.Errorf("ReplayDeferred succeeded: want 1, got %d (failed=%d dead=%d)", res.Succeeded, res.Failed, res.Dead)
+	}
+
+	// Deferred row must be gone.
+	if d := countDeferredRows(t, s, obsSyncID); d != 0 {
+		t.Errorf("deferred row still present after successful replay; got %d", d)
+	}
+
+	// Observation must now exist.
+	if o := countObservationRows(t, s, obsSyncID); o != 1 {
+		t.Errorf("expected 1 row in observations after replay; got %d", o)
+	}
+}
+
+// ─── WARNING-3: ApplyPulledChunk must defer FK-miss legacy entities ────────────
+
+// TestApplyPulledChunk_DefersOrphanObservation verifies that a chunk containing
+// an observation whose session does NOT exist locally:
+//   (a) does NOT return an error (FK miss is deferred, not propagated),
+//   (b) defers the orphan observation to sync_apply_deferred,
+//   (c) still applies the other (valid) mutations in the same chunk.
+func TestApplyPulledChunk_DefersOrphanObservation(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.ensureSyncState(DefaultSyncTargetKey); err != nil {
+		t.Fatalf("ensureSyncState: %v", err)
+	}
+
+	// One valid session + observation that will apply fine.
+	goodSesID := "ses-chunk-good"
+	if err := s.CreateSession(goodSesID, "proj-chunk", "/tmp/chunk-good"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	goodObsSyncID := newSyncID("obs-chunk-good")
+	goodObsPayload, _ := json.Marshal(syncObservationPayload{
+		SyncID:    goodObsSyncID,
+		SessionID: goodSesID,
+		Type:      "decision",
+		Title:     "Good observation",
+		Content:   "content",
+		Project:   ptrStr("proj-chunk"),
+		Scope:     "project",
+		CreatedAt: "2026-04-26T10:00:00Z",
+		UpdatedAt: "2026-04-26T10:00:00Z",
+	})
+
+	// One orphan observation whose session doesn't exist.
+	orphanSyncID := newSyncID("obs-chunk-orphan")
+	orphanPayload, _ := json.Marshal(syncObservationPayload{
+		SyncID:    orphanSyncID,
+		SessionID: "session-does-not-exist",
+		Type:      "decision",
+		Title:     "Orphan in chunk",
+		Content:   "content",
+		Project:   ptrStr("proj-chunk"),
+		Scope:     "project",
+		CreatedAt: "2026-04-26T10:00:00Z",
+		UpdatedAt: "2026-04-26T10:00:00Z",
+	})
+
+	mutations := []SyncMutation{
+		{
+			Entity:    SyncEntityObservation,
+			EntityKey: goodObsSyncID,
+			Op:        SyncOpUpsert,
+			Payload:   string(goodObsPayload),
+		},
+		{
+			Entity:    SyncEntityObservation,
+			EntityKey: orphanSyncID,
+			Op:        SyncOpUpsert,
+			Payload:   string(orphanPayload),
+		},
+	}
+
+	// (a) ApplyPulledChunk must NOT return an error — orphan is deferred.
+	err := s.ApplyPulledChunk(DefaultSyncTargetKey, "chunk-orphan-test", mutations)
+	if err != nil {
+		t.Fatalf("WARNING-3 ApplyPulledChunk: expected nil for orphan observation, got %v", err)
+	}
+
+	// (b) Orphan must be in sync_apply_deferred.
+	if d := countDeferredRows(t, s, orphanSyncID); d != 1 {
+		t.Errorf("WARNING-3: expected orphan observation in sync_apply_deferred, got %d rows", d)
+	}
+
+	// (c) Good observation must have been applied.
+	if o := countObservationRows(t, s, goodObsSyncID); o != 1 {
+		t.Errorf("WARNING-3: expected good observation to be applied (1 row), got %d", o)
+	}
+}


### PR DESCRIPTION
## Problem

A cloud sync deadlock: an `observation` reached the cloud **without its parent `session`**, so every client pulling it hit `FOREIGN KEY constraint failed (787)` and the entire pull stream stalled (cursor stuck, no new memories from the team).

Root cause (two independent gaps):
1. **Server** (`/sync/mutations/push`) does not validate session payloads — a legacy session without `directory` is blocked client-side and never pushed, but its child observation is pushed and accepted → orphan in the cloud. The `directory` / referential checks only existed on the legacy `/sync/push` (chunk) path.
2. **Client** (`ApplyPulledMutation` / `ApplyPulledChunk`) only deferred FK-misses for `relation`; for `observation`/`session`/`prompt` it failed hard and halted the pull. The `sync_apply_deferred` mechanism existed but was hardcoded to relations.

## Fix

**Client — pull resilience**
- Defer legacy entities (observation/session/prompt) on a SQLite FK-miss (787) to `sync_apply_deferred` and advance the cursor, instead of failing hard. Applied to both `ApplyPulledMutation` (autosync) and `ApplyPulledChunk` (initial sync).
- `sync_apply_deferred` gains an `op` column (idempotent migration) so a deferred **delete** replays as a delete, not an upsert.
- Deferred-row delete moved inside the apply tx (crash safety).

**Server — prevent orphans at origin**
- `/sync/mutations/push` now rejects a session **upsert** without `directory`. Delete variants (`deleted` / `hard_delete` / `deleted_at` / `op=delete`) are exempt.

## Tests
- `TestApplyPulledObservation_DefersOnSessionFKMiss` / `_ReplayAfterSessionArrives`
- `TestApplyPulledChunk_DefersOrphanObservation`
- `TestReplayDeferred_PreservesDeleteOp`
- `TestHandleMutationPush_SessionMissingDirectory_Returns400` + delete-variant exemptions (`hard_delete`, `deleted_at`, `op=delete`)
- Updated `TestApplyPulledChunkIsAtomicAndRetrySafe` to use a genuinely unrecoverable error (FK-miss is now deferrable, not fatal).

`go build ./...`, `go vet`, and `go test ./internal/store/ ./internal/cloud/cloudserver/` all green. (`cmd/engram` failures are pre-existing — require network/token.)