### PR TITLE
feat(setup): add Claude Desktop MCPB bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Windows, Linux, and other install methods → [docs/INSTALLATION.md](docs/INSTAL
 | Agent                       | One-liner                                                                                    |
 | --------------------------- | -------------------------------------------------------------------------------------------- |
 | Claude Code                 | `claude plugin marketplace add Gentleman-Programming/engram && claude plugin install engram` |
+| Claude Desktop              | `engram setup claude-desktop`                                                                |
 | Pi                          | `engram setup pi`                                                                            |
 | OpenCode                    | `engram setup opencode`                                                                      |
 | Gemini CLI                  | `engram setup gemini-cli`                                                                    |

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -95,7 +95,7 @@ var (
 	storeDeleteProject     = func(s *store.Store, name string, hard bool) (*store.DeleteProjectResult, error) {
 		return s.DeleteProject(name, hard)
 	}
-	storeTimeline       = func(s *store.Store, observationID int64, before, after int) (*store.TimelineResult, error) {
+	storeTimeline = func(s *store.Store, observationID int64, before, after int) (*store.TimelineResult, error) {
 		return s.Timeline(observationID, before, after)
 	}
 	storeFormatContext = func(s *store.Store, project, scope string) (string, error) { return s.FormatContext(project, scope) }
@@ -2417,6 +2417,13 @@ func printPostInstall(result *setup.Result) {
 		fmt.Println("  2. Verify with: claude plugin list")
 		fmt.Println("  3. MCP config written to ~/.claude/mcp/engram.json using absolute binary path")
 		fmt.Println("     (survives plugin auto-updates; re-run 'engram setup claude-code' if you move the binary)")
+	case "claude-desktop":
+		fmt.Println("\nNext steps:")
+		fmt.Println("  1. Open the generated .mcpb file with Claude Desktop")
+		fmt.Printf("     %s\n", result.Destination)
+		fmt.Println("  2. Or install it from Claude Desktop Settings -> Extensions -> Advanced settings")
+		fmt.Println("  3. Restart Claude Desktop if the Engram tools do not appear immediately")
+		fmt.Println("  4. Re-run 'engram setup claude-desktop' if you move or upgrade the Engram binary")
 	case "gemini-cli":
 		fmt.Println("\nNext steps:")
 		fmt.Println("  1. Restart Gemini CLI so MCP config is reloaded")
@@ -2477,7 +2484,7 @@ Commands:
                      Merge similar project names into one canonical name
                        --all      Scan ALL projects for similar name groups
                        --dry-run  Preview what would be merged (no changes)
-  setup [agent]      Install/setup agent integration (opencode, pi, claude-code, gemini-cli, codex)
+  setup [agent]      Install/setup agent integration (opencode, pi, claude-code, claude-desktop, gemini-cli, codex)
   sync               Export new memories as compressed chunk to .engram/
                          --import   Import new chunks from .engram/ into local DB
                          --status   Show sync status

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -17,6 +17,7 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 | Agent         | One-liner                                                                                    | Manual Config                                      |
 | ------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | Claude Code   | `claude plugin marketplace add Gentleman-Programming/engram && claude plugin install engram` | [Details](#claude-code)                            |
+| Claude Desktop | `engram setup claude-desktop`                                                               | [Details](#claude-desktop)                         |
 | Pi            | `engram setup pi`                                                                            | [Details](#pi)                                     |
 | OpenCode      | `engram setup opencode`                                                                      | [Details](#opencode)                               |
 | Gemini CLI    | `engram setup gemini-cli`                                                                    | [Details](#gemini-cli)                             |
@@ -26,6 +27,37 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 | Cursor        | Manual JSON config                                                                           | [Details](#cursor)                                 |
 | Windsurf      | Manual JSON config                                                                           | [Details](#windsurf)                               |
 | Any MCP agent | `engram mcp` (stdio)                                                                         | [Details](#any-other-mcp-agent)                    |
+
+## Claude Desktop
+
+Generate a local MCPB bundle for Claude Desktop regular chats and Cowork spaces:
+
+```bash
+engram setup claude-desktop
+```
+
+This writes:
+
+```text
+~/.engram/mcpb/engram-claude-desktop.mcpb
+```
+
+Open the generated `.mcpb` file with Claude Desktop, or install it from
+Claude Desktop Settings → Extensions → Advanced settings → Install Extension.
+
+The bundle launches the local Engram MCP server with the agent tool profile:
+
+```json
+{
+  "command": "/absolute/path/to/engram",
+  "args": ["mcp", "--tools=agent"]
+}
+```
+
+Use this when you want Engram memory in normal Claude Desktop conversations,
+including Cowork spaces, without manually editing `claude_desktop_config.json`.
+Re-run `engram setup claude-desktop` if you move or upgrade the Engram binary
+and Claude Desktop can no longer start the MCP server.
 
 ## Pi
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -245,7 +245,7 @@ engram/
 ## CLI Reference
 
 ```
-engram setup [agent]      Install/setup agent integration (opencode, claude-code, gemini-cli, codex)
+engram setup [agent]      Install/setup agent integration (opencode, pi, claude-code, claude-desktop, gemini-cli, codex)
 engram serve [port]       Start HTTP API server (default: 7437)
 engram mcp                Start MCP server (stdio transport)
 engram tui                Launch interactive terminal UI

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -8,7 +8,25 @@
 
 - [OpenCode Plugin](#opencode-plugin)
 - [Claude Code Plugin](#claude-code-plugin)
+- [Claude Desktop MCPB](#claude-desktop-mcpb)
 - [Privacy](#privacy)
+
+---
+
+## Claude Desktop MCPB
+
+Claude Desktop does not use Claude Code hooks or skills, so Engram ships a
+small MCPB bundle generator instead of a full lifecycle plugin:
+
+```bash
+engram setup claude-desktop
+```
+
+The generated `.mcpb` installs Engram as a local MCP stdio server for regular
+Claude Desktop chats and Cowork spaces, using `engram mcp --tools=agent`.
+It does not auto-start the HTTP server, inject compaction recovery prompts, or
+modify `claude_desktop_config.json` directly. For those richer lifecycle hooks,
+use the Claude Code plugin.
 
 ---
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -11,12 +11,16 @@
 //   - Gemini CLI: injects MCP registration in ~/.gemini/settings.json
 //   - Codex: injects MCP registration in ~/.codex/config.toml
 //   - Pi: installs gentle-engram/pi-mcp-adapter packages and writes Pi MCP config
+//   - Claude Desktop: writes a local .mcpb bundle for one-click Claude Desktop install
 package setup
 
 import (
+	"archive/zip"
+	"bytes"
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -255,6 +259,11 @@ func SupportedAgents() []Agent {
 			InstallDir:  "managed by claude plugin system",
 		},
 		{
+			Name:        "claude-desktop",
+			Description: "Claude Desktop — MCPB bundle for regular Claude/Cowork chats",
+			InstallDir:  claudeDesktopMCPBPath(),
+		},
+		{
 			Name:        "gemini-cli",
 			Description: "Gemini CLI — MCP registration plus system prompt compaction recovery",
 			InstallDir:  geminiConfigPath(),
@@ -276,12 +285,14 @@ func Install(agentName string) (*Result, error) {
 		return installPi()
 	case "claude-code":
 		return installClaudeCode()
+	case "claude-desktop":
+		return installClaudeDesktop()
 	case "gemini-cli":
 		return installGeminiCLI()
 	case "codex":
 		return installCodex()
 	default:
-		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, gemini-cli, codex)", agentName)
+		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, claude-desktop, gemini-cli, codex)", agentName)
 	}
 }
 
@@ -803,6 +814,120 @@ func stripJSONC(data []byte) []byte {
 		i++
 	}
 	return out
+}
+
+// ─── Claude Desktop ──────────────────────────────────────────────────────────
+
+func installClaudeDesktop() (*Result, error) {
+	path := claudeDesktopMCPBPath()
+	if err := writeClaudeDesktopMCPB(path); err != nil {
+		return nil, err
+	}
+	return &Result{Agent: "claude-desktop", Destination: path, Files: 1}, nil
+}
+
+func claudeDesktopMCPBPath() string {
+	home, err := userHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return filepath.Join(".engram", "mcpb", "engram-claude-desktop.mcpb")
+	}
+	return filepath.Join(home, ".engram", "mcpb", "engram-claude-desktop.mcpb")
+}
+
+func writeClaudeDesktopMCPB(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create MCPB dir: %w", err)
+	}
+
+	manifest, err := jsonMarshalIndentFn(claudeDesktopMCPBManifest(resolveEngramCommand()), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Claude Desktop MCPB manifest: %w", err)
+	}
+
+	readme := []byte(strings.Join([]string{
+		"# Engram for Claude Desktop",
+		"",
+		"This private MCPB bundle connects Claude Desktop regular chats and Cowork spaces",
+		"to the local Engram MCP server.",
+		"",
+		"It launches:",
+		"",
+		"`engram mcp --tools=agent`",
+		"",
+		"Open this .mcpb file with Claude Desktop, or install it from Settings ->",
+		"Extensions -> Advanced settings -> Install Extension.",
+		"",
+		"Notes:",
+		"- The bundle uses the absolute Engram binary path detected when it was generated.",
+		"- Re-run `engram setup claude-desktop` if you move or upgrade Engram and the path changes.",
+		"- The agent tool profile is used intentionally; admin tools are not exposed.",
+		"",
+	}, "\n"))
+
+	files := map[string][]byte{
+		"manifest.json": manifest,
+		"README.md":     readme,
+	}
+	if err := writeZipFile(path, files); err != nil {
+		return fmt.Errorf("write Claude Desktop MCPB: %w", err)
+	}
+	return nil
+}
+
+func claudeDesktopMCPBManifest(command string) map[string]any {
+	return map[string]any{
+		"manifest_version": "0.3",
+		"name":             "engram-claude-desktop",
+		"display_name":     "Engram Memory for Claude Desktop",
+		"version":          "1.0.0",
+		"description":      "Connects Claude Desktop regular chats and Cowork spaces to the local Engram persistent memory MCP server.",
+		"long_description": "Launches the local Engram binary as an MCP stdio server using the safe agent tool profile.",
+		"author": map[string]any{
+			"name": "Gentleman Programming",
+		},
+		"documentation": "https://github.com/Gentleman-Programming/engram/blob/main/docs/AGENT-SETUP.md#claude-desktop",
+		"support":       "https://github.com/Gentleman-Programming/engram/issues",
+		"server": map[string]any{
+			"type":        "binary",
+			"entry_point": "external:engram",
+			"mcp_config": map[string]any{
+				"command": command,
+				"args":    []string{"mcp", "--tools=agent"},
+				"env":     map[string]string{},
+			},
+		},
+		"tools_generated": true,
+		"keywords":        []string{"memory", "mcp", "claude", "claude-desktop", "engram"},
+		"license":         "MIT",
+		"compatibility": map[string]any{
+			"platforms": []string{"darwin", "win32", "linux"},
+		},
+	}
+}
+
+func writeZipFile(path string, files map[string][]byte) error {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		w, err := zw.Create(name)
+		if err != nil {
+			_ = zw.Close()
+			return err
+		}
+		if _, err := io.Copy(w, bytes.NewReader(files[name])); err != nil {
+			_ = zw.Close()
+			return err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return err
+	}
+	return writeFileFn(path, buf.Bytes(), 0644)
 }
 
 // ─── Claude Code ─────────────────────────────────────────────────────────────

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"archive/zip"
 	"encoding/json"
 	"errors"
 	"os"
@@ -69,17 +70,21 @@ func useTestHome(t *testing.T) string {
 	return home
 }
 
-func TestSupportedAgentsIncludesGeminiAndCodex(t *testing.T) {
+func TestSupportedAgentsIncludesGeminiCodexAndClaudeDesktop(t *testing.T) {
 	agents := SupportedAgents()
 
 	var hasGemini bool
 	var hasCodex bool
+	var hasClaudeDesktop bool
 	for _, agent := range agents {
 		if agent.Name == "gemini-cli" {
 			hasGemini = true
 		}
 		if agent.Name == "codex" {
 			hasCodex = true
+		}
+		if agent.Name == "claude-desktop" {
+			hasClaudeDesktop = true
 		}
 	}
 
@@ -88,6 +93,73 @@ func TestSupportedAgentsIncludesGeminiAndCodex(t *testing.T) {
 	}
 	if !hasCodex {
 		t.Fatalf("expected codex in supported agents")
+	}
+	if !hasClaudeDesktop {
+		t.Fatalf("expected claude-desktop in supported agents")
+	}
+}
+
+func TestInstallClaudeDesktopWritesMCPBBundle(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	osExecutable = func() (string, error) {
+		return filepath.Join(home, "bin", "engram"), nil
+	}
+
+	result, err := Install("claude-desktop")
+	if err != nil {
+		t.Fatalf("Install(claude-desktop) failed: %v", err)
+	}
+	if result.Agent != "claude-desktop" {
+		t.Fatalf("expected claude-desktop result, got %#v", result)
+	}
+	wantPath := filepath.Join(home, ".engram", "mcpb", "engram-claude-desktop.mcpb")
+	if result.Destination != wantPath {
+		t.Fatalf("unexpected bundle path: got %s want %s", result.Destination, wantPath)
+	}
+	if result.Files != 1 {
+		t.Fatalf("expected one generated bundle, got %d", result.Files)
+	}
+
+	zr, err := zip.OpenReader(wantPath)
+	if err != nil {
+		t.Fatalf("open generated mcpb: %v", err)
+	}
+	defer zr.Close()
+
+	var manifest map[string]any
+	var sawReadme bool
+	for _, file := range zr.File {
+		switch file.Name {
+		case "manifest.json":
+			rc, err := file.Open()
+			if err != nil {
+				t.Fatalf("open manifest: %v", err)
+			}
+			if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+				_ = rc.Close()
+				t.Fatalf("decode manifest: %v", err)
+			}
+			_ = rc.Close()
+		case "README.md":
+			sawReadme = true
+		}
+	}
+	if manifest == nil {
+		t.Fatalf("generated mcpb should contain manifest.json")
+	}
+	if !sawReadme {
+		t.Fatalf("generated mcpb should contain README.md")
+	}
+
+	server := manifest["server"].(map[string]any)
+	mcpConfig := server["mcp_config"].(map[string]any)
+	if got := mcpConfig["command"]; got != filepath.Join(home, "bin", "engram") {
+		t.Fatalf("unexpected command: %v", got)
+	}
+	args := mcpConfig["args"].([]any)
+	if len(args) != 2 || args[0] != "mcp" || args[1] != "--tools=agent" {
+		t.Fatalf("unexpected args: %#v", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `engram setup claude-desktop`, which generates a local MCPB bundle for Claude Desktop regular chats and Cowork spaces.

The generated bundle:
- writes to `~/.engram/mcpb/engram-claude-desktop.mcpb`
- launches the resolved Engram binary as an MCP stdio server
- uses the safer agent profile: `engram mcp --tools=agent`
- avoids editing `claude_desktop_config.json` directly

This gives Claude Desktop users a one-click install path similar to the Claude Code/OpenCode setup flows, while keeping the richer lifecycle hooks scoped to Claude Code.

## Changes

- Add `claude-desktop` to supported setup agents
- Generate a minimal MCPB zip with `manifest.json` and README
- Add CLI post-install guidance for installing the `.mcpb` in Claude Desktop
- Document Claude Desktop/Cowork setup in README, Agent Setup, Plugins, and Architecture docs
- Add tests for supported-agent discovery and MCPB bundle contents

## Validation

Passed locally on Windows:

```bash
go test ./internal/setup -run 'TestSupportedAgentsIncludesGeminiCodexAndClaudeDesktop|TestInstallClaudeDesktopWritesMCPBBundle' -count=1
go test ./cmd/engram -run '^$' -count=1
go build -o .tmp/engram-test.exe ./cmd/engram
.tmp/engram-test.exe setup claude-desktop
npx -y @anthropic-ai/mcpb info ~/.engram/mcpb/engram-claude-desktop.mcpb
```

`mcpb info` recognizes the generated bundle and reports only the expected unsigned warning for a local/private bundle.

Note: the full `go test ./internal/setup` suite currently has unrelated Windows-environment failures in this checkout (`sh` missing and existing Gemini/Codex/Claude Code fixture expectations). The new targeted tests pass.