### PR TITLE
fix(plugin): persist user prompt in UserPromptSubmit hook

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -602,6 +602,15 @@ func (s *Server) handleAddPrompt(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// When the client omits the project, derive it from the session so the
+	// prompt is attributed correctly without the hook detecting it eagerly on
+	// every message.
+	if strings.TrimSpace(body.Project) == "" {
+		if sess, err := s.store.GetSession(body.SessionID); err == nil {
+			body.Project = sess.Project
+		}
+	}
+
 	id, err := s.store.AddPrompt(body)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())

--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -30,7 +30,8 @@ function Invoke-EngramPromptPersist {
     [string]$Project,
     [string]$Prompt
   )
-  # Fire-and-forget: never blocks and never fails the hook.
+  # Fail-silent and bounded: a short timeout keeps a slow/unreachable server
+  # from stalling prompt submission, and any error is swallowed.
   if ([string]::IsNullOrWhiteSpace($Prompt) -or [string]::IsNullOrWhiteSpace($SessionId)) { return }
   try {
     $body = [PSCustomObject]@{
@@ -39,7 +40,7 @@ function Invoke-EngramPromptPersist {
       content    = $Prompt
     } | ConvertTo-Json -Compress
     $null = Invoke-RestMethod -Method Post -Uri "$EngramUrl/prompts" `
-      -ContentType 'application/json' -Body $body -TimeoutSec 2
+      -ContentType 'application/json' -Body $body -TimeoutSec 1
   } catch { }
 }
 

--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -27,16 +27,15 @@ function Invoke-EngramPromptPersist {
   param(
     [string]$EngramUrl,
     [string]$SessionId,
-    [string]$Project,
     [string]$Prompt
   )
   # Fail-silent and bounded: a short timeout keeps a slow/unreachable server
-  # from stalling prompt submission, and any error is swallowed.
+  # from stalling prompt submission, and any error is swallowed. The server
+  # derives the prompt's project from the session, so the hook sends none.
   if ([string]::IsNullOrWhiteSpace($Prompt) -or [string]::IsNullOrWhiteSpace($SessionId)) { return }
   try {
     $body = [PSCustomObject]@{
       session_id = $SessionId
-      project    = $Project
       content    = $Prompt
     } | ConvertTo-Json -Compress
     $null = Invoke-RestMethod -Method Post -Uri "$EngramUrl/prompts" `
@@ -57,24 +56,9 @@ try {
     $sessionID = "windows-$PID"
   }
 
-  # Derive project from cwd git remote, falling back to directory basename.
-  $project = ''
-  try {
-    $cwd = [string]($payload.cwd)
-    if (-not [string]::IsNullOrWhiteSpace($cwd)) {
-      $remoteUrl = git -C "$cwd" remote get-url origin 2>$null
-      if ($remoteUrl) {
-        $project = ($remoteUrl -replace '\.git$', '' -replace '^.*[/:]', '').ToLower()
-      }
-      if ([string]::IsNullOrWhiteSpace($project)) {
-        $project = (Split-Path -Leaf $cwd).ToLower()
-      }
-    }
-  } catch { }
-
-  # Persist the prompt (fire-and-forget, fail-silent).
-  Invoke-EngramPromptPersist -EngramUrl $engramUrl -SessionId $sessionID `
-    -Project $project -Prompt $prompt
+  # Persist the prompt (fire-and-forget, fail-silent). The server derives the
+  # project from the session, so the hook does not detect it here.
+  Invoke-EngramPromptPersist -EngramUrl $engramUrl -SessionId $sessionID -Prompt $prompt
 
   $safeSessionID = $sessionID -replace '[^a-zA-Z0-9_-]', '_'
   $stateFile = Join-Path ([IO.Path]::GetTempPath()) "engram-claude-$safeSessionID-tools-loaded"

--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -23,14 +23,57 @@ function Write-ToolSearchMessage {
   [PSCustomObject]@{ systemMessage = $message } | ConvertTo-Json -Compress
 }
 
+function Invoke-EngramPromptPersist {
+  param(
+    [string]$EngramUrl,
+    [string]$SessionId,
+    [string]$Project,
+    [string]$Prompt
+  )
+  # Fire-and-forget: never blocks and never fails the hook.
+  if ([string]::IsNullOrWhiteSpace($Prompt) -or [string]::IsNullOrWhiteSpace($SessionId)) { return }
+  try {
+    $body = [PSCustomObject]@{
+      session_id = $SessionId
+      project    = $Project
+      content    = $Prompt
+    } | ConvertTo-Json -Compress
+    $null = Invoke-RestMethod -Method Post -Uri "$EngramUrl/prompts" `
+      -ContentType 'application/json' -Body $body -TimeoutSec 2
+  } catch { }
+}
+
 try {
+  $engramPort = if ($env:ENGRAM_PORT) { $env:ENGRAM_PORT } else { '7437' }
+  $engramUrl  = "http://127.0.0.1:$engramPort"
+
   $inputJson = [Console]::In.ReadToEnd()
   $payload = $inputJson | ConvertFrom-Json
   $sessionID = [string]($payload.session_id)
+  $prompt    = [string]($payload.prompt)
 
   if ([string]::IsNullOrWhiteSpace($sessionID)) {
     $sessionID = "windows-$PID"
   }
+
+  # Derive project from cwd git remote, falling back to directory basename.
+  $project = ''
+  try {
+    $cwd = [string]($payload.cwd)
+    if (-not [string]::IsNullOrWhiteSpace($cwd)) {
+      $remoteUrl = git -C "$cwd" remote get-url origin 2>$null
+      if ($remoteUrl) {
+        $project = ($remoteUrl -replace '\.git$', '' -replace '^.*[/:]', '').ToLower()
+      }
+      if ([string]::IsNullOrWhiteSpace($project)) {
+        $project = (Split-Path -Leaf $cwd).ToLower()
+      }
+    }
+  } catch { }
+
+  # Persist the prompt (fire-and-forget, fail-silent).
+  Invoke-EngramPromptPersist -EngramUrl $engramUrl -SessionId $sessionID `
+    -Project $project -Prompt $prompt
 
   $safeSessionID = $sessionID -replace '[^a-zA-Z0-9_-]', '_'
   $stateFile = Join-Path ([IO.Path]::GetTempPath()) "engram-claude-$safeSessionID-tools-loaded"

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -105,14 +105,14 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 # ──────────────────────────────────────────────────────────────────────────────
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
 if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
-  # Detached subshell so neither detect_project nor the POST can stall the hook,
-  # even if the server is slow or unreachable.
+  # Detached subshell so the POST never stalls the hook. The server derives the
+  # prompt's project from the session, so project lookup stays off the hot path
+  # here (the hook keys by session_id first and only resolves the project later).
   (
-    _PROMPT_PROJECT=$(detect_project "$CWD")
     curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
       -H 'Content-Type: application/json' \
-      -d "$(jq -n --arg s "$SESSION_ID" --arg p "${_PROMPT_PROJECT:-}" --arg c "$PROMPT" \
-            '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
+      -d "$(jq -n --arg s "$SESSION_ID" --arg c "$PROMPT" \
+            '{session_id:$s, content:$c}')" >/dev/null 2>&1 || true
   ) &
 fi
 

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -105,11 +105,15 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 # ──────────────────────────────────────────────────────────────────────────────
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
 if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
-  _PROMPT_PROJECT=$(detect_project "$CWD")
-  curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
-    -H 'Content-Type: application/json' \
-    -d "$(jq -n --arg s "$SESSION_ID" --arg p "${_PROMPT_PROJECT:-}" --arg c "$PROMPT" \
-          '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
+  # Detached subshell so neither detect_project nor the POST can stall the hook,
+  # even if the server is slow or unreachable.
+  (
+    _PROMPT_PROJECT=$(detect_project "$CWD")
+    curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg s "$SESSION_ID" --arg p "${_PROMPT_PROJECT:-}" --arg c "$PROMPT" \
+            '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
+  ) &
 fi
 
 parse_epoch() {

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -96,6 +96,22 @@ INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 
+# ──────────────────────────────────────────────────────────────────────────────
+# PROMPT PERSIST
+#
+# Every user message is captured to POST /prompts so mem_save can attach the
+# originating prompt via SessionActivity.  Fire-and-forget: never blocks and
+# never fails the hook.
+# ──────────────────────────────────────────────────────────────────────────────
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
+  _PROMPT_PROJECT=$(detect_project "$CWD")
+  curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -n --arg s "$SESSION_ID" --arg p "${_PROMPT_PROJECT:-}" --arg c "$PROMPT" \
+          '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
+fi
+
 parse_epoch() {
   TS="$1"
   if [ -z "$TS" ]; then


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #509

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- The `UserPromptSubmit` hook advertised "passive capture" but never persisted the prompt: it read stdin yet only extracted `.cwd`/`.session_id`, never `.prompt`, and never called `POST /prompts`. The `prompts` table stayed near-empty so `mem_save` had no `SessionActivity` to attach.
- Adds a fail-silent `POST ${ENGRAM_URL}/prompts` with `{session_id, project, content}` to both the `.sh` and `.ps1` variants, fired on every message.
- Placed after the Windows Git Bash safe-mode fast path (which forbids `jq`/`curl`) and before any early `exit`, so it never runs in safe mode and never blocks prompt submission.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/claude-code/scripts/user-prompt-submit.sh` | Extract `.prompt`, derive project, `POST /prompts` (fire-and-forget, `--max-time 2`, `\|\| true`) |
| `plugin/claude-code/scripts/user-prompt-submit.ps1` | Add `Invoke-EngramPromptPersist` helper + ENGRAM_URL/project wiring; `Invoke-RestMethod` guarded by try/catch (`-TimeoutSec 2`) |

## 🧪 Test Plan

- [x] `shellcheck plugin/claude-code/scripts/user-prompt-submit.sh` — clean (only SC1091 info for the sourced helper)
- [x] `bash -n` on the `.sh`; PowerShell AST parse on the `.ps1` — both OK
- [x] Manually verified the body shape `{session_id, project, content}` matches the server's `POST /prompts` contract

Note: pure shell/PowerShell change — no Go code touched, so `go test ./...` is unaffected.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] Ran shellcheck on modified scripts
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic prompt capture and persistence using session tracking.
  * Prompts are now sent to a local backend endpoint for storage, using a non-blocking, best-effort submission with a short timeout.
* **Bug Fixes**
  * Improved backend prompt handling: when a request omits project info (or sends it blank), the system now fills in the correct project based on the provided session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->