### PR TITLE
fix(codex): add dedicated Codex plugin so hooks load correctly

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "engram",
+  "interface": {
+    "displayName": "Engram Persistent Memory"
+  },
+  "plugins": [
+    {
+      "name": "engram",
+      "source": {
+        "source": "local",
+        "path": "./plugin/codex"
+      },
+      "policy": {
+        "installation": "INSTALLED_BY_DEFAULT"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/plugin/codex/.codex-plugin/plugin.json
+++ b/plugin/codex/.codex-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "engram",
+  "displayName": "Engram Persistent Memory",
+  "version": "0.1.1",
+  "description": "Persistent memory for AI coding agents. Survives across sessions and compactions.",
+  "shortDescription": "Persistent memory with session tracking, compaction recovery, and Memory Protocol.",
+  "author": {
+    "name": "Gentleman Programming"
+  },
+  "homepage": "https://github.com/Gentleman-Programming/engram",
+  "repository": "https://github.com/Gentleman-Programming/engram",
+  "license": "MIT",
+  "category": "Productivity",
+  "keywords": ["memory", "persistence", "sessions", "context"],
+  "hooks": "./hooks/hooks.json",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugin/codex/.mcp.json
+++ b/plugin/codex/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "engram": {
+      "command": "engram",
+      "args": ["mcp", "--tools=agent"]
+    }
+  }
+}

--- a/plugin/codex/hooks/hooks.json
+++ b/plugin/codex/hooks/hooks.json
@@ -37,6 +37,7 @@
     ],
     "SubagentStop": [
       {
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",

--- a/plugin/codex/hooks/hooks.json
+++ b/plugin/codex/hooks/hooks.json
@@ -1,0 +1,61 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/scripts/session-start.sh\"",
+            "timeout": 10,
+            "statusMessage": "Loading engram memory..."
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/scripts/post-compaction.sh\"",
+            "timeout": 10,
+            "statusMessage": "Recovering engram context after compaction..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/scripts/user-prompt-submit.sh\"",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/scripts/subagent-stop.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/scripts/session-stop.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/codex/scripts/_helpers.sh
+++ b/plugin/codex/scripts/_helpers.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Engram — Shared helpers for Codex hooks
+# WARNING: Do not read from stdin here — scripts source this before reading their hook input.
+
+# Detect project name from git remote, with fallbacks.
+# Priority: git remote origin repo name > git root basename > cwd basename
+detect_project() {
+  local dir="$1"
+
+  # Try git remote origin URL
+  local url
+  url=$(git -C "$dir" remote get-url origin 2>/dev/null)
+  if [ -n "$url" ]; then
+    # Handles both SSH (git@github.com:user/repo.git) and HTTPS (https://github.com/user/repo.git)
+    local name
+    name=$(echo "$url" | sed 's/\.git$//' | sed 's|.*[/:]||' | tr '[:upper:]' '[:lower:]')
+    if [ -n "$name" ]; then
+      echo "$name"
+      return
+    fi
+  fi
+
+  # Fallback: git root directory name (works in worktrees)
+  local root
+  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$root" ]; then
+    basename "$root" | tr '[:upper:]' '[:lower:]'
+    return
+  fi
+
+  # Final fallback: cwd basename (current behavior)
+  basename "$dir" | tr '[:upper:]' '[:lower:]'
+}

--- a/plugin/codex/scripts/post-compaction.sh
+++ b/plugin/codex/scripts/post-compaction.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Engram — Post-compaction hook for Codex
+#
+# When compaction happens, inject Memory Protocol + context and instruct
+# the agent to persist the compacted summary via mem_session_summary.
+
+ENGRAM_PORT="${ENGRAM_PORT:-7437}"
+ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+
+# Load shared helpers
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/_helpers.sh"
+
+# Read hook input from stdin
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+PROJECT=$(detect_project "$CWD")
+
+# Ensure session exists
+if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
+  curl -sf "${ENGRAM_URL}/sessions" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg id "$SESSION_ID" --arg project "$PROJECT" --arg dir "$CWD" \
+      '{id: $id, project: $project, directory: $dir}')" \
+    > /dev/null 2>&1
+fi
+
+# Fetch context from previous sessions
+ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+
+# Inject Memory Protocol + compaction instruction + context
+cat <<'PROTOCOL'
+## Engram Persistent Memory — ACTIVE PROTOCOL
+
+You have engram memory tools. This protocol is MANDATORY and ALWAYS ACTIVE.
+
+### CORE TOOLS — always available, no ToolSearch needed
+mem_save, mem_search, mem_context, mem_session_summary, mem_get_observation, mem_save_prompt
+
+Use ToolSearch for other tools: mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end, mem_stats, mem_delete, mem_timeline, mem_capture_passive
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Notion/Jira/GitHub artifact created or updated with significant content
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+**Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything ("remember", "what did we do", or the equivalent in the user's language)
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SESSION CLOSE — before saying "done":
+Call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+---
+
+CRITICAL INSTRUCTION POST-COMPACTION — follow these steps IN ORDER:
+PROTOCOL
+
+printf "\n1. FIRST: Call mem_session_summary with the content of the compacted summary above. Use project: '%s'.\n" "$PROJECT"
+printf "   This preserves what was accomplished before compaction.\n\n"
+printf "2. THEN: Call mem_context with project: '%s' to recover recent session history and observations.\n" "$PROJECT"
+printf "   Read the returned context carefully — it tells you what was being worked on.\n\n"
+cat <<'PROTOCOL'
+3. If you need more detail on a specific topic, call mem_search with relevant keywords.
+
+4. Only THEN continue working on what the user asked.
+
+All 4 steps are MANDATORY. Without them, you lose context and start blind.
+PROTOCOL
+
+# Inject memory context if available
+if [ -n "$CONTEXT" ]; then
+  printf "\n%s\n" "$CONTEXT"
+fi
+
+exit 0

--- a/plugin/codex/scripts/session-start.sh
+++ b/plugin/codex/scripts/session-start.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Engram — SessionStart hook for Codex
+#
+# 1. Ensures the engram server is running
+# 2. Creates a session in engram
+# 3. Auto-imports git-synced chunks if .engram/manifest.json exists
+# 4. Injects Memory Protocol instructions + memory context
+
+ENGRAM_PORT="${ENGRAM_PORT:-7437}"
+ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+IMPORT_TIMEOUT_SECS=8
+LOCK_TTL_SECS=$((IMPORT_TIMEOUT_SECS + 4))
+LOCK_METADATA_STALE_SECS=$((LOCK_TTL_SECS * 5))
+
+# Load shared helpers
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/_helpers.sh"
+
+# Read hook input from stdin
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+OLD_PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(detect_project "$CWD")
+
+# Ensure engram server is running
+if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then
+  engram serve &>/dev/null &
+  sleep 0.5
+fi
+
+# Migrate project name if it changed (one-time, idempotent)
+if [ "$OLD_PROJECT" != "$PROJECT" ] && [ -n "$OLD_PROJECT" ] && [ -n "$PROJECT" ]; then
+  curl -sf "${ENGRAM_URL}/projects/migrate" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg old "$OLD_PROJECT" --arg new "$PROJECT" \
+      '{old_project: $old, new_project: $new}')" \
+    > /dev/null 2>&1
+fi
+
+# Create session
+if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
+  curl -sf "${ENGRAM_URL}/sessions" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg id "$SESSION_ID" --arg project "$PROJECT" --arg dir "$CWD" \
+      '{id: $id, project: $project, directory: $dir}')" \
+    > /dev/null 2>&1
+fi
+
+# Auto-import git-synced chunks
+if [ -f "${CWD}/.engram/manifest.json" ]; then
+  (
+    cd "$CWD" 2>/dev/null || exit 0
+    IMPORT_LOCK="/tmp/engram-sync-import-$(printf '%s' "$CWD" | cksum | cut -d ' ' -f 1).lock"
+    write_import_lock_info() {
+      LOCK_INFO_TMP="$IMPORT_LOCK/info.$$"
+      printf '%s %s\n' "$LOCK_PID" "$LOCK_NOW" > "$LOCK_INFO_TMP" 2>/dev/null \
+        && mv "$LOCK_INFO_TMP" "$IMPORT_LOCK/info" 2>/dev/null
+    }
+    lock_path_age_secs() {
+      LOCK_PATH=$1
+      LOCK_MTIME=""
+      if LOCK_MTIME=$(stat -f %m "$LOCK_PATH" 2>/dev/null); then
+        :
+      elif LOCK_MTIME=$(stat -c %Y "$LOCK_PATH" 2>/dev/null); then
+        :
+      else
+        return 1
+      fi
+      case "$LOCK_MTIME" in
+        ''|*[!0-9]*) return 1 ;;
+      esac
+      printf '%s\n' $(( LOCK_NOW - LOCK_MTIME ))
+    }
+    lock_metadata_is_stale() {
+      LOCK_METADATA_PATH=$1
+      LOCK_METADATA_AGE=$(lock_path_age_secs "$LOCK_METADATA_PATH") || return 1
+      [ "$LOCK_METADATA_AGE" -gt "$LOCK_METADATA_STALE_SECS" ]
+    }
+    acquire_import_lock() {
+      LOCK_PID="${BASHPID:-$$}"
+      LOCK_NOW=$(date +%s)
+      if mkdir "$IMPORT_LOCK" 2>/dev/null; then
+        write_import_lock_info || true
+        return 0
+      fi
+
+      LOCK_INFO=""
+      if [ -f "$IMPORT_LOCK/info" ]; then
+        LOCK_INFO=$(cat "$IMPORT_LOCK/info" 2>/dev/null || true)
+      fi
+      read -r OLD_PID OLD_EPOCH LOCK_INFO_EXTRA <<< "$LOCK_INFO"
+      STALE_LOCK=0
+      if [ -z "$LOCK_INFO" ] || [ -z "$OLD_PID" ] || [ -z "$OLD_EPOCH" ] || [ -n "$LOCK_INFO_EXTRA" ]; then
+        lock_metadata_is_stale "$IMPORT_LOCK" || return 1
+        STALE_LOCK=1
+      elif [[ "$OLD_PID" == *[!0-9]* ]] || [[ "$OLD_EPOCH" == *[!0-9]* ]]; then
+        lock_metadata_is_stale "$IMPORT_LOCK/info" || return 1
+        STALE_LOCK=1
+      elif kill -0 "$OLD_PID" 2>/dev/null; then
+        return 1
+      elif [ $(( LOCK_NOW - OLD_EPOCH )) -gt "$LOCK_TTL_SECS" ]; then
+        STALE_LOCK=1
+      fi
+
+      if [ "$STALE_LOCK" -ne 1 ]; then
+        return 1
+      fi
+      rm -f "$IMPORT_LOCK/info" 2>/dev/null || true
+      rmdir "$IMPORT_LOCK" 2>/dev/null || return 1
+      if mkdir "$IMPORT_LOCK" 2>/dev/null; then
+        write_import_lock_info || true
+        return 0
+      fi
+      return 1
+    }
+    if ! acquire_import_lock; then
+      exit 0
+    fi
+    trap 'rm -f "$IMPORT_LOCK/info" 2>/dev/null || true; rmdir "$IMPORT_LOCK" 2>/dev/null || true' EXIT
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "${IMPORT_TIMEOUT_SECS}s" engram sync --import >/dev/null 2>&1 || true
+    else
+      engram sync --import >/dev/null 2>&1 &
+      IMPORT_PID=$!
+      (sleep "$IMPORT_TIMEOUT_SECS"; kill "$IMPORT_PID" 2>/dev/null || true) &
+      WAITER_PID=$!
+      wait "$IMPORT_PID" 2>/dev/null || true
+      kill "$WAITER_PID" 2>/dev/null || true
+    fi
+  ) >/dev/null 2>&1 &
+fi
+
+# Fetch memory context
+ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+
+# Inject Memory Protocol + context — stdout is returned to Codex as additionalContext
+cat <<'PROTOCOL'
+## Engram Persistent Memory — ACTIVE PROTOCOL
+
+You have engram memory tools. This protocol is MANDATORY and ALWAYS ACTIVE.
+
+### CORE TOOLS — always available, no ToolSearch needed
+mem_save, mem_search, mem_context, mem_session_summary, mem_get_observation, mem_save_prompt
+
+Use ToolSearch for other tools: mem_update, mem_suggest_topic_key, mem_session_start, mem_session_end, mem_stats, mem_delete, mem_timeline, mem_capture_passive
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Notion/Jira/GitHub artifact created or updated with significant content
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+- User confirms your recommendation ("go with that", "sounds good", or the equivalent in the user's language)
+- User rejects an approach or expresses a preference ("no, better X", "I prefer X", or the equivalent in the user's language)
+- Discussion concludes with a clear direction chosen
+
+**Self-check after EVERY task**: "Did I or the user just make a decision, confirm a recommendation, express a preference, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything ("remember", "what did we do", or the equivalent in the user's language)
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+- User's FIRST message references the project, a feature, or a problem — call `mem_search` with keywords from their message to check for prior work before responding
+
+### SESSION CLOSE — before saying "done":
+Call `mem_session_summary` with: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+PROTOCOL
+
+# Inject memory context if available
+if [ -n "$CONTEXT" ]; then
+  printf "\n%s\n" "$CONTEXT"
+fi
+
+exit 0

--- a/plugin/codex/scripts/session-stop.sh
+++ b/plugin/codex/scripts/session-stop.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Engram — Stop hook for Codex (synchronous)
+#
+# Marks the session as ended via the HTTP API.
+# Runs synchronously (Codex does not support async: true).
+# The HTTP call is fast enough to complete well within the 5s timeout.
+
+ENGRAM_PORT="${ENGRAM_PORT:-7437}"
+ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}/end" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  --max-time 4 \
+  > /dev/null 2>&1
+
+exit 0

--- a/plugin/codex/scripts/subagent-stop.sh
+++ b/plugin/codex/scripts/subagent-stop.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Engram — SubagentStop hook for Codex (synchronous)
+#
+# Reads the subagent output from stdin and POSTs it to the passive capture
+# endpoint. All extraction logic lives in the Go server — this script is
+# intentionally minimal.
+#
+# Runs synchronously (Codex does not support async: true). The HTTP call
+# completes well within the 10s timeout on a local engram server.
+
+ENGRAM_PORT="${ENGRAM_PORT:-7437}"
+ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+
+# Load shared helpers
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/_helpers.sh"
+
+# Read hook input from stdin
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+OUTPUT=$(echo "$INPUT" | jq -r '.stdout // empty')
+PROJECT=$(detect_project "$CWD")
+
+# Nothing to capture if no output
+[ -z "$OUTPUT" ] && exit 0
+
+# Post to passive capture — server handles extraction, dedup, and storage
+curl -sf "${ENGRAM_URL}/observations/passive" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --max-time 9 \
+  -d "$(jq -n \
+    --arg sid "$SESSION_ID" \
+    --arg content "$OUTPUT" \
+    --arg project "$PROJECT" \
+    --arg source "subagent-stop" \
+    '{session_id: $sid, content: $content, project: $project, source: $source}')" \
+  > /dev/null 2>&1
+
+exit 0

--- a/plugin/codex/scripts/subagent-stop.sh
+++ b/plugin/codex/scripts/subagent-stop.sh
@@ -19,7 +19,7 @@ source "${SCRIPT_DIR}/_helpers.sh"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-OUTPUT=$(echo "$INPUT" | jq -r '.stdout // empty')
+OUTPUT=$(echo "$INPUT" | jq -r '.last_assistant_message // .stdout // empty')
 PROJECT=$(detect_project "$CWD")
 
 # Nothing to capture if no output

--- a/plugin/codex/scripts/user-prompt-submit.sh
+++ b/plugin/codex/scripts/user-prompt-submit.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Engram — UserPromptSubmit hook for Codex
+#
+# On the FIRST message of a session: injects a ToolSearch instruction to force
+# Codex to load all engram memory tools (which are deferred by default).
+#
+# On subsequent messages: checks when the last mem_save was for the current
+# project. If it's been > 15 minutes AND the session has been active > 5
+# minutes, injects a nudge reminding the agent to save.
+#
+# The nudge is debounced per session: once shown, it stays quiet for
+# ENGRAM_NUDGE_COOLDOWN_SECS (default 900s) before it can fire again.
+#
+# MUST exit 0 always and output valid JSON — otherwise Codex blocks the message.
+
+ENGRAM_PORT="${ENGRAM_PORT:-7437}"
+ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+
+print_toolsearch_message() {
+  printf '%s\n' '{"systemMessage":"CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:\nselect:mcp__engram__mem_save,mcp__engram__mem_search,mcp__engram__mem_context,mcp__engram__mem_session_summary,mcp__engram__mem_session_start,mcp__engram__mem_session_end,mcp__engram__mem_get_observation,mcp__engram__mem_suggest_topic_key,mcp__engram__mem_capture_passive,mcp__engram__mem_save_prompt,mcp__engram__mem_update,mcp__engram__mem_current_project,mcp__engram__mem_judge\n\nAfter loading tools, call mem_context to check for prior session history before responding."}'
+}
+
+# Load shared helpers
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/_helpers.sh"
+
+# Read hook input from stdin
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+parse_epoch() {
+  TS="$1"
+  if [ -z "$TS" ]; then
+    return 1
+  fi
+
+  # Drop fractional seconds without dropping timezone information.
+  if [[ "$TS" == *.* ]]; then
+    TS_PREFIX="${TS%%.*}"
+    TS_SUFFIX="${TS#*.}"
+    case "$TS_SUFFIX" in
+      *Z) TS="${TS_PREFIX}Z" ;;
+      *+*) TS="${TS_PREFIX}+${TS_SUFFIX#*+}" ;;
+      *-*) TS="${TS_PREFIX}-${TS_SUFFIX#*-}" ;;
+      *) TS="$TS_PREFIX" ;;
+    esac
+  fi
+
+  # BSD date accepts numeric RFC3339 offsets with %z, but requires +HHMM.
+  if [[ "$TS" =~ ^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})([+-][0-9]{2}):([0-9]{2})$ ]]; then
+    TZ_TS="${BASH_REMATCH[1]}${BASH_REMATCH[2]}${BASH_REMATCH[3]}"
+    date -j -f "%Y-%m-%dT%H:%M:%S%z" "$TZ_TS" "+%s" 2>/dev/null && return 0
+  fi
+  if [[ "$TS" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[+-][0-9]{4}$ ]]; then
+    date -j -f "%Y-%m-%dT%H:%M:%S%z" "$TS" "+%s" 2>/dev/null && return 0
+  fi
+
+  if [[ "$TS" == *Z ]]; then
+    Z_TS="${TS%Z}"
+    date -j -u -f "%Y-%m-%dT%H:%M:%S" "$Z_TS" "+%s" 2>/dev/null && return 0
+  fi
+
+  date -j -f "%Y-%m-%dT%H:%M:%S" "$TS" "+%s" 2>/dev/null \
+    || date -j -f "%Y-%m-%d %H:%M:%S" "$TS" "+%s" 2>/dev/null \
+    || date -d "$TS" "+%s" 2>/dev/null
+}
+
+# Default: no injection
+OUTPUT="{}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FIRST-MESSAGE DETECTION
+#
+# Use a state file per session to determine if this is the first user message.
+# State file lives in /tmp and is keyed by session_id (falls back to project+pid).
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Build a stable session key — prefer SESSION_ID, fall back to project name
+if [ -n "$SESSION_ID" ]; then
+  SESSION_KEY="engram-codex-${SESSION_ID}-tools-loaded"
+else
+  # No session ID available — only then detect project for the fallback state key.
+  PROJECT=$(detect_project "$CWD")
+  SAFE_PROJECT=$(printf '%s' "${PROJECT:-unknown}" | tr -cs 'a-zA-Z0-9_-' '_')
+  SESSION_KEY="engram-codex-${SAFE_PROJECT}-$$-tools-loaded"
+fi
+
+STATE_FILE="/tmp/${SESSION_KEY}"
+
+if [ ! -f "$STATE_FILE" ]; then
+  # ── FIRST MESSAGE ────────────────────────────────────────────────────────────
+  # Create the state file immediately to prevent repeat injections
+  touch "$STATE_FILE" 2>/dev/null || true
+
+  # Inject ToolSearch + mem_context instruction.
+  print_toolsearch_message
+  exit 0
+fi
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SUBSEQUENT MESSAGES — save-nudge logic
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Detect project only after the first-message path has had a chance to return.
+if [ -z "${PROJECT:-}" ]; then
+  PROJECT=$(detect_project "$CWD")
+fi
+
+# Bail early if we can't determine the project
+if [ -z "$PROJECT" ]; then
+  echo "$OUTPUT"
+  exit 0
+fi
+
+# Get session start time to check if session is > 5 minutes old
+SESSION_START=""
+if [ -n "$SESSION_ID" ]; then
+  SESSION_START=$(curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}" --max-time 0.2 2>/dev/null \
+    | jq -r '.started_at // empty' 2>/dev/null)
+fi
+
+# Check session age — skip nudge if session is new (< 5 minutes)
+if [ -n "$SESSION_START" ]; then
+  SESSION_START_EPOCH=$(parse_epoch "$SESSION_START")
+  if [ -z "$SESSION_START_EPOCH" ]; then
+    echo "$OUTPUT"
+    exit 0
+  fi
+  NOW_EPOCH=$(date "+%s")
+  SESSION_AGE_SECS=$(( NOW_EPOCH - SESSION_START_EPOCH ))
+
+  if [ "$SESSION_AGE_SECS" -lt 300 ]; then
+    # Session < 5 minutes old — no nudge yet
+    echo "$OUTPUT"
+    exit 0
+  fi
+fi
+
+# Fetch the most recent observation for this project (any type)
+ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+LAST_SAVE_JSON=$(curl -sf \
+  "${ENGRAM_URL}/observations?project=${ENCODED_PROJECT}&limit=1&sort=created_at:desc" \
+  --max-time 0.2 2>/dev/null)
+
+if [ -z "$LAST_SAVE_JSON" ]; then
+  # Server not responding or slow — fail silently, no nudge
+  echo "$OUTPUT"
+  exit 0
+fi
+
+LAST_SAVE_AT=$(echo "$LAST_SAVE_JSON" | jq -r '.[0].created_at // empty' 2>/dev/null)
+
+if [ -z "$LAST_SAVE_AT" ]; then
+  # No observations yet — no nudge (session might just be starting)
+  echo "$OUTPUT"
+  exit 0
+fi
+
+# Parse last save timestamp and compare to now
+LAST_EPOCH=$(parse_epoch "$LAST_SAVE_AT")
+if [ -z "$LAST_EPOCH" ]; then
+  echo "$OUTPUT"
+  exit 0
+fi
+NOW_EPOCH=$(date "+%s")
+ELAPSED=$(( NOW_EPOCH - LAST_EPOCH ))
+
+# Nudge if last save was > 15 minutes ago (900 seconds), but debounce so we do
+# not repeat the reminder on every message while the agent has nothing to save.
+if [ "$ELAPSED" -gt 900 ]; then
+  NUDGE_COOLDOWN="${ENGRAM_NUDGE_COOLDOWN_SECS:-900}"
+  NUDGE_STATE_FILE="${STATE_FILE%-tools-loaded}-last-nudge"
+
+  LAST_NUDGE_EPOCH=""
+  if [ -f "$NUDGE_STATE_FILE" ]; then
+    read -r LAST_NUDGE_EPOCH < "$NUDGE_STATE_FILE" 2>/dev/null || LAST_NUDGE_EPOCH=""
+  fi
+  # Ignore a corrupt/non-numeric state file — treat as "never nudged".
+  case "$LAST_NUDGE_EPOCH" in
+    ''|*[!0-9]*) LAST_NUDGE_EPOCH="" ;;
+  esac
+
+  if [ -z "$LAST_NUDGE_EPOCH" ] || [ "$(( NOW_EPOCH - LAST_NUDGE_EPOCH ))" -ge "$NUDGE_COOLDOWN" ]; then
+    printf '%s' "$NOW_EPOCH" > "$NUDGE_STATE_FILE" 2>/dev/null || true
+    OUTPUT=$(jq -n \
+      '{"systemMessage": "MEMORY REMINDER: It'\''s been over 15 minutes since your last save. If you'\''ve made decisions, discoveries, or completed significant work, call mem_save now."}')
+  fi
+fi
+
+echo "$OUTPUT"
+exit 0

--- a/plugin/codex/scripts/user-prompt-submit.sh
+++ b/plugin/codex/scripts/user-prompt-submit.sh
@@ -29,6 +29,24 @@ INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 
+# ──────────────────────────────────────────────────────────────────────────────
+# PROMPT PERSIST
+#
+# Every user message is captured to POST /prompts so mem_save can attach the
+# originating prompt via SessionActivity. Detached subshell: never blocks and
+# never fails the hook.
+# ──────────────────────────────────────────────────────────────────────────────
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
+  (
+    _PROMPT_PROJECT=$(detect_project "$CWD")
+    curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg s "$SESSION_ID" --arg p "${_PROMPT_PROJECT:-}" --arg c "$PROMPT" \
+            '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
+  ) &
+fi
+
 parse_epoch() {
   TS="$1"
   if [ -z "$TS" ]; then

--- a/plugin/codex/skills/memory/SKILL.md
+++ b/plugin/codex/skills/memory/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: engram-memory
+description: "ALWAYS ACTIVE — Persistent memory protocol. You MUST save decisions, conventions, bugs, and discoveries to engram proactively. Do NOT wait for the user to ask."
+---
+
+# Engram Persistent Memory — Protocol
+
+You have access to Engram, a persistent memory system that survives across sessions and compactions.
+This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
+
+## AVAILABLE TOOLS
+
+Core tools are loaded automatically at session start by the UserPromptSubmit hook.
+They are available immediately — no manual ToolSearch needed.
+
+- `mem_save`, `mem_search`, `mem_context`, `mem_session_summary`
+- `mem_get_observation`, `mem_suggest_topic_key`, `mem_update`
+- `mem_session_start`, `mem_session_end`, `mem_save_prompt`
+
+**Fallback**: If tools are unexpectedly unavailable, run `engram setup codex`
+again and restart Codex. Setup repairs the durable MCP config and
+permissions allowlist for the `mcp__engram__...` server ids.
+
+Admin tools (deferred — use ToolSearch only if needed):
+- `mem_stats`, `mem_delete`, `mem_timeline`, `mem_capture_passive`
+
+## PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
+
+Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
+
+### After decisions or conventions
+- Architecture or design decision made
+- Team convention documented or established
+- Workflow change agreed upon
+- Tool or library choice made with tradeoffs
+
+### After completing work
+- Bug fix completed (include root cause)
+- Feature implemented with non-obvious approach
+- Notion/Jira/GitHub artifact created or updated with significant content
+- Configuration change or environment setup done
+
+### After discoveries
+- Non-obvious discovery about the codebase
+- Gotcha, edge case, or unexpected behavior found
+- Pattern established (naming, structure, convention)
+- User preference or constraint learned
+
+### After user confirmation or rejection
+- User confirms a recommendation you made ("go with that", "let's do that", "sounds good", "agreed", "perfect", or the equivalent in the user's language)
+- User rejects an option or approach ("no, better X", "not that one", or the equivalent in the user's language)
+- User expresses a preference ("I prefer X over Y", "always do it this way", or the equivalent in the user's language)
+- User makes a decision after you presented tradeoffs or options
+- A discussion concludes with a clear direction chosen — even if the agent proposed it
+
+### Self-check — ask yourself after EVERY task:
+> "Did I or the user just make a decision, confirm a recommendation, express a preference, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
+
+Format for `mem_save`:
+- **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList", "Chose Zustand over Redux")
+- **type**: bugfix | decision | architecture | discovery | pattern | config | preference
+- **scope**: `project` (default) | `personal`
+- **topic_key** (optional but recommended for evolving topics): stable key like `architecture/auth-model`
+- **content**:
+  **What**: One sentence — what was done
+  **Why**: What motivated it (user request, bug, performance, etc.)
+  **Where**: Files or paths affected
+  **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+### Topic update rules (mandatory)
+
+- Different topics MUST NOT overwrite each other (example: architecture decision vs bugfix)
+- If the same topic evolves, call `mem_save` with the same `topic_key` so memory is updated (upsert) instead of creating a new observation
+- If unsure about the key, call `mem_suggest_topic_key` first, then reuse that key consistently
+- If you already know the exact ID to fix, use `mem_update`
+
+## WHEN TO SEARCH MEMORY
+
+When the user asks to recall something — any variation of "remember", "recall", "what did we do",
+"how did we solve", or the equivalent in the user's language, or references to past work:
+1. First call `mem_context` — checks recent session history (fast, cheap)
+2. If not found, call `mem_search` with relevant keywords (FTS5 full-text search)
+3. If you find a match, use `mem_get_observation` for full untruncated content
+
+Also search memory PROACTIVELY when:
+- Starting work on something that might have been done before
+- The user mentions a topic you have no context on — check if past sessions covered it
+- The user's FIRST message references the project, a feature, or a problem — call `mem_search` with keywords from their message to check for prior work before responding
+
+## SESSION CLOSE PROTOCOL (mandatory)
+
+Before ending a session or saying "done" / "that's it", you MUST:
+1. Call `mem_session_summary` with this structure:
+
+## Goal
+[What we were working on this session]
+
+## Instructions
+[User preferences or constraints discovered — skip if none]
+
+## Discoveries
+- [Technical findings, gotchas, non-obvious learnings]
+
+## Accomplished
+- [Completed items with key details]
+
+## Next Steps
+- [What remains to be done — for the next session]
+
+## Relevant Files
+- path/to/file — [what it does or what changed]
+
+This is NOT optional. If you skip this, the next session starts blind.
+
+## AFTER COMPACTION
+
+If you see a message about compaction or context reset:
+1. IMMEDIATELY call `mem_session_summary` with the compacted summary content — this persists what was done before compaction
+2. Then call `mem_context` to recover any additional context from previous sessions
+3. Only THEN continue working
+
+Do not skip step 1. Without it, everything done before compaction is lost from memory.
+All core tools are loaded automatically by the hook at session start. If they are unexpectedly missing, rerun `engram setup codex` and restart Codex.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #507

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- **Root cause:** there is no Codex plugin in the repo — Codex was installing the **claude-code** plugin (same `engram` `0.1.1` from the marketplace). That `hooks.json` carries a top-level `description` field (Codex uses `deny_unknown_fields` → fatal parse error) and `async: true` hooks (Codex parses but **silently skips** them), so passive capture (`subagent-stop`) and `session-stop` never fire under Codex.
- **Fix:** add a **dedicated** `plugin/codex` with a `hooks.json` that has **no** `description` and **no** `async: true`. `plugin/claude-code` is left untouched, so Claude Code keeps its legitimate async hooks.
- Codex's format was verified against the official docs (developers.openai.com/codex): manifest at `.codex-plugin/plugin.json`, plugin-root env var `PLUGIN_ROOT` (with `CLAUDE_PLUGIN_ROOT` kept for compat), discovery via `.agents/plugins/marketplace.json` with a `{source, path}` entry, and async hooks documented as skipped.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/codex/.codex-plugin/plugin.json` | Codex plugin manifest |
| `plugin/codex/hooks/hooks.json` | Hooks mapping — no `description`, no `async:true`, uses `${PLUGIN_ROOT}` |
| `plugin/codex/scripts/*.sh` | `_helpers`, `session-start`, `session-stop`, `subagent-stop`, `post-compaction`, `user-prompt-submit` adapted to Codex (codex-prefixed state, no Windows safe-mode path) |
| `plugin/codex/.mcp.json` | MCP server config (agent-agnostic copy) |
| `plugin/codex/skills/memory/SKILL.md` | Memory Protocol skill (`engram setup codex` fallback) |
| `.agents/plugins/marketplace.json` | Codex-native discovery entry → `./plugin/codex` |

## 🧪 Test Plan

- [x] `shellcheck plugin/codex/scripts/*.sh` — clean (only SC1091 info for the sourced helper)
- [x] `jq .` validates `hooks.json`, `plugin.json`, `.mcp.json`, `.agents/plugins/marketplace.json`
- [x] `git diff -- plugin/claude-code` is empty (Claude Code untouched, async preserved)
- [x] Codex plugin format cross-checked against developers.openai.com/codex docs

## 📌 Notes for reviewer (please confirm on a real Codex)

- `.agents/plugins/marketplace.json` discovery + `policy.installation` value — verify Codex picks the plugin up as expected.
- `skills/` loading mechanism under Codex is assumed equivalent to Claude Code (harmless if ignored).
- The Codex `user-prompt-submit.sh` does **not** yet include the `POST /prompts` prompt-persist added in #509 (sibling claude-code fix). A follow-up should port it for parity once #509 lands.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] Ran shellcheck on modified scripts
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the “Engram Persistent Memory” plugin with automatic session setup, project-scoped context save/restore, and compaction recovery.
  * Introduced event-driven hooks to capture user prompts, track session/subagent outputs, and provide memory reminders and recall behavior.
  * Added MCP server support for integrating Engram tools.
* **Documentation**
  * Published the mandatory “Engram Persistent Memory — Protocol” skill guide defining required memory tools, saving triggers, and session-close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->