### PR TITLE
feat(memory): surface observation lifecycle state

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -14,7 +14,7 @@ This is the complete technical reference for Engram. For getting started, see th
 | --------------------------------------------------------- | ------------------------------------------------------------ |
 | [Database Schema](#database-schema)                       | Tables, FTS5, SQLite config                                  |
 | [HTTP API](#http-api-endpoints)                           | All REST endpoints with request/response details             |
-| [MCP Tools](#mcp-tools-19-tools)                          | Detailed reference for all 19 memory tools                   |
+| [MCP Tools](#mcp-tools-20-tools)                          | Detailed reference for all 20 memory tools                   |
 | [MCP Project Resolution](#mcp-project-resolution)         | Auto-detection algorithm, response envelope, tool categories |
 | [Memory Protocol](#memory-protocol)                       | When/how agents should use the tools                         |
 | [Project Name Normalization](#project-name-normalization) | Auto-detection, normalization, similar-project warnings      |
@@ -768,7 +768,7 @@ Returns success even when cwd is ambiguous — empty `project` + non-empty `avai
 
 ---
 
-## MCP Tools (19 tools)
+## MCP Tools (20 tools)
 
 ### mem_search
 
@@ -777,6 +777,8 @@ Search persistent memory across all sessions. Supports FTS5 full-text search wit
 Set `all_projects: true` to search across every project instead of the resolved one. This bypasses project detection entirely and ignores the `project` argument, so an agent can recall a decision logged elsewhere without knowing the project key. The response envelope reports `project_source: "all_projects"` and an empty `project` to reflect the cross-project scope.
 
 Scope values accepted by the `scope` parameter: `project` (default), `personal`, `global`. When `scope: personal` is passed without an explicit `project` override, the project filter is cleared and personal observations are searched across all projects (cross-project personal scope).
+
+Each structured search result includes lifecycle metadata: `state` (`active` or `needs_review`) and, when set, `review_after`. Text output also appends `state: needs_review` for stale observations.
 
 When an observation has judged relations in `memory_relations`, the result entry includes annotation lines immediately after the title/content block:
 
@@ -805,10 +807,22 @@ Save structured observations. The tool description teaches agents the format:
 
 Exact duplicate saves are deduplicated in a rolling time window using a normalized content hash + project + scope + type + title.
 When `topic_key` is provided, `mem_save` upserts the latest observation in the same `project + scope + topic_key`, incrementing `revision_count`.
+Save responses include lifecycle metadata for the saved observation: computed `state` (`active` or `needs_review`) and `review_after` when the observation type has a review cycle.
 
 ### mem_update
 
 Update an observation by ID. Public schema supports partial updates for `title`, `content`, `type`, `scope`, and `topic_key`. For legacy/raw MCP clients, a non-empty `project` argument is still tolerated by the handler even though it is not exposed in the schema.
+
+### mem_review
+
+Review observation lifecycle state. Available in the `agent` profile (`engram mcp --tools=agent`).
+
+Actions:
+
+- `action: "list"` — returns observations whose `review_after` has passed. Optional parameters: `project` and `limit` (default 10).
+- `action: "mark_reviewed"` — requires `observation_id`; resets that observation's local review cycle using its type decay policy. The legacy `id` alias is accepted for compatibility.
+
+`mark_reviewed` is local-only for now: `review_after` is intentionally not part of sync payloads in this phase, so resetting the review cycle does not enqueue a sync mutation or propagate to other machines.
 
 ### mem_suggest_topic_key
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ It gives Pi persistent project memory, compaction recovery, and shared memory wi
 
 Full details on session lifecycle, topic keys, and memory hygiene → [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
-## MCP Tools (19)
+## MCP Tools (20)
 
 | Category               | Tools                                                                                                            |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
@@ -90,9 +90,10 @@ Full details on session lifecycle, topic keys, and memory hygiene → [docs/ARCH
 | **Search & Retrieve**  | `mem_search`, `mem_context`, `mem_timeline`, `mem_get_observation`                                               |
 | **Session Lifecycle**  | `mem_session_start`, `mem_session_end`, `mem_session_summary`                                                    |
 | **Conflict Surfacing** | `mem_judge`, `mem_compare`                                                                                       |
+| **Lifecycle Review**   | `mem_review`                                                                                                      |
 | **Utilities**          | `mem_save_prompt`, `mem_stats`, `mem_capture_passive`, `mem_merge_projects`, `mem_current_project`, `mem_doctor` |
 
-Full tool reference with parameters → [DOCS.md#mcp-tools-19-tools](DOCS.md#mcp-tools-19-tools)
+Full tool reference with parameters → [DOCS.md#mcp-tools-20-tools](DOCS.md#mcp-tools-20-tools)
 
 ## Terminal UI
 

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -202,7 +202,7 @@ engram setup opencode
 This does three things:
 
 1. Copies the plugin to `~/.config/opencode/plugins/engram.ts` (session tracking, Memory Protocol, compaction recovery)
-2. Adds the `engram` MCP server entry to your `opencode.json` with `--tools=agent` (15 agent-facing tools)
+2. Adds the `engram` MCP server entry to your `opencode.json` with `--tools=agent` (16 agent-facing tools)
 3. Adds `opencode-subagent-statusline` to your `tui.json` or `tui.jsonc` so OpenCode shows sub-agent activity in the sidebar/home footer
 
 The plugin auto-starts the HTTP server if needed for session tracking. If your environment blocks background processes, run it manually:
@@ -213,7 +213,7 @@ engram serve &
 
 > **Windows**: OpenCode uses `~/.config/opencode/` on Windows too (it does not read `%APPDATA%\opencode\`). `engram setup opencode` writes to `~/.config/opencode/plugins/` and `~/.config/opencode/opencode.json`. To run the server in the background: `Start-Process engram -ArgumentList "serve" -WindowStyle Hidden` (PowerShell) or just run `engram serve` in a separate terminal.
 
-**Alternative: Manual MCP-only setup** (no plugin, all 19 tools by default):
+**Alternative: Manual MCP-only setup** (no plugin, all 20 tools by default):
 
 Add to your `opencode.json` (global: `~/.config/opencode/opencode.json` on all platforms, or project-level):
 
@@ -265,7 +265,7 @@ engram setup claude-code
 
 During setup, you'll be asked whether to add engram's agent-profile MCP tools to `~/.claude/settings.json` `permissions.allow`. The setup writes entries for both the durable user-level MCP server id (`mcp__engram__...`) and the plugin-scoped server id used by older Claude Code plugin installs, so re-running setup repairs stale or incomplete allowlists without adding startup delay.
 
-**Option C: Bare MCP** — all 19 tools by default, no session management:
+**Option C: Bare MCP** — all 20 tools by default, no session management:
 
 Add to your `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,6 +70,7 @@ Next session starts → Previous session context is injected automatically
 | `mem_merge_projects` | Merge project name variants into canonical name (admin) |
 | `mem_current_project` | Detect project from cwd — never errors, recommended first call |
 | `mem_doctor` | Run read-only operational diagnostics for project detection and store health |
+| `mem_review` | List observations whose `review_after` lifecycle is stale; `mark_reviewed` resets the local review cycle |
 | `mem_judge` | Record a verdict for a pending memory conflict surfaced by `mem_save` |
 | `mem_compare` | Persist a semantic relation verdict between two existing observations |
 
@@ -92,6 +93,8 @@ Token-efficient memory retrieval — don't dump everything, drill in:
 - `mem_save` now supports `scope` (`project` default, `personal` and `global` also accepted)
 - `mem_save` also supports `topic_key`; with a topic key, saves become upserts (same project+scope+topic updates the existing memory)
 - `mem_save` supports `capture_prompt` (`true` by default). When the same MCP process lifecycle has current prompt context for the same project and session, it best-effort records that prompt alongside the observation. The prompt context must be fed before the later `mem_save` (typically via `mem_save_prompt`); `mem_save` still succeeds if context is unavailable or prompt capture fails. Automated saves such as SDD artifacts should pass `capture_prompt=false`.
+- `mem_save` and `mem_search` expose lifecycle metadata: computed `state` (`active` or `needs_review`) and `review_after` when a review cycle applies.
+- `mem_review` supports `action="list"` (`project`, `limit`) and `action="mark_reviewed"` (`observation_id`). Marking reviewed is local-only for now because `review_after` is intentionally not part of sync payloads in this phase.
 - Exact dedupe prevents repeated inserts in a rolling window (hash + project + scope + type + title)
 - Duplicates update metadata (`duplicate_count`, `last_seen_at`, `updated_at`) instead of creating new rows
 - Topic upserts increment `revision_count` so evolving decisions stay in one memory
@@ -208,7 +211,7 @@ engram/
 ├── internal/
 │   ├── store/store.go              # Core: SQLite + FTS5 + all data ops
 │   ├── server/server.go            # HTTP REST API (port 7437)
-│   ├── mcp/mcp.go                  # MCP stdio server (19 tools)
+│   ├── mcp/mcp.go                  # MCP stdio server (20 tools)
 │   ├── setup/setup.go              # Agent plugin installer (go:embed)
 │   ├── cloud/                       # Optional cloud runtime (Postgres + dashboard)
 │   │   ├── cloudserver/             # /sync API + dashboard mount + auth/session bridge

--- a/docs/codebase/interfaces.md
+++ b/docs/codebase/interfaces.md
@@ -27,7 +27,7 @@ Important points:
 - `ambiguous_project` recovery requires the user to choose an exact project.
 - If `mem_save` returns conflict candidates, the agent must judge with `mem_judge` or ask when the relationship is sensitive.
 
-For tool parameters and envelopes, use [DOCS.md — MCP Tools](../../DOCS.md#mcp-tools-19-tools).
+For tool parameters and envelopes, use [DOCS.md — MCP Tools](../../DOCS.md#mcp-tools-20-tools).
 
 ## Local API: `internal/server`
 

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -111,6 +111,7 @@ var ProfileAgent = map[string]bool{
 	"mem_judge":             true, // record verdict on a pending memory conflict (REQ-003, Phase D)
 	"mem_compare":           true, // persist an agent-judged semantic verdict via JudgeBySemantic (REQ-011, Phase G)
 	"mem_doctor":            true, // read-only operational diagnostics for agents
+	"mem_review":            true, // list/mark observations whose review_after lifecycle is stale
 }
 
 // ProfileAdmin contains tools for TUI, dashboards, and manual curation
@@ -182,7 +183,7 @@ CORE TOOLS (always available — use without ToolSearch):
   mem_current_project — detect current project from cwd (recommended first call)
 
 DEFERRED TOOLS (use ToolSearch when needed):
-  mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end,
+  mem_update, mem_review, mem_suggest_topic_key, mem_session_start, mem_session_end,
   mem_stats, mem_delete, mem_timeline, mem_capture_passive, mem_merge_projects
 
 PROACTIVE SAVE RULE: Call mem_save immediately after ANY decision, bug fix, discovery, or convention — not just when asked.
@@ -394,6 +395,27 @@ Examples:
 				),
 			),
 			queuedWriteHandler(writeQueue, handleUpdate(s)),
+		)
+	}
+
+	// ─── mem_review (profile: agent, deferred) ──────────────────────────
+	if shouldRegister("mem_review", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_review",
+				mcp.WithDescription("Review observation lifecycle state. action=list returns observations whose review_after has passed; action=mark_reviewed resets one observation's review_after using its type decay policy."),
+				mcp.WithDeferLoading(true),
+				mcp.WithTitleAnnotation("Review Memories"),
+				mcp.WithReadOnlyHintAnnotation(false),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(false),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("action", mcp.Required(), mcp.Description("Action: list | mark_reviewed")),
+				mcp.WithString("project", mcp.Description("Optional project filter for action=list; omit to list all projects.")),
+				mcp.WithNumber("limit", mcp.Description("Max results for action=list (default: 10).")),
+				mcp.WithNumber("observation_id", mcp.Description("Observation id for action=mark_reviewed.")),
+				mcp.WithNumber("id", mcp.Description("Backward-compatible alias for observation_id.")),
+			),
+			queuedWriteHandler(writeQueue, handleReview(s, cfg)),
 		)
 	}
 
@@ -977,6 +999,7 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		var b strings.Builder
 		fmt.Fprintf(&b, "Found %d memories:\n\n", len(results))
 		anyTruncated := false
+		structuredResults := make([]map[string]any, 0, len(results))
 		for i, r := range results {
 			projectDisplay := ""
 			if r.Project != nil {
@@ -987,10 +1010,29 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 				anyTruncated = true
 				preview += " [preview]"
 			}
-			fmt.Fprintf(&b, "[%d] #%d (%s) — %s\n    %s\n    %s%s | scope: %s\n",
+			stateDisplay := ""
+			if r.State() == store.ObservationStateNeedsReview {
+				stateDisplay = " | state: needs_review"
+			}
+			fmt.Fprintf(&b, "[%d] #%d (%s) — %s\n    %s\n    %s%s | scope: %s%s\n",
 				i+1, r.ID, r.Type, r.Title,
 				preview,
-				timeutil.FormatLocal(r.CreatedAt), projectDisplay, r.Scope)
+				timeutil.FormatLocal(r.CreatedAt), projectDisplay, r.Scope, stateDisplay)
+			entry := map[string]any{
+				"id":      r.ID,
+				"sync_id": r.SyncID,
+				"title":   r.Title,
+				"type":    r.Type,
+				"state":   r.State(),
+				"scope":   r.Scope,
+			}
+			if r.Project != nil {
+				entry["project"] = *r.Project
+			}
+			if r.ReviewAfter != nil {
+				entry["review_after"] = *r.ReviewAfter
+			}
+			structuredResults = append(structuredResults, entry)
 
 			// Append relation annotations. Skip orphaned (filtered by store).
 			//
@@ -1048,7 +1090,7 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		}
 
 		// JW4: use respondWithProject for the success path (REQ-314).
-		return respondWithProject(detRes, b.String(), nil), nil
+		return respondWithProject(detRes, b.String(), map[string]any{"results": structuredResults}), nil
 	}
 }
 
@@ -1198,6 +1240,10 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 			savedSyncID = obs.SyncID
 			extra["id"] = savedID
 			extra["sync_id"] = savedSyncID
+			extra["state"] = obs.State()
+			if obs.ReviewAfter != nil {
+				extra["review_after"] = *obs.ReviewAfter
+			}
 		}
 
 		if len(candidates) > 0 {
@@ -1302,6 +1348,107 @@ func handleUpdate(s *store.Store) server.ToolHandlerFunc {
 			return mcp.NewToolResultText(msg), nil
 		}
 		return respondWithProject(detRes, msg, nil), nil
+	}
+}
+
+func handleReview(s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		action, _ := req.GetArguments()["action"].(string)
+		switch strings.TrimSpace(action) {
+		case "list":
+			projectFilter, _ := req.GetArguments()["project"].(string)
+			limit := intArg(req, "limit", 10)
+			detRes := projectpkg.DetectionResult{Project: projectFilter, Source: projectpkg.SourceAllProjects}
+			if strings.TrimSpace(projectFilter) != "" {
+				var err error
+				detRes, err = resolveReadProject(s, projectFilter)
+				if err != nil {
+					var upe *unknownProjectError
+					if errors.As(err, &upe) {
+						return errorWithMeta("unknown_project",
+							fmt.Sprintf("Project %q not found in store", upe.Name),
+							upe.AvailableProjects,
+						), nil
+					}
+					return mcp.NewToolResultError(fmt.Sprintf("Project resolution failed: %s", err)), nil
+				}
+				projectFilter = detRes.Project
+			} else if res, err := resolveReadProjectWithProcessOverride(s, "", cfg.DefaultProject); err == nil {
+				detRes = res
+				detRes.Source = projectpkg.SourceAllProjects
+			}
+
+			observations, err := s.ObservationsNeedingReview(projectFilter, limit)
+			if err != nil {
+				return mcp.NewToolResultError("Review list error: " + err.Error()), nil
+			}
+
+			structured := make([]map[string]any, 0, len(observations))
+			if len(observations) == 0 {
+				return respondWithProject(detRes, "No memories need review.", map[string]any{"observations": structured}), nil
+			}
+
+			var b strings.Builder
+			fmt.Fprintf(&b, "Found %d memories needing review:\n\n", len(observations))
+			for i, obs := range observations {
+				projectDisplay := ""
+				if obs.Project != nil {
+					projectDisplay = fmt.Sprintf(" | project: %s", *obs.Project)
+				}
+				reviewDisplay := ""
+				if obs.ReviewAfter != nil {
+					reviewDisplay = fmt.Sprintf(" | review_after: %s", *obs.ReviewAfter)
+				}
+				fmt.Fprintf(&b, "[%d] #%d (%s) — %s\n    state: %s%s%s\n",
+					i+1, obs.ID, obs.Type, obs.Title, obs.State(), projectDisplay, reviewDisplay)
+
+				entry := map[string]any{
+					"id":      obs.ID,
+					"sync_id": obs.SyncID,
+					"title":   obs.Title,
+					"type":    obs.Type,
+					"state":   obs.State(),
+				}
+				if obs.Project != nil {
+					entry["project"] = *obs.Project
+				}
+				if obs.ReviewAfter != nil {
+					entry["review_after"] = *obs.ReviewAfter
+				}
+				structured = append(structured, entry)
+			}
+			return respondWithProject(detRes, b.String(), map[string]any{"observations": structured}), nil
+
+		case "mark_reviewed":
+			id := int64(intArg(req, "observation_id", 0))
+			if id == 0 {
+				id = int64(intArg(req, "id", 0))
+			}
+			if id == 0 {
+				return mcp.NewToolResultError("observation_id is required for mark_reviewed"), nil
+			}
+			if err := s.MarkReviewed(id); err != nil {
+				return mcp.NewToolResultError("Failed to mark reviewed: " + err.Error()), nil
+			}
+			obs, err := s.GetObservation(id)
+			if err != nil {
+				return mcp.NewToolResultError("Marked reviewed but failed to reload observation: " + err.Error()), nil
+			}
+			extra := map[string]any{"id": obs.ID, "sync_id": obs.SyncID, "state": obs.State()}
+			if obs.ReviewAfter != nil {
+				extra["review_after"] = *obs.ReviewAfter
+			}
+			detRes, detErr := resolveReadProjectWithProcessOverride(s, "", cfg.DefaultProject)
+			msg := fmt.Sprintf("Memory marked reviewed: #%d %q (%s)", obs.ID, obs.Title, obs.Type)
+			if detErr != nil {
+				out, _ := jsonMarshal(map[string]any{"result": msg, "id": obs.ID, "sync_id": obs.SyncID, "state": obs.State()})
+				return mcp.NewToolResultText(string(out)), nil
+			}
+			return respondWithProject(detRes, msg, extra), nil
+
+		default:
+			return mcp.NewToolResultError("action must be one of: list, mark_reviewed"), nil
+		}
 	}
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -805,6 +805,15 @@ func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 	if !strings.Contains(callResultText(t, searchRes), "Found 1 memories") {
 		t.Fatalf("expected non-empty search result")
 	}
+	searchBody := callResultJSON(t, searchRes)
+	results, ok := searchBody["results"].([]any)
+	if !ok || len(results) != 1 {
+		t.Fatalf("expected structured search results with lifecycle metadata, got %v", searchBody["results"])
+	}
+	firstResult, _ := results[0].(map[string]any)
+	if firstResult["state"] != store.ObservationStateActive {
+		t.Fatalf("expected search result state active, got %v", firstResult["state"])
+	}
 
 	update := handleUpdate(s)
 	updateReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -845,6 +854,137 @@ func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 	}
 	if !strings.Contains(callResultText(t, delRes), "permanently deleted") {
 		t.Fatalf("expected hard delete message")
+	}
+}
+
+func TestHandleSaveReturnsLifecycleState(t *testing.T) {
+	s := newMCPTestStore(t)
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Lifecycle save",
+		"content": "Save response should expose lifecycle state",
+		"type":    "decision",
+		"project": "engram",
+	}}})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected save error: %s", callResultText(t, res))
+	}
+	body := callResultJSON(t, res)
+	if body["state"] != store.ObservationStateActive {
+		t.Fatalf("expected save response state active, got %v", body["state"])
+	}
+	if _, ok := body["review_after"].(string); !ok {
+		t.Fatalf("expected save response review_after for decision, got %v", body["review_after"])
+	}
+}
+
+func TestHandleReviewListAndMarkReviewed(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-review", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(store.AddObservationParams{SessionID: "s-review", Type: "decision", Title: "Review me", Content: "Needs lifecycle review", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	past := time.Now().UTC().Add(-time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := s.DB().Exec(`UPDATE observations SET review_after = ? WHERE id = ?`, past, id); err != nil {
+		t.Fatalf("backdate review_after: %v", err)
+	}
+
+	h := handleReview(s, MCPConfig{})
+	listRes, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"action":  "list",
+		"project": "engram",
+		"limit":   5.0,
+	}}})
+	if err != nil {
+		t.Fatalf("review list handler error: %v", err)
+	}
+	if listRes.IsError {
+		t.Fatalf("unexpected review list error: %s", callResultText(t, listRes))
+	}
+	listBody := callResultJSON(t, listRes)
+	observations, ok := listBody["observations"].([]any)
+	if !ok || len(observations) != 1 {
+		t.Fatalf("expected one review observation, got %v", listBody["observations"])
+	}
+	entry, _ := observations[0].(map[string]any)
+	if entry["state"] != store.ObservationStateNeedsReview {
+		t.Fatalf("expected needs_review state, got %v", entry["state"])
+	}
+
+	markRes, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"action":         "mark_reviewed",
+		"observation_id": float64(id),
+	}}})
+	if err != nil {
+		t.Fatalf("mark reviewed handler error: %v", err)
+	}
+	if markRes.IsError {
+		t.Fatalf("unexpected mark reviewed error: %s", callResultText(t, markRes))
+	}
+	markBody := callResultJSON(t, markRes)
+	if markBody["state"] != store.ObservationStateActive {
+		t.Fatalf("expected active after mark_reviewed, got %v", markBody["state"])
+	}
+}
+
+func TestHandleReviewMarkReviewedAcceptsIDAlias(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-review-alias", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(store.AddObservationParams{SessionID: "s-review-alias", Type: "decision", Title: "Review alias", Content: "Needs lifecycle review", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	past := time.Now().UTC().Add(-time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := s.DB().Exec(`UPDATE observations SET review_after = ? WHERE id = ?`, past, id); err != nil {
+		t.Fatalf("backdate review_after: %v", err)
+	}
+
+	h := handleReview(s, MCPConfig{})
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"action": "mark_reviewed",
+		"id":     float64(id),
+	}}})
+	if err != nil {
+		t.Fatalf("mark reviewed handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected mark reviewed error: %s", callResultText(t, res))
+	}
+	body := callResultJSON(t, res)
+	if body["state"] != store.ObservationStateActive {
+		t.Fatalf("expected active after id alias mark_reviewed, got %v", body["state"])
+	}
+}
+
+func TestHandleReviewListUnknownProjectReturnsStructuredError(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-review-project", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	h := handleReview(s, MCPConfig{})
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"action":  "list",
+		"project": "engarm",
+	}}})
+	if err != nil {
+		t.Fatalf("review list handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected unknown project error, got success: %s", callResultText(t, res))
+	}
+	body := callResultJSON(t, res)
+	if body["error_code"] != "unknown_project" {
+		t.Fatalf("expected unknown_project error, got %v", body)
 	}
 }
 
@@ -1418,6 +1558,7 @@ func TestResolveToolsAgentProfile(t *testing.T) {
 		"mem_judge",           // REQ-003: conflict verdict tool (Phase D)
 		"mem_compare",         // REQ-011: persist agent-judged semantic verdict (Phase G)
 		"mem_doctor",          // read-only operational diagnostics
+		"mem_review",          // lifecycle review list/maintenance
 	}
 	for _, tool := range expectedTools {
 		if !result[tool] {
@@ -1462,13 +1603,13 @@ func TestResolveToolsCombinedProfiles(t *testing.T) {
 		t.Fatal("expected non-nil allowlist for combined profiles")
 	}
 
-	// Should have all 19 tools (mem_doctor added for operational diagnostics)
+	// Should have all agent and admin tools.
 	allTools := []string{
 		"mem_save", "mem_search", "mem_context", "mem_session_summary",
 		"mem_session_start", "mem_session_end", "mem_get_observation",
 		"mem_suggest_topic_key", "mem_capture_passive", "mem_save_prompt",
 		"mem_update", "mem_delete", "mem_stats", "mem_timeline", "mem_merge_projects",
-		"mem_current_project", "mem_judge", "mem_compare", "mem_doctor",
+		"mem_current_project", "mem_judge", "mem_compare", "mem_doctor", "mem_review",
 	}
 	for _, tool := range allTools {
 		if !result[tool] {
@@ -2054,7 +2195,7 @@ func TestNewServerWithToolsNilRegistersAll(t *testing.T) {
 		"mem_session_start", "mem_session_end", "mem_get_observation",
 		"mem_suggest_topic_key", "mem_capture_passive", "mem_save_prompt",
 		"mem_update", "mem_delete", "mem_stats", "mem_timeline", "mem_merge_projects",
-		"mem_current_project", "mem_judge", "mem_compare", "mem_doctor",
+		"mem_current_project", "mem_judge", "mem_compare", "mem_doctor", "mem_review",
 	}
 
 	for _, name := range allTools {
@@ -2160,13 +2301,13 @@ func TestNewServerBackwardsCompatible(t *testing.T) {
 	tools := srv.ListTools()
 
 	// 15 agent + 4 admin = 19 total (mem_doctor added for diagnostics)
-	if len(tools) != 19 {
-		t.Errorf("NewServer should register all 19 tools, got %d", len(tools))
+	if len(tools) != 20 {
+		t.Errorf("NewServer should register all 20 tools, got %d", len(tools))
 	}
 }
 
 func TestProfileConsistency(t *testing.T) {
-	// Verify that agent + admin = all 19 tools
+	// Verify that agent + admin = all 20 tools
 	combined := make(map[string]bool)
 	for tool := range ProfileAgent {
 		combined[tool] = true
@@ -2176,8 +2317,8 @@ func TestProfileConsistency(t *testing.T) {
 	}
 
 	// 15 agent + 4 admin = 19 total (mem_doctor added for diagnostics)
-	if len(combined) != 19 {
-		t.Errorf("agent + admin should cover all 19 tools, got %d", len(combined))
+	if len(combined) != 20 {
+		t.Errorf("agent + admin should cover all 20 tools, got %d", len(combined))
 	}
 
 	// Verify no overlap between profiles
@@ -2505,9 +2646,9 @@ func TestNewServerWithConfig(t *testing.T) {
 		t.Fatal("expected MCP server instance")
 	}
 	tools := srv.ListTools()
-	// Should have all 19 tools (15 agent + 4 admin; mem_doctor added)
-	if len(tools) != 19 {
-		t.Errorf("NewServerWithConfig should register all 19 tools, got %d", len(tools))
+	// Should have all 20 tools (16 agent + 4 admin).
+	if len(tools) != 20 {
+		t.Errorf("NewServerWithConfig should register all 20 tools, got %d", len(tools))
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -99,9 +99,30 @@ type Observation struct {
 	RevisionCount  int     `json:"revision_count"`
 	DuplicateCount int     `json:"duplicate_count"`
 	LastSeenAt     *string `json:"last_seen_at,omitempty"`
+	ReviewAfter    *string `json:"review_after,omitempty"`
 	CreatedAt      string  `json:"created_at"`
 	UpdatedAt      string  `json:"updated_at"`
 	DeletedAt      *string `json:"deleted_at,omitempty"`
+}
+
+const (
+	ObservationStateActive      = "active"
+	ObservationStateNeedsReview = "needs_review"
+)
+
+// State returns the virtual lifecycle state derived from review_after.
+func (o Observation) State() string {
+	if o.ReviewAfter == nil || strings.TrimSpace(*o.ReviewAfter) == "" {
+		return ObservationStateActive
+	}
+	reviewAfter, err := parseObservationTime(*o.ReviewAfter)
+	if err != nil {
+		return ObservationStateActive
+	}
+	if !reviewAfter.After(time.Now().UTC()) {
+		return ObservationStateNeedsReview
+	}
+	return ObservationStateActive
 }
 
 type SearchResult struct {
@@ -229,6 +250,9 @@ var decayReviewAfterMonths = map[string]int{
 	"policy":     decayPolicyMonths,
 	"preference": decayPreferenceMonths,
 }
+
+const observationSelectColumns = `id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
+	       scope, topic_key, revision_count, duplicate_count, last_seen_at, review_after, created_at, updated_at, deleted_at`
 
 type SyncState struct {
 	TargetKey           string  `json:"target_key"`
@@ -2182,7 +2206,7 @@ func (s *Store) AllObservations(project, scope string, limit int) ([]Observation
 
 	query := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at
+		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at
 		FROM observations o
 		WHERE o.deleted_at IS NULL
 	`
@@ -2210,8 +2234,7 @@ func (s *Store) SessionObservations(sessionID string, limit int) ([]Observation,
 	}
 
 	query := `
-		SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		SELECT ` + observationSelectColumns + `
 		FROM observations
 		WHERE session_id = ? AND deleted_at IS NULL
 		ORDER BY created_at ASC
@@ -2374,7 +2397,7 @@ func (s *Store) RecentObservations(project, scope string, limit int) ([]Observat
 
 	query := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at
+		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at
 		FROM observations o
 		WHERE o.deleted_at IS NULL
 	`
@@ -2393,6 +2416,56 @@ func (s *Store) RecentObservations(project, scope string, limit int) ([]Observat
 	args = append(args, limit)
 
 	return s.queryObservations(query, args...)
+}
+
+// ObservationsNeedingReview returns non-deleted observations whose review_after has passed.
+// An empty project searches all projects, matching existing browse/search conventions.
+func (s *Store) ObservationsNeedingReview(project string, limit int) ([]Observation, error) {
+	project, _ = NormalizeProject(project)
+	if limit <= 0 {
+		limit = s.cfg.MaxContextResults
+	}
+	query := `
+		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
+		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at
+		FROM observations o
+		WHERE o.deleted_at IS NULL
+		  AND o.review_after IS NOT NULL
+		  AND datetime(o.review_after) <= datetime('now')
+	`
+	args := []any{}
+	if project != "" {
+		query += " AND LOWER(o.project) = ?"
+		args = append(args, project)
+	}
+	query += " ORDER BY datetime(o.review_after) ASC, o.id ASC LIMIT ?"
+	args = append(args, limit)
+
+	return s.queryObservations(query, args...)
+}
+
+// MarkReviewed resets an observation's review_after using its type's configured decay offset.
+// Types without a decay offset return to a NULL review_after value.
+// This lifecycle reset is intentionally local-only until the sync wire format includes review_after.
+func (s *Store) MarkReviewed(id int64) error {
+	return s.withTx(func(tx *sql.Tx) error {
+		obs, err := s.getObservationTx(tx, id)
+		if err == sql.ErrNoRows {
+			return ErrObservationNotFound
+		}
+		if err != nil {
+			return err
+		}
+
+		var reviewAfter any
+		if months, ok := decayReviewAfterMonths[obs.Type]; ok {
+			reviewAfter = time.Now().UTC().AddDate(0, months, 0).Format("2006-01-02 15:04:05")
+		}
+		if _, err := s.execHook(tx, `UPDATE observations SET review_after = ?, updated_at = datetime('now') WHERE id = ? AND deleted_at IS NULL`, reviewAfter, id); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // ─── User Prompts ────────────────────────────────────────────────────────────
@@ -2702,16 +2775,11 @@ func (s *Store) DeletePrompt(id int64) error {
 
 func (s *Store) GetObservation(id int64) (*Observation, error) {
 	row := s.db.QueryRow(
-		`SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		`SELECT `+observationSelectColumns+`
 		 FROM observations WHERE id = ? AND deleted_at IS NULL`, id,
 	)
 	var o Observation
-	if err := row.Scan(
-		&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
-		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
-		&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
-	); err != nil {
+	if err := scanObservationRow(row, &o); err != nil {
 		return nil, err
 	}
 	return &o, nil
@@ -2970,8 +3038,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 	var directResults []SearchResult
 	if strings.Contains(query, "/") {
 		tkSQL := `
-			SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-			       scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+			SELECT ` + observationSelectColumns + `
 			FROM observations
 			WHERE topic_key = ? AND deleted_at IS NULL
 		`
@@ -3001,7 +3068,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 				if err := tkRows.Scan(
 					&sr.ID, &sr.SyncID, &sr.SessionID, &sr.Type, &sr.Title, &sr.Content,
 					&sr.ToolName, &sr.Project, &sr.Scope, &sr.TopicKey, &sr.RevisionCount, &sr.DuplicateCount,
-					&sr.LastSeenAt, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
+					&sr.LastSeenAt, &sr.ReviewAfter, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
 				); err != nil {
 					break
 				}
@@ -3016,7 +3083,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 
 	sqlQ := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at, o.deleted_at,
+		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at,
 		       fts.rank
 		FROM observations_fts fts
 		JOIN observations o ON o.id = fts.rowid
@@ -3060,7 +3127,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		if err := rows.Scan(
 			&sr.ID, &sr.SyncID, &sr.SessionID, &sr.Type, &sr.Title, &sr.Content,
 			&sr.ToolName, &sr.Project, &sr.Scope, &sr.TopicKey, &sr.RevisionCount, &sr.DuplicateCount,
-			&sr.LastSeenAt, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
+			&sr.LastSeenAt, &sr.ReviewAfter, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
 			&sr.Rank,
 		); err != nil {
 			return nil, err
@@ -3258,8 +3325,7 @@ func (s *Store) exportWithProjectScope(project string) (*ExportData, error) {
 	}
 
 	// Observations
-	obsQuery := `SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-	        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+	obsQuery := `SELECT ` + observationSelectColumns + `
 	 FROM observations`
 	obsArgs := []any{}
 	if project != "" {
@@ -3278,7 +3344,7 @@ func (s *Store) exportWithProjectScope(project string) (*ExportData, error) {
 		var o Observation
 		if err := obsRows.Scan(
 			&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
-			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
+			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.ReviewAfter,
 			&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
 		); err != nil {
 			return nil, err
@@ -3344,8 +3410,8 @@ func (s *Store) Import(data *ExportData) (*ImportResult, error) {
 	// Import observations (use new IDs — AUTOINCREMENT)
 	for _, obs := range data.Observations {
 		_, err := s.execHook(tx,
-			`INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			`INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, revision_count, duplicate_count, last_seen_at, review_after, created_at, updated_at, deleted_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			normalizeExistingSyncID(obs.SyncID, "obs"),
 			obs.SessionID,
 			obs.Type,
@@ -3359,6 +3425,7 @@ func (s *Store) Import(data *ExportData) (*ImportResult, error) {
 			maxInt(obs.RevisionCount, 1),
 			maxInt(obs.DuplicateCount, 1),
 			obs.LastSeenAt,
+			obs.ReviewAfter,
 			obs.CreatedAt,
 			obs.UpdatedAt,
 			obs.DeletedAt,
@@ -4087,13 +4154,12 @@ func (s *Store) ApplyPulledChunk(targetKey, chunkID string, mutations []SyncMuta
 
 func (s *Store) GetObservationBySyncID(syncID string) (*Observation, error) {
 	row := s.db.QueryRow(
-		`SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		`SELECT `+observationSelectColumns+`
 		 FROM observations WHERE sync_id = ? AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`,
 		syncID,
 	)
 	var o Observation
-	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
+	if err := scanObservationRow(row, &o); err != nil {
 		return nil, err
 	}
 	return &o, nil
@@ -4588,11 +4654,11 @@ func (s *Store) PruneProject(project string) (*PruneResult, error) {
 
 // DeleteProjectResult summarises a cascade project deletion.
 type DeleteProjectResult struct {
-	Project              string `json:"project"`
-	ObservationsDeleted  int64  `json:"observations_deleted"`
-	PromptsDeleted       int64  `json:"prompts_deleted"`
-	SessionsDeleted      int64  `json:"sessions_deleted"`
-	HardDelete           bool   `json:"hard_delete"`
+	Project             string `json:"project"`
+	ObservationsDeleted int64  `json:"observations_deleted"`
+	PromptsDeleted      int64  `json:"prompts_deleted"`
+	SessionsDeleted     int64  `json:"sessions_deleted"`
+	HardDelete          bool   `json:"hard_delete"`
 }
 
 // DeleteProject removes all data associated with a project in a single
@@ -5427,20 +5493,18 @@ func decodeSyncPayload(payload []byte, dest any) error {
 
 func (s *Store) getObservationTx(tx *sql.Tx, id int64) (*Observation, error) {
 	row := tx.QueryRow(
-		`SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+		`SELECT `+observationSelectColumns+`
 		 FROM observations WHERE id = ? AND deleted_at IS NULL`, id,
 	)
 	var o Observation
-	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
+	if err := scanObservationRow(row, &o); err != nil {
 		return nil, err
 	}
 	return &o, nil
 }
 
 func (s *Store) getObservationBySyncIDTx(tx *sql.Tx, syncID string, includeDeleted bool) (*Observation, error) {
-	query := `SELECT id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-		        scope, topic_key, revision_count, duplicate_count, last_seen_at, created_at, updated_at, deleted_at
+	query := `SELECT ` + observationSelectColumns + `
 		 FROM observations WHERE sync_id = ?`
 	if !includeDeleted {
 		query += ` AND deleted_at IS NULL`
@@ -5448,7 +5512,7 @@ func (s *Store) getObservationBySyncIDTx(tx *sql.Tx, syncID string, includeDelet
 	query += ` ORDER BY id DESC LIMIT 1`
 	row := tx.QueryRow(query, syncID)
 	var o Observation
-	if err := row.Scan(&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content, &o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt); err != nil {
+	if err := scanObservationRow(row, &o); err != nil {
 		return nil, err
 	}
 	return &o, nil
@@ -5701,6 +5765,32 @@ func normalizeComparableTimestamp(value string) string {
 	return trimmed
 }
 
+func parseObservationTime(value string) (time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}, fmt.Errorf("empty timestamp")
+	}
+	formats := []string{"2006-01-02 15:04:05", time.RFC3339, time.RFC3339Nano, "2006-01-02"}
+	for _, layout := range formats {
+		if parsed, err := time.Parse(layout, trimmed); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported timestamp %q", value)
+}
+
+type observationScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanObservationRow(scanner observationScanner, o *Observation) error {
+	return scanner.Scan(
+		&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
+		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.ReviewAfter,
+		&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
+	)
+}
+
 func (s *Store) queryObservations(query string, args ...any) ([]Observation, error) {
 	rows, err := s.queryItHook(s.db, query, args...)
 	if err != nil {
@@ -5711,11 +5801,7 @@ func (s *Store) queryObservations(query string, args ...any) ([]Observation, err
 	var results []Observation
 	for rows.Next() {
 		var o Observation
-		if err := rows.Scan(
-			&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
-			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt,
-			&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
-		); err != nil {
+		if err := scanObservationRow(rows, &o); err != nil {
 			return nil, err
 		}
 		results = append(results, o)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7714,6 +7714,175 @@ func TestAddObservation_DecayNotAppliedToExistingRows(t *testing.T) {
 	}
 }
 
+func TestObservationState(t *testing.T) {
+	future := time.Now().UTC().Add(time.Hour).Format("2006-01-02 15:04:05")
+	past := time.Now().UTC().Add(-time.Hour).Format("2006-01-02 15:04:05")
+
+	if got := (Observation{}).State(); got != ObservationStateActive {
+		t.Fatalf("nil review_after state = %q, want active", got)
+	}
+	if got := (Observation{ReviewAfter: &future}).State(); got != ObservationStateActive {
+		t.Fatalf("future review_after state = %q, want active", got)
+	}
+	if got := (Observation{ReviewAfter: &past}).State(); got != ObservationStateNeedsReview {
+		t.Fatalf("past review_after state = %q, want needs_review", got)
+	}
+}
+
+func TestObservationsNeedingReview(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("review-sess", "review-proj", "/tmp/review"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	staleID, err := s.AddObservation(AddObservationParams{SessionID: "review-sess", Type: "decision", Title: "stale", Content: "stale content", Project: "review-proj"})
+	if err != nil {
+		t.Fatalf("add stale: %v", err)
+	}
+	futureID, err := s.AddObservation(AddObservationParams{SessionID: "review-sess", Type: "decision", Title: "future", Content: "future content", Project: "review-proj"})
+	if err != nil {
+		t.Fatalf("add future: %v", err)
+	}
+	otherID, err := s.AddObservation(AddObservationParams{SessionID: "review-sess", Type: "decision", Title: "other", Content: "other content", Project: "other-proj"})
+	if err != nil {
+		t.Fatalf("add other: %v", err)
+	}
+
+	past := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02 15:04:05")
+	future := time.Now().UTC().Add(24 * time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := s.db.Exec(`UPDATE observations SET review_after = ? WHERE id IN (?, ?)`, past, staleID, otherID); err != nil {
+		t.Fatalf("backdate review_after: %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE observations SET review_after = ? WHERE id = ?`, future, futureID); err != nil {
+		t.Fatalf("future review_after: %v", err)
+	}
+
+	got, err := s.ObservationsNeedingReview("review-proj", 10)
+	if err != nil {
+		t.Fatalf("ObservationsNeedingReview(project): %v", err)
+	}
+	if len(got) != 1 || got[0].ID != staleID || got[0].State() != ObservationStateNeedsReview {
+		t.Fatalf("project review list = %#v, want only staleID", got)
+	}
+
+	all, err := s.ObservationsNeedingReview("", 10)
+	if err != nil {
+		t.Fatalf("ObservationsNeedingReview(all): %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("all review list len = %d, want 2: %#v", len(all), all)
+	}
+}
+
+func TestObservationsNeedingReviewExcludesDeletedObservations(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("review-deleted-sess", "review-deleted-proj", "/tmp/review"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	activeID, err := s.AddObservation(AddObservationParams{SessionID: "review-deleted-sess", Type: "decision", Title: "active", Content: "active content", Project: "review-deleted-proj"})
+	if err != nil {
+		t.Fatalf("add active: %v", err)
+	}
+	deletedID, err := s.AddObservation(AddObservationParams{SessionID: "review-deleted-sess", Type: "decision", Title: "deleted", Content: "deleted content", Project: "review-deleted-proj"})
+	if err != nil {
+		t.Fatalf("add deleted: %v", err)
+	}
+	past := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := s.db.Exec(`UPDATE observations SET review_after = ? WHERE id IN (?, ?)`, past, activeID, deletedID); err != nil {
+		t.Fatalf("backdate review_after: %v", err)
+	}
+	if err := s.DeleteObservation(deletedID, false); err != nil {
+		t.Fatalf("delete observation: %v", err)
+	}
+
+	got, err := s.ObservationsNeedingReview("review-deleted-proj", 10)
+	if err != nil {
+		t.Fatalf("ObservationsNeedingReview(project): %v", err)
+	}
+	if len(got) != 1 || got[0].ID != activeID {
+		t.Fatalf("review list = %#v, want only activeID", got)
+	}
+}
+
+func TestMarkReviewedResetsReviewAfter(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("mark-reviewed-sess", "mark-reviewed-proj", "/tmp/review"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	decisionID, err := s.AddObservation(AddObservationParams{SessionID: "mark-reviewed-sess", Type: "decision", Title: "decision", Content: "decision content", Project: "mark-reviewed-proj"})
+	if err != nil {
+		t.Fatalf("add decision: %v", err)
+	}
+	manualID, err := s.AddObservation(AddObservationParams{SessionID: "mark-reviewed-sess", Type: "manual", Title: "manual", Content: "manual content", Project: "mark-reviewed-proj"})
+	if err != nil {
+		t.Fatalf("add manual: %v", err)
+	}
+	past := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := s.db.Exec(`UPDATE observations SET review_after = ? WHERE id IN (?, ?)`, past, decisionID, manualID); err != nil {
+		t.Fatalf("backdate review_after: %v", err)
+	}
+
+	start := time.Now().UTC()
+	if err := s.MarkReviewed(decisionID); err != nil {
+		t.Fatalf("MarkReviewed decision: %v", err)
+	}
+	reviewAfter, reviewNull, _, _ := queryDecayFields(t, s, decisionID)
+	if reviewNull {
+		t.Fatal("decision review_after should be reset, got NULL")
+	}
+	withinDays(t, "mark reviewed decision", reviewAfter, start.AddDate(0, decayDecisionMonths, 0), 2)
+	obs, err := s.GetObservation(decisionID)
+	if err != nil {
+		t.Fatalf("GetObservation decision: %v", err)
+	}
+	if obs.State() != ObservationStateActive {
+		t.Fatalf("reviewed decision state = %q, want active", obs.State())
+	}
+
+	if err := s.MarkReviewed(manualID); err != nil {
+		t.Fatalf("MarkReviewed manual: %v", err)
+	}
+	_, manualReviewNull, _, _ := queryDecayFields(t, s, manualID)
+	if !manualReviewNull {
+		t.Fatal("manual review_after should be NULL after mark reviewed")
+	}
+}
+
+func TestMarkReviewedDoesNotEnqueueSyncMutation(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("mark-reviewed-sync-proj"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+	if err := s.CreateSession("mark-reviewed-sync-sess", "mark-reviewed-sync-proj", "/tmp/review-sync"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	obsID, err := s.AddObservation(AddObservationParams{SessionID: "mark-reviewed-sync-sess", Type: "decision", Title: "decision", Content: "decision content", Project: "mark-reviewed-sync-proj"})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	past := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := s.db.Exec(`UPDATE observations SET review_after = ? WHERE id = ?`, past, obsID); err != nil {
+		t.Fatalf("backdate review_after: %v", err)
+	}
+
+	before, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
+	if err != nil {
+		t.Fatalf("ListPendingSyncMutations before: %v", err)
+	}
+	if err := s.MarkReviewed(obsID); err != nil {
+		t.Fatalf("MarkReviewed: %v", err)
+	}
+	after, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
+	if err != nil {
+		t.Fatalf("ListPendingSyncMutations after: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("MarkReviewed enqueued sync mutation: before=%d after=%d", len(before), len(after))
+	}
+}
+
 // ─── C.2 [RED] — ListDeferred / GetDeferred ──────────────────────────────────
 
 // seedDeferredRow is a test helper that inserts a row into sync_apply_deferred.

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -121,6 +121,11 @@ var (
 			Foreground(colorPeach).
 			Bold(true)
 
+	// Observation lifecycle warning badge
+	stateWarningBadgeStyle = lipgloss.NewStyle().
+				Foreground(colorYellow).
+				Bold(true)
+
 	// Observation ID
 	idStyle = lipgloss.NewStyle().
 		Foreground(colorBlue)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Gentleman-Programming/engram/internal/timeutil"
 	"github.com/Gentleman-Programming/engram/internal/version"
@@ -222,7 +223,7 @@ func (m Model) viewSearchResults() string {
 
 	for i := m.Scroll; i < end; i++ {
 		r := m.SearchResults[i]
-		b.WriteString(m.renderObservationListItem(i, r.ID, r.Type, r.Title, r.Content, r.CreatedAt, r.Project))
+		b.WriteString(m.renderObservationListItem(i, r.ID, r.Type, r.Title, r.Content, r.CreatedAt, r.Project, r.State(), r.ReviewAfter))
 	}
 
 	// Scroll indicator
@@ -265,7 +266,7 @@ func (m Model) viewRecent() string {
 
 	for i := m.Scroll; i < end; i++ {
 		o := m.RecentObservations[i]
-		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project))
+		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, o.State(), o.ReviewAfter))
 	}
 
 	if count > visibleItems {
@@ -312,6 +313,16 @@ func (m Model) viewObservationDetail() string {
 	b.WriteString(fmt.Sprintf("%s %s\n",
 		detailLabelStyle.Render("Created:"),
 		timestampStyle.Render(localTime(obs.CreatedAt))))
+
+	b.WriteString(fmt.Sprintf("%s %s\n",
+		detailLabelStyle.Render("State:"),
+		renderObservationState(obs.State())))
+
+	if obs.ReviewAfter != nil {
+		b.WriteString(fmt.Sprintf("%s %s\n",
+			detailLabelStyle.Render("Review:"),
+			timestampStyle.Render(formatReviewDate(*obs.ReviewAfter))))
+	}
 
 	if obs.ToolName != nil {
 		b.WriteString(fmt.Sprintf("%s %s\n",
@@ -550,7 +561,7 @@ func (m Model) viewSessionDetail() string {
 
 	for i := m.SessionDetailScroll; i < end; i++ {
 		o := m.SessionObservations[i]
-		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project))
+		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, o.State(), o.ReviewAfter))
 	}
 
 	if count > visibleItems {
@@ -684,7 +695,7 @@ func (m Model) viewSetup() string {
 
 // ─── Shared Renderers ────────────────────────────────────────────────────────
 
-func (m Model) renderObservationListItem(index int, id int64, obsType, title, content, createdAt string, project *string) string {
+func (m Model) renderObservationListItem(index int, id int64, obsType, title, content, createdAt string, project *string, state string, reviewAfter *string) string {
 	cursor := "  "
 	style := listItemStyle
 	if index == m.Cursor {
@@ -697,10 +708,16 @@ func (m Model) renderObservationListItem(index int, id int64, obsType, title, co
 		proj = "  " + projectStyle.Render(*project)
 	}
 
-	line := fmt.Sprintf("%s%s %s %s%s  %s\n",
+	stateBadge := ""
+	if state == "needs_review" {
+		stateBadge = " " + stateWarningBadgeStyle.Render("[needs_review]")
+	}
+
+	line := fmt.Sprintf("%s%s %s%s %s%s  %s\n",
 		cursor,
 		idStyle.Render(fmt.Sprintf("#%-5d", id)),
 		typeBadgeStyle.Render(fmt.Sprintf("[%-12s]", obsType)),
+		stateBadge,
 		style.Render(truncateStr(title, 50)),
 		proj,
 		timestampStyle.Render(localTime(createdAt)))
@@ -719,6 +736,27 @@ func (m Model) renderObservationListItem(index int, id int64, obsType, title, co
 // localTime converts a UTC timestamp string from SQLite to local time for display.
 func localTime(utc string) string {
 	return timeutil.FormatLocal(utc)
+}
+
+func renderObservationState(state string) string {
+	if state == "needs_review" {
+		return stateWarningBadgeStyle.Render(state)
+	}
+	return detailValueStyle.Render(state)
+}
+
+func formatReviewDate(value string) string {
+	trimmed := strings.TrimSpace(value)
+	formats := []string{"2006-01-02 15:04:05", time.RFC3339, time.RFC3339Nano, "2006-01-02"}
+	for _, layout := range formats {
+		if parsed, err := time.Parse(layout, trimmed); err == nil {
+			return parsed.Format("2006-01-02")
+		}
+	}
+	if len(trimmed) >= len("2006-01-02") {
+		return trimmed[:len("2006-01-02")]
+	}
+	return trimmed
 }
 
 func truncateStr(s string, max int) string {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -47,6 +47,8 @@ func TestRenderObservationListItem(t *testing.T) {
 		"content line 1\ncontent line 2",
 		"2026-01-01",
 		&project,
+		"active",
+		nil,
 	)
 
 	if !strings.Contains(line, "▸") {
@@ -60,6 +62,12 @@ func TestRenderObservationListItem(t *testing.T) {
 	}
 	if !strings.Contains(line, "engram") {
 		t.Fatal("project label should be rendered when project is set")
+	}
+
+	reviewAfter := "2026-01-01 00:00:00"
+	staleLine := m.renderObservationListItem(0, 43, "decision", "Needs review", "content", "2026-01-01", &project, "needs_review", &reviewAfter)
+	if !strings.Contains(staleLine, "needs_review") {
+		t.Fatal("stale item should include needs_review badge")
 	}
 }
 
@@ -229,10 +237,15 @@ func TestViewObservationDetailTimelineSessionsAndSessionDetail(t *testing.T) {
 		Project:   &project,
 		Content:   strings.Repeat("line\n", 20),
 	}
+	reviewAfter := "2027-02-03 04:05:06"
+	m.SelectedObservation.ReviewAfter = &reviewAfter
 	m.DetailScroll = 99
 	out = m.viewObservationDetail()
 	if !strings.Contains(out, "Observation #42") || !strings.Contains(out, "Content") {
 		t.Fatal("detail view should render metadata and content section")
+	}
+	if !strings.Contains(out, "State:") || !strings.Contains(out, "active") || !strings.Contains(out, "Review:") || !strings.Contains(out, "2027-02-03") {
+		t.Fatal("detail view should render lifecycle state and review date")
 	}
 	if !strings.Contains(out, "line") {
 		t.Fatal("detail view should render content lines")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #437

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Surface virtual observation lifecycle state from `review_after` across store, MCP, and TUI.
- Add `mem_review` list/mark-reviewed workflow with local-only review resets.
- Document lifecycle metadata and the new MCP tool contract.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Adds `ReviewAfter`, virtual state, review query, and local-only mark-reviewed behavior. |
| `internal/mcp/mcp.go` | Adds `mem_review` and lifecycle metadata in save/search responses. |
| `internal/tui/view.go` / `internal/tui/styles.go` | Shows `needs_review` badges plus state/review details. |
| `internal/*/*_test.go` | Covers store, MCP, and TUI lifecycle behavior. |
| `DOCS.md`, `README.md`, `docs/*` | Documents `mem_review`, lifecycle metadata, and local-only reset behavior. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Manual/review validation:
- [x] `git diff --check`
- [x] Judgment Day dual review completed; confirmed issue fixed and re-judged approved.
- [x] `go test -cover ./...` investigated: existing `cmd/engram` coverage-mode package failure reproduces on clean `HEAD`, unrelated to this PR.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

`mark_reviewed` is intentionally local-only in this phase because `review_after` is not part of the sync wire format. A future sync-schema change can make lifecycle review state cross-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new `mem_review` tool for managing observation review lifecycles, enabling listing and marking of stale observations as reviewed.
  * Extended search results with lifecycle metadata, displaying observation state and review dates.
  * Observation state indicators now show whether items are active or need review.

* **Documentation**
  * Updated documentation to reflect expanded toolset (20 MCP tools) and new lifecycle management capabilities.

* **Tests**
  * Added comprehensive test coverage for observation review workflows and lifecycle state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->