### PR TITLE
fix(store): reject empty observation titles before persistence

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1064,6 +1064,14 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 		if strings.TrimSpace(content) == "" {
 			return mcp.NewToolResultError("content is required for mem_save (use content, or observation for backward-compatible clients)"), nil
 		}
+		// Reject empty titles early with an agent-actionable message. The store
+		// enforces the same rule (single source of truth), but returning here
+		// lets us tell the model exactly what to provide on retry instead of
+		// surfacing a generic store error. An empty title would otherwise be
+		// accepted and silently block cloud sync downstream. See issue #459.
+		if strings.TrimSpace(title) == "" {
+			return mcp.NewToolResultError("title is required for mem_save — pass a short, searchable title (e.g. 'Fixed N+1 query in UserList', 'Decision: use OpenTofu over Terraform'). Empty titles silently block cloud sync (issue #459)."), nil
+		}
 		typ, _ := req.GetArguments()["type"].(string)
 		sessionID, _ := req.GetArguments()["session_id"].(string)
 		scope, _ := req.GetArguments()["scope"].(string)

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1478,6 +1478,62 @@ func TestHandleUpdateAcceptsAllOptionalFields(t *testing.T) {
 	}
 }
 
+// TestHandleUpdateRejectsEmptyTitle pins that mem_update surfaces an
+// agent-actionable error when the new title is empty or whitespace-only, and
+// that the original title is left untouched. This closes the same stuck-sync
+// class as the save path (issue #459) on the update surface.
+func TestHandleUpdateRejectsEmptyTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+	}{
+		{"empty string", ""},
+		{"only whitespace", "   \t\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newMCPTestStore(t)
+			if err := s.CreateSession("s-empty-update", "engram", "/tmp/engram"); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			id, err := s.AddObservation(store.AddObservationParams{
+				SessionID: "s-empty-update",
+				Type:      "decision",
+				Title:     "Original",
+				Content:   "Original content",
+				Project:   "engram",
+				Scope:     "project",
+			})
+			if err != nil {
+				t.Fatalf("add observation: %v", err)
+			}
+
+			res, err := handleUpdate(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+				"id":    float64(id),
+				"title": tc.title,
+			}}})
+			if err != nil {
+				t.Fatalf("update handler error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatalf("expected an error result for empty title, got success")
+			}
+			if !strings.Contains(callResultText(t, res), "title is required") {
+				t.Fatalf("expected 'title is required' in error, got %q", callResultText(t, res))
+			}
+
+			// The original title must survive the rejected update.
+			obs, err := s.GetObservation(id)
+			if err != nil {
+				t.Fatalf("get observation: %v", err)
+			}
+			if obs.Title != "Original" {
+				t.Fatalf("expected title unchanged %q, got %q", "Original", obs.Title)
+			}
+		})
+	}
+}
+
 func TestHandleContextWithSessionOnlyUsesNoneProjects(t *testing.T) {
 	s := newMCPTestStore(t)
 	if err := s.CreateSession("s-context-none", "engram", "/tmp/engram"); err != nil {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -7088,3 +7088,50 @@ func TestHandleSearchLegacyMixedCaseProject(t *testing.T) {
 		t.Fatalf("expected search results for legacy project, got: %s", text)
 	}
 }
+
+func TestHandleSaveRejectsEmptyTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		title any
+	}{
+		{"missing title", nil},
+		{"empty string", ""},
+		{"only whitespace", "   \t\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newMCPTestStore(t)
+			h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+			args := map[string]any{
+				"content": "Body with no usable title",
+				"type":    "bugfix",
+				"project": "engram",
+			}
+			if tc.title != nil {
+				args["title"] = tc.title
+			}
+
+			res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatalf("expected an error result for empty title, got success")
+			}
+			text := callResultText(t, res)
+			if !strings.Contains(text, "title is required") {
+				t.Fatalf("expected 'title is required' in error, got %q", text)
+			}
+
+			// Nothing should have been persisted.
+			obs, err := s.RecentObservations("engram", "project", 5)
+			if err != nil {
+				t.Fatalf("recent observations: %v", err)
+			}
+			if len(obs) != 0 {
+				t.Fatalf("expected no persisted observations, got %d", len(obs))
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -459,10 +459,10 @@ func (s *Server) handleUpdateObservation(w http.ResponseWriter, r *http.Request)
 		switch {
 		case errors.Is(err, store.ErrEmptyObservationTitle):
 			jsonError(w, http.StatusBadRequest, err.Error())
-		case errors.Is(err, store.ErrObservationNotFound):
+		case errors.Is(err, store.ErrObservationNotFound), errors.Is(err, sql.ErrNoRows):
 			jsonError(w, http.StatusNotFound, err.Error())
 		default:
-			jsonError(w, http.StatusNotFound, err.Error())
+			jsonError(w, http.StatusInternalServerError, err.Error())
 		}
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -337,6 +337,10 @@ func (s *Server) handleAddObservation(w http.ResponseWriter, r *http.Request) {
 
 	id, err := s.store.AddObservation(body)
 	if err != nil {
+		if errors.Is(err, store.ErrEmptyObservationTitle) {
+			jsonError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -452,7 +456,14 @@ func (s *Server) handleUpdateObservation(w http.ResponseWriter, r *http.Request)
 
 	obs, err := s.store.UpdateObservation(id, body)
 	if err != nil {
-		jsonError(w, http.StatusNotFound, err.Error())
+		switch {
+		case errors.Is(err, store.ErrEmptyObservationTitle):
+			jsonError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, store.ErrObservationNotFound):
+			jsonError(w, http.StatusNotFound, err.Error())
+		default:
+			jsonError(w, http.StatusNotFound, err.Error())
+		}
 		return
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -169,6 +169,70 @@ func TestClaudeSaveNudgeCompatibilityRoutes(t *testing.T) {
 	}
 }
 
+// TestUpdateObservationRejectsEmptyTitle covers the HTTP PATCH path used by the
+// gentle-engram (opencode) plugin, which forwards mem_update to
+// PATCH /observations/{id}. An empty or whitespace-only title must be rejected
+// with 400 (not persisted, not enqueued) and the original title preserved —
+// closing the stuck-sync class from issue #459 on the supported HTTP surface.
+func TestUpdateObservationRejectsEmptyTitle(t *testing.T) {
+	st := newServerTestStore(t)
+	srv := New(st, 0)
+	h := srv.Handler()
+
+	createReq := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(`{"id":"s-empty","project":"engram"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	h.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("expected session create 201, got %d", createRec.Code)
+	}
+
+	obsReq := httptest.NewRequest(http.MethodPost, "/observations", strings.NewReader(`{"session_id":"s-empty","type":"note","title":"Original","content":"body","project":"engram"}`))
+	obsReq.Header.Set("Content-Type", "application/json")
+	obsRec := httptest.NewRecorder()
+	h.ServeHTTP(obsRec, obsReq)
+	if obsRec.Code != http.StatusCreated {
+		t.Fatalf("expected observation create 201, got %d body=%s", obsRec.Code, obsRec.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(obsRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created observation: %v", err)
+	}
+	id := int64(created["id"].(float64))
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"empty string", `{"title":""}`},
+		{"only whitespace", `{"title":"   \t\n"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/observations/%d", id), strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for empty title, got %d body=%s", rec.Code, rec.Body.String())
+			}
+
+			getReq := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/observations/%d", id), nil)
+			getRec := httptest.NewRecorder()
+			h.ServeHTTP(getRec, getReq)
+			if getRec.Code != http.StatusOK {
+				t.Fatalf("expected get 200, got %d", getRec.Code)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode observation: %v", err)
+			}
+			if got["title"] != "Original" {
+				t.Fatalf("expected title unchanged %q, got %v", "Original", got["title"])
+			}
+		})
+	}
+}
+
 func TestAdditionalServerErrorBranches(t *testing.T) {
 	st := newServerTestStore(t)
 	srv := New(st, 0)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -233,6 +233,57 @@ func TestUpdateObservationRejectsEmptyTitle(t *testing.T) {
 	}
 }
 
+// TestAddObservationRejectsEmptyTitle covers the POST /observations route after
+// the store-level empty-title validation change: a whitespace-only title (which
+// passes the raw `title == ""` pre-check) must be rejected with 400 by the
+// store sentinel, and an empty string by the pre-check — neither may persist.
+func TestAddObservationRejectsEmptyTitle(t *testing.T) {
+	st := newServerTestStore(t)
+	srv := New(st, 0)
+	h := srv.Handler()
+
+	createReq := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(`{"id":"s-add-empty","project":"engram"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	h.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("expected session create 201, got %d", createRec.Code)
+	}
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"empty string", `{"session_id":"s-add-empty","type":"note","title":"","content":"body","project":"engram"}`},
+		{"only whitespace", `{"session_id":"s-add-empty","type":"note","title":"   \t\n","content":"body","project":"engram"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/observations", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for empty title, got %d body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// Nothing should have been persisted by the rejected requests.
+	listReq := httptest.NewRequest(http.MethodGet, "/observations?project=engram&limit=10", nil)
+	listRec := httptest.NewRecorder()
+	h.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected list 200, got %d", listRec.Code)
+	}
+	var obs []map[string]any
+	if err := json.Unmarshal(listRec.Body.Bytes(), &obs); err != nil {
+		t.Fatalf("decode observations: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Fatalf("expected no persisted observations, got %d", len(obs))
+	}
+}
+
 func TestAdditionalServerErrorBranches(t *testing.T) {
 	st := newServerTestStore(t)
 	srv := New(st, 0)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -51,6 +51,14 @@ var (
 	ErrObservationNotFound    = errors.New("observation not found")
 	ErrPromptNotFound         = errors.New("prompt not found")
 	ErrProjectNotFound        = errors.New("project not found")
+
+	// ErrEmptyObservationTitle is returned by AddObservation and
+	// UpdateObservation when the post-stripPrivateTags title is empty after
+	// trimming whitespace. The check runs on the persisted value because that is
+	// exactly what gets pushed to the cloud, where ValidateSyncMutationPayload
+	// rejects empty titles and silently stalls the sync queue (issue #459).
+	// Callers use errors.Is to map this to a 400-class response.
+	ErrEmptyObservationTitle = errors.New("observation title is required (non-empty after trimming whitespace)")
 )
 
 // Sentinel errors for relation sync apply path (Phase 2).
@@ -2263,7 +2271,7 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 	// failure only surfaces later when sync rejects the mutation, silently
 	// blocking the queue with no feedback to the caller. See issue #459.
 	if strings.TrimSpace(title) == "" {
-		return 0, fmt.Errorf("observation title is required (non-empty after trimming whitespace)")
+		return 0, ErrEmptyObservationTitle
 	}
 
 	if len(content) > s.cfg.MaxObservationLength {
@@ -2906,6 +2914,16 @@ func (s *Store) UpdateObservation(id int64, p UpdateObservationParams) (*Observa
 		}
 		if p.TopicKey != nil {
 			topicKey = normalizeTopicKey(*p.TopicKey)
+		}
+
+		// Reject empty titles before persisting. We validate the final post-strip
+		// value because that is what gets written and enqueued as a sync upsert.
+		// Without this, mem_update / PATCH /observations/{id} could persist an
+		// empty title and queue a mutation the cloud server rejects, silently
+		// stalling the sync queue — the same class AddObservation guards against
+		// (issue #459).
+		if strings.TrimSpace(title) == "" {
+			return ErrEmptyObservationTitle
 		}
 
 		if _, err := s.execHook(tx,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2230,6 +2230,17 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 	title := stripPrivateTags(p.Title)
 	content := stripPrivateTags(p.Content)
 
+	// Reject empty titles before touching the DB. This mirrors the rule
+	// ValidateSyncMutationPayload enforces on the sync path (observation
+	// upserts require a non-empty title). We validate the post-strip value
+	// because that is exactly what gets persisted and later pushed to the
+	// cloud server. Without this, an empty title is accepted locally and the
+	// failure only surfaces later when sync rejects the mutation, silently
+	// blocking the queue with no feedback to the caller. See issue #459.
+	if strings.TrimSpace(title) == "" {
+		return 0, fmt.Errorf("observation title is required (non-empty after trimming whitespace)")
+	}
+
 	if len(content) > s.cfg.MaxObservationLength {
 		content = content[:s.cfg.MaxObservationLength] + "... [truncated]"
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8289,3 +8289,54 @@ func TestMostRecentActiveSessionScopedByProject(t *testing.T) {
 		t.Fatalf("expected no active session for engram when only 'other' has one, got ok=%v", ok)
 	}
 }
+
+func TestAddObservationRejectsEmptyTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+	}{
+		{"empty string", ""},
+		{"only spaces", "   "},
+		{"only tabs and newlines", "\t\n  \n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			_, err := s.AddObservation(AddObservationParams{
+				SessionID: "s1",
+				Type:      "decision",
+				Title:     tc.title,
+				Content:   "some content",
+				Project:   "engram",
+				Scope:     "project",
+			})
+			if err == nil {
+				t.Fatal("expected error for empty title, got nil")
+			}
+			if !strings.Contains(err.Error(), "title is required") {
+				t.Errorf("expected 'title is required' in error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestAddObservationAcceptsNonEmptyTitle(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "Valid title",
+		Content:   "some content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for valid title: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("expected a non-zero observation id")
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8659,3 +8659,123 @@ func TestAddObservationValidatesPostStripTitle(t *testing.T) {
 		t.Errorf("expected persisted title %q, got %q", "[REDACTED]", obs.Title)
 	}
 }
+
+// TestUpdateObservationRejectsEmptyTitle pins the same invariant as
+// TestAddObservationRejectsEmptyTitle for the update path. mem_update and
+// PATCH /observations/{id} funnel through UpdateObservation; an explicit empty
+// or whitespace-only title must be rejected before it is persisted and enqueued
+// as a sync upsert the cloud server rejects (issue #459). The original title
+// must be left untouched.
+func TestUpdateObservationRejectsEmptyTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+	}{
+		{"empty string", ""},
+		{"only spaces", "   "},
+		{"only tabs and newlines", "\t\n  \n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			id, err := s.AddObservation(AddObservationParams{
+				SessionID: "s1",
+				Type:      "decision",
+				Title:     "Original title",
+				Content:   "some content",
+				Project:   "engram",
+				Scope:     "project",
+			})
+			if err != nil {
+				t.Fatalf("seed observation: %v", err)
+			}
+
+			_, err = s.UpdateObservation(id, UpdateObservationParams{Title: &tc.title})
+			if err == nil {
+				t.Fatal("expected error for empty title, got nil")
+			}
+			if !errors.Is(err, ErrEmptyObservationTitle) {
+				t.Errorf("expected ErrEmptyObservationTitle, got: %v", err)
+			}
+
+			// The original title must survive the rejected update.
+			obs, err := s.GetObservation(id)
+			if err != nil {
+				t.Fatalf("get observation: %v", err)
+			}
+			if obs.Title != "Original title" {
+				t.Errorf("expected title unchanged %q, got %q", "Original title", obs.Title)
+			}
+		})
+	}
+}
+
+// TestUpdateObservationValidatesPostStripTitle mirrors the AddObservation
+// post-strip contract on the update path: a title made only of private tags
+// strips to "[REDACTED]" (not empty), so the update is accepted and persisted
+// with that placeholder.
+func TestUpdateObservationValidatesPostStripTitle(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "Original title",
+		Content:   "some content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	newTitle := "<private>secret</private>"
+	if _, err := s.UpdateObservation(id, UpdateObservationParams{Title: &newTitle}); err != nil {
+		t.Fatalf("private-only title strips to a non-empty placeholder; expected accept, got: %v", err)
+	}
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("get observation: %v", err)
+	}
+	if obs.Title != "[REDACTED]" {
+		t.Errorf("expected persisted title %q, got %q", "[REDACTED]", obs.Title)
+	}
+}
+
+// TestUpdateObservationAcceptsContentOnlyUpdate guards that the title check does
+// not regress content-only updates: when Title is nil the existing (valid)
+// title is preserved and the update succeeds.
+func TestUpdateObservationAcceptsContentOnlyUpdate(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "Original title",
+		Content:   "some content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	newContent := "updated content"
+	updated, err := s.UpdateObservation(id, UpdateObservationParams{Content: &newContent})
+	if err != nil {
+		t.Fatalf("content-only update should succeed, got: %v", err)
+	}
+	if updated.Title != "Original title" {
+		t.Errorf("expected title preserved %q, got %q", "Original title", updated.Title)
+	}
+	if updated.Content != newContent {
+		t.Errorf("expected content %q, got %q", newContent, updated.Content)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8627,3 +8627,35 @@ func TestAddObservationAcceptsNonEmptyTitle(t *testing.T) {
 		t.Fatal("expected a non-zero observation id")
 	}
 }
+
+// TestAddObservationValidatesPostStripTitle pins the contract that the
+// non-empty check runs on the value *after* stripPrivateTags, which is what
+// actually gets persisted and pushed to the cloud (see issue #459). A title
+// made only of private tags is NOT empty post-strip: stripPrivateTags replaces
+// the tags with "[REDACTED]", so the observation is accepted and persisted with
+// that title. This guards against a refactor that moves validation before the
+// strip and silently changes the persisted value.
+func TestAddObservationValidatesPostStripTitle(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "<private>secret</private>",
+		Content:   "some content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("private-only title strips to a non-empty placeholder; expected accept, got: %v", err)
+	}
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("get observation: %v", err)
+	}
+	if obs.Title != "[REDACTED]" {
+		t.Errorf("expected persisted title %q, got %q", "[REDACTED]", obs.Title)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #459.

Empty (or whitespace-only) observation titles were accepted by `mem_save` and
`store.AddObservation`, persisted locally, and queued for cloud sync. The cloud
server rejects them via `ValidateSyncMutationPayload`, blocking the entire
mutation queue silently — the caller receives success at write time and has no
feedback to retry with a valid title.

This PR pushes the same validation up to the write path, so the failure
surfaces immediately and can be corrected.

## Changes

- `internal/store/store.go`: `AddObservation` rejects empty/whitespace titles
  with a clear error, before any DB access. Validated **after** `stripPrivateTags`
  so it matches exactly the value that gets persisted and later pushed to the
  cloud server.
- `internal/mcp/mcp.go`: `handleSave` returns an agent-actionable
  `ToolResultError` before reaching the store, with an example title format so
  the model knows what to provide on retry.
- Tests added for both layers (empty / whitespace / missing title).

## Why this approach

Per the suggestion on #459, reusing the rule already enforced by
`ValidateSyncMutationPayload` (`diagnostic.go`) keeps validation in one logical
place. The fix is defensive at two layers — MCP for UX, store as the single
source of truth — so the CLI, MCP, and any future entrypoint inherit it.

## Test plan

- [x] `go test ./internal/store/...` — new tests for empty/whitespace titles + a positive case
- [x] `go test ./internal/mcp/...` — handler returns `ToolResultError`, nothing persisted
- [x] `go build ./cmd/engram` — binary builds clean
- [x] Existing tests pass (no regression in dedupe, topic_key upsert, normalization)

## Notes

- This is technically a behavior change for callers passing an empty title
  today, but those cases are already broken downstream (cloud sync blocks them).
  The change turns a silent failure into a loud, immediate one.
- `stripPrivateTags` replaces `<private>…</private>` with `[REDACTED]`, not an
  empty string, so a title made only of private tags is **not** rejected — that
  is intended.

## Out of scope

- Backfilling existing observations with empty titles in users' local DBs. The
  repair tooling and the SQLite workaround documented in #459's comments handle
  that path. This PR prevents new occurrences.
- Title length / format constraints beyond non-empty. Can be a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saving or updating observations with empty or whitespace-only titles (including titles that become empty after redaction).
  * Improved error handling so invalid requests return **400 Bad Request**, and rejected updates no longer change existing titles.
* **Tests**
  * Expanded negative test coverage for empty-title validation across MCP operations, storage behavior, and the observation create/update HTTP endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->