### PR TITLE
feat(setup): install the Codex plugin during 'engram setup codex'

### DIFF
--- a/internal/setup/agents.go
+++ b/internal/setup/agents.go
@@ -49,13 +49,15 @@ func agentAdapters() []agentAdapter {
 		},
 		{
 			slug:        "codex",
-			description: "Codex — MCP registration plus model/compaction instruction files",
+			description: "Codex — MCP registration, model/compaction instruction files, and plugin (hooks)",
 			custom:      installCodex,
 			installDir:  codexConfigPath,
 			postInstall: []string{
-				"Restart Codex so MCP config is reloaded",
+				"Restart Codex so MCP config and plugin are reloaded",
 				"Verify ~/.codex/config.toml has [mcp_servers.engram]",
 				"Verify model_instructions_file + experimental_compact_prompt_file are set",
+				"Verify plugin is installed with: codex plugin list",
+				"If codex CLI was absent during setup, install manually: codex plugin marketplace add Gentleman-Programming/engram --ref main && codex plugin add engram@engram",
 			},
 		},
 		{

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -79,6 +79,7 @@ type Result struct {
 }
 
 const claudeCodeMarketplace = "Gentleman-Programming/engram"
+const codexMarketplace = "Gentleman-Programming/engram"
 
 const openCodeSubagentStatuslinePlugin = "opencode-subagent-statusline"
 
@@ -1168,6 +1169,38 @@ func installCodex() (*Result, error) {
 	compactPromptPath := codexCompactPromptPath()
 	if err := injectCodexMemoryConfigFn(path, instructionsPath, compactPromptPath); err != nil {
 		return nil, err
+	}
+
+	// Best-effort: install the Codex plugin (hooks) via the Codex CLI.
+	// Failures here are non-fatal — the MCP TOML is already written and works
+	// without the plugin. The plugin adds hooks (compaction recovery, etc.).
+	codexBin, err := lookPathFn("codex")
+	if err != nil {
+		// codex CLI not in PATH — warn and return success with files written so far.
+		fmt.Fprintf(os.Stderr, "warning: codex CLI not found in PATH — MCP config and instruction files were written,\n")
+		fmt.Fprintf(os.Stderr, "  but the Engram plugin (hooks) was not installed.\n")
+		fmt.Fprintf(os.Stderr, "  To install manually, run:\n")
+		fmt.Fprintf(os.Stderr, "    codex plugin marketplace add %s --ref main\n", codexMarketplace)
+		fmt.Fprintf(os.Stderr, "    codex plugin add engram@engram\n")
+		return &Result{
+			Agent:       "codex",
+			Destination: filepath.Dir(path),
+			Files:       3,
+		}, nil
+	}
+
+	// Step 1: add the marketplace (idempotent — tolerate "already" in output).
+	addOut, err := runCommand(codexBin, "plugin", "marketplace", "add", codexMarketplace, "--ref", "main")
+	addOutputStr := strings.TrimSpace(string(addOut))
+	if err != nil && !strings.Contains(strings.ToLower(addOutputStr), "already") {
+		fmt.Fprintf(os.Stderr, "warning: codex plugin marketplace add failed (non-fatal): %s\n", addOutputStr)
+	}
+
+	// Step 2: install the plugin (idempotent — tolerate "already" in output).
+	pluginOut, err := runCommand(codexBin, "plugin", "add", "engram@engram")
+	pluginOutputStr := strings.TrimSpace(string(pluginOut))
+	if err != nil && !strings.Contains(strings.ToLower(pluginOutputStr), "already") {
+		fmt.Fprintf(os.Stderr, "warning: codex plugin add failed (non-fatal): %s\n", pluginOutputStr)
 	}
 
 	return &Result{

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -298,6 +298,142 @@ func TestInstallCodexInjectsTOMLAndIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestInstallCodexPluginCLIPresent verifies that when the codex CLI is in PATH,
+// installCodex() runs marketplace add + plugin add with the correct arguments.
+func TestInstallCodexPluginCLIPresent(t *testing.T) {
+	resetSetupSeams(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var commands [][]string
+	lookPathFn = func(file string) (string, error) {
+		if file == "codex" {
+			return "/usr/local/bin/codex", nil
+		}
+		return "", errors.New("not found")
+	}
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, append([]string{name}, args...))
+		return []byte("ok"), nil
+	}
+
+	result, err := Install("codex")
+	if err != nil {
+		t.Fatalf("Install(codex) failed: %v", err)
+	}
+	if result.Agent != "codex" {
+		t.Fatalf("unexpected agent: %q", result.Agent)
+	}
+	if result.Files != 3 {
+		t.Fatalf("expected 3 files written, got %d", result.Files)
+	}
+
+	// Verify marketplace add was called with the right args.
+	var foundMarketplace bool
+	for _, cmd := range commands {
+		if len(cmd) >= 7 &&
+			cmd[0] == "/usr/local/bin/codex" &&
+			cmd[1] == "plugin" && cmd[2] == "marketplace" && cmd[3] == "add" &&
+			cmd[4] == codexMarketplace &&
+			cmd[5] == "--ref" && cmd[6] == "main" {
+			foundMarketplace = true
+		}
+	}
+	if !foundMarketplace {
+		t.Fatalf("expected 'codex plugin marketplace add %s --ref main' to be invoked, got: %v", codexMarketplace, commands)
+	}
+
+	// Verify plugin add was called with the right args.
+	var foundPluginAdd bool
+	for _, cmd := range commands {
+		if len(cmd) >= 4 &&
+			cmd[0] == "/usr/local/bin/codex" &&
+			cmd[1] == "plugin" && cmd[2] == "add" && cmd[3] == "engram@engram" {
+			foundPluginAdd = true
+		}
+	}
+	if !foundPluginAdd {
+		t.Fatalf("expected 'codex plugin add engram@engram' to be invoked, got: %v", commands)
+	}
+}
+
+// TestInstallCodexPluginCLIAbsent verifies that when the codex CLI is not in
+// PATH, installCodex() does not fail — MCP config is still written and Files==3.
+func TestInstallCodexPluginCLIAbsent(t *testing.T) {
+	resetSetupSeams(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	lookPathFn = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		t.Fatalf("runCommand should not be called when codex CLI is absent, got: %s %v", name, args)
+		return nil, nil
+	}
+
+	result, err := Install("codex")
+	if err != nil {
+		t.Fatalf("Install(codex) should succeed even without codex CLI, got: %v", err)
+	}
+	if result.Agent != "codex" {
+		t.Fatalf("unexpected agent: %q", result.Agent)
+	}
+	if result.Files != 3 {
+		t.Fatalf("expected 3 files written, got %d", result.Files)
+	}
+
+	// Verify the TOML config was still written.
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config.toml to be written: %v", err)
+	}
+	if !strings.Contains(string(raw), "[mcp_servers.engram]") {
+		t.Fatalf("expected [mcp_servers.engram] in config, got:\n%s", raw)
+	}
+}
+
+// TestInstallCodexPluginIdempotentAlreadyInOutput verifies that when
+// marketplace add or plugin add returns an error whose output contains "already",
+// the install is still treated as successful (idempotent).
+func TestInstallCodexPluginIdempotentAlreadyInOutput(t *testing.T) {
+	resetSetupSeams(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	lookPathFn = func(file string) (string, error) {
+		if file == "codex" {
+			return "/usr/local/bin/codex", nil
+		}
+		return "", errors.New("not found")
+	}
+	calls := 0
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			// marketplace add returns "already exists" with a non-zero exit
+			return []byte("marketplace already added"), errors.New("exit 1")
+		}
+		if calls == 2 {
+			// plugin add returns "already installed" with a non-zero exit
+			return []byte("plugin already installed"), errors.New("exit 1")
+		}
+		return []byte("ok"), nil
+	}
+
+	result, err := Install("codex")
+	if err != nil {
+		t.Fatalf("Install(codex) should succeed on already-installed outputs, got: %v", err)
+	}
+	if result.Files != 3 {
+		t.Fatalf("expected 3 files written, got %d", result.Files)
+	}
+	if calls < 2 {
+		t.Fatalf("expected at least 2 codex CLI calls, got %d", calls)
+	}
+}
+
 func TestInstallPiInstallsPackagesAndWritesConfig(t *testing.T) {
 	resetSetupSeams(t)
 	agentDir := t.TempDir()


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #517

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- `engram setup codex` now **installs the Codex plugin** (hooks), not just the MCP TOML + instruction files. This closes the distribution gap from the #507 follow-up: previously the `plugin/codex` hooks only loaded when Codex ran inside the engram repo, so Homebrew users got no session-tracking / passive-capture / prompt-persist.
- Mirrors `installClaudeCode`'s CLI approach, with the Codex CLI: `codex plugin marketplace add Gentleman-Programming/engram --ref main`, then `codex plugin add engram@engram`. Codex reads `.agents/plugins/marketplace.json` first, so `engram@engram` resolves to `./plugin/codex` (not the claude-code plugin).
- **Best-effort**: if the `codex` CLI is not in PATH, setup still writes the MCP TOML + instruction files and warns — it never hard-fails (the TOML is the primary deliverable). **Idempotent**: tolerates `already` in command output.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/setup/setup.go` | `installCodex` installs the plugin via the codex CLI (best-effort, idempotent); new `codexMarketplace` constant |
| `internal/setup/agents.go` | Codex post-install next-steps mention plugin verification + manual fallback |
| `internal/setup/setup_test.go` | 3 tests: CLI present (exact args), CLI absent (no exec, still succeeds), idempotent `already` |

## 🧪 Test Plan

- [x] `go test ./internal/setup/...`, `go vet`, `go build ./...` all pass
- [x] **Verified end-to-end against a real Codex (v0.141.0)**: `engram setup codex` ran `codex plugin marketplace add` + `codex plugin add` non-interactively, tolerated the already-installed case, exited 0, and printed the updated next-steps

## 📌 Notes for reviewer

- The idempotency check is `strings.Contains(strings.ToLower(output), "already")` against the combined command output. The exact wording Codex emits for "already registered/installed" wasn't enumerated from docs, but the broad match covers the common patterns and the real-Codex run confirmed the already-installed path is tolerated.
- Scope is the distribution gap (Issue B of the #507 follow-up). The dev-only double-load (Issue A) is intentionally not addressed — Codex's first-match-wins per root means real users with a single install never see it.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex setup now automatically installs the Engram Codex plugin during the installation process.
  * Added verification to confirm the Codex plugin is properly installed.
  * Provides manual installation instructions as a fallback option when automatic installation is unavailable.

* **Tests**
  * Added comprehensive test coverage for Codex plugin installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->