### PR TITLE
feat(setup): data-driven agent registry + native setup for 7 more agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,14 @@ Windows, Linux, and other install methods → [docs/INSTALLATION.md](docs/INSTAL
 | OpenCode                    | `engram setup opencode`                                                                      |
 | Gemini CLI                  | `engram setup gemini-cli`                                                                    |
 | Codex                       | `engram setup codex`                                                                         |
-| VS Code                     | `code --add-mcp '{"name":"engram","command":"engram","args":["mcp"]}'`                       |
-| Cursor / Windsurf / Any MCP | See [docs/AGENT-SETUP.md](docs/AGENT-SETUP.md)                                               |
+| Antigravity CLI             | `engram setup antigravity-cli`                                                               |
+| Windsurf                    | `engram setup windsurf`                                                                      |
+| Qwen Code                   | `engram setup qwen`                                                                          |
+| Kiro                        | `engram setup kiro`                                                                          |
+| Cursor                      | `engram setup cursor`                                                                        |
+| VS Code (Copilot)           | `engram setup vscode-copilot`                                                                |
+| Kilo Code                   | `engram setup kilocode`                                                                      |
+| Any other MCP client        | See [docs/AGENT-SETUP.md](docs/AGENT-SETUP.md)                                               |
 
 Full per-agent config, Memory Protocol, and compaction survival → [docs/AGENT-SETUP.md](docs/AGENT-SETUP.md)
 

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -95,7 +95,7 @@ var (
 	storeDeleteProject     = func(s *store.Store, name string, hard bool) (*store.DeleteProjectResult, error) {
 		return s.DeleteProject(name, hard)
 	}
-	storeTimeline       = func(s *store.Store, observationID int64, before, after int) (*store.TimelineResult, error) {
+	storeTimeline = func(s *store.Store, observationID int64, before, after int) (*store.TimelineResult, error) {
 		return s.Timeline(observationID, before, after)
 	}
 	storeFormatContext = func(s *store.Store, project, scope string) (string, error) { return s.FormatContext(project, scope) }
@@ -2417,16 +2417,21 @@ func printPostInstall(result *setup.Result) {
 		fmt.Println("  2. Verify with: claude plugin list")
 		fmt.Println("  3. MCP config written to ~/.claude/mcp/engram.json using absolute binary path")
 		fmt.Println("     (survives plugin auto-updates; re-run 'engram setup claude-code' if you move the binary)")
-	case "gemini-cli":
-		fmt.Println("\nNext steps:")
-		fmt.Println("  1. Restart Gemini CLI so MCP config is reloaded")
-		fmt.Println("  2. Verify ~/.gemini/settings.json includes mcpServers.engram")
-		fmt.Println("  3. Verify ~/.gemini/system.md + ~/.gemini/.env exist for compaction recovery")
-	case "codex":
-		fmt.Println("\nNext steps:")
-		fmt.Println("  1. Restart Codex so MCP config is reloaded")
-		fmt.Println("  2. Verify ~/.codex/config.toml has [mcp_servers.engram]")
-		fmt.Println("  3. Verify model_instructions_file + experimental_compact_prompt_file are set")
+	default:
+		// Every other agent's "next steps" are declared as data in the registry,
+		// so the message is rendered generically instead of one case per agent.
+		printNextSteps(setup.PostInstallSteps(result.Agent))
+	}
+}
+
+// printNextSteps renders a numbered "Next steps" list, or nothing when empty.
+func printNextSteps(steps []string) {
+	if len(steps) == 0 {
+		return
+	}
+	fmt.Println("\nNext steps:")
+	for i, step := range steps {
+		fmt.Printf("  %d. %s\n", i+1, step)
 	}
 }
 
@@ -2477,7 +2482,9 @@ Commands:
                      Merge similar project names into one canonical name
                        --all      Scan ALL projects for similar name groups
                        --dry-run  Preview what would be merged (no changes)
-  setup [agent]      Install/setup agent integration (opencode, pi, claude-code, gemini-cli, codex)
+  setup [agent]      Install/setup agent integration (opencode, pi, claude-code,
+                     gemini-cli, codex, antigravity-cli, windsurf, qwen, kiro,
+                     cursor, vscode-copilot, kilocode)
   sync               Export new memories as compressed chunk to .engram/
                          --import   Import new chunks from .engram/ into local DB
                          --status   Show sync status

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -166,8 +166,10 @@ func TestPrintUsage(t *testing.T) {
 	if !strings.Contains(stdout, "search <query>") || !strings.Contains(stdout, "setup [agent]") {
 		t.Fatalf("usage missing expected commands: %q", stdout)
 	}
-	if !strings.Contains(stdout, "opencode, pi, claude-code, gemini-cli, codex") {
-		t.Fatalf("usage missing pi setup agent: %q", stdout)
+	for _, agent := range []string{"opencode", "pi", "claude-code", "gemini-cli", "codex", "antigravity-cli", "windsurf", "qwen", "kiro", "cursor", "vscode-copilot", "kilocode"} {
+		if !strings.Contains(stdout, agent) {
+			t.Fatalf("usage missing setup agent %q: %q", agent, stdout)
+		}
 	}
 	if !strings.Contains(stdout, "cloud <subcommand>") {
 		t.Fatalf("usage missing cloud command tree: %q", stdout)
@@ -228,6 +230,41 @@ func TestPrintPostInstall(t *testing.T) {
 			name:    "codex",
 			result:  &setup.Result{Agent: "codex"},
 			expects: []string{"Restart Codex", "~/.codex/config.toml"},
+		},
+		{
+			name:    "antigravity-cli",
+			result:  &setup.Result{Agent: "antigravity-cli"},
+			expects: []string{"Restart Antigravity", "~/.gemini/config/mcp_config.json", "~/.gemini/GEMINI.md"},
+		},
+		{
+			name:    "windsurf",
+			result:  &setup.Result{Agent: "windsurf"},
+			expects: []string{"Restart Windsurf", "~/.codeium/windsurf/mcp_config.json"},
+		},
+		{
+			name:    "qwen",
+			result:  &setup.Result{Agent: "qwen"},
+			expects: []string{"Restart Qwen Code", "~/.qwen/settings.json"},
+		},
+		{
+			name:    "kiro",
+			result:  &setup.Result{Agent: "kiro"},
+			expects: []string{"Restart Kiro", "~/.kiro/settings/mcp.json"},
+		},
+		{
+			name:    "cursor",
+			result:  &setup.Result{Agent: "cursor"},
+			expects: []string{"Restart Cursor", "~/.cursor/mcp.json", "engram.mdc"},
+		},
+		{
+			name:    "vscode-copilot",
+			result:  &setup.Result{Agent: "vscode-copilot"},
+			expects: []string{"Restart VS Code", "servers.engram", "engram.instructions.md"},
+		},
+		{
+			name:    "kilocode",
+			result:  &setup.Result{Agent: "kilocode"},
+			expects: []string{"Restart Kilo Code", "~/.config/kilo/opencode.json"},
 		},
 		{
 			name:   "unknown",

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -20,12 +20,21 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 | Pi            | `engram setup pi`                                                                            | [Details](#pi)                                     |
 | OpenCode      | `engram setup opencode`                                                                      | [Details](#opencode)                               |
 | Gemini CLI    | `engram setup gemini-cli`                                                                    | [Details](#gemini-cli)                             |
-| Codex         | `engram setup codex`                                                                         | [Details](#codex)                                  |
-| VS Code       | `code --add-mcp '{"name":"engram","command":"engram","args":["mcp"]}'`                       | [Details](#vs-code-copilot--claude-code-extension) |
-| Antigravity   | Manual JSON config                                                                           | [Details](#antigravity)                            |
-| Cursor        | Manual JSON config                                                                           | [Details](#cursor)                                 |
-| Windsurf      | Manual JSON config                                                                           | [Details](#windsurf)                               |
-| Any MCP agent | `engram mcp` (stdio)                                                                         | [Details](#any-other-mcp-agent)                    |
+| Codex           | `engram setup codex`                                                                         | [Details](#codex)                                  |
+| Antigravity CLI | `engram setup antigravity-cli`                                                               | [Details](#antigravity)                            |
+| Windsurf        | `engram setup windsurf`                                                                      | [Details](#windsurf)                               |
+| Qwen Code       | `engram setup qwen`                                                                          | [Details](#qwen-code)                              |
+| Kiro            | `engram setup kiro`                                                                          | [Details](#kiro)                                   |
+| Cursor          | `engram setup cursor`                                                                        | [Details](#cursor)                                 |
+| VS Code Copilot | `engram setup vscode-copilot`                                                                | [Details](#vs-code-copilot--claude-code-extension) |
+| Kilo Code       | `engram setup kilocode`                                                                      | [Details](#kilo-code)                              |
+| Any MCP agent   | `engram mcp` (stdio)                                                                         | [Details](#any-other-mcp-agent)                    |
+
+> **Native setup for all agents above.** `engram setup <agent>` writes the right
+> MCP registration (handling each client's config format — `mcpServers`,
+> `servers`, or OpenCode's `mcp` object) plus the Memory Protocol into that
+> agent's instruction surface, idempotently. The per-agent sections below describe
+> the exact files each command touches and the manual equivalent.
 
 ## Pi
 
@@ -435,6 +444,14 @@ Transport closed
 
 VS Code supports MCP servers natively in its chat panel (Copilot agent mode). This works with **any** AI agent running inside VS Code — Copilot, Claude Code extension, or any other MCP-compatible chat provider.
 
+**Automated (user profile):**
+
+```bash
+engram setup vscode-copilot
+```
+
+This registers the engram server under the `servers` object (with `type: stdio`) in your VS Code User `mcp.json` and writes a Copilot instructions file at `<User>/prompts/engram.instructions.md` (frontmatter `applyTo: "**"`). User dir per platform: macOS `~/Library/Application Support/Code/User/`, Linux `~/.config/Code/User/`, Windows `%APPDATA%\Code\User\`.
+
 **Option A: Workspace config** (recommended for teams — commit to source control):
 
 Add to `.vscode/mcp.json` in your project:
@@ -540,39 +557,53 @@ Same pattern applies to:
 
 ## Antigravity
 
-[Antigravity](https://antigravity.google) is Google's AI-first IDE with native MCP and skill support.
+[Antigravity](https://antigravity.google) is Google's AI-first IDE/CLI with native MCP and skill support.
 
-**Add the MCP server** — open the MCP Store (`...` dropdown in the agent panel) → **Manage MCP Servers** → **View raw config**, and add to `~/.gemini/antigravity/mcp_config.json`:
+**Automated:**
+
+```bash
+engram setup antigravity-cli
+```
+
+This registers `mcpServers.engram` in the shared `~/.gemini/config/mcp_config.json` (read by Antigravity CLI, IDE, and SDK) and writes the Memory Protocol as a marker-delimited block in `~/.gemini/GEMINI.md`, preserving any existing content.
+
+**Manual** — open the MCP Store (`...` dropdown in the agent panel) → **Manage MCP Servers** → **View raw config**, and add to `~/.gemini/config/mcp_config.json`:
 
 ```json
 {
   "mcpServers": {
     "engram": {
       "command": "engram",
-      "args": ["mcp"]
+      "args": ["mcp", "--tools=agent"]
     }
   }
 }
 ```
 
-**Adding the Memory Protocol** (recommended):
+Then add the Memory Protocol as a global rule in `~/.gemini/GEMINI.md`. See [DOCS.md](../DOCS.md#memory-protocol-full-text) for the full text.
 
-Add the Memory Protocol as a global rule in `~/.gemini/GEMINI.md`, or as a workspace rule in `.agent/rules/`. See [DOCS.md](../DOCS.md#memory-protocol-full-text) for the full text, or use the minimal version from [Surviving Compaction](#surviving-compaction-recommended).
-
-> **Note:** Antigravity has its own skill, rule, and MCP systems separate from VS Code. Do not use `.vscode/mcp.json`.
+> **Note:** Antigravity has its own skill, rule, and MCP systems separate from VS Code. Do not use `.vscode/mcp.json`. This is distinct from `engram setup gemini-cli`, which writes the Gemini CLI's own `settings.json` / `system.md`.
 
 ---
 
 ## Cursor
 
-Add to your `.cursor/mcp.json` (same path on all platforms — it's project-relative):
+**Automated:**
+
+```bash
+engram setup cursor
+```
+
+This registers `mcpServers.engram` in the global `~/.cursor/mcp.json` and writes an always-applied rule to `~/.cursor/rules/engram.mdc` (with the `alwaysApply: true` frontmatter Cursor needs).
+
+**Manual** — add to your `.cursor/mcp.json` (global: `~/.cursor/mcp.json`; or project-relative `.cursor/mcp.json`):
 
 ```json
 {
   "mcpServers": {
     "engram": {
       "command": "engram",
-      "args": ["mcp"]
+      "args": ["mcp", "--tools=agent"]
     }
   }
 }
@@ -593,20 +624,64 @@ Add to your `.cursor/mcp.json` (same path on all platforms — it's project-rela
 
 ## Windsurf
 
-Add to your `~/.windsurf/mcp.json` (Windows: `%USERPROFILE%\.windsurf\mcp.json`):
+**Automated:**
+
+```bash
+engram setup windsurf
+```
+
+This registers `mcpServers.engram` in `~/.codeium/windsurf/mcp_config.json` (Cascade's MCP config) and writes the Memory Protocol as a marker block in `~/.codeium/windsurf/memories/global_rules.md`.
+
+**Manual** — add to `~/.codeium/windsurf/mcp_config.json`:
 
 ```json
 {
   "mcpServers": {
     "engram": {
       "command": "engram",
-      "args": ["mcp"]
+      "args": ["mcp", "--tools=agent"]
     }
   }
 }
 ```
 
-> **Memory Protocol:** Add the Memory Protocol instructions to your `.windsurfrules` file. See [DOCS.md](../DOCS.md#memory-protocol-full-text) for the full text.
+> **Memory Protocol:** Add the Memory Protocol to `~/.codeium/windsurf/memories/global_rules.md`. See [DOCS.md](../DOCS.md#memory-protocol-full-text) for the full text.
+
+---
+
+## Qwen Code
+
+**Automated:**
+
+```bash
+engram setup qwen
+```
+
+Registers `mcpServers.engram` in `~/.qwen/settings.json` and writes the Memory Protocol as a marker block in `~/.qwen/QWEN.md`.
+
+---
+
+## Kiro
+
+**Automated:**
+
+```bash
+engram setup kiro
+```
+
+Registers `mcpServers.engram` in `~/.kiro/settings/mcp.json` and writes the Memory Protocol as a marker block in `~/.kiro/steering/engram.md`. (Kiro uses a split layout: MCP and steering live under `~/.kiro/` regardless of where the IDE keeps app settings.)
+
+---
+
+## Kilo Code
+
+**Automated:**
+
+```bash
+engram setup kilocode
+```
+
+Registers the engram server under the OpenCode-style `mcp` object in `~/.config/kilo/opencode.json` and writes the Memory Protocol as a marker block in `~/.config/kilo/AGENTS.md`.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -190,6 +190,11 @@ When using `engram setup`, config files are written to platform-appropriate loca
 | Gemini CLI | `~/.gemini/` | `%APPDATA%\gemini\` |
 | Codex | `~/.codex/` | `%APPDATA%\codex\` |
 | Claude Code | Managed by `claude` CLI | Managed by `claude` CLI |
-| VS Code | `.vscode/mcp.json` (workspace) or `~/Library/Application Support/Code/User/mcp.json` (user) | `.vscode\mcp.json` (workspace) or `%APPDATA%\Code\User\mcp.json` (user) |
-| Antigravity | `~/.gemini/antigravity/mcp_config.json` | `%USERPROFILE%\.gemini\antigravity\mcp_config.json` |
+| Antigravity CLI | `~/.gemini/config/mcp_config.json` + `~/.gemini/GEMINI.md` | `%APPDATA%\gemini\config\mcp_config.json` + `%APPDATA%\gemini\GEMINI.md` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` + `.../memories/global_rules.md` | `%USERPROFILE%\.codeium\windsurf\...` |
+| Qwen Code | `~/.qwen/settings.json` + `~/.qwen/QWEN.md` | `%USERPROFILE%\.qwen\...` |
+| Kiro | `~/.kiro/settings/mcp.json` + `~/.kiro/steering/engram.md` | `%USERPROFILE%\.kiro\...` |
+| Cursor | `~/.cursor/mcp.json` + `~/.cursor/rules/engram.mdc` | `%USERPROFILE%\.cursor\...` |
+| VS Code Copilot | `~/.config/Code/User/mcp.json` + `.../prompts/engram.instructions.md` (macOS: `~/Library/Application Support/Code/User/`) | `%APPDATA%\Code\User\...` |
+| Kilo Code | `~/.config/kilo/opencode.json` + `~/.config/kilo/AGENTS.md` | `%USERPROFILE%\.config\kilo\...` |
 | Data directory | `~/.engram/` | `%USERPROFILE%\.engram\` |

--- a/docs/codebase/integrations.md
+++ b/docs/codebase/integrations.md
@@ -24,14 +24,26 @@ Agent
   │     ├── plugin/claude-code/scripts/*.sh / *.ps1
   │     └── plugin/claude-code/skills/memory/SKILL.md
   │
-  ├── Gemini / Codex setup
-  │     └── internal/setup/setup.go
-  │
-  └── VS Code / Antigravity / Cursor / Windsurf manual MCP
-        └── JSON configuration documented in docs/AGENT-SETUP.md
+  └── Agent registry (declarative setup)
+        ├── internal/setup/registry.go   (generic injectMCP / writeInstruction driver)
+        └── internal/setup/agents.go     (one data entry per agent)
 ```
 
-`internal/setup` does not install every possible integration. VS Code, Antigravity, Cursor, and Windsurf are manual MCP configuration paths documented in `docs/AGENT-SETUP.md`.
+`internal/setup` exposes a data-driven agent registry (`agentAdapters()` in
+`agents.go`). `Install()` and `SupportedAgents()` are derived from it. Each entry
+is either:
+
+- **bespoke** — a `custom` installer for agents with special needs (OpenCode embeds
+  a TS plugin, Pi runs a package manager, Claude Code drives the `claude` CLI, Codex
+  writes TOML, Gemini CLI cleans up legacy env state), or
+- **declarative** — just an MCP path + format (`mcpServers` / `servers` / OpenCode's
+  `mcp` object) and instruction surfaces; the generic `injectMCP` / `writeInstruction`
+  driver in `registry.go` does the writes. Antigravity CLI, Windsurf, Qwen, Kiro,
+  Cursor, VS Code Copilot, and Kilo Code are all declarative.
+
+Adding a declarative agent is normally just a new entry in `agentAdapters()` plus
+its path helpers — no new install code path. Agents not in the registry remain
+manual MCP configs documented in `docs/AGENT-SETUP.md`.
 
 ## Thin plugin principle
 

--- a/internal/setup/agents.go
+++ b/internal/setup/agents.go
@@ -1,0 +1,291 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// agentAdapters returns the full agent registry in display order.
+//
+// Existing agents with bespoke install needs (embedded plugin, package manager,
+// CLI bootstrapping, TOML config) keep their hand-written installers via `custom`.
+// Declarative agents only describe where their MCP config and instruction surfaces
+// live; the generic injectMCP / writeInstruction machinery in registry.go does the
+// rest. Adding a new agent of the declarative kind is just another entry here.
+func agentAdapters() []agentAdapter {
+	return []agentAdapter{
+		{
+			slug:        "opencode",
+			description: "OpenCode — TypeScript plugin with session tracking, compaction recovery, and Memory Protocol",
+			custom:      installOpenCode,
+			installDir:  openCodePluginDir,
+		},
+		{
+			slug:        "pi",
+			description: "Pi — gentle-engram package plus pi-mcp-adapter MCP tools",
+			custom:      installPi,
+			installDir:  piAgentDir,
+			postInstall: []string{
+				"Restart Pi so packages and MCP config are reloaded",
+				"Verify with: pi list",
+			},
+		},
+		{
+			slug:        "claude-code",
+			description: "Claude Code — Native plugin via marketplace (hooks, skills, MCP, compaction recovery)",
+			custom:      installClaudeCode,
+			installDir:  func() string { return "managed by claude plugin system" },
+		},
+		{
+			slug:        "gemini-cli",
+			description: "Gemini CLI — MCP registration plus system prompt compaction recovery",
+			custom:      installGeminiCLI,
+			installDir:  geminiConfigPath,
+			postInstall: []string{
+				"Restart Gemini CLI so MCP config is reloaded",
+				"Verify ~/.gemini/settings.json includes mcpServers.engram",
+				"Verify ~/.gemini/system.md + ~/.gemini/.env exist for compaction recovery",
+			},
+		},
+		{
+			slug:        "codex",
+			description: "Codex — MCP registration plus model/compaction instruction files",
+			custom:      installCodex,
+			installDir:  codexConfigPath,
+			postInstall: []string{
+				"Restart Codex so MCP config is reloaded",
+				"Verify ~/.codex/config.toml has [mcp_servers.engram]",
+				"Verify model_instructions_file + experimental_compact_prompt_file are set",
+			},
+		},
+		{
+			slug:        "antigravity-cli",
+			description: "Antigravity CLI — MCP registration in the shared ~/.gemini config plus GEMINI.md Memory Protocol",
+			mcpPath:     antigravityMCPConfigPath,
+			mcpFormat:   mcpServersObject,
+			instructions: []instrSurface{
+				{path: antigravityContextPath, style: markerBlock, body: memoryProtocolMarkdown},
+			},
+			postInstall: []string{
+				"Restart Antigravity so the shared MCP config is reloaded",
+				"Verify ~/.gemini/config/mcp_config.json includes mcpServers.engram",
+				"Verify ~/.gemini/GEMINI.md has the Engram Memory Protocol block",
+			},
+		},
+		{
+			slug:        "windsurf",
+			description: "Windsurf (Cascade) — MCP registration plus global_rules.md Memory Protocol",
+			mcpPath:     windsurfMCPPath,
+			mcpFormat:   mcpServersObject,
+			instructions: []instrSurface{
+				{path: windsurfRulesPath, style: markerBlock, body: memoryProtocolMarkdown},
+			},
+			postInstall: []string{
+				"Restart Windsurf so Cascade reloads MCP config",
+				"Verify ~/.codeium/windsurf/mcp_config.json includes mcpServers.engram",
+				"Verify ~/.codeium/windsurf/memories/global_rules.md has the Memory Protocol block",
+			},
+		},
+		{
+			slug:        "qwen",
+			description: "Qwen Code — MCP registration in ~/.qwen/settings.json plus QWEN.md Memory Protocol",
+			mcpPath:     qwenSettingsPath,
+			mcpFormat:   mcpServersObject,
+			instructions: []instrSurface{
+				{path: qwenContextPath, style: markerBlock, body: memoryProtocolMarkdown},
+			},
+			postInstall: []string{
+				"Restart Qwen Code so MCP config is reloaded",
+				"Verify ~/.qwen/settings.json includes mcpServers.engram",
+				"Verify ~/.qwen/QWEN.md has the Engram Memory Protocol block",
+			},
+		},
+		{
+			slug:        "kiro",
+			description: "Kiro IDE — MCP registration in ~/.kiro/settings/mcp.json plus steering Memory Protocol",
+			mcpPath:     kiroMCPPath,
+			mcpFormat:   mcpServersObject,
+			instructions: []instrSurface{
+				{path: kiroSteeringPath, style: markerBlock, body: memoryProtocolMarkdown},
+			},
+			postInstall: []string{
+				"Restart Kiro so MCP config is reloaded",
+				"Verify ~/.kiro/settings/mcp.json includes mcpServers.engram",
+				"Verify ~/.kiro/steering/engram.md has the Memory Protocol block",
+			},
+		},
+		{
+			slug:        "cursor",
+			description: "Cursor — MCP registration in ~/.cursor/mcp.json plus an always-applied .mdc rule",
+			mcpPath:     cursorMCPPath,
+			mcpFormat:   mcpServersObject,
+			instructions: []instrSurface{
+				{path: cursorRulesPath, style: wholeFile, body: cursorRulesBody()},
+			},
+			postInstall: []string{
+				"Restart Cursor so MCP config is reloaded",
+				"Verify ~/.cursor/mcp.json includes mcpServers.engram",
+				"Verify ~/.cursor/rules/engram.mdc exists (always-applied rule)",
+			},
+		},
+		{
+			slug:        "vscode-copilot",
+			description: "VS Code (Copilot) — MCP registration in the User mcp.json plus a Copilot instructions file",
+			mcpPath:     vscodeMCPPath,
+			mcpFormat:   serversObject,
+			instructions: []instrSurface{
+				{path: vscodePromptPath, style: wholeFile, body: vscodeInstructionsBody()},
+			},
+			postInstall: []string{
+				"Restart VS Code so Copilot reloads MCP config",
+				"Verify <VS Code User>/mcp.json includes servers.engram",
+				"Verify <VS Code User>/prompts/engram.instructions.md exists",
+			},
+		},
+		{
+			slug:        "kilocode",
+			description: "Kilo Code — MCP registration in ~/.config/kilo/opencode.json plus AGENTS.md Memory Protocol",
+			mcpPath:     kilocodeConfigPath,
+			mcpFormat:   opencodeObject,
+			instructions: []instrSurface{
+				{path: kilocodeAgentsPath, style: markerBlock, body: memoryProtocolMarkdown},
+			},
+			postInstall: []string{
+				"Restart Kilo Code so MCP config is reloaded",
+				"Verify ~/.config/kilo/opencode.json includes mcp.engram",
+				"Verify ~/.config/kilo/AGENTS.md has the Memory Protocol block",
+			},
+		},
+	}
+}
+
+// cursorRulesBody wraps the Memory Protocol in the YAML frontmatter Cursor needs
+// for an always-applied rule (alwaysApply:true ignores globs and attaches the rule
+// regardless of context).
+func cursorRulesBody() string {
+	return "---\ndescription: Engram persistent memory protocol\nalwaysApply: true\n---\n\n" + memoryProtocolMarkdown
+}
+
+// vscodeInstructionsBody wraps the Memory Protocol in the frontmatter VS Code
+// Copilot uses for a user-level instructions file that applies to every file.
+func vscodeInstructionsBody() string {
+	return "---\napplyTo: \"**\"\n---\n\n" + memoryProtocolMarkdown
+}
+
+// ─── Antigravity CLI paths ───────────────────────────────────────────────────
+//
+// Antigravity (CLI and IDE) read MCP servers from the shared ~/.gemini/config/
+// mcp_config.json (top-level "mcpServers") and global instructions from
+// ~/.gemini/GEMINI.md. These live under ~/.gemini but are distinct from the
+// Gemini CLI's own settings.json / system.md surfaces.
+
+func antigravityMCPConfigPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".gemini", "config", "mcp_config.json")
+}
+
+func antigravityContextPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".gemini", "GEMINI.md")
+}
+
+// ─── Windsurf paths ──────────────────────────────────────────────────────────
+
+func windsurfMCPPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+}
+
+func windsurfRulesPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md")
+}
+
+// ─── Qwen Code paths ─────────────────────────────────────────────────────────
+
+func qwenSettingsPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".qwen", "settings.json")
+}
+
+func qwenContextPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".qwen", "QWEN.md")
+}
+
+// ─── Kiro IDE paths ──────────────────────────────────────────────────────────
+//
+// Kiro uses a split layout: MCP config and steering both live under ~/.kiro/
+// regardless of where the IDE keeps its app settings.
+
+func kiroMCPPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".kiro", "settings", "mcp.json")
+}
+
+func kiroSteeringPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".kiro", "steering", "engram.md")
+}
+
+// ─── Cursor paths ────────────────────────────────────────────────────────────
+
+func cursorMCPPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".cursor", "mcp.json")
+}
+
+func cursorRulesPath() string {
+	home, _ := userHomeDir()
+	return filepath.Join(home, ".cursor", "rules", "engram.mdc")
+}
+
+// ─── VS Code (Copilot) paths ─────────────────────────────────────────────────
+
+// vscodeUserDir returns the platform-specific VS Code "User" config directory.
+func vscodeUserDir() string {
+	home, _ := userHomeDir()
+	switch runtimeGOOS {
+	case "windows":
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			return filepath.Join(appData, "Code", "User")
+		}
+		return filepath.Join(home, "AppData", "Roaming", "Code", "User")
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Code", "User")
+	default:
+		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+			return filepath.Join(xdg, "Code", "User")
+		}
+		return filepath.Join(home, ".config", "Code", "User")
+	}
+}
+
+func vscodeMCPPath() string {
+	return filepath.Join(vscodeUserDir(), "mcp.json")
+}
+
+func vscodePromptPath() string {
+	return filepath.Join(vscodeUserDir(), "prompts", "engram.instructions.md")
+}
+
+// ─── Kilo Code paths ─────────────────────────────────────────────────────────
+//
+// Kilo Code follows OpenCode's config model (top-level "mcp" object) but under
+// its own ~/.config/kilo/ root.
+
+func kilocodeConfigDir() string {
+	home, _ := userHomeDir()
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "kilo")
+	}
+	return filepath.Join(home, ".config", "kilo")
+}
+
+func kilocodeConfigPath() string {
+	return filepath.Join(kilocodeConfigDir(), "opencode.json")
+}
+
+func kilocodeAgentsPath() string {
+	return filepath.Join(kilocodeConfigDir(), "AGENTS.md")
+}

--- a/internal/setup/agents.go
+++ b/internal/setup/agents.go
@@ -180,36 +180,36 @@ func vscodeInstructionsBody() string {
 // Gemini CLI's own settings.json / system.md surfaces.
 
 func antigravityMCPConfigPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".gemini", "config", "mcp_config.json")
 }
 
 func antigravityContextPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".gemini", "GEMINI.md")
 }
 
 // ─── Windsurf paths ──────────────────────────────────────────────────────────
 
 func windsurfMCPPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
 }
 
 func windsurfRulesPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md")
 }
 
 // ─── Qwen Code paths ─────────────────────────────────────────────────────────
 
 func qwenSettingsPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".qwen", "settings.json")
 }
 
 func qwenContextPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".qwen", "QWEN.md")
 }
 
@@ -219,24 +219,24 @@ func qwenContextPath() string {
 // regardless of where the IDE keeps its app settings.
 
 func kiroMCPPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".kiro", "settings", "mcp.json")
 }
 
 func kiroSteeringPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".kiro", "steering", "engram.md")
 }
 
 // ─── Cursor paths ────────────────────────────────────────────────────────────
 
 func cursorMCPPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".cursor", "mcp.json")
 }
 
 func cursorRulesPath() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	return filepath.Join(home, ".cursor", "rules", "engram.mdc")
 }
 
@@ -244,7 +244,7 @@ func cursorRulesPath() string {
 
 // vscodeUserDir returns the platform-specific VS Code "User" config directory.
 func vscodeUserDir() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	switch runtimeGOOS {
 	case "windows":
 		if appData := os.Getenv("APPDATA"); appData != "" {
@@ -275,7 +275,7 @@ func vscodePromptPath() string {
 // its own ~/.config/kilo/ root.
 
 func kilocodeConfigDir() string {
-	home, _ := userHomeDir()
+	home, _ := userHome()
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		return filepath.Join(xdg, "kilo")
 	}

--- a/internal/setup/registry.go
+++ b/internal/setup/registry.go
@@ -82,6 +82,23 @@ func (a agentAdapter) displayDir() string {
 	}
 }
 
+// userHome centralizes home-directory resolution for every declarative path
+// helper. It returns an error when no non-empty absolute home can be determined,
+// so callers never silently fall back to a relative path (which would write
+// agent config into the current working directory instead of the user config
+// root). Path helpers ignore the error because installFromAdapter validates
+// resolvability up front via this same function before any write happens.
+func userHome() (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home directory: %w", err)
+	}
+	if strings.TrimSpace(home) == "" || !filepath.IsAbs(home) {
+		return "", fmt.Errorf("could not determine an absolute user home directory (got %q)", home)
+	}
+	return home, nil
+}
+
 // mcpTopKey returns the top-level JSON key under which servers are stored.
 func mcpTopKey(format mcpFormat) string {
 	switch format {
@@ -134,6 +151,11 @@ func injectMCP(path string, format mcpFormat) error {
 	if raw, ok := config[topKey]; ok {
 		if err := json.Unmarshal(raw, &servers); err != nil {
 			return fmt.Errorf("parse %s block in %s: %w", topKey, path, err)
+		}
+		// Unmarshalling a JSON null leaves the map nil; re-init so the engram
+		// assignment below doesn't panic on configs like "mcpServers": null.
+		if servers == nil {
+			servers = make(map[string]json.RawMessage)
 		}
 	}
 
@@ -210,6 +232,13 @@ func writeInstruction(ins instrSurface) error {
 func installFromAdapter(a agentAdapter) (*Result, error) {
 	if a.custom != nil {
 		return a.custom()
+	}
+
+	// Declarative path helpers build their destinations from the user home dir.
+	// Validate once here so an unresolvable home fails the install instead of
+	// silently writing config into the current working directory.
+	if _, err := userHome(); err != nil {
+		return nil, err
 	}
 
 	files := 0

--- a/internal/setup/registry.go
+++ b/internal/setup/registry.go
@@ -1,0 +1,261 @@
+package setup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This file holds the agent registry: a data-driven description of every agent
+// engram knows how to set up. Adding a new agent is (almost) only a matter of
+// appending an entry to agentAdapters() — the generic injectMCP / writeInstruction
+// machinery below handles the actual file writes. Agents with bespoke needs
+// (embedded plugins, package managers, CLI bootstrapping, TOML configs) provide a
+// `custom` installer instead and keep their hand-written logic in setup.go.
+
+// mcpFormat describes how an agent stores its MCP server registration on disk.
+type mcpFormat int
+
+const (
+	// mcpServersObject stores servers under a top-level "mcpServers" object, each
+	// entry shaped {command, args}. Used by Gemini, Antigravity, Windsurf, Qwen,
+	// Kiro, and Cursor.
+	mcpServersObject mcpFormat = iota
+	// serversObject stores servers under a top-level "servers" object, each entry
+	// shaped {type:"stdio", command, args}. Used by VS Code (Copilot).
+	serversObject
+	// opencodeObject stores servers under a top-level "mcp" object, each entry
+	// shaped {type:"local", command:[bin, ...args], enabled:true}. Used by
+	// OpenCode and Kilocode.
+	opencodeObject
+)
+
+// instrStyle describes how an agent's instruction/prompt surface is written.
+type instrStyle int
+
+const (
+	// markerBlock writes the protocol as a marker-delimited block inside a shared
+	// file, replacing only the managed block on re-run and preserving user content.
+	markerBlock instrStyle = iota
+	// wholeFile writes a dedicated file fully owned by engram (overwrite on re-run).
+	wholeFile
+)
+
+// engramMarkerBegin/End delimit the managed Memory Protocol block in shared
+// instruction surfaces so re-running setup replaces only that block.
+const engramMarkerBegin = "<!-- BEGIN ENGRAM MEMORY PROTOCOL — managed by engram setup -->"
+const engramMarkerEnd = "<!-- END ENGRAM MEMORY PROTOCOL -->"
+
+// instrSurface is one instruction/prompt file an agent reads for the Memory Protocol.
+type instrSurface struct {
+	path  func() string
+	style instrStyle
+	body  string
+}
+
+// agentAdapter is the registry entry for a single agent. A declarative adapter
+// sets mcpPath/mcpFormat and instructions; a bespoke one sets custom (which fully
+// owns the install and ignores the declarative fields).
+type agentAdapter struct {
+	slug         string
+	description  string
+	mcpPath      func() string  // nil when the agent registers MCP some other way
+	mcpFormat    mcpFormat      // how the MCP entry is shaped (ignored when mcpPath is nil)
+	instructions []instrSurface // zero or more instruction surfaces to write
+	bootstrap    func() error   // optional post-setup hook (e.g. seed a sibling config)
+	custom       func() (*Result, error)
+	installDir   func() string // display path for SupportedAgents (defaults to mcpPath)
+	postInstall  []string      // "next steps" lines shown after install (nil = handled specially)
+}
+
+// displayDir returns the path shown to the user in `engram setup --help`.
+func (a agentAdapter) displayDir() string {
+	switch {
+	case a.installDir != nil:
+		return a.installDir()
+	case a.mcpPath != nil:
+		return a.mcpPath()
+	default:
+		return ""
+	}
+}
+
+// mcpTopKey returns the top-level JSON key under which servers are stored.
+func mcpTopKey(format mcpFormat) string {
+	switch format {
+	case serversObject:
+		return "servers"
+	case opencodeObject:
+		return "mcp"
+	default:
+		return "mcpServers"
+	}
+}
+
+// mcpEntry builds the engram server entry in the shape the given format expects,
+// always resolving the absolute binary path so headless/Windows subprocesses
+// don't depend on PATH.
+func mcpEntry(format mcpFormat) any {
+	cmd := resolveEngramCommand()
+	switch format {
+	case opencodeObject:
+		return map[string]any{
+			"type":    "local",
+			"command": []string{cmd, "mcp", "--tools=agent"},
+			"enabled": true,
+		}
+	case serversObject:
+		return map[string]any{
+			"type":    "stdio",
+			"command": cmd,
+			"args":    []string{"mcp", "--tools=agent"},
+		}
+	default:
+		return map[string]any{
+			"command": cmd,
+			"args":    []string{"mcp", "--tools=agent"},
+		}
+	}
+}
+
+// injectMCP registers the engram MCP server in the JSON config at path using the
+// given format, preserving any other servers and top-level keys. Idempotent:
+// re-running updates the engram entry in place. Parent dirs are created as needed.
+func injectMCP(path string, format mcpFormat) error {
+	config, err := readJSONConfig(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	topKey := mcpTopKey(format)
+	servers := make(map[string]json.RawMessage)
+	if raw, ok := config[topKey]; ok {
+		if err := json.Unmarshal(raw, &servers); err != nil {
+			return fmt.Errorf("parse %s block in %s: %w", topKey, path, err)
+		}
+	}
+
+	entryJSON, err := jsonMarshalFn(mcpEntry(format))
+	if err != nil {
+		return fmt.Errorf("marshal engram entry: %w", err)
+	}
+	servers["engram"] = json.RawMessage(entryJSON)
+
+	blockJSON, err := jsonMarshalFn(servers)
+	if err != nil {
+		return fmt.Errorf("marshal %s block: %w", topKey, err)
+	}
+	config[topKey] = json.RawMessage(blockJSON)
+
+	return writeJSONConfig(path, config)
+}
+
+// upsertMarkerBlock writes body delimited by begin/end markers into the file at
+// path. If the markers already exist the managed block is replaced in place;
+// otherwise it is appended, preserving existing user content. CRLF is normalized
+// to LF. The file (and its parent dir) is created when missing.
+func upsertMarkerBlock(path, begin, end, body string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create dir for %s: %w", path, err)
+	}
+	block := begin + "\n\n" + body + "\n" + end + "\n"
+
+	existing, err := readFileFn(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := writeFileFn(path, []byte(block), 0644); err != nil {
+				return fmt.Errorf("write %s: %w", path, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	text := strings.ReplaceAll(string(existing), "\r\n", "\n")
+	start := strings.Index(text, begin)
+	stop := strings.Index(text, end)
+	if start != -1 && stop != -1 && stop > start {
+		stop += len(end)
+		text = text[:start] + strings.TrimRight(block, "\n") + text[stop:]
+	} else {
+		text = strings.TrimRight(text, "\n") + "\n\n" + block
+	}
+
+	if err := writeFileFn(path, []byte(text), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// writeInstruction writes a single instruction surface according to its style.
+func writeInstruction(ins instrSurface) error {
+	path := ins.path()
+	if ins.style == wholeFile {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return fmt.Errorf("create dir for %s: %w", path, err)
+		}
+		if err := writeFileFn(path, []byte(ins.body), 0644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+		return nil
+	}
+	return upsertMarkerBlock(path, engramMarkerBegin, engramMarkerEnd, ins.body)
+}
+
+// installFromAdapter runs a declarative adapter's install steps: MCP registration,
+// instruction surfaces, then an optional bootstrap hook. Bespoke adapters delegate
+// entirely to their custom installer.
+func installFromAdapter(a agentAdapter) (*Result, error) {
+	if a.custom != nil {
+		return a.custom()
+	}
+
+	files := 0
+	if a.mcpPath != nil {
+		if err := injectMCP(a.mcpPath(), a.mcpFormat); err != nil {
+			return nil, err
+		}
+		files++
+	}
+	for _, ins := range a.instructions {
+		if err := writeInstruction(ins); err != nil {
+			return nil, err
+		}
+		files++
+	}
+	if a.bootstrap != nil {
+		if err := a.bootstrap(); err != nil {
+			return nil, err
+		}
+	}
+
+	dest := ""
+	if a.mcpPath != nil {
+		dest = filepath.Dir(a.mcpPath())
+	}
+	return &Result{Agent: a.slug, Destination: dest, Files: files}, nil
+}
+
+// PostInstallSteps returns the human-facing "next steps" lines for an agent, or
+// nil when the agent's post-install messaging is handled specially by the CLI
+// (opencode's conditional TUI note, claude-code's interactive allowlist prompt).
+func PostInstallSteps(agent string) []string {
+	for _, a := range agentAdapters() {
+		if a.slug == agent {
+			return a.postInstall
+		}
+	}
+	return nil
+}
+
+// supportedSlugs returns the registry slugs in registration order.
+func supportedSlugs() []string {
+	adapters := agentAdapters()
+	slugs := make([]string, 0, len(adapters))
+	for _, a := range adapters {
+		slugs = append(slugs, a.slug)
+	}
+	return slugs
+}

--- a/internal/setup/registry_test.go
+++ b/internal/setup/registry_test.go
@@ -145,18 +145,35 @@ func TestInstallDeclarativeAgentsRegisterMCPAndInstructions(t *testing.T) {
 			if !strings.Contains(instr, "Engram Persistent Memory") {
 				t.Errorf("%s: instruction file missing protocol content", agent.slug)
 			}
-			if agent.style == markerBlock && !strings.Contains(instr, engramMarkerBegin) {
-				t.Errorf("%s: marker-block instruction missing begin marker", agent.slug)
+			if agent.style == markerBlock {
+				begin := strings.Index(instr, engramMarkerBegin)
+				end := strings.Index(instr, engramMarkerEnd)
+				if begin == -1 {
+					t.Errorf("%s: marker-block instruction missing begin marker", agent.slug)
+				}
+				if end == -1 {
+					t.Errorf("%s: marker-block instruction missing end marker", agent.slug)
+				}
+				if begin != -1 && end != -1 && end <= begin {
+					t.Errorf("%s: end marker (%d) does not follow begin marker (%d)", agent.slug, end, begin)
+				}
 			}
 
 			// Idempotency: second run does not duplicate the entry or marker block.
 			if _, err := Install(agent.slug); err != nil {
 				t.Fatalf("second Install(%s) failed: %v", agent.slug, err)
 			}
-			instr2Raw, _ := os.ReadFile(agent.instrPath())
+			instr2Raw, err := os.ReadFile(agent.instrPath())
+			if err != nil {
+				t.Fatalf("read instruction file after second install: %v", err)
+			}
 			if agent.style == markerBlock {
-				if n := strings.Count(string(instr2Raw), engramMarkerBegin); n != 1 {
+				instr2 := string(instr2Raw)
+				if n := strings.Count(instr2, engramMarkerBegin); n != 1 {
 					t.Errorf("%s: expected 1 marker block after re-run, got %d", agent.slug, n)
+				}
+				if n := strings.Count(instr2, engramMarkerEnd); n != 1 {
+					t.Errorf("%s: expected 1 marker end after re-run, got %d", agent.slug, n)
 				}
 			}
 		})
@@ -252,6 +269,59 @@ func TestInstallDeclarativeAgentMCPWriteError(t *testing.T) {
 
 	if _, err := Install("windsurf"); err == nil {
 		t.Fatalf("expected write error to propagate")
+	}
+}
+
+// TestInstallDeclarativeAgentInstructionWriteError verifies an instruction-surface
+// write failure propagates even when the MCP write succeeds: writeFileFn fails only
+// for the (non-JSON) instruction file so injectMCP — which goes through
+// writeJSONConfig — completes first.
+func TestInstallDeclarativeAgentInstructionWriteError(t *testing.T) {
+	stubRegistryEnv(t)
+	instrPath := windsurfRulesPath()
+	writeFileFn = func(path string, _ []byte, _ os.FileMode) error {
+		if path == instrPath {
+			return errors.New("disk full")
+		}
+		return os.WriteFile(path, nil, 0644)
+	}
+
+	if _, err := Install("windsurf"); err == nil {
+		t.Fatalf("expected instruction write error to propagate")
+	}
+}
+
+// TestInjectMCPHandlesNullServersObject guards the case where an existing config
+// stores the top-level servers key as JSON null — unmarshalling leaves the map
+// nil, and the engram assignment must not panic.
+func TestInjectMCPHandlesNullServersObject(t *testing.T) {
+	stubRegistryEnv(t)
+	path := windsurfMCPPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"mcpServers":null}`), 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	if err := injectMCP(path, mcpServersObject); err != nil {
+		t.Fatalf("injectMCP with null servers: %v", err)
+	}
+	entry := readEngramEntry(t, path, "mcpServers")
+	if entry["command"] != testEngramBin {
+		t.Errorf("expected engram entry written, got %#v", entry)
+	}
+}
+
+// TestInstallDeclarativeAgentFailsOnUnresolvableHome verifies that a home-dir
+// lookup failure fails the install rather than silently writing to a relative
+// path under the current working directory.
+func TestInstallDeclarativeAgentFailsOnUnresolvableHome(t *testing.T) {
+	stubRegistryEnv(t)
+	userHomeDir = func() (string, error) { return "", errors.New("no home") }
+
+	if _, err := Install("windsurf"); err == nil {
+		t.Fatalf("expected install to fail when home is unresolvable")
 	}
 }
 

--- a/internal/setup/registry_test.go
+++ b/internal/setup/registry_test.go
@@ -1,0 +1,274 @@
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testEngramBin = "/usr/local/bin/engram"
+
+// declarativeAgent describes a registry agent installed through the generic
+// driver (no custom installer), for table-driven assertions.
+type declarativeAgent struct {
+	slug      string
+	mcpPath   func() string
+	topKey    string
+	mcpFormat mcpFormat
+	instrPath func() string
+	style     instrStyle
+}
+
+func declarativeAgents() []declarativeAgent {
+	return []declarativeAgent{
+		{"antigravity-cli", antigravityMCPConfigPath, "mcpServers", mcpServersObject, antigravityContextPath, markerBlock},
+		{"windsurf", windsurfMCPPath, "mcpServers", mcpServersObject, windsurfRulesPath, markerBlock},
+		{"qwen", qwenSettingsPath, "mcpServers", mcpServersObject, qwenContextPath, markerBlock},
+		{"kiro", kiroMCPPath, "mcpServers", mcpServersObject, kiroSteeringPath, markerBlock},
+		{"cursor", cursorMCPPath, "mcpServers", mcpServersObject, cursorRulesPath, wholeFile},
+		{"vscode-copilot", vscodeMCPPath, "servers", serversObject, vscodePromptPath, wholeFile},
+		{"kilocode", kilocodeConfigPath, "mcp", opencodeObject, kilocodeAgentsPath, markerBlock},
+	}
+}
+
+// stubRegistryEnv isolates path resolution to a temp HOME with no XDG/APPDATA
+// leakage and a deterministic OS and binary path.
+func stubRegistryEnv(t *testing.T) string {
+	t.Helper()
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	runtimeGOOS = "linux"
+	osExecutable = func() (string, error) { return testEngramBin, nil }
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("APPDATA", "")
+	return home
+}
+
+func TestSupportedAgentsIncludesAllRegistryAgents(t *testing.T) {
+	stubRegistryEnv(t)
+
+	got := make(map[string]bool)
+	for _, a := range SupportedAgents() {
+		got[a.Name] = true
+	}
+
+	want := []string{
+		"opencode", "pi", "claude-code", "gemini-cli", "codex",
+		"antigravity-cli", "windsurf", "qwen", "kiro", "cursor",
+		"vscode-copilot", "kilocode",
+	}
+	for _, slug := range want {
+		if !got[slug] {
+			t.Errorf("expected %q in SupportedAgents()", slug)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("expected %d agents, got %d", len(want), len(got))
+	}
+}
+
+// readEngramEntry parses the MCP config at path and returns the engram server
+// entry stored under topKey.
+func readEngramEntry(t *testing.T, path, topKey string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read mcp config %s: %v", path, err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse mcp config %s: %v", path, err)
+	}
+	block, ok := cfg[topKey].(map[string]any)
+	if !ok {
+		t.Fatalf("expected %q object in %s, got %#v", topKey, path, cfg[topKey])
+	}
+	entry, ok := block["engram"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected %s.engram object in %s", topKey, path)
+	}
+	return entry
+}
+
+func TestInstallDeclarativeAgentsRegisterMCPAndInstructions(t *testing.T) {
+	for _, agent := range declarativeAgents() {
+		t.Run(agent.slug, func(t *testing.T) {
+			stubRegistryEnv(t)
+
+			result, err := Install(agent.slug)
+			if err != nil {
+				t.Fatalf("Install(%s) failed: %v", agent.slug, err)
+			}
+			if result.Agent != agent.slug {
+				t.Fatalf("expected agent %q, got %q", agent.slug, result.Agent)
+			}
+			if result.Files != 2 {
+				t.Fatalf("expected 2 files for %s, got %d", agent.slug, result.Files)
+			}
+
+			// MCP entry shape per format.
+			entry := readEngramEntry(t, agent.mcpPath(), agent.topKey)
+			switch agent.mcpFormat {
+			case opencodeObject:
+				if entry["type"] != "local" {
+					t.Errorf("%s: expected type local, got %#v", agent.slug, entry["type"])
+				}
+				if entry["enabled"] != true {
+					t.Errorf("%s: expected enabled true, got %#v", agent.slug, entry["enabled"])
+				}
+				cmd, ok := entry["command"].([]any)
+				if !ok || len(cmd) != 3 || cmd[0] != testEngramBin || cmd[1] != "mcp" || cmd[2] != "--tools=agent" {
+					t.Errorf("%s: unexpected command array %#v", agent.slug, entry["command"])
+				}
+			default:
+				if entry["command"] != testEngramBin {
+					t.Errorf("%s: expected command %q, got %#v", agent.slug, testEngramBin, entry["command"])
+				}
+				args, ok := entry["args"].([]any)
+				if !ok || len(args) != 2 || args[0] != "mcp" || args[1] != "--tools=agent" {
+					t.Errorf("%s: unexpected args %#v", agent.slug, entry["args"])
+				}
+				if agent.mcpFormat == serversObject && entry["type"] != "stdio" {
+					t.Errorf("%s: expected type stdio, got %#v", agent.slug, entry["type"])
+				}
+			}
+
+			// Instruction surface contains the protocol.
+			instrRaw, err := os.ReadFile(agent.instrPath())
+			if err != nil {
+				t.Fatalf("read instruction file %s: %v", agent.instrPath(), err)
+			}
+			instr := string(instrRaw)
+			if !strings.Contains(instr, "Engram Persistent Memory") {
+				t.Errorf("%s: instruction file missing protocol content", agent.slug)
+			}
+			if agent.style == markerBlock && !strings.Contains(instr, engramMarkerBegin) {
+				t.Errorf("%s: marker-block instruction missing begin marker", agent.slug)
+			}
+
+			// Idempotency: second run does not duplicate the entry or marker block.
+			if _, err := Install(agent.slug); err != nil {
+				t.Fatalf("second Install(%s) failed: %v", agent.slug, err)
+			}
+			instr2Raw, _ := os.ReadFile(agent.instrPath())
+			if agent.style == markerBlock {
+				if n := strings.Count(string(instr2Raw), engramMarkerBegin); n != 1 {
+					t.Errorf("%s: expected 1 marker block after re-run, got %d", agent.slug, n)
+				}
+			}
+		})
+	}
+}
+
+func TestCursorAndVSCodeInstructionsCarryFrontmatter(t *testing.T) {
+	stubRegistryEnv(t)
+
+	if _, err := Install("cursor"); err != nil {
+		t.Fatalf("Install(cursor): %v", err)
+	}
+	cursorRaw, _ := os.ReadFile(cursorRulesPath())
+	if !strings.Contains(string(cursorRaw), "alwaysApply: true") {
+		t.Errorf("cursor .mdc missing alwaysApply frontmatter")
+	}
+
+	if _, err := Install("vscode-copilot"); err != nil {
+		t.Fatalf("Install(vscode-copilot): %v", err)
+	}
+	vscodeRaw, _ := os.ReadFile(vscodePromptPath())
+	if !strings.Contains(string(vscodeRaw), `applyTo: "**"`) {
+		t.Errorf("vscode instructions missing applyTo frontmatter")
+	}
+}
+
+func TestInjectMCPPreservesExistingServersAndKeys(t *testing.T) {
+	stubRegistryEnv(t)
+	path := windsurfMCPPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := `{"theme":"dark","mcpServers":{"other":{"command":"foo","args":["bar"]}}}`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	if err := injectMCP(path, mcpServersObject); err != nil {
+		t.Fatalf("injectMCP: %v", err)
+	}
+
+	raw, _ := os.ReadFile(path)
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg["theme"] != "dark" {
+		t.Errorf("expected top-level theme preserved, got %#v", cfg["theme"])
+	}
+	servers := cfg["mcpServers"].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Errorf("expected existing 'other' server preserved")
+	}
+	if _, ok := servers["engram"]; !ok {
+		t.Errorf("expected engram server added")
+	}
+}
+
+func TestUpsertMarkerBlockPreservesUserContentAndReplaces(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	path := filepath.Join(home, "notes.md")
+	if err := os.WriteFile(path, []byte("# My notes\n\nkeep me\n"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := upsertMarkerBlock(path, engramMarkerBegin, engramMarkerEnd, "BODY ONE"); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := upsertMarkerBlock(path, engramMarkerBegin, engramMarkerEnd, "BODY TWO"); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	raw, _ := os.ReadFile(path)
+	text := string(raw)
+	if !strings.Contains(text, "keep me") {
+		t.Errorf("user content not preserved: %q", text)
+	}
+	if strings.Contains(text, "BODY ONE") {
+		t.Errorf("stale managed block not replaced: %q", text)
+	}
+	if !strings.Contains(text, "BODY TWO") {
+		t.Errorf("new managed block missing: %q", text)
+	}
+	if n := strings.Count(text, engramMarkerBegin); n != 1 {
+		t.Errorf("expected exactly 1 marker block, got %d", n)
+	}
+}
+
+func TestInstallDeclarativeAgentMCPWriteError(t *testing.T) {
+	stubRegistryEnv(t)
+	writeFileFn = func(string, []byte, os.FileMode) error { return errors.New("disk full") }
+
+	if _, err := Install("windsurf"); err == nil {
+		t.Fatalf("expected write error to propagate")
+	}
+}
+
+func TestVSCodeUserDirPerPlatform(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("APPDATA", "")
+
+	cases := map[string]string{
+		"linux":  filepath.Join(home, ".config", "Code", "User"),
+		"darwin": filepath.Join(home, "Library", "Application Support", "Code", "User"),
+	}
+	for goos, want := range cases {
+		runtimeGOOS = goos
+		if got := vscodeUserDir(); got != want {
+			t.Errorf("vscodeUserDir(%s) = %q, want %q", goos, got, want)
+		}
+	}
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -237,52 +237,30 @@ After that sentence, summarize:
 Keep it concise and high-signal.`
 
 // SupportedAgents returns the list of agents that have plugins available.
+// The list is derived from the registry (agentAdapters) so adding an agent there
+// surfaces it here and in `engram setup --help` automatically.
 func SupportedAgents() []Agent {
-	return []Agent{
-		{
-			Name:        "opencode",
-			Description: "OpenCode — TypeScript plugin with session tracking, compaction recovery, and Memory Protocol",
-			InstallDir:  openCodePluginDir(),
-		},
-		{
-			Name:        "pi",
-			Description: "Pi — gentle-engram package plus pi-mcp-adapter MCP tools",
-			InstallDir:  piAgentDir(),
-		},
-		{
-			Name:        "claude-code",
-			Description: "Claude Code — Native plugin via marketplace (hooks, skills, MCP, compaction recovery)",
-			InstallDir:  "managed by claude plugin system",
-		},
-		{
-			Name:        "gemini-cli",
-			Description: "Gemini CLI — MCP registration plus system prompt compaction recovery",
-			InstallDir:  geminiConfigPath(),
-		},
-		{
-			Name:        "codex",
-			Description: "Codex — MCP registration plus model/compaction instruction files",
-			InstallDir:  codexConfigPath(),
-		},
+	adapters := agentAdapters()
+	agents := make([]Agent, 0, len(adapters))
+	for _, a := range adapters {
+		agents = append(agents, Agent{
+			Name:        a.slug,
+			Description: a.description,
+			InstallDir:  a.displayDir(),
+		})
 	}
+	return agents
 }
 
-// Install installs the plugin for the given agent.
+// Install installs the plugin for the given agent by looking it up in the
+// registry and running its adapter (a bespoke installer or the generic driver).
 func Install(agentName string) (*Result, error) {
-	switch agentName {
-	case "opencode":
-		return installOpenCode()
-	case "pi":
-		return installPi()
-	case "claude-code":
-		return installClaudeCode()
-	case "gemini-cli":
-		return installGeminiCLI()
-	case "codex":
-		return installCodex()
-	default:
-		return nil, fmt.Errorf("unknown agent: %q (supported: opencode, pi, claude-code, gemini-cli, codex)", agentName)
+	for _, a := range agentAdapters() {
+		if a.slug == agentName {
+			return installFromAdapter(a)
+		}
 	}
+	return nil, fmt.Errorf("unknown agent: %q (supported: %s)", agentName, strings.Join(supportedSlugs(), ", "))
 }
 
 // ─── Pi ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Generalizes `engram setup` into a **data-driven agent registry** and adds native setup for 7 more agents.

Closes #199. Supersedes #492 (Antigravity is reimplemented here as a registry adapter).

## Why

`Install()` was a hard-coded `switch` with one bespoke `installXxx()` per agent, and downstream tools (gentle-ai) were re-implementing setup for agents engram didn't support. This makes `engram setup <agent>` the single source of truth and turns "add an agent" into mostly a data change.

## How

- **Registry** (`internal/setup/agents.go`): one entry per agent. `Install()` and `SupportedAgents()` are derived from it.
- **Generic driver** (`internal/setup/registry.go`):
  - `injectMCP(path, format)` handles the three real MCP config shapes:
    - `mcpServers` `{command,args}` — Gemini, Antigravity, Windsurf, Qwen, Kiro, Cursor
    - `servers` `{type:"stdio",command,args}` — VS Code Copilot
    - OpenCode's `mcp` `{type:"local",command:[…],enabled}` — OpenCode, Kilo Code
  - `upsertMarkerBlock` / `writeInstruction` write the Memory Protocol idempotently (marker-delimited block preserving user content, or a whole dedicated file).
  - Post-install "next steps" are registry data rendered generically; only OpenCode (conditional TUI note) and Claude Code (interactive allowlist prompt) stay special-cased.
- **Existing agents unchanged**: opencode, pi, claude-code, gemini-cli, codex keep their hand-written installers via the registry's `custom` field — zero behavior change.

## New native agents

`antigravity-cli`, `windsurf`, `qwen`, `kiro`, `cursor`, `vscode-copilot`, `kilocode`.

Paths/formats verified against each tool's current docs. Notably, **Antigravity** uses the shared `~/.gemini/config/mcp_config.json` (read by CLI/IDE/SDK) + `~/.gemini/GEMINI.md` — confirmed against current Antigravity docs (this is the path #492 used; the `~/.gemini/antigravity/` variant in the issue is stale).

| agent | MCP file | top-key | instructions |
|---|---|---|---|
| antigravity-cli | `~/.gemini/config/mcp_config.json` | `mcpServers` | `~/.gemini/GEMINI.md` (marker) |
| windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers` | `…/memories/global_rules.md` (marker) |
| qwen | `~/.qwen/settings.json` | `mcpServers` | `~/.qwen/QWEN.md` (marker) |
| kiro | `~/.kiro/settings/mcp.json` | `mcpServers` | `~/.kiro/steering/engram.md` (marker) |
| cursor | `~/.cursor/mcp.json` | `mcpServers` | `~/.cursor/rules/engram.mdc` (whole-file, `alwaysApply`) |
| vscode-copilot | `<User>/mcp.json` | `servers` | `<User>/prompts/engram.instructions.md` (whole-file, `applyTo:"**"`) |
| kilocode | `~/.config/kilo/opencode.json` | `mcp` | `~/.config/kilo/AGENTS.md` (marker) |

## Tests

`go test ./...` green. New `registry_test.go` covers the registry, each declarative agent (MCP shape, idempotency, user-content preservation, error propagation), Cursor/VS Code frontmatter, and the VS Code per-platform User dir. CLI usage/post-install tests updated. Smoke-tested end-to-end against a temp `HOME`.

## Docs

README setup table, `docs/AGENT-SETUP.md` (native command per agent + new sections), `docs/INSTALLATION.md` (Windows/macOS paths), `docs/codebase/integrations.md` (registry architecture).

> Note for maintainers: this PR needs an issue with `status:approved` (#199) and a `type:feature` label to satisfy `pr-check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added automated setup for Antigravity CLI, Cursor, Windsurf, Qwen Code, Kiro, VS Code Copilot, and Kilo Code, including MCP registration and Memory Protocol instruction placement.

* **Documentation**
  * Updated agent setup and installation docs with per-agent instructions and revised platform config paths.
  * Expanded README setup tables for clearer, agent-specific installation guidance.

* **Improvements**
  * Enhanced `engram setup` to show agent-specific “Next steps” when available.

* **Tests**
  * Added coverage for declarative installs, MCP/instruction handling, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->