### PR TITLE
fix(sync): export pre-existing relations missing from local chunks

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1155,11 +1155,13 @@ func (sy *Syncer) exportedRelationKeys(m *Manifest) (map[string]struct{}, error)
 	if m == nil {
 		return keys, nil
 	}
-	chunksDir := filepath.Join(sy.syncDir, "chunks")
 	for _, entry := range m.Chunks {
-		raw, err := readGzip(filepath.Join(chunksDir, entry.ID+".jsonl.gz"))
+		// Read through the transport (not the local filesystem directly) so the
+		// scan honors the active backend — the import path uses the same
+		// contract. A missing chunk surfaces as ErrChunkNotFound.
+		raw, err := sy.transport.ReadChunk(entry.ID)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if errors.Is(err, ErrChunkNotFound) {
 				// The manifest can list chunks that live on another machine and
 				// were never pulled locally. A missing chunk contributes no known
 				// relations; at worst a relation is re-exported, which is an

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -404,7 +404,14 @@ func (sy *Syncer) Export(createdBy string, project string) (*SyncResult, error) 
 
 		// Filter to only new data (created after last chunk)
 		chunk = sy.filterNewData(data, lastChunkTime)
-		chunk.Mutations = filterNewRelationMutations(relationMutations, lastChunkTime)
+
+		// Relations are filtered by chunk presence, not timestamp; see the
+		// rationale on filterRelationMutationsForExport and issue #353.
+		exportedRelations, err := sy.exportedRelationKeys(manifest)
+		if err != nil {
+			return nil, fmt.Errorf("scan exported relations: %w", err)
+		}
+		chunk.Mutations = filterRelationMutationsForExport(relationMutations, exportedRelations, lastChunkTime)
 	}
 
 	// Nothing new to export
@@ -1134,18 +1141,67 @@ func (sy *Syncer) filterNewData(data *store.ExportData, lastChunkTime string) *C
 	return chunk
 }
 
-func filterNewRelationMutations(mutations []store.SyncMutation, lastChunkTime string) []store.SyncMutation {
+// exportedRelationKeys returns the set of relation EntityKeys already present
+// in the chunks recorded by the manifest. The manifest itself does not track
+// relations, so the chunk contents are the source of truth for "has this
+// relation ever been exported".
+//
+// Cost: this reads every chunk listed in the manifest on each export. A
+// relation may live in any chunk, so the scan cannot stop early. For very long
+// sync histories this is O(total chunks); tracking relation keys in the
+// manifest would remove the rescan if it ever becomes a bottleneck.
+func (sy *Syncer) exportedRelationKeys(m *Manifest) (map[string]struct{}, error) {
+	keys := make(map[string]struct{})
+	if m == nil {
+		return keys, nil
+	}
+	chunksDir := filepath.Join(sy.syncDir, "chunks")
+	for _, entry := range m.Chunks {
+		raw, err := readGzip(filepath.Join(chunksDir, entry.ID+".jsonl.gz"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// The manifest can list chunks that live on another machine and
+				// were never pulled locally. A missing chunk contributes no known
+				// relations; at worst a relation is re-exported, which is an
+				// idempotent upsert — never a silent drop. A chunk that exists
+				// but cannot be read is a real fault and fails loudly below.
+				continue
+			}
+			return nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
+		}
+		var chunk ChunkData
+		if err := json.Unmarshal(raw, &chunk); err != nil {
+			return nil, fmt.Errorf("unmarshal chunk %s: %w", entry.ID, err)
+		}
+		for _, mutation := range chunk.Mutations {
+			if mutation.Entity == store.SyncEntityRelation {
+				keys[mutation.EntityKey] = struct{}{}
+			}
+		}
+	}
+	return keys, nil
+}
+
+// filterRelationMutationsForExport returns the relation mutations that still
+// need to be written to a chunk. A relation is exported when it is absent from
+// every prior chunk (covers brand-new relations and the upgrade/backfill case
+// where pre-existing relations never reached a chunk) or when it was updated
+// after the most recent chunk (so re-judged relations still propagate).
+// Presence is the source of truth; the timestamp only adds updates.
+func filterRelationMutationsForExport(mutations []store.SyncMutation, exported map[string]struct{}, lastChunkTime string) []store.SyncMutation {
 	if len(mutations) == 0 {
 		return nil
 	}
 	if lastChunkTime == "" {
-		return mutations
+		return mutations // first sync — nothing has been exported yet
 	}
 
 	cutoff := normalizeTime(lastChunkTime)
 	filtered := make([]store.SyncMutation, 0, len(mutations))
 	for _, mutation := range mutations {
-		if normalizeTime(mutation.OccurredAt) > cutoff {
+		_, alreadyExported := exported[mutation.EntityKey]
+		updatedSinceLastChunk := normalizeTime(mutation.OccurredAt) > cutoff
+		if !alreadyExported || updatedSinceLastChunk {
 			filtered = append(filtered, mutation)
 		}
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -780,6 +780,68 @@ func TestLocalChunkExportFailsLoudlyOnCorruptPriorChunk(t *testing.T) {
 	}
 }
 
+// TestLocalChunkExportReexportsRelationUpdatedAfterLastChunk covers the second
+// branch of the export filter: a relation already present in a prior chunk but
+// re-judged after the latest chunk must be exported again so the update
+// propagates. A regression to pure presence-based filtering would silently drop
+// this update while every other relation test still passes.
+func TestLocalChunkExportReexportsRelationUpdatedAfterLastChunk(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+
+	// rel-updated already lives in a prior chunk (already exported)...
+	seedRelationForProject(t, s, "proj-a", "sess-updated", "rel-updated")
+	// ...but it was re-judged AFTER that chunk's CreatedAt (2025-06-01).
+	if _, err := s.DB().Exec(
+		`UPDATE memory_relations SET updated_at='2025-07-01 00:00:00' WHERE sync_id='rel-updated'`,
+	); err != nil {
+		t.Fatalf("bump rel-updated: %v", err)
+	}
+
+	chunksDir := filepath.Join(syncDir, "chunks")
+	if err := os.MkdirAll(chunksDir, 0o755); err != nil {
+		t.Fatalf("mkdir chunks: %v", err)
+	}
+	writeLocalChunkFile(t, syncDir, "pastchunk00", ChunkData{
+		Mutations: []store.SyncMutation{{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: "rel-updated",
+			Op:        store.SyncOpUpsert,
+		}},
+	})
+	writeManifestFile(t, syncDir, &Manifest{
+		Version: 1,
+		Chunks:  []ChunkEntry{{ID: "pastchunk00", CreatedBy: "alice", CreatedAt: "2025-06-01T00:00:00Z"}},
+	})
+
+	result, err := New(s, syncDir).Export("alice", "proj-a")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if result.IsEmpty {
+		t.Fatal("expected export to re-export the updated relation, got empty result")
+	}
+
+	chunkJSON, err := readGzip(filepath.Join(syncDir, "chunks", result.ChunkID+".jsonl.gz"))
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	var chunk ChunkData
+	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+		t.Fatalf("unmarshal chunk: %v", err)
+	}
+
+	found := false
+	for _, m := range chunk.Mutations {
+		if m.EntityKey == "rel-updated" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("relation updated after the last chunk must be re-exported, got mutations %+v", chunk.Mutations)
+	}
+}
+
 func TestUpgradeDeterministicReasonCodes(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -624,15 +624,25 @@ func TestIncrementalRelationExport(t *testing.T) {
 		t.Fatalf("backdate rel-inc-1: %v", err)
 	}
 
-	// Write a manifest whose most-recent chunk CreatedAt sits between the
-	// backdated relation (2025-01-01) and "now", so the incremental filter will
-	// treat rel-inc-1 as already exported and rel-inc-2 as new.
+	// Write a prior chunk that genuinely CONTAINS rel-inc-1 as a relation
+	// mutation — that is what "already exported" actually means. Its CreatedAt
+	// (2025-06-01) sits between the backdated relation (2025-01-01) and "now",
+	// so the export must skip rel-inc-1 (present and not updated) and carry only
+	// rel-inc-2 (absent from every chunk).
 	chunksDir := filepath.Join(syncDir, "chunks")
 	if err := os.MkdirAll(chunksDir, 0o755); err != nil {
 		t.Fatalf("mkdir chunks: %v", err)
 	}
 	pastChunkID := "pastchunk00"
-	writeLocalChunkFile(t, syncDir, pastChunkID, ChunkData{})
+	writeLocalChunkFile(t, syncDir, pastChunkID, ChunkData{
+		// rel-inc-1 is genuinely present in this prior chunk, so
+		// exportedRelationKeys treats it as already exported and skips it.
+		Mutations: []store.SyncMutation{{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: "rel-inc-1",
+			Op:        store.SyncOpUpsert,
+		}},
+	})
 	writeManifestFile(t, syncDir, &Manifest{
 		Version: 1,
 		Chunks:  []ChunkEntry{{ID: pastChunkID, CreatedBy: "alice", CreatedAt: "2025-06-01T00:00:00Z"}},
@@ -676,6 +686,97 @@ func TestIncrementalRelationExport(t *testing.T) {
 	}
 	if !result2.IsEmpty {
 		t.Fatal("expected second export (no new data) to be empty")
+	}
+}
+
+// TestLocalChunkExportBackfillsRelationsCreatedBeforeLastChunk reproduces the
+// upgrade/backfill gap from issue #353: relations that already existed before
+// relation-sync shipped (so they were never written into any prior chunk) have
+// an updated_at older than the latest chunk. The time-only incremental filter
+// treats them as "already exported" and silently drops them, even though no
+// chunk actually contains them.
+//
+// Expected behavior: a relation absent from every prior chunk must be exported
+// regardless of its timestamp. On current code this fails (zero relations).
+func TestLocalChunkExportBackfillsRelationsCreatedBeforeLastChunk(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+
+	// Seed a relation, then backdate it so it predates the latest chunk —
+	// exactly the state of a project that judged relations before 1.16.3.
+	seedRelationForProject(t, s, "proj-a", "sess-backfill", "rel-backfill")
+	if _, err := s.DB().Exec(
+		`UPDATE memory_relations SET updated_at='2025-01-01 00:00:00', created_at='2025-01-01 00:00:00' WHERE sync_id='rel-backfill'`,
+	); err != nil {
+		t.Fatalf("backdate rel-backfill: %v", err)
+	}
+
+	// A prior chunk dated AFTER the relation but which does NOT contain it
+	// (observations were synced before relation-sync existed). This is the
+	// crucial difference from a genuinely already-exported relation.
+	chunksDir := filepath.Join(syncDir, "chunks")
+	if err := os.MkdirAll(chunksDir, 0o755); err != nil {
+		t.Fatalf("mkdir chunks: %v", err)
+	}
+	writeLocalChunkFile(t, syncDir, "pastchunk00", ChunkData{})
+	writeManifestFile(t, syncDir, &Manifest{
+		Version: 1,
+		Chunks:  []ChunkEntry{{ID: "pastchunk00", CreatedBy: "alice", CreatedAt: "2025-06-01T00:00:00Z"}},
+	})
+
+	result, err := New(s, syncDir).Export("alice", "proj-a")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if result.IsEmpty {
+		t.Fatal("expected export to backfill the pre-existing relation, got empty result")
+	}
+
+	chunkJSON, err := readGzip(filepath.Join(syncDir, "chunks", result.ChunkID+".jsonl.gz"))
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	var chunk ChunkData
+	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+		t.Fatalf("unmarshal chunk: %v", err)
+	}
+
+	found := false
+	for _, m := range chunk.Mutations {
+		if m.EntityKey == "rel-backfill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("pre-existing relation rel-backfill absent from every chunk must be exported, got mutations %+v", chunk.Mutations)
+	}
+}
+
+// TestLocalChunkExportFailsLoudlyOnCorruptPriorChunk pins the new failure mode
+// introduced by reading prior chunks during export: a chunk file that exists
+// but cannot be decoded is a real fault and must fail loudly, never be skipped.
+// Skipping it would treat its relations as un-exported and could re-introduce a
+// drop on a later prune — the opposite of the "no silent drops" invariant.
+func TestLocalChunkExportFailsLoudlyOnCorruptPriorChunk(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+	seedRelationForProject(t, s, "proj-a", "sess-corrupt", "rel-corrupt")
+
+	chunksDir := filepath.Join(syncDir, "chunks")
+	if err := os.MkdirAll(chunksDir, 0o755); err != nil {
+		t.Fatalf("mkdir chunks: %v", err)
+	}
+	corruptID := "corruptchunk"
+	if err := os.WriteFile(filepath.Join(chunksDir, corruptID+".jsonl.gz"), []byte("not a gzip stream"), 0o644); err != nil {
+		t.Fatalf("write corrupt chunk: %v", err)
+	}
+	writeManifestFile(t, syncDir, &Manifest{
+		Version: 1,
+		Chunks:  []ChunkEntry{{ID: corruptID, CreatedBy: "alice", CreatedAt: "2025-06-01T00:00:00Z"}},
+	})
+
+	if _, err := New(s, syncDir).Export("alice", "proj-a"); err == nil {
+		t.Fatal("expected Export to fail loudly on a corrupt prior chunk, got nil error")
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #353

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Follow-up to #489. The local chunk sync writes relation mutations, but on **upgrade** it still dropped every pre-existing relation — the original #353 repro exported 0 of 35 relations.
- Filter relations by **chunk presence** instead of `lastChunkTime`: a relation is exported when it is absent from every prior chunk (brand-new *and* pre-existing) or was updated after the last chunk (re-judged relations still propagate).
- Round-trip restored: export 0 → 35, import into a fresh DB 0 → 35.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/sync/sync.go` | Replace `filterNewRelationMutations` (time-only) with `filterRelationMutationsForExport` (presence ∪ updated-since) plus `exportedRelationKeys`, which reads prior chunks via `Transport.ReadChunk` and collects already-exported relation keys. Missing chunks are skipped (idempotent re-export); corrupt chunks fail loudly. |
| `internal/sync/sync_test.go` | Add `…BackfillsRelationsCreatedBeforeLastChunk` (repro), `…ReexportsRelationUpdatedAfterLastChunk` (updated-since branch), `…FailsLoudlyOnCorruptPriorChunk`; fix `TestIncrementalRelationExport` so its prior chunk actually contains the relation it treats as already exported. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` *(not run — change is confined to local chunk sync; full unit suite + `go vet` + `go build ./...` are green)*
- [x] Manually tested the affected functionality

Manual test: isolated copy of a real project's DB and `.engram` (nothing mutated). `engram sync` wrote a chunk with **35** relation mutations (was 0); importing it into a fresh DB restored `conflicts list` **Total: 35** (was 0).

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #353`)
- [ ] I added exactly **one** `type:*` label to this PR *(blocked — external/fork contributors cannot add labels; please see Notes)*
- [x] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] Docs updated (if behavior changed) *(no docs change — the fix enforces the existing "no silent drops" invariant, it does not change documented behavior)*
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

- **`type:bug` label needed**: I can't add it myself — GitHub blocks label edits from external (fork) contributors (`forNerzul does not have permission to AddLabelsToLabelable`). Could a maintainer add `type:bug`? It mirrors #489.
- **Cost**: `exportedRelationKeys` reads every chunk in the manifest per export (a relation may live in any chunk, so the scan cannot stop early). O(total chunks) — fine for typical histories; tracking relation keys in the manifest would remove the rescan if it ever matters. Flagged in a code comment.
- **Possibly related, separate from this PR**: the cloud upgrade-repair `backfillProjectSyncMutationsTx` backfills sessions/observations/prompts into the journal but **not relations**, and `projectNeedsBackfill` does not count them. If `JudgeRelation` did not always enqueue a relation mutation, cloud could have an analogous backfill gap. Unverified — happy to open a separate issue if useful.
