### PR TITLE
feat(store): derive memory confidence and blend it into search ranking

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1048,24 +1048,39 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 			if r.State() == store.ObservationStateNeedsReview {
 				stateDisplay = " | state: needs_review"
 			}
-			fmt.Fprintf(&b, "[%d] #%d (%s) — %s\n    %s\n    %s%s | scope: %s%s\n",
+			// Surface derived confidence + the evidence behind it (part D), so the
+			// agent can judge trust at search time without a second lookup.
+			confidenceDisplay := fmt.Sprintf(" | confidence: %s (%.2f)", r.ConfidenceLabel, r.Confidence)
+			if r.DuplicateCount > 1 {
+				confidenceDisplay += fmt.Sprintf(" | confirmed %d×", r.DuplicateCount)
+			}
+			if r.LastSeenAt != nil && strings.TrimSpace(*r.LastSeenAt) != "" {
+				confidenceDisplay += fmt.Sprintf(" | last seen: %s", timeutil.FormatLocal(*r.LastSeenAt))
+			}
+			fmt.Fprintf(&b, "[%d] #%d (%s) — %s\n    %s\n    %s%s | scope: %s%s%s\n",
 				i+1, r.ID, r.Type, r.Title,
 				preview,
-				timeutil.FormatLocal(r.CreatedAt), projectDisplay, r.Scope, stateDisplay)
+				timeutil.FormatLocal(r.CreatedAt), projectDisplay, r.Scope, stateDisplay, confidenceDisplay)
 			entry := map[string]any{
-				"id":      r.ID,
-				"sync_id": r.SyncID,
-				"title":   r.Title,
-				"type":    r.Type,
-				"state":   r.State(),
-				"scope":   r.Scope,
-				"pinned":  r.Pinned,
+				"id":               r.ID,
+				"sync_id":          r.SyncID,
+				"title":            r.Title,
+				"type":             r.Type,
+				"state":            r.State(),
+				"scope":            r.Scope,
+				"pinned":           r.Pinned,
+				"confidence":       r.Confidence,
+				"confidence_label": r.ConfidenceLabel,
+				"duplicate_count":  r.DuplicateCount,
 			}
 			if r.Project != nil {
 				entry["project"] = *r.Project
 			}
 			if r.ReviewAfter != nil {
 				entry["review_after"] = *r.ReviewAfter
+			}
+			if r.LastSeenAt != nil && strings.TrimSpace(*r.LastSeenAt) != "" {
+				entry["last_seen_at"] = *r.LastSeenAt
 			}
 			structuredResults = append(structuredResults, entry)
 

--- a/internal/store/confidence_test.go
+++ b/internal/store/confidence_test.go
@@ -1,0 +1,104 @@
+package store
+
+import "testing"
+
+func obsWith(dup int, pinned bool, reviewAfter *string) Observation {
+	return Observation{
+		DuplicateCount: dup,
+		Pinned:         pinned,
+		ReviewAfter:    reviewAfter,
+	}
+}
+
+func TestComputeConfidence(t *testing.T) {
+	past := "2000-01-01T00:00:00Z"   // review_after in the past → needs_review (stale)
+	future := "2999-01-01T00:00:00Z" // review_after in the future → active
+
+	cases := []struct {
+		name string
+		obs  Observation
+		want float64
+	}{
+		{"one-off active", obsWith(1, false, nil), 0.5},
+		{"confirmed x3", obsWith(3, false, &future), 0.5 + 2*confidenceDupStep},
+		{"confirmation capped", obsWith(50, false, &future), 0.5 + confidenceDupMaxSteps*confidenceDupStep},
+		{"pinned", obsWith(1, true, nil), 0.5 + confidencePinnedBoost},
+		{"stale penalized", obsWith(1, false, &past), 0.5 - confidenceStalenessPenalty},
+		{"clamped to 1", obsWith(50, true, &future), 1.0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeConfidence(tc.obs)
+			if got < 0 || got > 1 {
+				t.Fatalf("confidence out of [0,1]: %v", got)
+			}
+			if !almostEqual(got, tc.want) {
+				t.Errorf("computeConfidence = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfidenceLabel(t *testing.T) {
+	cases := map[float64]string{
+		0.95: "confirmed",
+		0.80: "confirmed",
+		0.70: "likely",
+		0.60: "likely",
+		0.50: "tentative",
+		0.40: "tentative",
+		0.30: "unverified",
+		0.00: "unverified",
+	}
+	for score, want := range cases {
+		if got := confidenceLabel(score); got != want {
+			t.Errorf("confidenceLabel(%v) = %q, want %q", score, got, want)
+		}
+	}
+}
+
+// Within a graded candidate pool, a confirmed result whose lexical relevance is
+// only marginally below the top should overtake the one-off top hit once
+// confidence is blended in. (With a wide relevance gap, relevance still wins —
+// that is by design; see the weights.)
+func TestRerankByConfidenceLiftsConfirmed(t *testing.T) {
+	future := "2999-01-01T00:00:00Z"
+	mk := func(dup int, rank float64) SearchResult {
+		o := obsWith(dup, false, &future)
+		return SearchResult{Observation: o, Rank: rank, Confidence: computeConfidence(o)}
+	}
+	results := []SearchResult{
+		mk(1, -5.0), // one-off, top lexical relevance
+		mk(6, -4.8), // confirmed x6, marginally less relevant
+		mk(1, -2.0), // filler
+		mk(1, -1.0), // filler (defines the spread)
+	}
+	rerankByConfidence(results)
+	if results[0].DuplicateCount != 6 {
+		t.Errorf("expected confirmed memory first, got DuplicateCount=%d", results[0].DuplicateCount)
+	}
+}
+
+// Topic-key hits (topicRankBoost) must stay pinned at the front, untouched.
+func TestRerankPreservesTopicHits(t *testing.T) {
+	future := "2999-01-01T00:00:00Z"
+	results := []SearchResult{
+		{Observation: Observation{ID: 100, DuplicateCount: 1, ReviewAfter: &future}, Rank: topicRankBoost},
+		{Observation: obsWith(9, true, &future), Rank: -1.0, Confidence: 1.0},
+		{Observation: obsWith(1, false, &future), Rank: -0.1, Confidence: 0.5},
+	}
+	rerankByConfidence(results)
+	if results[0].ID != 100 || results[0].Rank != topicRankBoost {
+		t.Errorf("topic hit should remain first, got ID=%d rank=%v", results[0].ID, results[0].Rank)
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < eps
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -129,6 +130,110 @@ func (o Observation) State() string {
 type SearchResult struct {
 	Observation
 	Rank float64 `json:"rank"`
+	// Confidence is a derived (never persisted) trust signal in [0,1].
+	Confidence      float64 `json:"confidence"`
+	ConfidenceLabel string  `json:"confidence_label"`
+}
+
+// ─── Confidence scoring ──────────────────────────────────────────────────────
+//
+// Confidence is a derived trust signal in [0,1], computed only from columns that
+// already exist on an observation. It lets retrieval tell a repeatedly-confirmed,
+// pinned, or recently-valid memory apart from a one-off, stale, or tentative one
+// — with no schema change and without asking the model to estimate anything
+// (which would invite hallucination). The number is read, never invented.
+const (
+	confidenceBase             = 0.5
+	confidenceDupStep          = 0.08 // per extra confirmation (duplicate_count-1)
+	confidenceDupMaxSteps      = 5    // → caps the confirmation bonus at +0.40
+	confidencePinnedBoost      = 0.20
+	confidenceStalenessPenalty = 0.30
+
+	// Re-rank blend weights and candidate over-fetch (see Search).
+	confidenceRelevanceWeight = 0.7
+	confidenceWeight          = 0.3
+	confidenceCandidateFactor = 3
+
+	// topicRankBoost is the synthetic rank assigned to topic_key direct hits so
+	// they sort ahead of FTS results. Re-ranking leaves these untouched.
+	topicRankBoost = -1000.0
+)
+
+// computeConfidence derives a [0,1] confidence score from existing columns.
+func computeConfidence(o Observation) float64 {
+	c := confidenceBase
+	if extra := o.DuplicateCount - 1; extra > 0 {
+		if extra > confidenceDupMaxSteps {
+			extra = confidenceDupMaxSteps
+		}
+		c += float64(extra) * confidenceDupStep
+	}
+	if o.Pinned {
+		c += confidencePinnedBoost
+	}
+	if o.State() == ObservationStateNeedsReview {
+		c -= confidenceStalenessPenalty
+	}
+	switch {
+	case c < 0:
+		return 0
+	case c > 1:
+		return 1
+	default:
+		return c
+	}
+}
+
+// confidenceLabel maps a score to a human-facing trust tier.
+func confidenceLabel(c float64) string {
+	switch {
+	case c >= 0.8:
+		return "confirmed"
+	case c >= 0.6:
+		return "likely"
+	case c >= 0.4:
+		return "tentative"
+	default:
+		return "unverified"
+	}
+}
+
+// rerankByConfidence reorders the FTS portion of results in place by a blend of
+// normalized lexical relevance and derived confidence. Topic-key hits (assigned
+// topicRankBoost and prepended by Search) are left pinned at the front.
+func rerankByConfidence(results []SearchResult) {
+	start := 0
+	for start < len(results) && results[start].Rank == topicRankBoost {
+		start++
+	}
+	fts := results[start:]
+	if len(fts) < 2 {
+		return
+	}
+
+	// bm25 rank: smaller (more negative) = more relevant.
+	minRank, maxRank := fts[0].Rank, fts[0].Rank
+	for _, r := range fts {
+		if r.Rank < minRank {
+			minRank = r.Rank
+		}
+		if r.Rank > maxRank {
+			maxRank = r.Rank
+		}
+	}
+	span := maxRank - minRank
+
+	score := func(r SearchResult) float64 {
+		relevanceNorm := 1.0
+		if span > 0 {
+			relevanceNorm = (maxRank - r.Rank) / span
+		}
+		return confidenceRelevanceWeight*relevanceNorm + confidenceWeight*r.Confidence
+	}
+
+	sort.SliceStable(fts, func(i, j int) bool {
+		return score(fts[i]) > score(fts[j])
+	})
 }
 
 type SessionSummary struct {
@@ -448,6 +553,9 @@ type Config struct {
 	MaxContextResults    int
 	MaxSearchResults     int
 	DedupeWindow         time.Duration
+	// ConfidenceRanking blends derived confidence into search ordering and
+	// surfaces it to callers. Defaults to true.
+	ConfidenceRanking bool
 }
 
 func DefaultConfig() (Config, error) {
@@ -461,6 +569,7 @@ func DefaultConfig() (Config, error) {
 		MaxContextResults:    20,
 		MaxSearchResults:     20,
 		DedupeWindow:         15 * time.Minute,
+		ConfidenceRanking:    true,
 	}, nil
 }
 
@@ -474,6 +583,7 @@ func FallbackConfig(dataDir string) Config {
 		MaxContextResults:    20,
 		MaxSearchResults:     20,
 		DedupeWindow:         15 * time.Minute,
+		ConfidenceRanking:    true,
 	}
 }
 
@@ -3147,7 +3257,7 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 				); err != nil {
 					break
 				}
-				sr.Rank = -1000
+				sr.Rank = topicRankBoost
 				directResults = append(directResults, sr)
 			}
 		}
@@ -3181,8 +3291,15 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		args = append(args, normalizeScope(opts.Scope))
 	}
 
+	// When confidence ranking is on, over-fetch FTS candidates so a highly
+	// confirmed but lexically-weaker memory can still surface after re-ranking,
+	// instead of being cut by the bm25-only LIMIT before it is ever scored.
+	fetchLimit := limit
+	if s.cfg.ConfidenceRanking {
+		fetchLimit = limit * confidenceCandidateFactor
+	}
 	sqlQ += " ORDER BY fts.rank LIMIT ?"
-	args = append(args, limit)
+	args = append(args, fetchLimit)
 
 	rows, err := s.queryItHook(s.db, sqlQ, args...)
 	if err != nil {
@@ -3213,6 +3330,19 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+
+	// Populate derived confidence on every result (topic + FTS) so callers can
+	// surface it without a second lookup. Derived from existing columns only.
+	for i := range results {
+		results[i].Confidence = computeConfidence(results[i].Observation)
+		results[i].ConfidenceLabel = confidenceLabel(results[i].Confidence)
+	}
+
+	// Blend confidence into ordering for the FTS portion (topic hits stay first),
+	// then truncate to the caller's limit so the over-fetched pool is narrowed.
+	if s.cfg.ConfidenceRanking {
+		rerankByConfidence(results)
 	}
 
 	if len(results) > limit {


### PR DESCRIPTION
## Problem

`Store.Search` orders results purely by FTS5/bm25 lexical relevance (`ORDER BY fts.rank`). The `duplicate_count`, `last_seen_at`, and `pinned` columns already exist on observations but have **no effect on retrieval** — a memory confirmed many times ranks identically to a one-off hit. And `mem_search` callers never see the evidence behind a result without a second `mem_get_observation` lookup.

## What this adds

A **derived** confidence signal (never stored, never asked of the model) used for ranking and surfacing:

- **`computeConfidence()`** — a `[0,1]` score from existing columns only: base `0.5`; `+0.08` per extra `duplicate_count` (capped `+0.40`); `+0.20` if `pinned`; `-0.30` when `review_after` marks the memory `needs_review`.
- **`rerankByConfidence()`** — blends min-max normalized lexical relevance (`0.7`) with confidence (`0.3`) for the FTS portion. `topic_key` direct hits (`topicRankBoost`) stay pinned at the front, untouched.
- **Candidate over-fetch** — when ranking is on, FTS fetches `limit * confidenceCandidateFactor` rows so a confirmed-but-lexically-weaker memory can surface instead of being cut by the bm25-only `LIMIT` before it is ever scored.
- **Surfacing** — `mem_search` now shows confidence label + score, `duplicate_count`, and `last_seen_at` in both the text and structured output. `SearchResult` gains computed `Confidence` / `ConfidenceLabel` fields.

## Design guarantees

- **No schema migration** — every input is an existing column.
- **No hallucination** — the number is computed from data, never estimated by the model.
- **Not bypassable** — lives in `Search()`, the data path of every `mem_search`.
- **Reversible** — gated behind `Config.ConfidenceRanking` (default `true`); legacy bm25-only path remains.

## Note on behavior

The confidence lift is proportional to how close lexical scores are: it breaks near-ties and gives a modest boost, but a wide relevance gap still wins (by design, given the `0.7/0.3` weights). With only 2 candidates min-max is degenerate (1.0 vs 0.0); the lift is meaningful within the realistic over-fetched pool.

## Tests

Adds `internal/store/confidence_test.go`: scoring cases, label tiers, re-rank lift within a graded pool, and topic-hit preservation. `gofmt`, `go vet`, `go build ./...` and `go test ./internal/store ./internal/mcp` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now include confidence levels (confirmed, likely, tentative, unverified) based on observation history and patterns
  * Results can be reordered by confidence to prioritize more reliable matches (enabled by default)

* **Tests**
  * Added comprehensive test coverage for confidence scoring and result reordering logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->