### PR TITLE
fix(memory): pin critical observations in context

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -112,6 +112,8 @@ var ProfileAgent = map[string]bool{
 	"mem_compare":           true, // persist an agent-judged semantic verdict via JudgeBySemantic (REQ-011, Phase G)
 	"mem_doctor":            true, // read-only operational diagnostics for agents
 	"mem_review":            true, // list/mark observations whose review_after lifecycle is stale
+	"mem_pin":               true, // local pin for context priority
+	"mem_unpin":             true, // local unpin for context priority
 }
 
 // ProfileAdmin contains tools for TUI, dashboards, and manual curation
@@ -183,7 +185,7 @@ CORE TOOLS (always available — use without ToolSearch):
   mem_current_project — detect current project from cwd (recommended first call)
 
 DEFERRED TOOLS (use ToolSearch when needed):
-  mem_update, mem_review, mem_suggest_topic_key, mem_session_start, mem_session_end,
+  mem_update, mem_review, mem_pin, mem_unpin, mem_suggest_topic_key, mem_session_start, mem_session_end,
   mem_stats, mem_delete, mem_timeline, mem_capture_passive, mem_merge_projects
 
 PROACTIVE SAVE RULE: Call mem_save immediately after ANY decision, bug fix, discovery, or convention — not just when asked.
@@ -495,6 +497,38 @@ Examples:
 				),
 			),
 			queuedWriteHandler(writeQueue, handleSavePrompt(s, cfg, activity)),
+		)
+	}
+
+	// ─── mem_pin / mem_unpin (profile: agent, deferred) ──────────────────
+	if shouldRegister("mem_pin", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_pin",
+				mcp.WithDescription("Pin a local observation so it appears before recent observations in memory context. Pinned state is local to this device and is not synced."),
+				mcp.WithDeferLoading(true),
+				mcp.WithTitleAnnotation("Pin Memory"),
+				mcp.WithReadOnlyHintAnnotation(false),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithNumber("id", mcp.Required(), mcp.Description("Observation ID to pin")),
+			),
+			handlePin(s, true),
+		)
+	}
+	if shouldRegister("mem_unpin", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_unpin",
+				mcp.WithDescription("Unpin a local observation so it only appears in normal recency order. Pinned state is local to this device and is not synced."),
+				mcp.WithDeferLoading(true),
+				mcp.WithTitleAnnotation("Unpin Memory"),
+				mcp.WithReadOnlyHintAnnotation(false),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithNumber("id", mcp.Required(), mcp.Description("Observation ID to unpin")),
+			),
+			handlePin(s, false),
 		)
 	}
 
@@ -1025,6 +1059,7 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 				"type":    r.Type,
 				"state":   r.State(),
 				"scope":   r.Scope,
+				"pinned":  r.Pinned,
 			}
 			if r.Project != nil {
 				entry["project"] = *r.Project
@@ -1091,6 +1126,41 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 
 		// JW4: use respondWithProject for the success path (REQ-314).
 		return respondWithProject(detRes, b.String(), map[string]any{"results": structuredResults}), nil
+	}
+}
+
+func handlePin(s *store.Store, pinned bool) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id := int64(intArg(req, "id", 0))
+		if id == 0 {
+			return mcp.NewToolResultError("id is required"), nil
+		}
+
+		var err error
+		if pinned {
+			err = s.PinObservation(id)
+		} else {
+			err = s.UnpinObservation(id)
+		}
+		if err != nil {
+			return mcp.NewToolResultError("Failed to update pin state: " + err.Error()), nil
+		}
+
+		obs, err := s.GetObservation(id)
+		if err != nil {
+			return mcp.NewToolResultError("Updated pin state but failed to reload observation: " + err.Error()), nil
+		}
+		state := "unpinned"
+		if pinned {
+			state = "pinned"
+		}
+		out, _ := jsonMarshal(map[string]any{
+			"result":  fmt.Sprintf("Memory #%d %s", id, state),
+			"id":      obs.ID,
+			"sync_id": obs.SyncID,
+			"pinned":  obs.Pinned,
+		})
+		return mcp.NewToolResultText(string(out)), nil
 	}
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -131,6 +131,61 @@ func TestHandleSuggestTopicKeyRequiresInput(t *testing.T) {
 	}
 }
 
+func TestHandlePinAndUnpinObservation(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s1",
+		Type:      "decision",
+		Title:     "Architecture choice",
+		Content:   "Keep critical context visible.",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"id": float64(id)}}}
+	res, err := handlePin(s, true)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("pin handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected pin tool error: %s", callResultText(t, res))
+	}
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("get pinned observation: %v", err)
+	}
+	if !obs.Pinned {
+		t.Fatalf("expected observation to be pinned")
+	}
+	if !strings.Contains(callResultText(t, res), `"pinned":true`) {
+		t.Fatalf("pin result should expose pinned=true, got %q", callResultText(t, res))
+	}
+
+	res, err = handlePin(s, false)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unpin handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected unpin tool error: %s", callResultText(t, res))
+	}
+	obs, err = s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("get unpinned observation: %v", err)
+	}
+	if obs.Pinned {
+		t.Fatalf("expected observation to be unpinned")
+	}
+	if !strings.Contains(callResultText(t, res), `"pinned":false`) {
+		t.Fatalf("unpin result should expose pinned=false, got %q", callResultText(t, res))
+	}
+}
+
 func TestHandleSaveSuggestsTopicKeyWhenMissing(t *testing.T) {
 	s := newMCPTestStore(t)
 	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
@@ -787,6 +842,9 @@ func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("add observation: %v", err)
 	}
+	if err := s.PinObservation(obsID); err != nil {
+		t.Fatalf("pin observation: %v", err)
+	}
 
 	search := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	searchReq := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -813,6 +871,9 @@ func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 	firstResult, _ := results[0].(map[string]any)
 	if firstResult["state"] != store.ObservationStateActive {
 		t.Fatalf("expected search result state active, got %v", firstResult["state"])
+	}
+	if firstResult["pinned"] != true {
+		t.Fatalf("expected search result pinned=true, got %v", firstResult["pinned"])
 	}
 
 	update := handleUpdate(s)
@@ -1559,6 +1620,8 @@ func TestResolveToolsAgentProfile(t *testing.T) {
 		"mem_compare",         // REQ-011: persist agent-judged semantic verdict (Phase G)
 		"mem_doctor",          // read-only operational diagnostics
 		"mem_review",          // lifecycle review list/maintenance
+		"mem_pin",             // local context priority
+		"mem_unpin",           // local context priority
 	}
 	for _, tool := range expectedTools {
 		if !result[tool] {
@@ -1609,7 +1672,7 @@ func TestResolveToolsCombinedProfiles(t *testing.T) {
 		"mem_session_start", "mem_session_end", "mem_get_observation",
 		"mem_suggest_topic_key", "mem_capture_passive", "mem_save_prompt",
 		"mem_update", "mem_delete", "mem_stats", "mem_timeline", "mem_merge_projects",
-		"mem_current_project", "mem_judge", "mem_compare", "mem_doctor", "mem_review",
+		"mem_current_project", "mem_judge", "mem_compare", "mem_doctor", "mem_review", "mem_pin", "mem_unpin",
 	}
 	for _, tool := range allTools {
 		if !result[tool] {
@@ -2196,6 +2259,7 @@ func TestNewServerWithToolsNilRegistersAll(t *testing.T) {
 		"mem_suggest_topic_key", "mem_capture_passive", "mem_save_prompt",
 		"mem_update", "mem_delete", "mem_stats", "mem_timeline", "mem_merge_projects",
 		"mem_current_project", "mem_judge", "mem_compare", "mem_doctor", "mem_review",
+		"mem_pin", "mem_unpin",
 	}
 
 	for _, name := range allTools {
@@ -2300,14 +2364,14 @@ func TestNewServerBackwardsCompatible(t *testing.T) {
 	srv := NewServer(s)
 	tools := srv.ListTools()
 
-	// 15 agent + 4 admin = 19 total (mem_doctor added for diagnostics)
-	if len(tools) != 20 {
-		t.Errorf("NewServer should register all 20 tools, got %d", len(tools))
+	// 18 agent + 4 admin = 22 total.
+	if len(tools) != 22 {
+		t.Errorf("NewServer should register all 22 tools, got %d", len(tools))
 	}
 }
 
 func TestProfileConsistency(t *testing.T) {
-	// Verify that agent + admin = all 20 tools
+	// Verify that agent + admin = all 22 tools
 	combined := make(map[string]bool)
 	for tool := range ProfileAgent {
 		combined[tool] = true
@@ -2316,9 +2380,9 @@ func TestProfileConsistency(t *testing.T) {
 		combined[tool] = true
 	}
 
-	// 15 agent + 4 admin = 19 total (mem_doctor added for diagnostics)
-	if len(combined) != 20 {
-		t.Errorf("agent + admin should cover all 20 tools, got %d", len(combined))
+	// 18 agent + 4 admin = 22 total.
+	if len(combined) != 22 {
+		t.Errorf("agent + admin should cover all 22 tools, got %d", len(combined))
 	}
 
 	// Verify no overlap between profiles
@@ -2646,9 +2710,9 @@ func TestNewServerWithConfig(t *testing.T) {
 		t.Fatal("expected MCP server instance")
 	}
 	tools := srv.ListTools()
-	// Should have all 20 tools (16 agent + 4 admin).
-	if len(tools) != 20 {
-		t.Errorf("NewServerWithConfig should register all 20 tools, got %d", len(tools))
+	// Should have all 22 tools (18 agent + 4 admin).
+	if len(tools) != 22 {
+		t.Errorf("NewServerWithConfig should register all 22 tools, got %d", len(tools))
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -100,6 +100,7 @@ type Observation struct {
 	DuplicateCount int     `json:"duplicate_count"`
 	LastSeenAt     *string `json:"last_seen_at,omitempty"`
 	ReviewAfter    *string `json:"review_after,omitempty"`
+	Pinned         bool    `json:"-"`
 	CreatedAt      string  `json:"created_at"`
 	UpdatedAt      string  `json:"updated_at"`
 	DeletedAt      *string `json:"deleted_at,omitempty"`
@@ -252,7 +253,7 @@ var decayReviewAfterMonths = map[string]int{
 }
 
 const observationSelectColumns = `id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-	       scope, topic_key, revision_count, duplicate_count, last_seen_at, review_after, created_at, updated_at, deleted_at`
+	       scope, topic_key, revision_count, duplicate_count, last_seen_at, review_after, pinned, created_at, updated_at, deleted_at`
 
 type SyncState struct {
 	TargetKey           string  `json:"target_key"`
@@ -714,6 +715,7 @@ func (s *Store) migrate() error {
 			revision_count INTEGER NOT NULL DEFAULT 1,
 			duplicate_count INTEGER NOT NULL DEFAULT 1,
 			last_seen_at TEXT,
+			pinned     BOOLEAN NOT NULL DEFAULT 0,
 			created_at TEXT    NOT NULL DEFAULT (datetime('now')),
 			updated_at TEXT    NOT NULL DEFAULT (datetime('now')),
 			deleted_at TEXT,
@@ -825,6 +827,7 @@ func (s *Store) migrate() error {
 		{name: "revision_count", definition: "INTEGER NOT NULL DEFAULT 1"},
 		{name: "duplicate_count", definition: "INTEGER NOT NULL DEFAULT 1"},
 		{name: "last_seen_at", definition: "TEXT"},
+		{name: "pinned", definition: "BOOLEAN NOT NULL DEFAULT 0"},
 		{name: "updated_at", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "deleted_at", definition: "TEXT"},
 	}
@@ -2205,8 +2208,7 @@ func (s *Store) AllObservations(project, scope string, limit int) ([]Observation
 	}
 
 	query := `
-		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at
+		SELECT ` + observationSelectColumns + `
 		FROM observations o
 		WHERE o.deleted_at IS NULL
 	`
@@ -2396,8 +2398,7 @@ func (s *Store) RecentObservations(project, scope string, limit int) ([]Observat
 	}
 
 	query := `
-		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at
+		SELECT ` + observationSelectColumns + `
 		FROM observations o
 		WHERE o.deleted_at IS NULL
 	`
@@ -2418,6 +2419,81 @@ func (s *Store) RecentObservations(project, scope string, limit int) ([]Observat
 	return s.queryObservations(query, args...)
 }
 
+func (s *Store) PinnedObservations(project, scope string) ([]Observation, error) {
+	project, _ = NormalizeProject(project)
+
+	query := `
+		SELECT ` + observationSelectColumns + `
+		FROM observations o
+		WHERE o.deleted_at IS NULL AND o.pinned = 1
+	`
+	args := []any{}
+
+	if project != "" {
+		query += " AND LOWER(o.project) = ?"
+		args = append(args, project)
+	}
+	if scope != "" {
+		query += " AND o.scope = ?"
+		args = append(args, normalizeScope(scope))
+	}
+
+	query += " ORDER BY datetime(o.created_at) DESC, o.id DESC"
+	return s.queryObservations(query, args...)
+}
+
+func (s *Store) PinObservation(id int64) error {
+	return s.setObservationPinned(id, true)
+}
+
+func (s *Store) UnpinObservation(id int64) error {
+	return s.setObservationPinned(id, false)
+}
+
+func (s *Store) setObservationPinned(id int64, pinned bool) error {
+	value := 0
+	if pinned {
+		value = 1
+	}
+	res, err := s.execHook(s.db, `UPDATE observations SET pinned = ? WHERE id = ? AND deleted_at IS NULL`, value, id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrObservationNotFound
+	}
+	return nil
+}
+
+func (s *Store) recentUnpinnedObservations(project, scope string, limit int) ([]Observation, error) {
+	project, _ = NormalizeProject(project)
+	if limit <= 0 {
+		limit = s.cfg.MaxContextResults
+	}
+
+	query := `
+		SELECT ` + observationSelectColumns + `
+		FROM observations o
+		WHERE o.deleted_at IS NULL AND o.pinned = 0
+	`
+	args := []any{}
+	if project != "" {
+		query += " AND LOWER(o.project) = ?"
+		args = append(args, project)
+	}
+	if scope != "" {
+		query += " AND o.scope = ?"
+		args = append(args, normalizeScope(scope))
+	}
+	query += " ORDER BY datetime(o.created_at) DESC, o.id DESC LIMIT ?"
+	args = append(args, limit)
+	return s.queryObservations(query, args...)
+}
+
 // ObservationsNeedingReview returns non-deleted observations whose review_after has passed.
 // An empty project searches all projects, matching existing browse/search conventions.
 func (s *Store) ObservationsNeedingReview(project string, limit int) ([]Observation, error) {
@@ -2426,8 +2502,7 @@ func (s *Store) ObservationsNeedingReview(project string, limit int) ([]Observat
 		limit = s.cfg.MaxContextResults
 	}
 	query := `
-		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at
+		SELECT ` + observationSelectColumns + `
 		FROM observations o
 		WHERE o.deleted_at IS NULL
 		  AND o.review_after IS NOT NULL
@@ -3068,7 +3143,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 				if err := tkRows.Scan(
 					&sr.ID, &sr.SyncID, &sr.SessionID, &sr.Type, &sr.Title, &sr.Content,
 					&sr.ToolName, &sr.Project, &sr.Scope, &sr.TopicKey, &sr.RevisionCount, &sr.DuplicateCount,
-					&sr.LastSeenAt, &sr.ReviewAfter, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
+					&sr.LastSeenAt, &sr.ReviewAfter, &sr.Pinned, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
 				); err != nil {
 					break
 				}
@@ -3083,7 +3158,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 
 	sqlQ := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.created_at, o.updated_at, o.deleted_at,
+		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.pinned, o.created_at, o.updated_at, o.deleted_at,
 		       fts.rank
 		FROM observations_fts fts
 		JOIN observations o ON o.id = fts.rowid
@@ -3127,7 +3202,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		if err := rows.Scan(
 			&sr.ID, &sr.SyncID, &sr.SessionID, &sr.Type, &sr.Title, &sr.Content,
 			&sr.ToolName, &sr.Project, &sr.Scope, &sr.TopicKey, &sr.RevisionCount, &sr.DuplicateCount,
-			&sr.LastSeenAt, &sr.ReviewAfter, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
+			&sr.LastSeenAt, &sr.ReviewAfter, &sr.Pinned, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
 			&sr.Rank,
 		); err != nil {
 			return nil, err
@@ -3212,7 +3287,12 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 		return "", err
 	}
 
-	observations, err := s.RecentObservations(project, scope, s.cfg.MaxContextResults)
+	pinned, err := s.PinnedObservations(project, scope)
+	if err != nil {
+		return "", err
+	}
+
+	observations, err := s.recentUnpinnedObservations(project, scope, s.cfg.MaxContextResults)
 	if err != nil {
 		return "", err
 	}
@@ -3222,7 +3302,7 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 		return "", err
 	}
 
-	if len(sessions) == 0 && len(observations) == 0 && len(prompts) == 0 {
+	if len(sessions) == 0 && len(pinned) == 0 && len(observations) == 0 && len(prompts) == 0 {
 		return "", nil
 	}
 
@@ -3246,6 +3326,15 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 		b.WriteString("### Recent User Prompts\n")
 		for _, p := range prompts {
 			fmt.Fprintf(&b, "- %s: %s\n", timeutil.FormatLocal(p.CreatedAt), truncate(p.Content, 200))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(pinned) > 0 {
+		b.WriteString("### Pinned\n")
+		for _, obs := range pinned {
+			fmt.Fprintf(&b, "- [%s] **%s**: %s\n",
+				obs.Type, obs.Title, truncate(obs.Content, 300))
 		}
 		b.WriteString("\n")
 	}
@@ -3342,11 +3431,7 @@ func (s *Store) exportWithProjectScope(project string) (*ExportData, error) {
 	defer obsRows.Close()
 	for obsRows.Next() {
 		var o Observation
-		if err := obsRows.Scan(
-			&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
-			&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.ReviewAfter,
-			&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
-		); err != nil {
+		if err := scanObservationRow(obsRows, &o); err != nil {
 			return nil, err
 		}
 		data.Observations = append(data.Observations, o)
@@ -5787,7 +5872,7 @@ func scanObservationRow(scanner observationScanner, o *Observation) error {
 	return scanner.Scan(
 		&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
 		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.ReviewAfter,
-		&o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
+		&o.Pinned, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
 	)
 }
 
@@ -5987,6 +6072,7 @@ func (s *Store) migrateLegacyObservationsTable() error {
 			revision_count INTEGER NOT NULL DEFAULT 1,
 			duplicate_count INTEGER NOT NULL DEFAULT 1,
 			last_seen_at TEXT,
+			pinned     BOOLEAN NOT NULL DEFAULT 0,
 			created_at TEXT    NOT NULL DEFAULT (datetime('now')),
 			updated_at TEXT    NOT NULL DEFAULT (datetime('now')),
 			deleted_at TEXT,
@@ -6000,7 +6086,7 @@ func (s *Store) migrateLegacyObservationsTable() error {
 		INSERT INTO observations_migrated (
 			id, sync_id, session_id, type, title, content, tool_name, project,
 			scope, topic_key, normalized_hash, revision_count, duplicate_count,
-			last_seen_at, created_at, updated_at, deleted_at
+			last_seen_at, pinned, created_at, updated_at, deleted_at
 		)
 		SELECT
 			CASE
@@ -6021,6 +6107,7 @@ func (s *Store) migrateLegacyObservationsTable() error {
 			CASE WHEN revision_count IS NULL OR revision_count < 1 THEN 1 ELSE revision_count END,
 			CASE WHEN duplicate_count IS NULL OR duplicate_count < 1 THEN 1 ELSE duplicate_count END,
 			last_seen_at,
+			0,
 			COALESCE(NULLIF(created_at, ''), datetime('now')),
 			COALESCE(NULLIF(updated_at, ''), NULLIF(created_at, ''), datetime('now')),
 			deleted_at

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -263,6 +263,124 @@ func TestUpdateAndSoftDeleteExcludedFromSearchAndTimeline(t *testing.T) {
 	}
 }
 
+func TestPinnedObservationsAndFormatContextPriority(t *testing.T) {
+	cfg := mustDefaultConfig(t)
+	cfg.DataDir = t.TempDir()
+	cfg.DedupeWindow = time.Hour
+	cfg.MaxContextResults = 2
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	titles := []string{"pinned architecture", "recent one", "recent two", "recent three"}
+	ids := make([]int64, 0, len(titles))
+	for i, title := range titles {
+		id, err := s.AddObservation(AddObservationParams{
+			SessionID: "s1",
+			Type:      "decision",
+			Title:     title,
+			Content:   fmt.Sprintf("content %d", i),
+			Project:   "engram",
+			Scope:     "project",
+		})
+		if err != nil {
+			t.Fatalf("add observation %q: %v", title, err)
+		}
+		ids = append(ids, id)
+		createdAt := fmt.Sprintf("2026-01-0%d 00:00:00", i+1)
+		if _, err := s.db.Exec(`UPDATE observations SET created_at = ?, updated_at = ? WHERE id = ?`, createdAt, createdAt, id); err != nil {
+			t.Fatalf("set created_at for %q: %v", title, err)
+		}
+	}
+	exportedBeforePin, err := s.ExportProject("engram")
+	if err != nil {
+		t.Fatalf("export project before pin: %v", err)
+	}
+	exportedBeforePinJSON, err := json.Marshal(exportedBeforePin)
+	if err != nil {
+		t.Fatalf("marshal export before pin: %v", err)
+	}
+	var updatedAtBeforePin string
+	if err := s.db.QueryRow(`SELECT updated_at FROM observations WHERE id = ?`, ids[0]).Scan(&updatedAtBeforePin); err != nil {
+		t.Fatalf("get updated_at before pin: %v", err)
+	}
+
+	if err := s.PinObservation(ids[0]); err != nil {
+		t.Fatalf("pin observation: %v", err)
+	}
+	var updatedAtAfterPin string
+	if err := s.db.QueryRow(`SELECT updated_at FROM observations WHERE id = ?`, ids[0]).Scan(&updatedAtAfterPin); err != nil {
+		t.Fatalf("get updated_at after pin: %v", err)
+	}
+	if updatedAtAfterPin != updatedAtBeforePin {
+		t.Fatalf("pin should not change updated_at: before=%q after=%q", updatedAtBeforePin, updatedAtAfterPin)
+	}
+	pinned, err := s.PinnedObservations("engram", "project")
+	if err != nil {
+		t.Fatalf("pinned observations: %v", err)
+	}
+	if len(pinned) != 1 || pinned[0].ID != ids[0] || !pinned[0].Pinned {
+		t.Fatalf("expected pinned observation %d, got %#v", ids[0], pinned)
+	}
+
+	ctx, err := s.FormatContext("engram", "project")
+	if err != nil {
+		t.Fatalf("format context: %v", err)
+	}
+	pinnedIdx := strings.Index(ctx, "### Pinned")
+	recentIdx := strings.Index(ctx, "### Recent Observations")
+	if pinnedIdx < 0 || recentIdx < 0 || pinnedIdx > recentIdx {
+		t.Fatalf("expected pinned section before recent observations, got:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "pinned architecture") {
+		t.Fatalf("expected pinned observation in context, got:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "recent three") || !strings.Contains(ctx, "recent two") {
+		t.Fatalf("expected max recent unpinned observations in context, got:\n%s", ctx)
+	}
+	if strings.Contains(ctx, "recent one") {
+		t.Fatalf("expected recent window to stay at MaxContextResults, got:\n%s", ctx)
+	}
+	exported, err := s.ExportProject("engram")
+	if err != nil {
+		t.Fatalf("export project: %v", err)
+	}
+	exportedJSON, err := json.Marshal(exported)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+	if strings.Contains(string(exportedJSON), `"pinned"`) {
+		t.Fatalf("pinned state must stay out of sync/export JSON, got %s", exportedJSON)
+	}
+	if string(exportedJSON) != string(exportedBeforePinJSON) {
+		t.Fatalf("pinning must not change export payload:\nbefore: %s\nafter:  %s", exportedBeforePinJSON, exportedJSON)
+	}
+
+	if err := s.UnpinObservation(ids[0]); err != nil {
+		t.Fatalf("unpin observation: %v", err)
+	}
+	var updatedAtAfterUnpin string
+	if err := s.db.QueryRow(`SELECT updated_at FROM observations WHERE id = ?`, ids[0]).Scan(&updatedAtAfterUnpin); err != nil {
+		t.Fatalf("get updated_at after unpin: %v", err)
+	}
+	if updatedAtAfterUnpin != updatedAtBeforePin {
+		t.Fatalf("unpin should not change updated_at: before=%q after=%q", updatedAtBeforePin, updatedAtAfterUnpin)
+	}
+	pinned, err = s.PinnedObservations("engram", "project")
+	if err != nil {
+		t.Fatalf("pinned observations after unpin: %v", err)
+	}
+	if len(pinned) != 0 {
+		t.Fatalf("expected no pinned observations after unpin, got %#v", pinned)
+	}
+}
+
 func TestTopicKeyUpsertUpdatesSameTopicWithoutCreatingNewRow(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -223,7 +223,7 @@ func (m Model) viewSearchResults() string {
 
 	for i := m.Scroll; i < end; i++ {
 		r := m.SearchResults[i]
-		b.WriteString(m.renderObservationListItem(i, r.ID, r.Type, r.Title, r.Content, r.CreatedAt, r.Project, r.State(), r.ReviewAfter))
+		b.WriteString(m.renderObservationListItem(i, r.ID, r.Type, r.Title, r.Content, r.CreatedAt, r.Project, r.State(), r.ReviewAfter, r.Pinned))
 	}
 
 	// Scroll indicator
@@ -266,7 +266,7 @@ func (m Model) viewRecent() string {
 
 	for i := m.Scroll; i < end; i++ {
 		o := m.RecentObservations[i]
-		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, o.State(), o.ReviewAfter))
+		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, o.State(), o.ReviewAfter, o.Pinned))
 	}
 
 	if count > visibleItems {
@@ -317,6 +317,10 @@ func (m Model) viewObservationDetail() string {
 	b.WriteString(fmt.Sprintf("%s %s\n",
 		detailLabelStyle.Render("State:"),
 		renderObservationState(obs.State())))
+
+	b.WriteString(fmt.Sprintf("%s %s\n",
+		detailLabelStyle.Render("Pinned:"),
+		detailValueStyle.Render(fmt.Sprintf("%t", obs.Pinned))))
 
 	if obs.ReviewAfter != nil {
 		b.WriteString(fmt.Sprintf("%s %s\n",
@@ -561,7 +565,7 @@ func (m Model) viewSessionDetail() string {
 
 	for i := m.SessionDetailScroll; i < end; i++ {
 		o := m.SessionObservations[i]
-		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, o.State(), o.ReviewAfter))
+		b.WriteString(m.renderObservationListItem(i, o.ID, o.Type, o.Title, o.Content, o.CreatedAt, o.Project, o.State(), o.ReviewAfter, o.Pinned))
 	}
 
 	if count > visibleItems {
@@ -695,7 +699,7 @@ func (m Model) viewSetup() string {
 
 // ─── Shared Renderers ────────────────────────────────────────────────────────
 
-func (m Model) renderObservationListItem(index int, id int64, obsType, title, content, createdAt string, project *string, state string, reviewAfter *string) string {
+func (m Model) renderObservationListItem(index int, id int64, obsType, title, content, createdAt string, project *string, state string, reviewAfter *string, pinned bool) string {
 	cursor := "  "
 	style := listItemStyle
 	if index == m.Cursor {
@@ -712,12 +716,17 @@ func (m Model) renderObservationListItem(index int, id int64, obsType, title, co
 	if state == "needs_review" {
 		stateBadge = " " + stateWarningBadgeStyle.Render("[needs_review]")
 	}
+	pinBadge := ""
+	if pinned {
+		pinBadge = " " + detailValueStyle.Render("[pinned]")
+	}
 
-	line := fmt.Sprintf("%s%s %s%s %s%s  %s\n",
+	line := fmt.Sprintf("%s%s %s%s%s %s%s  %s\n",
 		cursor,
 		idStyle.Render(fmt.Sprintf("#%-5d", id)),
 		typeBadgeStyle.Render(fmt.Sprintf("[%-12s]", obsType)),
 		stateBadge,
+		pinBadge,
 		style.Render(truncateStr(title, 50)),
 		proj,
 		timestampStyle.Render(localTime(createdAt)))

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -49,6 +49,7 @@ func TestRenderObservationListItem(t *testing.T) {
 		&project,
 		"active",
 		nil,
+		true,
 	)
 
 	if !strings.Contains(line, "▸") {
@@ -63,9 +64,12 @@ func TestRenderObservationListItem(t *testing.T) {
 	if !strings.Contains(line, "engram") {
 		t.Fatal("project label should be rendered when project is set")
 	}
+	if !strings.Contains(line, "pinned") {
+		t.Fatal("pinned item should include pin indicator")
+	}
 
 	reviewAfter := "2026-01-01 00:00:00"
-	staleLine := m.renderObservationListItem(0, 43, "decision", "Needs review", "content", "2026-01-01", &project, "needs_review", &reviewAfter)
+	staleLine := m.renderObservationListItem(0, 43, "decision", "Needs review", "content", "2026-01-01", &project, "needs_review", &reviewAfter, false)
 	if !strings.Contains(staleLine, "needs_review") {
 		t.Fatal("stale item should include needs_review badge")
 	}
@@ -236,6 +240,7 @@ func TestViewObservationDetailTimelineSessionsAndSessionDetail(t *testing.T) {
 		ToolName:  &tool,
 		Project:   &project,
 		Content:   strings.Repeat("line\n", 20),
+		Pinned:    true,
 	}
 	reviewAfter := "2027-02-03 04:05:06"
 	m.SelectedObservation.ReviewAfter = &reviewAfter
@@ -246,6 +251,9 @@ func TestViewObservationDetailTimelineSessionsAndSessionDetail(t *testing.T) {
 	}
 	if !strings.Contains(out, "State:") || !strings.Contains(out, "active") || !strings.Contains(out, "Review:") || !strings.Contains(out, "2027-02-03") {
 		t.Fatal("detail view should render lifecycle state and review date")
+	}
+	if !strings.Contains(out, "Pinned:") || !strings.Contains(out, "true") {
+		t.Fatal("detail view should render pinned state")
 	}
 	if !strings.Contains(out, "line") {
 		t.Fatal("detail view should render content lines")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #483

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds local pinned observations so critical memories render before recent context.
- Adds MCP pin/unpin tools and exposes pinned state in search results.
- Shows pinned state in the TUI list and detail views while keeping pinned state out of sync/export payloads.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Adds pinned storage, pin/unpin methods, pinned context section, and local-only export behavior. |
| `internal/store/store_test.go` | Covers pin/unpin, context priority, recent-window behavior, and export invariants. |
| `internal/mcp/mcp.go` | Registers `mem_pin` / `mem_unpin` and includes `pinned` in search results. |
| `internal/mcp/mcp_test.go` | Covers pin/unpin handlers and pinned search output. |
| `internal/tui/view.go` | Renders pinned indicators in observation list/detail views. |
| `internal/tui/view_test.go` | Covers pinned rendering in list/detail views. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Manual testing: verified MCP/search/TUI behavior through focused regression tests and fresh review.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #483`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Pinned state is intentionally local-only/per-device. Pin/unpin does not mutate `updated_at`, and tests assert the export payload stays unchanged before and after pinning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to pin and unpin observations to mark them as important.
  * Pinned observations now display with a visual indicator in lists and detail views.
  * Search results show which observations are pinned.
  * Pinned observations are prioritized in context rendering before recent items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->