### PR TITLE
feat(store,mcp): add match_mode option to Search and mem_search

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -280,6 +280,9 @@ func registerTools(srv *server.MCPServer, s *store.Store, cfg MCPConfig, allowli
 				mcp.WithString("scope",
 					mcp.Description("Filter by scope: project (default) or personal"),
 				),
+				mcp.WithString("match_mode",
+					mcp.Description("Token matching: \"all\" (default — every token must match, FTS5 AND) or \"any\" (any token matches — broader recall for multi-token queries). Any other value returns an error."),
+				),
 				mcp.WithNumber("limit",
 					mcp.Description("Max results (default: 10, max: 20)"),
 				),
@@ -903,8 +906,14 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		typ, _ := req.GetArguments()["type"].(string)
 		projectOverride, _ := req.GetArguments()["project"].(string)
 		scope, _ := req.GetArguments()["scope"].(string)
+		matchMode, _ := req.GetArguments()["match_mode"].(string)
 		allProjects := boolArg(req, "all_projects", false)
 		limit := intArg(req, "limit", 10)
+
+		// Validate match_mode before any project resolution or DB work.
+		if matchMode != "" && matchMode != "all" && matchMode != "any" {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid match_mode %q: must be \"all\" or \"any\"", matchMode)), nil
+		}
 
 		// all_projects=true short-circuits project resolution: we search globally
 		// regardless of the project override or any auto-detected project. This
@@ -945,10 +954,11 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		activity.RecordToolCall(sessionID)
 
 		results, err := s.Search(query, store.SearchOptions{
-			Type:    typ,
-			Project: searchProject,
-			Scope:   scope,
-			Limit:   limit,
+			Type:      typ,
+			Project:   searchProject,
+			Scope:     scope,
+			Limit:     limit,
+			MatchMode: matchMode,
 		})
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Search error: %s. Try simpler keywords.", err)), nil

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -7088,3 +7088,90 @@ func TestHandleSearchLegacyMixedCaseProject(t *testing.T) {
 		t.Fatalf("expected search results for legacy project, got: %s", text)
 	}
 }
+
+// ─── match_mode MCP tests (issue #352) ──────────────────────────────────────
+
+// seedMCPMatchModeFixture creates a session and three observations with partial
+// token overlap — mirrors the store-level fixture.
+func seedMCPMatchModeFixture(t *testing.T, s *store.Store) {
+	t.Helper()
+	if err := s.CreateSession("s-mcp-matchmode", "engram", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obs := []store.AddObservationParams{
+		{SessionID: "s-mcp-matchmode", Type: "decision", Title: "Auth session middleware", Content: "", Project: "engram", Scope: "project"},
+		{SessionID: "s-mcp-matchmode", Type: "decision", Title: "Compliance audit notes", Content: "session policy", Project: "engram", Scope: "project"},
+		{SessionID: "s-mcp-matchmode", Type: "decision", Title: "OAuth tokens", Content: "auth and compliance", Project: "engram", Scope: "project"},
+	}
+	for _, p := range obs {
+		if _, err := s.AddObservation(p); err != nil {
+			t.Fatalf("seed observation %q: %v", p.Title, err)
+		}
+	}
+}
+
+// TestHandleSearch_MatchModeAny verifies that passing match_mode="any" through
+// the MCP handler returns the broader result set.
+func TestHandleSearch_MatchModeAny(t *testing.T) {
+	s := newMCPTestStore(t)
+	seedMCPMatchModeFixture(t, s)
+
+	h := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"query":      "auth compliance session",
+		"project":    "engram",
+		"match_mode": "any",
+		"limit":      10.0,
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearch error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", callResultText(t, res))
+	}
+	text := callResultText(t, res)
+	if strings.Contains(text, "No memories found") {
+		t.Fatalf("expected results for match_mode=any, got: %s", text)
+	}
+	if !strings.Contains(text, "Found 3") {
+		t.Fatalf("expected 'Found 3' in response (all 3 seeded observations), got: %s", text)
+	}
+	// All three observation titles must appear in the output.
+	for _, title := range []string{"Auth session middleware", "Compliance audit notes", "OAuth tokens"} {
+		if !strings.Contains(text, title) {
+			t.Fatalf("expected title %q in response, got: %s", title, text)
+		}
+	}
+}
+
+// TestHandleSearch_MatchModeInvalidError verifies that an invalid match_mode
+// value surfaces as an error tool result (not a silent empty list).
+func TestHandleSearch_MatchModeInvalidError(t *testing.T) {
+	s := newMCPTestStore(t)
+	seedMCPMatchModeFixture(t, s)
+
+	h := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"query":      "auth compliance session",
+		"project":    "engram",
+		"match_mode": "or",
+		"limit":      10.0,
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearch error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected tool error for invalid match_mode, got success: %s", callResultText(t, res))
+	}
+	text := callResultText(t, res)
+	if !strings.Contains(text, "invalid match_mode") {
+		t.Fatalf("expected error text to contain \"invalid match_mode\", got: %s", text)
+	}
+	if strings.Contains(text, "Try simpler keywords") {
+		t.Fatalf("parameter-validation error must not contain query-advice suffix \"Try simpler keywords\", got: %s", text)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -153,10 +153,11 @@ type TimelineResult struct {
 }
 
 type SearchOptions struct {
-	Type    string `json:"type,omitempty"`
-	Project string `json:"project,omitempty"`
-	Scope   string `json:"scope,omitempty"`
-	Limit   int    `json:"limit,omitempty"`
+	Type      string `json:"type,omitempty"`
+	Project   string `json:"project,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	Limit     int    `json:"limit,omitempty"`
+	MatchMode string `json:"match_mode,omitempty"` // "all" (default) | "any"
 }
 
 type AddObservationParams struct {
@@ -2956,6 +2957,14 @@ func (s *Store) Timeline(observationID int64, before, after int) (*TimelineResul
 // ─── Search (FTS5) ───────────────────────────────────────────────────────────
 
 func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error) {
+	// Validate match_mode early so invalid values always error regardless of query shape.
+	switch opts.MatchMode {
+	case "", "all", "any":
+		// valid
+	default:
+		return nil, fmt.Errorf("invalid match_mode %q: must be \"all\" or \"any\"", opts.MatchMode)
+	}
+
 	// Normalize project filter so "Engram" finds records stored as "engram"
 	opts.Project, _ = NormalizeProject(opts.Project)
 
@@ -3011,8 +3020,13 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		}
 	}
 
-	// Sanitize query for FTS5 — wrap each term in quotes to avoid syntax errors
-	ftsQuery := sanitizeFTS(query)
+	// Build FTS5 query: "all" (default) uses AND semantics; "any" uses OR for broader recall.
+	var ftsQuery string
+	if opts.MatchMode == "any" {
+		ftsQuery = sanitizeFTSCandidates(query)
+	} else {
+		ftsQuery = sanitizeFTS(query)
+	}
 
 	sqlQ := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8289,3 +8289,121 @@ func TestMostRecentActiveSessionScopedByProject(t *testing.T) {
 		t.Fatalf("expected no active session for engram when only 'other' has one, got ok=%v", ok)
 	}
 }
+
+// ─── match_mode tests (issue #352) ──────────────────────────────────────────
+
+// seedMatchModeFixture creates a session and three observations with partial
+// token overlap — no single observation contains all three query tokens.
+//
+//	obs1: title "Auth session middleware"       content ""
+//	obs2: title "Compliance audit notes"        content "session policy"
+//	obs3: title "OAuth tokens"                  content "auth and compliance"
+func seedMatchModeFixture(t *testing.T, s *Store) {
+	t.Helper()
+	if err := s.CreateSession("s-matchmode", "engram", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obs := []AddObservationParams{
+		{SessionID: "s-matchmode", Type: "decision", Title: "Auth session middleware", Content: "", Project: "engram", Scope: "project"},
+		{SessionID: "s-matchmode", Type: "decision", Title: "Compliance audit notes", Content: "session policy", Project: "engram", Scope: "project"},
+		{SessionID: "s-matchmode", Type: "decision", Title: "OAuth tokens", Content: "auth and compliance", Project: "engram", Scope: "project"},
+	}
+	for _, p := range obs {
+		if _, err := s.AddObservation(p); err != nil {
+			t.Fatalf("seed observation %q: %v", p.Title, err)
+		}
+	}
+}
+
+// TestSearchMatchMode_DefaultIsAND verifies that the default (AND) behaviour
+// returns 0 results when no single observation contains all query tokens.
+func TestSearchMatchMode_DefaultIsAND(t *testing.T) {
+	s := newTestStore(t)
+	seedMatchModeFixture(t, s)
+
+	results, err := s.Search("auth compliance session", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for AND query, got %d", len(results))
+	}
+}
+
+// TestSearchMatchMode_AllExplicit verifies that MatchMode "all" behaves
+// identically to the default AND mode.
+func TestSearchMatchMode_AllExplicit(t *testing.T) {
+	s := newTestStore(t)
+	seedMatchModeFixture(t, s)
+
+	results, err := s.Search("auth compliance session", SearchOptions{Project: "engram", Limit: 10, MatchMode: "all"})
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for explicit match_mode=all, got %d", len(results))
+	}
+}
+
+// TestSearchMatchMode_Any verifies that MatchMode "any" returns all three
+// observations because each contains at least one of the query tokens.
+func TestSearchMatchMode_Any(t *testing.T) {
+	s := newTestStore(t)
+	seedMatchModeFixture(t, s)
+
+	results, err := s.Search("auth compliance session", SearchOptions{Project: "engram", Limit: 10, MatchMode: "any"})
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results for match_mode=any, got %d", len(results))
+	}
+}
+
+// TestSearchMatchMode_InvalidReturnsError verifies that an unrecognised
+// match_mode value returns an explicit error regardless of query shape.
+func TestSearchMatchMode_InvalidReturnsError(t *testing.T) {
+	s := newTestStore(t)
+	seedMatchModeFixture(t, s)
+
+	_, err := s.Search("auth compliance session", SearchOptions{Project: "engram", Limit: 10, MatchMode: "or"})
+	if err == nil {
+		t.Fatalf("expected error for invalid match_mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid match_mode") {
+		t.Fatalf("expected error to contain \"invalid match_mode\", got: %v", err)
+	}
+}
+
+// TestSearchMatchMode_SingleToken verifies that a single-token query returns
+// the same result regardless of match_mode (both modes are equivalent for one
+// token because AND and OR over a single term are identical).
+func TestSearchMatchMode_SingleToken(t *testing.T) {
+	s := newTestStore(t)
+	seedMatchModeFixture(t, s)
+
+	defaultRes, err := s.Search("auth", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("default Search error: %v", err)
+	}
+	anyRes, err := s.Search("auth", SearchOptions{Project: "engram", Limit: 10, MatchMode: "any"})
+	if err != nil {
+		t.Fatalf("any Search error: %v", err)
+	}
+	if len(defaultRes) != len(anyRes) {
+		t.Fatalf("single-token results differ: default=%d any=%d", len(defaultRes), len(anyRes))
+	}
+}
+
+// TestSearchMatchMode_EmptyQueryAnyReturnsError pins that Search("", …{MatchMode:"any"})
+// returns an error — the FTS5 engine rejects an empty match expression, and this
+// behaviour is the same as the default AND mode with an empty query.
+func TestSearchMatchMode_EmptyQueryAnyReturnsError(t *testing.T) {
+	s := newTestStore(t)
+	seedMatchModeFixture(t, s)
+
+	_, err := s.Search("", SearchOptions{Project: "engram", Limit: 10, MatchMode: "any"})
+	if err == nil {
+		t.Fatal("expected error for empty query with match_mode=any, got nil")
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #352

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds `match_mode: "all" | "any"` to `Store.Search()` and the `mem_search` MCP tool. Default (`""`/`"all"`) preserves today's FTS5 implicit-AND behavior exactly; `"any"` joins tokens with OR for broader recall, fixing the silent zero-result failure when no single observation contains every query token.
- The OR branch reuses the existing `sanitizeFTSCandidates` helper from `internal/store/relations.go` (already used by `FindCandidates`) — no new query-building logic.
- Invalid values error explicitly at both layers (store + MCP pre-validation) instead of silently falling back — this issue is precisely about silent failures, so the new knob refuses to fail silently itself.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | `MatchMode` field on `SearchOptions`; early validation in `Search()` (before the topic-key path); AND/OR branch at FTS query build |
| `internal/mcp/mcp.go` | `match_mode` param on the `mem_search` tool schema; pre-validation in `handleSearch` with a targeted error (no generic "Try simpler keywords" advice for a parameter mistake) |
| `internal/store/store_test.go` | 6 tests: default-AND preserved, explicit `"all"`, `"any"` recall (issue's synthetic repro: 3 observations with partial token overlap → 0 hits AND, 3 hits ANY), invalid value errors, single-token equivalence, empty-query behavior pinned |
| `internal/mcp/mcp_test.go` | 2 tests: `"any"` flows through the handler (asserts all 3 titles + count), invalid value surfaces as tool error without the misleading suffix |

Net: 4 files, +239/−10. HTTP server, CLI, and TUI intentionally untouched — the approved issue scopes store + MCP; propagating the flag there is a natural follow-up if wanted.

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...` (see note)
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (see note)
- [x] Manually tested the affected functionality

Manual verification: reproduced the issue's exact synthetic scenario via the new store tests — `mem_search("auth compliance session")` → 0 hits with AND, 3 hits with `match_mode: "any"`.

Note (Windows environment): 16 tests across `cmd/engram` (cloud/serve/sync-status), `internal/setup`, `internal/sync`, and `internal/store` (`TestMigrate_Idempotent`, `TestNewErrorBranches`) fail locally on Windows. All 16 verified to fail identically on a clean checkout of `upstream/main` — environment issues unrelated to this change. The packages this PR touches (`internal/store` match_mode tests, `internal/mcp` full suite) pass.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #352`)
- [ ] I added exactly **one** `type:*` label to this PR — external contributors can't self-apply labels; requesting `type:feature`
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed) — checked: `mem_search` params aren't documented in README/docs, so there was nothing to update; the tool's self-describing MCP schema documents the new param
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

- **Why error instead of silent fallback for invalid values**: this issue exists because zero-results failures were silent. A `match_mode: "or"` typo silently treated as `"all"` would reproduce the same class of bug one layer up.
- **Why `sanitizeFTSCandidates` reuse**: same package, already battle-tested by `FindCandidates`, identical quoting/injection surface as the existing AND path.
- Alternatives considered are in the issue body (auto-relax fallback, client-side validation); field evidence (149-query log, zero-hit rate scaling with token count) is in the issue comments.
- Related issues: #257 (trigram/fuzzy — different failure mode), #233 (semantic recall — design-gated). This PR is the syntactic-relaxation slice of that stack.
