### PR TITLE
feat(opencode): add 15-minute save-nudge for memory parity

### DIFF
--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -76,7 +76,7 @@ Topic rules:
 ### WHEN TO SEARCH MEMORY
 
 When the user asks to recall something — any variation of "remember", "recall", "what did we do",
-"how did we solve", "recordar", "acordate", "qué hicimos", or references to past work:
+"how did we solve", or the equivalent in the user's language, or references to past work:
 1. First call \`mem_context\` — checks recent session history (fast, cheap)
 2. If not found, call \`mem_search\` with relevant keywords (FTS5 full-text search)
 3. If you find a match, use \`mem_get_observation\` for full untruncated content
@@ -88,7 +88,7 @@ Also search memory PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", you MUST:
+Before ending a session or saying "done" / "that's it", you MUST:
 1. Call \`mem_session_summary\` with this structure:
 
 ## Goal
@@ -203,6 +203,9 @@ export const Engram: Plugin = async (ctx) => {
   // Track tool counts per session (in-memory only, not critical)
   const toolCounts = new Map<string, number>()
 
+  // Track last nudge time per session to debounce save reminders
+  const lastNudgeTime = new Map<string, number>() // sessionID -> epoch seconds
+
   // Track which sessions we've already ensured exist in engram
   const knownSessions = new Set<string>()
 
@@ -316,6 +319,7 @@ export const Engram: Plugin = async (ctx) => {
           toolCounts.delete(sessionId)
           knownSessions.delete(sessionId)
           subAgentSessions.delete(sessionId)
+          lastNudgeTime.delete(sessionId)
         }
       }
 
@@ -404,11 +408,95 @@ export const Engram: Plugin = async (ctx) => {
     // block at the beginning. By concatenating, we avoid adding extra system
     // messages that would break these models. See: GitHub issue #23.
 
-    "experimental.chat.system.transform": async (_input, output) => {
+    "experimental.chat.system.transform": async (input, output) => {
       if (output.system.length > 0) {
         output.system[output.system.length - 1] += "\n\n" + MEMORY_INSTRUCTIONS
       } else {
         output.system.push(MEMORY_INSTRUCTIONS)
+      }
+
+      // ── Save nudge ──────────────────────────────────────────────────────────
+      // If it has been a long time since the last mem_save, append a reminder
+      // to the system prompt so the agent notices. All fetches are fire-and-
+      // forget with short timeouts — any failure silently skips the nudge.
+      try {
+        const sessionID: string = input.sessionID ?? ""
+        if (!sessionID || subAgentSessions.has(sessionID)) return
+
+        // SQLite datetime('now') returns "YYYY-MM-DD HH:MM:SS" in UTC with no
+        // zone suffix; new Date() would parse that as local time. Normalize to
+        // UTC first so the thresholds are correct in every timezone.
+        const toEpochSecs = (ts: string): number => {
+          if (!ts) return 0
+          const normalized = ts.includes("T") ? ts : ts.replace(" ", "T") + "Z"
+          const ms = new Date(normalized).getTime()
+          return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000)
+        }
+
+        const cooldownSecs = parseInt(process.env.ENGRAM_NUDGE_COOLDOWN_SECS ?? "900", 10)
+        const nowSecs = Math.floor(Date.now() / 1000)
+
+        // Debounce: skip if we nudged recently this session
+        const lastNudge = lastNudgeTime.get(sessionID)
+        if (lastNudge !== undefined && nowSecs - lastNudge < cooldownSecs) return
+
+        // Skip if the session is too young (< 5 minutes)
+        let sessionStartEpoch = 0
+        try {
+          const sessionRes = await fetch(`${ENGRAM_URL}/sessions/${encodeURIComponent(sessionID)}`, {
+            signal: AbortSignal.timeout(200),
+          })
+          if (sessionRes.ok) {
+            const sessionData = await sessionRes.json()
+            const startedAt: string = sessionData?.started_at ?? ""
+            if (startedAt) {
+              sessionStartEpoch = toEpochSecs(startedAt)
+            }
+          }
+        } catch {
+          // Server unreachable or timed out — skip nudge
+          return
+        }
+        if (sessionStartEpoch > 0 && nowSecs - sessionStartEpoch < 300) return
+
+        // Check when the last observation was saved for this project
+        let lastObsEpoch = 0
+        try {
+          const obsRes = await fetch(
+            `${ENGRAM_URL}/observations?project=${encodeURIComponent(project)}&limit=1&sort=created_at:desc`,
+            { signal: AbortSignal.timeout(200) }
+          )
+          if (obsRes.ok) {
+            const obsData = await obsRes.json()
+            const createdAt: string = obsData?.[0]?.created_at ?? ""
+            if (createdAt) {
+              lastObsEpoch = toEpochSecs(createdAt)
+            }
+          }
+        } catch {
+          // Server unreachable or timed out — skip nudge
+          return
+        }
+
+        // No observations yet — nothing to nudge about
+        if (lastObsEpoch === 0) return
+
+        // Only nudge if last save was more than 15 minutes ago
+        if (nowSecs - lastObsEpoch < 900) return
+
+        // Append the nudge to the last system message
+        const nudge =
+          "\n\nMEMORY REMINDER: It's been over 15 minutes since your last memory save. " +
+          "If you've made decisions, discoveries, completed significant work, or found non-obvious things, " +
+          "call mem_save now."
+        if (output.system.length > 0) {
+          output.system[output.system.length - 1] += nudge
+        } else {
+          output.system.push(nudge)
+        }
+        lastNudgeTime.set(sessionID, nowSecs)
+      } catch {
+        // Any unexpected error — silently skip the nudge, never crash the hook
       }
     },
 

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -203,6 +203,9 @@ export const Engram: Plugin = async (ctx) => {
   // Track tool counts per session (in-memory only, not critical)
   const toolCounts = new Map<string, number>()
 
+  // Track last nudge time per session to debounce save reminders
+  const lastNudgeTime = new Map<string, number>() // sessionID -> epoch seconds
+
   // Track which sessions we've already ensured exist in engram
   const knownSessions = new Set<string>()
 
@@ -316,6 +319,7 @@ export const Engram: Plugin = async (ctx) => {
           toolCounts.delete(sessionId)
           knownSessions.delete(sessionId)
           subAgentSessions.delete(sessionId)
+          lastNudgeTime.delete(sessionId)
         }
       }
 
@@ -404,11 +408,95 @@ export const Engram: Plugin = async (ctx) => {
     // block at the beginning. By concatenating, we avoid adding extra system
     // messages that would break these models. See: GitHub issue #23.
 
-    "experimental.chat.system.transform": async (_input, output) => {
+    "experimental.chat.system.transform": async (input, output) => {
       if (output.system.length > 0) {
         output.system[output.system.length - 1] += "\n\n" + MEMORY_INSTRUCTIONS
       } else {
         output.system.push(MEMORY_INSTRUCTIONS)
+      }
+
+      // ── Save nudge ──────────────────────────────────────────────────────────
+      // If it has been a long time since the last mem_save, append a reminder
+      // to the system prompt so the agent notices. All fetches are fire-and-
+      // forget with short timeouts — any failure silently skips the nudge.
+      try {
+        const sessionID: string = input.sessionID ?? ""
+        if (!sessionID || subAgentSessions.has(sessionID)) return
+
+        // SQLite datetime('now') returns "YYYY-MM-DD HH:MM:SS" in UTC with no
+        // zone suffix; new Date() would parse that as local time. Normalize to
+        // UTC first so the thresholds are correct in every timezone.
+        const toEpochSecs = (ts: string): number => {
+          if (!ts) return 0
+          const normalized = ts.includes("T") ? ts : ts.replace(" ", "T") + "Z"
+          const ms = new Date(normalized).getTime()
+          return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000)
+        }
+
+        const cooldownSecs = parseInt(process.env.ENGRAM_NUDGE_COOLDOWN_SECS ?? "900", 10)
+        const nowSecs = Math.floor(Date.now() / 1000)
+
+        // Debounce: skip if we nudged recently this session
+        const lastNudge = lastNudgeTime.get(sessionID)
+        if (lastNudge !== undefined && nowSecs - lastNudge < cooldownSecs) return
+
+        // Skip if the session is too young (< 5 minutes)
+        let sessionStartEpoch = 0
+        try {
+          const sessionRes = await fetch(`${ENGRAM_URL}/sessions/${encodeURIComponent(sessionID)}`, {
+            signal: AbortSignal.timeout(200),
+          })
+          if (sessionRes.ok) {
+            const sessionData = await sessionRes.json()
+            const startedAt: string = sessionData?.started_at ?? ""
+            if (startedAt) {
+              sessionStartEpoch = toEpochSecs(startedAt)
+            }
+          }
+        } catch {
+          // Server unreachable or timed out — skip nudge
+          return
+        }
+        if (sessionStartEpoch > 0 && nowSecs - sessionStartEpoch < 300) return
+
+        // Check when the last observation was saved for this project
+        let lastObsEpoch = 0
+        try {
+          const obsRes = await fetch(
+            `${ENGRAM_URL}/observations?project=${encodeURIComponent(project)}&limit=1&sort=created_at:desc`,
+            { signal: AbortSignal.timeout(200) }
+          )
+          if (obsRes.ok) {
+            const obsData = await obsRes.json()
+            const createdAt: string = obsData?.[0]?.created_at ?? ""
+            if (createdAt) {
+              lastObsEpoch = toEpochSecs(createdAt)
+            }
+          }
+        } catch {
+          // Server unreachable or timed out — skip nudge
+          return
+        }
+
+        // No observations yet — nothing to nudge about
+        if (lastObsEpoch === 0) return
+
+        // Only nudge if last save was more than 15 minutes ago
+        if (nowSecs - lastObsEpoch < 900) return
+
+        // Append the nudge to the last system message
+        const nudge =
+          "\n\nMEMORY REMINDER: It's been over 15 minutes since your last memory save. " +
+          "If you've made decisions, discoveries, completed significant work, or found non-obvious things, " +
+          "call mem_save now."
+        if (output.system.length > 0) {
+          output.system[output.system.length - 1] += nudge
+        } else {
+          output.system.push(nudge)
+        }
+        lastNudgeTime.set(sessionID, nowSecs)
+      } catch {
+        // Any unexpected error — silently skip the nudge, never crash the hook
       }
     },
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #515

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds the **15-minute save-nudge** to the OpenCode plugin for parity with the claude-code/codex plugins. It injects a `MEMORY REMINDER` into the system prompt when: session age > 300s, the last observation for the project is > 900s old, and a per-session 900s cooldown (`ENGRAM_NUDGE_COOLDOWN_SECS`) has elapsed.
- Implemented in `experimental.chat.system.transform` — the only OpenCode hook that can inject into the system prompt (`chat.message` cannot). Debounced via an in-memory `Map` (no state files). Fetches use `AbortSignal.timeout(200)` and fail-closed, so the hook never breaks a turn and the existing `MEMORY_INSTRUCTIONS` injection is preserved.
- **Prompt-persist (`POST /prompts`) was already implemented** in the `chat.message` hook — only the nudge was missing. First-message ToolSearch injection is not needed (OpenCode tools are not deferred).

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/opencode/engram.ts` | Save-nudge in `experimental.chat.system.transform`; `lastNudgeTime` map + cleanup on `session.deleted`; UTC-safe timestamp parsing |
| `internal/setup/plugins/opencode/engram.ts` | Regenerated via `go generate` (kept byte-identical with the source) |

## 🧪 Test Plan

- [x] `go build ./...` passes
- [x] `go generate ./internal/setup/` run; both copies byte-identical
- [x] Fresh code review (thresholds/endpoints match the claude-code reference; `sessionID` confirmed present in the `experimental.chat.system.transform` input type; UTC timezone bug fixed; fetches fail-closed)

## 📌 Notes for reviewer

- The `go generate` also synced a **pre-existing MEMORY_INSTRUCTIONS divergence**: the embedded copy still had leftover Spanish phrases (`"recordar"`, `"acordate"`, `"qué hicimos"`, `"listo"`) that the source had already replaced with the generic `"or the equivalent in the user's language"`. Regenerating brings the embedded copy in line with the source (English), per the project's English-default-for-artifacts convention. That's why two MEMORY_INSTRUCTIONS lines change in the embedded file — not part of the nudge.
- Worth a quick smoke test on a real OpenCode session to confirm the nudge actually fires after 15 min idle (the thresholds and `sessionID` availability are verified against types/server, but live behavior wasn't exercised).

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined memory instruction accuracy for enhanced context retention.

* **New Features**
  * Added periodic save reminders for long-running sessions, with intelligent debouncing to prevent excessive notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->