### PR TITLE
feat(setup): add antigravity-cli installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Windows, Linux, and other install methods → [docs/INSTALLATION.md](docs/INSTAL
 | Pi                          | `engram setup pi`                                                                            |
 | OpenCode                    | `engram setup opencode`                                                                      |
 | Gemini CLI                  | `engram setup gemini-cli`                                                                    |
+| Antigravity CLI             | `engram setup antigravity-cli`                                                              |
 | Codex                       | `engram setup codex`                                                                         |
 | VS Code                     | `code --add-mcp '{"name":"engram","command":"engram","args":["mcp"]}'`                       |
 | Cursor / Windsurf / Any MCP | See [docs/AGENT-SETUP.md](docs/AGENT-SETUP.md)                                               |

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2422,6 +2422,12 @@ func printPostInstall(result *setup.Result) {
 		fmt.Println("  1. Restart Gemini CLI so MCP config is reloaded")
 		fmt.Println("  2. Verify ~/.gemini/settings.json includes mcpServers.engram")
 		fmt.Println("  3. Verify ~/.gemini/system.md + ~/.gemini/.env exist for compaction recovery")
+	case "antigravity-cli":
+		fmt.Println("\nNext steps:")
+		fmt.Println("  1. Restart Antigravity CLI so MCP config is reloaded")
+		fmt.Println("  2. Verify ~/.gemini/config/mcp_config.json includes mcpServers.engram")
+		fmt.Println("  3. Verify the Engram Memory Protocol block exists in ~/.gemini/GEMINI.md")
+		fmt.Println("  4. Inspect connected servers with: agy inspect")
 	case "codex":
 		fmt.Println("\nNext steps:")
 		fmt.Println("  1. Restart Codex so MCP config is reloaded")
@@ -2477,7 +2483,7 @@ Commands:
                      Merge similar project names into one canonical name
                        --all      Scan ALL projects for similar name groups
                        --dry-run  Preview what would be merged (no changes)
-  setup [agent]      Install/setup agent integration (opencode, pi, claude-code, gemini-cli, codex)
+  setup [agent]      Install/setup agent integration (opencode, pi, claude-code, gemini-cli, antigravity-cli, codex)
   sync               Export new memories as compressed chunk to .engram/
                          --import   Import new chunks from .engram/ into local DB
                          --status   Show sync status

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -166,7 +166,7 @@ func TestPrintUsage(t *testing.T) {
 	if !strings.Contains(stdout, "search <query>") || !strings.Contains(stdout, "setup [agent]") {
 		t.Fatalf("usage missing expected commands: %q", stdout)
 	}
-	if !strings.Contains(stdout, "opencode, pi, claude-code, gemini-cli, codex") {
+	if !strings.Contains(stdout, "opencode, pi, claude-code, gemini-cli, antigravity-cli, codex") {
 		t.Fatalf("usage missing pi setup agent: %q", stdout)
 	}
 	if !strings.Contains(stdout, "cloud <subcommand>") {
@@ -223,6 +223,11 @@ func TestPrintPostInstall(t *testing.T) {
 			name:    "gemini-cli",
 			result:  &setup.Result{Agent: "gemini-cli"},
 			expects: []string{"Restart Gemini CLI", "~/.gemini/settings.json"},
+		},
+		{
+			name:    "antigravity-cli",
+			result:  &setup.Result{Agent: "antigravity-cli"},
+			expects: []string{"Restart Antigravity CLI", "~/.gemini/config/mcp_config.json", "~/.gemini/GEMINI.md", "agy inspect"},
 		},
 		{
 			name:    "codex",

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -20,9 +20,10 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 | Pi            | `engram setup pi`                                                                            | [Details](#pi)                                     |
 | OpenCode      | `engram setup opencode`                                                                      | [Details](#opencode)                               |
 | Gemini CLI    | `engram setup gemini-cli`                                                                    | [Details](#gemini-cli)                             |
+| Antigravity CLI | `engram setup antigravity-cli`                                                             | [Details](#antigravity-cli)                        |
 | Codex         | `engram setup codex`                                                                         | [Details](#codex)                                  |
 | VS Code       | `code --add-mcp '{"name":"engram","command":"engram","args":["mcp"]}'`                       | [Details](#vs-code-copilot--claude-code-extension) |
-| Antigravity   | Manual JSON config                                                                           | [Details](#antigravity)                            |
+| Antigravity IDE | Manual JSON config                                                                         | [Details](#antigravity-ide)                        |
 | Cursor        | Manual JSON config                                                                           | [Details](#cursor)                                 |
 | Windsurf      | Manual JSON config                                                                           | [Details](#windsurf)                               |
 | Any MCP agent | `engram mcp` (stdio)                                                                         | [Details](#any-other-mcp-agent)                    |
@@ -378,6 +379,40 @@ gemini mcp add engram engram mcp
 
 ---
 
+## Antigravity CLI
+
+> This is the terminal coding agent (`agy`). For the Antigravity IDE, see [Antigravity IDE](#antigravity-ide).
+
+Recommended: one command to set up MCP + the Memory Protocol:
+
+```bash
+engram setup antigravity-cli
+```
+
+Antigravity shares the `~/.gemini/` root with Gemini CLI but reads from **different files**, so `engram setup gemini-cli` does **not** configure it. `engram setup antigravity-cli` does two things:
+
+- Registers `mcpServers.engram` in `~/.gemini/config/mcp_config.json` — the unified MCP config read by Antigravity CLI, IDE, and SDK (NOT `~/.gemini/settings.json`)
+- Writes the Engram Memory Protocol into `~/.gemini/GEMINI.md` as a marker-delimited block (`<!-- BEGIN ENGRAM MEMORY PROTOCOL … -->`). Existing content in `GEMINI.md` is preserved; re-running replaces only the managed block.
+
+After installing, restart Antigravity CLI and verify the server with `agy inspect`.
+
+Manual alternative — add to `~/.gemini/config/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "engram": {
+      "command": "engram",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Then add the Memory Protocol as a global rule in `~/.gemini/GEMINI.md` (or a workspace rule in `.agent/rules/`). See [DOCS.md](../DOCS.md#memory-protocol-full-text) for the full text.
+
+---
+
 ## Codex
 
 Recommended: one command to set up MCP + compaction recovery instructions:
@@ -538,7 +573,9 @@ Same pattern applies to:
 
 ---
 
-## Antigravity
+## Antigravity IDE
+
+> For the terminal agent (`agy`), see [Antigravity CLI](#antigravity-cli), which has a one-command installer.
 
 [Antigravity](https://antigravity.google) is Google's AI-first IDE with native MCP and skill support.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -188,8 +188,9 @@ When using `engram setup`, config files are written to platform-appropriate loca
 |-------|---------------|---------|
 | OpenCode | `~/.config/opencode/` | `%APPDATA%\opencode\` |
 | Gemini CLI | `~/.gemini/` | `%APPDATA%\gemini\` |
+| Antigravity CLI | `~/.gemini/config/mcp_config.json` + `~/.gemini/GEMINI.md` | `%USERPROFILE%\.gemini\config\mcp_config.json` + `%USERPROFILE%\.gemini\GEMINI.md` |
 | Codex | `~/.codex/` | `%APPDATA%\codex\` |
 | Claude Code | Managed by `claude` CLI | Managed by `claude` CLI |
 | VS Code | `.vscode/mcp.json` (workspace) or `~/Library/Application Support/Code/User/mcp.json` (user) | `.vscode\mcp.json` (workspace) or `%APPDATA%\Code\User\mcp.json` (user) |
-| Antigravity | `~/.gemini/antigravity/mcp_config.json` | `%USERPROFILE%\.gemini\antigravity\mcp_config.json` |
+| Antigravity IDE | `~/.gemini/antigravity/mcp_config.json` | `%USERPROFILE%\.gemini\antigravity\mcp_config.json` |
 | Data directory | `~/.engram/` | `%USERPROFILE%\.engram\` |

--- a/docs/codebase/integrations.md
+++ b/docs/codebase/integrations.md
@@ -24,14 +24,14 @@ Agent
   │     ├── plugin/claude-code/scripts/*.sh / *.ps1
   │     └── plugin/claude-code/skills/memory/SKILL.md
   │
-  ├── Gemini / Codex setup
+  ├── Gemini CLI / Antigravity CLI / Codex setup
   │     └── internal/setup/setup.go
   │
-  └── VS Code / Antigravity / Cursor / Windsurf manual MCP
+  └── VS Code / Antigravity IDE / Cursor / Windsurf manual MCP
         └── JSON configuration documented in docs/AGENT-SETUP.md
 ```
 
-`internal/setup` does not install every possible integration. VS Code, Antigravity, Cursor, and Windsurf are manual MCP configuration paths documented in `docs/AGENT-SETUP.md`.
+`internal/setup` does not install every possible integration. VS Code, the Antigravity IDE, Cursor, and Windsurf are manual MCP configuration paths documented in `docs/AGENT-SETUP.md`. Note: the Antigravity **CLI** (`agy`) has an automated installer (`engram setup antigravity-cli`) — it is distinct from the Antigravity IDE, which remains manual.
 
 ## Thin plugin principle
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -9,6 +9,9 @@
 //     then writes a durable MCP config to ~/.claude/mcp/engram.json using the
 //     absolute binary path so the subprocess never needs PATH resolution.
 //   - Gemini CLI: injects MCP registration in ~/.gemini/settings.json
+//   - Antigravity CLI: injects MCP registration in ~/.gemini/config/mcp_config.json
+//     (shared across Antigravity CLI/IDE/SDK) and writes the Memory Protocol as a
+//     marker-delimited block in ~/.gemini/GEMINI.md
 //   - Codex: injects MCP registration in ~/.codex/config.toml
 //   - Pi: installs gentle-engram/pi-mcp-adapter packages and writes Pi MCP config
 package setup
@@ -48,6 +51,8 @@ var (
 	injectOpenCodeTUIPluginFn          = injectOpenCodeTUIPlugin
 	injectGeminiMCPFn                  = injectGeminiMCP
 	writeGeminiSystemPromptFn          = writeGeminiSystemPrompt
+	injectAntigravityMCPFn             = injectGeminiMCP
+	writeAntigravityContextFn          = writeAntigravityContext
 	writeCodexMemoryInstructionFilesFn = writeCodexMemoryInstructionFiles
 	injectCodexMCPFn                   = injectCodexMCP
 	injectCodexMemoryConfigFn          = injectCodexMemoryConfig
@@ -260,6 +265,11 @@ func SupportedAgents() []Agent {
 			InstallDir:  geminiConfigPath(),
 		},
 		{
+			Name:        "antigravity-cli",
+			Description: "Antigravity CLI — MCP registration in shared config plus Memory Protocol in GEMINI.md",
+			InstallDir:  antigravityMCPConfigPath(),
+		},
+		{
 			Name:        "codex",
 			Description: "Codex — MCP registration plus model/compaction instruction files",
 			InstallDir:  codexConfigPath(),
@@ -278,10 +288,12 @@ func Install(agentName string) (*Result, error) {
 		return installClaudeCode()
 	case "gemini-cli":
 		return installGeminiCLI()
+	case "antigravity-cli":
+		return installAntigravityCLI()
 	case "codex":
 		return installCodex()
 	default:
-		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, gemini-cli, codex)", agentName)
+		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, gemini-cli, antigravity-cli, codex)", agentName)
 	}
 }
 
@@ -1106,6 +1118,76 @@ func writeGeminiSystemPrompt() error {
 	return nil
 }
 
+// ─── Antigravity CLI ───────────────────────────────────────────────────────
+//
+// Antigravity shares the ~/.gemini/ root with Gemini CLI but reads MCP servers
+// from a different file: the unified ~/.gemini/config/mcp_config.json (shared by
+// the CLI, IDE, and SDK), NOT ~/.gemini/settings.json. Its agent context/rules
+// also live in ~/.gemini/GEMINI.md rather than Gemini CLI's system.md. Running
+// `engram setup gemini-cli` therefore does NOT configure Antigravity CLI.
+
+const antigravityContextBeginMarker = "<!-- BEGIN ENGRAM MEMORY PROTOCOL — managed by engram setup -->"
+const antigravityContextEndMarker = "<!-- END ENGRAM MEMORY PROTOCOL -->"
+
+func installAntigravityCLI() (*Result, error) {
+	mcpPath := antigravityMCPConfigPath()
+	// The MCP entry has the same shape as Gemini CLI's mcpServers block, so we
+	// reuse the generic injector against Antigravity's config path.
+	if err := injectAntigravityMCPFn(mcpPath); err != nil {
+		return nil, err
+	}
+
+	if err := writeAntigravityContextFn(); err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Agent:       "antigravity-cli",
+		Destination: filepath.Dir(mcpPath),
+		Files:       2,
+	}, nil
+}
+
+// writeAntigravityContext injects the Memory Protocol into ~/.gemini/GEMINI.md as
+// a marker-delimited block. Unlike Gemini CLI's dedicated system.md, GEMINI.md is
+// a general user context file that may already hold content, so we never clobber
+// it: the protocol block is replaced in place when present and appended otherwise,
+// making re-runs idempotent.
+func writeAntigravityContext() error {
+	path := antigravityContextPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create antigravity context dir: %w", err)
+	}
+
+	block := antigravityContextBeginMarker + "\n\n" + memoryProtocolMarkdown + "\n" + antigravityContextEndMarker + "\n"
+
+	existing, err := readFileFn(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := writeFileFn(path, []byte(block), 0644); err != nil {
+				return fmt.Errorf("write antigravity context: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("read antigravity context: %w", err)
+	}
+
+	text := strings.ReplaceAll(string(existing), "\r\n", "\n")
+	start := strings.Index(text, antigravityContextBeginMarker)
+	end := strings.Index(text, antigravityContextEndMarker)
+	if start != -1 && end != -1 && end > start {
+		end += len(antigravityContextEndMarker)
+		text = text[:start] + strings.TrimRight(block, "\n") + text[end:]
+	} else {
+		text = strings.TrimRight(text, "\n") + "\n\n" + block
+	}
+
+	if err := writeFileFn(path, []byte(text), 0644); err != nil {
+		return fmt.Errorf("write antigravity context: %w", err)
+	}
+	return nil
+}
+
 // removeGeminiEnvOverride removes any GEMINI_SYSTEM_MD line from ~/.gemini/.env.
 // Previous versions of engram added this line, but it causes Gemini CLI to look
 // for system.md relative to CWD instead of ~/.gemini/. Best-effort cleanup.
@@ -1309,6 +1391,21 @@ func geminiSystemPromptPath() string {
 
 func geminiEnvPath() string {
 	return filepath.Join(filepath.Dir(geminiConfigPath()), ".env")
+}
+
+// antigravityMCPConfigPath returns the shared Antigravity MCP config file.
+// Antigravity CLI/IDE/SDK read MCP servers from ~/.gemini/config/mcp_config.json
+// on all platforms (it lives under the home-dir .gemini folder, not %APPDATA%).
+func antigravityMCPConfigPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".gemini", "config", "mcp_config.json")
+}
+
+// antigravityContextPath returns ~/.gemini/GEMINI.md, Antigravity's global agent
+// context/rules file (distinct from Gemini CLI's system.md).
+func antigravityContextPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".gemini", "GEMINI.md")
 }
 
 func codexConfigPath() string {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -28,6 +28,8 @@ func resetSetupSeams(t *testing.T) {
 	oldInjectOpenCodeTUIPluginFn := injectOpenCodeTUIPluginFn
 	oldInjectGeminiMCPFn := injectGeminiMCPFn
 	oldWriteGeminiSystemPromptFn := writeGeminiSystemPromptFn
+	oldInjectAntigravityMCPFn := injectAntigravityMCPFn
+	oldWriteAntigravityContextFn := writeAntigravityContextFn
 	oldWriteCodexMemoryInstructionFilesFn := writeCodexMemoryInstructionFilesFn
 	oldInjectCodexMCPFn := injectCodexMCPFn
 	oldInjectCodexMemoryConfigFn := injectCodexMemoryConfigFn
@@ -52,6 +54,8 @@ func resetSetupSeams(t *testing.T) {
 		injectOpenCodeTUIPluginFn = oldInjectOpenCodeTUIPluginFn
 		injectGeminiMCPFn = oldInjectGeminiMCPFn
 		writeGeminiSystemPromptFn = oldWriteGeminiSystemPromptFn
+		injectAntigravityMCPFn = oldInjectAntigravityMCPFn
+		writeAntigravityContextFn = oldWriteAntigravityContextFn
 		writeCodexMemoryInstructionFilesFn = oldWriteCodexMemoryInstructionFilesFn
 		injectCodexMCPFn = oldInjectCodexMCPFn
 		injectCodexMemoryConfigFn = oldInjectCodexMemoryConfigFn
@@ -182,6 +186,150 @@ func TestInstallGeminiCLIInjectsMCPConfig(t *testing.T) {
 
 	if _, err := Install("gemini-cli"); err != nil {
 		t.Fatalf("second install should be idempotent: %v", err)
+	}
+}
+
+func TestSupportedAgentsIncludesAntigravityCLI(t *testing.T) {
+	var found bool
+	for _, agent := range SupportedAgents() {
+		if agent.Name == "antigravity-cli" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected antigravity-cli in supported agents")
+	}
+}
+
+func TestInstallAntigravityCLIInjectsMCPAndContext(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+
+	result, err := Install("antigravity-cli")
+	if err != nil {
+		t.Fatalf("install antigravity-cli: %v", err)
+	}
+	if result.Agent != "antigravity-cli" {
+		t.Fatalf("unexpected agent in result: %q", result.Agent)
+	}
+	if result.Files != 2 {
+		t.Fatalf("expected 2 files written, got %d", result.Files)
+	}
+
+	// MCP must land in the shared Antigravity config, NOT ~/.gemini/settings.json.
+	mcpPath := filepath.Join(home, ".gemini", "config", "mcp_config.json")
+	raw, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatalf("read mcp_config.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse mcp_config.json: %v", err)
+	}
+	mcpServers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mcpServers object, got %#v", cfg["mcpServers"])
+	}
+	engram, ok := mcpServers["engram"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mcpServers.engram object")
+	}
+	if cmd, ok := engram["command"].(string); !ok || cmd == "" || cmd == "engram" {
+		t.Fatalf("expected absolute command path, got %#v", engram["command"])
+	}
+
+	// settings.json (Gemini CLI's file) must NOT be touched.
+	if _, err := os.Stat(filepath.Join(home, ".gemini", "settings.json")); !os.IsNotExist(err) {
+		t.Fatalf("antigravity install must not write ~/.gemini/settings.json (err=%v)", err)
+	}
+
+	// Protocol must be in GEMINI.md inside the managed marker block.
+	ctxPath := filepath.Join(home, ".gemini", "GEMINI.md")
+	ctxRaw, err := os.ReadFile(ctxPath)
+	if err != nil {
+		t.Fatalf("read GEMINI.md: %v", err)
+	}
+	ctxText := string(ctxRaw)
+	if !strings.Contains(ctxText, antigravityContextBeginMarker) || !strings.Contains(ctxText, antigravityContextEndMarker) {
+		t.Fatalf("expected managed markers in GEMINI.md")
+	}
+	if !strings.Contains(ctxText, "### AFTER COMPACTION") {
+		t.Fatalf("expected Memory Protocol body in GEMINI.md")
+	}
+
+	// system.md (Gemini CLI's prompt file) must NOT be created.
+	if _, err := os.Stat(filepath.Join(home, ".gemini", "system.md")); !os.IsNotExist(err) {
+		t.Fatalf("antigravity install must not write ~/.gemini/system.md (err=%v)", err)
+	}
+}
+
+func TestInstallAntigravityCLIPreservesGeminiMdAndIsIdempotent(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+
+	ctxPath := filepath.Join(home, ".gemini", "GEMINI.md")
+	if err := os.MkdirAll(filepath.Dir(ctxPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	userContent := "# My project rules\n\nAlways use tabs.\n"
+	if err := os.WriteFile(ctxPath, []byte(userContent), 0644); err != nil {
+		t.Fatalf("seed GEMINI.md: %v", err)
+	}
+
+	if _, err := Install("antigravity-cli"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if _, err := Install("antigravity-cli"); err != nil {
+		t.Fatalf("second install (idempotent): %v", err)
+	}
+
+	raw, err := os.ReadFile(ctxPath)
+	if err != nil {
+		t.Fatalf("read GEMINI.md: %v", err)
+	}
+	text := string(raw)
+
+	if !strings.Contains(text, "Always use tabs.") {
+		t.Fatalf("user content must be preserved, got:\n%s", text)
+	}
+	if got := strings.Count(text, antigravityContextBeginMarker); got != 1 {
+		t.Fatalf("expected exactly one managed block after re-run, got %d", got)
+	}
+	if got := strings.Count(text, antigravityContextEndMarker); got != 1 {
+		t.Fatalf("expected exactly one end marker after re-run, got %d", got)
+	}
+}
+
+func TestInstallAntigravityCLIErrorPropagation(t *testing.T) {
+	t.Run("mcp inject error", func(t *testing.T) {
+		resetSetupSeams(t)
+		useTestHome(t)
+		injectAntigravityMCPFn = func(string) error { return errors.New("inject failed") }
+		if _, err := Install("antigravity-cli"); err == nil || !strings.Contains(err.Error(), "inject failed") {
+			t.Fatalf("expected inject error, got %v", err)
+		}
+	})
+
+	t.Run("context write error", func(t *testing.T) {
+		resetSetupSeams(t)
+		useTestHome(t)
+		injectAntigravityMCPFn = func(string) error { return nil }
+		writeAntigravityContextFn = func() error { return errors.New("context failed") }
+		if _, err := Install("antigravity-cli"); err == nil || !strings.Contains(err.Error(), "context failed") {
+			t.Fatalf("expected context error, got %v", err)
+		}
+	})
+}
+
+func TestAntigravityPathHelpers(t *testing.T) {
+	resetSetupSeams(t)
+	userHomeDir = func() (string, error) { return "/home/tester", nil }
+
+	if got := antigravityMCPConfigPath(); got != filepath.Join("/home/tester", ".gemini", "config", "mcp_config.json") {
+		t.Fatalf("unexpected antigravityMCPConfigPath: %s", got)
+	}
+	if got := antigravityContextPath(); got != filepath.Join("/home/tester", ".gemini", "GEMINI.md") {
+		t.Fatalf("unexpected antigravityContextPath: %s", got)
 	}
 }
 


### PR DESCRIPTION
## What

Adds `engram setup antigravity-cli`, an automated installer for Google's Antigravity CLI (`agy`).

## Why

The existing `gemini-cli` installer does **not** configure the Antigravity CLI. They share the `~/.gemini/` root, but Antigravity reads from different files:

| | `engram setup gemini-cli` writes | Antigravity CLI reads |
|---|---|---|
| MCP registration | `~/.gemini/settings.json` | `~/.gemini/config/mcp_config.json` (shared by CLI/IDE/SDK) |
| Agent context / protocol | `~/.gemini/system.md` | `~/.gemini/GEMINI.md` |

So running `gemini-cli` for an Antigravity user silently registers nothing the agent can see.

## What it does

- Injects `mcpServers.engram` into `~/.gemini/config/mcp_config.json`
- Writes the Memory Protocol into `~/.gemini/GEMINI.md` as an **idempotent, marker-delimited block** (`<!-- BEGIN ENGRAM MEMORY PROTOCOL … -->`) that preserves any existing user content; re-runs replace only the managed block

## Tests

- MCP lands in `mcp_config.json` and never touches `settings.json` / `system.md`
- `GEMINI.md` user content preserved + idempotency on re-run
- Error propagation for both steps
- Path helpers

## Docs

Updated AGENT-SETUP, INSTALLATION, README, and the integrations guide, disambiguating Antigravity **CLI** (automated installer) from the Antigravity **IDE** (remains manual).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated setup support for Antigravity CLI agent via `engram setup antigravity-cli` command.

* **Documentation**
  * Updated setup guides to distinguish between Antigravity CLI (terminal) and Antigravity IDE configurations.
  * Added Windows configuration paths documentation for Antigravity CLI.

* **Tests**
  * Expanded test coverage for Antigravity CLI integration and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->