### PR TITLE
fix(search): OR+prefix FTS query + title-weighted bm25 to fix natural-language recall

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3039,7 +3039,12 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		args = append(args, normalizeScope(opts.Scope))
 	}
 
-	sqlQ += " ORDER BY fts.rank LIMIT ?"
+	// Weighted bm25: favor matches in `title` (10×) and `topic_key` (8×) over
+	// `content` (2×) so the OR-recall expansion in sanitizeFTS still surfaces the
+	// most on-topic observation first instead of any doc that merely shares a
+	// common term. Column order matches the FTS5 schema:
+	// title, content, tool_name, type, project, topic_key. (regtime/fts-tuning)
+	sqlQ += " ORDER BY bm25(observations_fts, 10.0, 2.0, 1.0, 1.0, 1.0, 8.0) LIMIT ?"
 	args = append(args, limit)
 
 	rows, err := s.queryItHook(s.db, sqlQ, args...)
@@ -6222,16 +6227,31 @@ func stripPrivateTags(s string) string {
 	return result
 }
 
-// sanitizeFTS wraps each word in quotes so FTS5 doesn't choke on special chars.
-// "fix auth bug" → `"fix" "auth" "bug"`
+// sanitizeFTS turns a query into an FTS5 MATCH expression that favors RECALL.
+// Each term becomes a quoted PREFIX token and terms are joined with OR:
+//   "How long have Mel married" → `"how"* OR "long"* OR "have"* OR "mel"* OR "married"*`
+//
+// Rationale (regtime/fts-tuning, 2026-06): the prior implementation quoted each
+// term and joined with SPACES, which is FTS5 implicit-AND — every term had to
+// match, so natural-language / paraphrased / multi-term queries returned
+// nothing even when the answer was stored verbatim (measured 0% recall on a
+// LoCoMo slice). OR restores recall; the bm25 `ORDER BY fts.rank` in Search()
+// still ranks documents matching more (and rarer) terms on top, so precision
+// is preserved at the head of the result list. Prefix (`*`) additionally makes
+// "mel" match "melanie", "delet" match "deleted", etc. Internal quotes are
+// escaped ("" = a literal " inside an FTS5 string).
 func sanitizeFTS(query string) string {
 	words := strings.Fields(query)
-	for i, w := range words {
-		// Strip existing quotes to avoid double-quoting
+	terms := make([]string, 0, len(words))
+	for _, w := range words {
 		w = strings.Trim(w, `"`)
-		words[i] = `"` + w + `"`
+		if w == "" {
+			continue
+		}
+		w = strings.ReplaceAll(w, `"`, `""`)
+		terms = append(terms, `"`+w+`"*`)
 	}
-	return strings.Join(words, " ")
+	return strings.Join(terms, " OR ")
 }
 
 // ─── Passive Capture ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`Search()` runs `mem_search` through `sanitizeFTS`, which quotes each term and joins them with **spaces** — i.e. FTS5 **implicit AND**. Every term must match, so any natural-language / paraphrased / multi-term query returns nothing even when the answer is stored verbatim. Examples that returned `No memories found` on v1.16.1 against a populated DB:

- `"how do I permanently remove a saved memory from engram"`
- `"should we adopt X for better memory recall"`
- `"How long have Mel ..."` (where the stored text says `Melanie`)

The longer / more natural the query, the more certain the miss. (I measured ~0% recall on a multi-question retrieval slice with raw questions; short keyword queries worked, natural questions did not.)

## Change

Two small, localized edits in `internal/store/store.go`:

1. **`sanitizeFTS`** now emits `"t1"* OR "t2"* OR ...` instead of space-joined AND:
   - `OR` restores recall (any term may match),
   - prefix (`*`) makes `mel` match `melanie`, `delet` match `deleted`,
   - internal quotes are escaped (`""`).
2. **`Search()` ORDER BY** uses weighted `bm25(observations_fts, 10,2,1,1,1,8)` (title 10×, topic_key 8×, content 2×) so the OR expansion still surfaces the most on-topic observation first rather than any doc that merely shares a common term.

Existing `internal/store` tests pass.

## Result (same DB, before → after)

| query | before | after |
|---|---|---|
| "should we adopt X for better memory recall" | 0 | correct obs at #1 |
| "what did we learn about retrieval quality being poor" | 0 | correct obs at #1 |
| "how do I permanently remove a saved memory" | 0 | relevant obs returned |

Precise keyword queries still rank tightly because bm25 orders multi-term matches highest.

## Tradeoff + happy to adjust

Defaulting to `OR` favors **recall over precision**, which is a behavior change. If you'd prefer to preserve strict-AND precision, two options I'm glad to implement instead:
- **AND-first, OR-fallback**: run the current implicit-AND query, and only expand to OR when it returns fewer than N results — best of both.
- **Config flag** to opt into the OR behavior.

I can also add unit tests for `sanitizeFTS` and a `Search` recall test if you'd like. Let me know which direction you prefer.