### PR TITLE
feat: Session Bus — real-time cross-session heartbeat registry

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -6,8 +6,8 @@
 //
 // Tool profiles allow agents to load only the tools they need:
 //
-//	engram mcp                    → all 19 tools (default)
-//	engram mcp --tools=agent      → 15 tools agents actually use (per skill files)
+//	engram mcp                    → all 22 tools (default)
+//	engram mcp --tools=agent      → 18 tools agents actually use (per skill files)
 //	engram mcp --tools=admin      → 4 tools for TUI/CLI (delete, stats, timeline, merge)
 //	engram mcp --tools=agent,admin → combine profiles
 //	engram mcp --tools=mem_save,mem_search → individual tool names
@@ -85,7 +85,10 @@ func ensureImplicitSessionWithCWD(s *store.Store, sessionID, project string) err
 // "agent" — tools AI agents use during coding sessions:
 //   mem_save, mem_search, mem_context, mem_session_summary,
 //   mem_session_start, mem_session_end, mem_get_observation,
-//   mem_suggest_topic_key, mem_capture_passive, mem_save_prompt
+//   mem_suggest_topic_key, mem_capture_passive, mem_save_prompt,
+//   mem_update, mem_current_project, mem_judge, mem_compare,
+//   mem_doctor, mem_session_heartbeat, mem_session_status,
+//   mem_active_sessions
 //
 // "admin" — tools for manual curation, TUI, and dashboards:
 //   mem_update, mem_delete, mem_stats, mem_timeline, mem_merge_projects
@@ -111,6 +114,9 @@ var ProfileAgent = map[string]bool{
 	"mem_judge":             true, // record verdict on a pending memory conflict (REQ-003, Phase D)
 	"mem_compare":           true, // persist an agent-judged semantic verdict via JudgeBySemantic (REQ-011, Phase G)
 	"mem_doctor":            true, // read-only operational diagnostics for agents
+	"mem_session_heartbeat": true, // session bus: heartbeat with task description
+	"mem_session_status":    true, // session bus: store detailed JSON status
+	"mem_active_sessions":   true, // session bus: list active sessions in project
 }
 
 // ProfileAdmin contains tools for TUI, dashboards, and manual curation
@@ -663,6 +669,77 @@ GUIDELINES:
 				),
 			),
 			queuedWriteHandler(writeQueue, handleSessionEnd(s, cfg, activity)),
+		)
+	}
+
+	// ─── mem_session_heartbeat (profile: agent, deferred) ─────────────────
+	// Session bus: sends a heartbeat with current task description and receives
+	// the list of other active sessions for the same project.
+	if shouldRegister("mem_session_heartbeat", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_session_heartbeat",
+				mcp.WithDescription("Send a session heartbeat with current task info. Returns the list of other active sessions in the same project so agents know what else is happening in real time."),
+				mcp.WithDeferLoading(true),
+				mcp.WithTitleAnnotation("Session Heartbeat"),
+				mcp.WithReadOnlyHintAnnotation(false),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("session_id",
+					mcp.Required(),
+					mcp.Description("Current session identifier"),
+				),
+				mcp.WithString("current_task",
+					mcp.Required(),
+					mcp.Description("Short description of what this session is currently doing (e.g. 'editing Hero.astro', 'SDD apply dark-mode')"),
+				),
+			),
+			queuedWriteHandler(writeQueue, handleSessionHeartbeat(s, cfg, activity)),
+		)
+	}
+
+	// ─── mem_session_status (profile: agent, deferred) ────────────────────
+	// Writes a richer JSON status blob for detailed cross-session visibility.
+	if shouldRegister("mem_session_status", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_session_status",
+				mcp.WithDescription("Store a detailed JSON status for the current session. This appears in the active sessions list returned by heartbeats, giving other sessions richer context about what you're doing."),
+				mcp.WithDeferLoading(true),
+				mcp.WithTitleAnnotation("Update Session Status"),
+				mcp.WithReadOnlyHintAnnotation(false),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("session_id",
+					mcp.Required(),
+					mcp.Description("Current session identifier"),
+				),
+				mcp.WithString("status",
+					mcp.Required(),
+					mcp.Description("JSON string with status details (e.g. {\"phase\":\"implement\",\"progress\":\"3/7 tasks\",\"blockers\":[]})"),
+				),
+			),
+			queuedWriteHandler(writeQueue, handleSessionStatus(s, cfg, activity)),
+		)
+	}
+
+	// ─── mem_active_sessions (profile: agent, deferred) ───────────────────
+	// Read-only list of active sessions for the current project.
+	if shouldRegister("mem_active_sessions", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_active_sessions",
+				mcp.WithDescription("List all sessions currently active in this project (sent a heartbeat within the last 2 minutes). Use this to see what other agents are working on right now."),
+				mcp.WithDeferLoading(true),
+				mcp.WithTitleAnnotation("Active Sessions"),
+				mcp.WithReadOnlyHintAnnotation(true),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("project",
+					mcp.Description("Filter by project (auto-detected if omitted)"),
+				),
+			),
+			handleActiveSessions(s, activity, cfg),
 		)
 	}
 
@@ -1744,6 +1821,124 @@ func handleSessionEnd(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 
 		detRes.Project = project
 		return respondWithProject(detRes, fmt.Sprintf("Session %q completed", id), nil), nil
+	}
+}
+
+// ─── Session Bus Handlers ─────────────────────────────────────────────────────
+
+func handleSessionHeartbeat(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sessionID, _ := req.GetArguments()["session_id"].(string)
+		currentTask, _ := req.GetArguments()["current_task"].(string)
+
+		if strings.TrimSpace(sessionID) == "" {
+			return mcp.NewToolResultError("session_id is required"), nil
+		}
+
+		detRes, err := resolveWriteProject()
+		if err != nil {
+			return writeProjectErrorResult(nil, "", detRes, err), nil
+		}
+		project, _ := store.NormalizeProject(detRes.Project)
+
+		if err := s.UpsertHeartbeat(sessionID, project, currentTask); err != nil {
+			return mcp.NewToolResultError("Failed to register heartbeat: " + err.Error()), nil
+		}
+
+		activity.RecordToolCall(defaultSessionID(project))
+
+		// Return active sessions so the caller knows what else is happening
+		sessions, err := s.ActiveSessions(project)
+		if err != nil {
+			return mcp.NewToolResultError("Heartbeat saved but failed to read active sessions: " + err.Error()), nil
+		}
+
+		// Build a compact summary
+		var b strings.Builder
+		fmt.Fprintf(&b, "Heartbeat registered for session %q.\n", sessionID)
+		if len(sessions) <= 1 {
+			b.WriteString("No other active sessions for this project.")
+		} else {
+			fmt.Fprintf(&b, "%d other active session(s):\n", len(sessions)-1)
+			for _, as := range sessions {
+				if as.SessionID == sessionID {
+					continue
+				}
+				fmt.Fprintf(&b, "  • %s — %s\n", as.SessionID, as.CurrentTask)
+			}
+		}
+
+		return respondWithProject(detRes, b.String(), nil), nil
+	}
+}
+
+func handleSessionStatus(s *store.Store, cfg MCPConfig, activity *SessionActivity) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sessionID, _ := req.GetArguments()["session_id"].(string)
+		status, _ := req.GetArguments()["status"].(string)
+
+		if strings.TrimSpace(sessionID) == "" {
+			return mcp.NewToolResultError("session_id is required"), nil
+		}
+		if strings.TrimSpace(status) == "" {
+			return mcp.NewToolResultError("status is required"), nil
+		}
+
+		detRes, err := resolveWriteProject()
+		if err != nil {
+			return writeProjectErrorResult(nil, "", detRes, err), nil
+		}
+		project, _ := store.NormalizeProject(detRes.Project)
+
+		if err := s.UpdateSessionStatus(sessionID, status); err != nil {
+			return mcp.NewToolResultError("Failed to update status: " + err.Error()), nil
+		}
+
+		activity.RecordToolCall(defaultSessionID(project))
+
+		return respondWithProject(detRes, fmt.Sprintf("Status updated for session %q.", sessionID), nil), nil
+	}
+}
+
+func handleActiveSessions(s *store.Store, activity *SessionActivity, cfg MCPConfig) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		projectArg, _ := req.GetArguments()["project"].(string)
+
+		detRes, err := resolveReadProjectWithProcessOverride(s, projectArg, cfg.DefaultProject)
+		if err != nil {
+			return respondWithProject(detRes, "", nil), nil
+		}
+
+		project := detRes.Project
+		project, _ = store.NormalizeProject(project)
+		detRes.Project = project
+
+		activity.RecordToolCall(defaultSessionID(project))
+
+		sessions, err := s.ActiveSessions(project)
+		if err != nil {
+			return mcp.NewToolResultError("Failed to list active sessions: " + err.Error()), nil
+		}
+
+		sessionList := make([]map[string]any, 0, len(sessions))
+		for _, as := range sessions {
+			sessionList = append(sessionList, map[string]any{
+				"session_id":   as.SessionID,
+				"current_task": as.CurrentTask,
+				"last_seen":    as.LastSeen,
+			})
+		}
+
+		envelope := map[string]any{
+			"project":        detRes.Project,
+			"project_source": detRes.Source,
+			"project_path":   detRes.Path,
+			"result":         fmt.Sprintf("%d active session(s) for project %q.", len(sessions), project),
+			"sessions":       sessionList,
+			"stale_count":    0,
+		}
+		out, _ := jsonMarshal(envelope)
+		return mcp.NewToolResultText(string(out)), nil
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -228,6 +228,11 @@ func (s *Server) routes() {
 	// Sync status (degraded-state visibility for autosync)
 	s.mux.HandleFunc("GET /sync/status", s.handleSyncStatus)
 
+	// Session bus (real-time cross-session awareness)
+	s.mux.HandleFunc("POST /sessions/{id}/heartbeat", s.handleSessionHeartbeat)
+	s.mux.HandleFunc("POST /sessions/{id}/status", s.handleSessionStatus)
+	s.mux.HandleFunc("GET /sessions/active", s.handleActiveSessions)
+
 	// Conflicts — CRITICAL ORDER: literals before wildcard (Go 1.22 mux panics on overlap)
 	s.mux.HandleFunc("GET /conflicts", s.handleListConflicts)
 	s.mux.HandleFunc("GET /conflicts/stats", s.handleConflictsStats)
@@ -315,6 +320,98 @@ func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResponse(w, http.StatusOK, session)
+}
+
+// ─── Session Bus Handlers ─────────────────────────────────────────────────────
+
+func (s *Server) handleSessionHeartbeat(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Project     string `json:"project"`
+		CurrentTask string `json:"current_task"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json: "+err.Error())
+		return
+	}
+
+	sessionID := r.PathValue("id")
+	if sessionID == "" {
+		jsonError(w, http.StatusBadRequest, "session id is required")
+		return
+	}
+	if body.Project == "" {
+		jsonError(w, http.StatusBadRequest, "project is required")
+		return
+	}
+
+	if err := s.store.UpsertHeartbeat(sessionID, body.Project, body.CurrentTask); err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Return active sessions for the project
+	sessions, err := s.store.ActiveSessions(body.Project)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]any{
+		"status":         "ok",
+		"session_id":     sessionID,
+		"active_sessions": sessions,
+		"count":          len(sessions),
+	})
+}
+
+func (s *Server) handleSessionStatus(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json: "+err.Error())
+		return
+	}
+
+	sessionID := r.PathValue("id")
+	if sessionID == "" {
+		jsonError(w, http.StatusBadRequest, "session id is required")
+		return
+	}
+	if body.Status == "" {
+		jsonError(w, http.StatusBadRequest, "status is required")
+		return
+	}
+
+	if err := s.store.UpdateSessionStatus(sessionID, body.Status); err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]string{
+		"status":     "ok",
+		"session_id": sessionID,
+	})
+}
+
+func (s *Server) handleActiveSessions(w http.ResponseWriter, r *http.Request) {
+	project := r.URL.Query().Get("project")
+	if project == "" {
+		jsonError(w, http.StatusBadRequest, "project query param is required")
+		return
+	}
+
+	sessions, err := s.store.ActiveSessions(project)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]any{
+		"project":  project,
+		"sessions": sessions,
+		"count":    len(sessions),
+	})
 }
 
 func (s *Server) handleAddObservation(w http.ResponseWriter, r *http.Request) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -118,6 +118,15 @@ type SessionSummary struct {
 	ObservationCount int     `json:"observation_count"`
 }
 
+type ActiveSession struct {
+	SessionID   string `json:"session_id"`
+	Project     string `json:"project"`
+	Directory   string `json:"directory"`
+	CurrentTask string `json:"current_task"`
+	StatusBlob  string `json:"status_blob,omitempty"`
+	LastSeen    string `json:"last_seen"`
+}
+
 type Stats struct {
 	TotalSessions     int      `json:"total_sessions"`
 	TotalObservations int      `json:"total_observations"`
@@ -2220,6 +2229,82 @@ func (s *Store) SessionObservations(sessionID string, limit int) ([]Observation,
 	return s.queryObservations(query, sessionID, limit)
 }
 
+// ─── Session Heartbeats ─────────────────────────────────────────────────────
+
+// heartbeatStaleSeconds defines how long a session is considered active after
+// its last heartbeat before being cleaned up as stale.
+const heartbeatStaleSeconds = 120 // 2 minutes
+
+// UpsertHeartbeat registers a session heartbeat with the current task description.
+// Idempotent — re-calling updates last_seen and current_task.
+func (s *Store) UpsertHeartbeat(sessionID, project, currentTask string) error {
+	project, _ = NormalizeProject(project)
+	return s.withTx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			INSERT INTO session_heartbeats (session_id, project, current_task, last_seen)
+			VALUES (?, ?, ?, datetime('now'))
+			ON CONFLICT(session_id) DO UPDATE SET
+				current_task = excluded.current_task,
+				last_seen = datetime('now')
+		`, sessionID, project, currentTask)
+		return err
+	})
+}
+
+// UpdateSessionStatus writes a JSON status blob for a session. Used by
+// mem_session_status to store richer context (progress, blockers, etc.).
+func (s *Store) UpdateSessionStatus(sessionID, statusBlob string) error {
+	return s.withTx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			UPDATE session_heartbeats SET status_blob = ?, last_seen = datetime('now')
+			WHERE session_id = ?
+		`, statusBlob, sessionID)
+		return err
+	})
+}
+
+// CleanStaleHeartbeats removes heartbeat records where last_seen is older than
+// heartbeatStaleSeconds. Called automatically by ActiveSessions before reading.
+func (s *Store) CleanStaleHeartbeats() error {
+	_, err := s.execHook(s.db, `
+		DELETE FROM session_heartbeats
+		WHERE last_seen < datetime('now', ?)
+	`, fmt.Sprintf("-%d seconds", heartbeatStaleSeconds))
+	return err
+}
+
+// ActiveSessions returns all sessions that have sent a heartbeat within the
+// staleness window, joined with their session metadata. Stale records are
+// cleaned before the read.
+func (s *Store) ActiveSessions(project string) ([]ActiveSession, error) {
+	project, _ = NormalizeProject(project)
+
+	// Clean stale before reading
+	_ = s.CleanStaleHeartbeats()
+
+	rows, err := s.queryItHook(s.db, `
+		SELECT sh.session_id, sh.project, COALESCE(s.directory, ''), sh.current_task, sh.status_blob, sh.last_seen
+		FROM session_heartbeats sh
+		LEFT JOIN sessions s ON s.id = sh.session_id
+		WHERE LOWER(sh.project) = ?
+		ORDER BY sh.last_seen DESC
+	`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var sessions []ActiveSession
+	for rows.Next() {
+		var as ActiveSession
+		if err := rows.Scan(&as.SessionID, &as.Project, &as.Directory, &as.CurrentTask, &as.StatusBlob, &as.LastSeen); err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, as)
+	}
+	return sessions, rows.Err()
+}
+
 // ─── Observations ────────────────────────────────────────────────────────────
 
 func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
@@ -3863,8 +3948,26 @@ func (s *Store) AcquireSyncLease(targetKey, owner string, ttl time.Duration, now
 			leaseUntil, err := time.Parse(time.RFC3339, *state.LeaseUntil)
 			if err == nil && leaseUntil.After(now) && derefString(state.LeaseOwner) != "" && derefString(state.LeaseOwner) != owner {
 				acquired = false
-				return nil
-			}
+	// Session heartbeat — real-time session bus for cross-session awareness.
+	// Sessions send periodic heartbeats (via mem_session_heartbeat) to register
+	// liveness. ActiveSessions() returns sessions seen within the last 2 minutes.
+	// Stale entries are cleaned on every read.
+	if _, err := s.execHook(s.db, `
+		CREATE TABLE IF NOT EXISTS session_heartbeats (
+			session_id   TEXT PRIMARY KEY,
+			project      TEXT NOT NULL,
+			current_task TEXT NOT NULL DEFAULT '',
+			status_blob  TEXT NOT NULL DEFAULT '{}',
+			last_seen    TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+		CREATE INDEX IF NOT EXISTS idx_sh_project ON session_heartbeats(project);
+		CREATE INDEX IF NOT EXISTS idx_sh_lastseen ON session_heartbeats(last_seen);
+	`); err != nil {
+		return err
+	}
+
+	return nil
+}
 		}
 		leaseUntil := now.Add(ttl).UTC().Format(time.RFC3339)
 		_, err = s.execHook(tx,


### PR DESCRIPTION
## What

Adds a **Session Bus** layer for real-time cross-session awareness. Sessions send periodic heartbeats with task descriptions, and Engram tracks active sessions with a 2-minute staleness window.

## How it works

Each coding session sends a heartbeat on every tool call (throttled to 30s):
\\\
POST /sessions/{id}/heartbeat → returns list of other active sessions
\\\

Other sessions can query the bus:
\\\
GET /sessions/active?project=X → all sessions with recent heartbeats
\\\

Stale sessions (no heartbeat in 2 min) are auto-cleaned on every read.

## Changes

### Store (store.go)
- \session_heartbeats\ table (session_id, project, current_task, status_blob, last_seen)
- \ActiveSession\ struct
- 5 methods: \UpsertHeartbeat\, \UpdateSessionStatus\, \CleanStaleHeartbeats\, \ActiveSessions\

### MCP (mcp.go) — 3 new tools (agent profile, 22 total)
- \mem_session_heartbeat\ — send heartbeat + receive active sessions list
- \mem_session_status\ — store detailed JSON status blob
- \mem_active_sessions\ — read-only list of active sessions

### HTTP (server.go) — 3 new endpoints
- \POST /sessions/{id}/heartbeat\
- \POST /sessions/{id}/status\
- \GET /sessions/active?project=X\

## Dependencies

Zero. No new imports, no new services, no Redis, no WebSocket. Pure SQLite + existing REST API.

## Companion PRs

- OpenCode plugin heartbeat hooks: https://github.com/creandoaldia/web-ai-lab
- Model routing + env cleanup: https://github.com/creandoaldia/premium-static-landing-001