### PR TITLE
fix(setup): stop writing unread Cursor global rule, write informational copy

### DIFF
--- a/internal/setup/agents.go
+++ b/internal/setup/agents.go
@@ -118,16 +118,18 @@ func agentAdapters() []agentAdapter {
 		},
 		{
 			slug:        "cursor",
-			description: "Cursor — MCP registration in ~/.cursor/mcp.json plus an always-applied .mdc rule",
+			description: "Cursor — MCP registration in ~/.cursor/mcp.json plus an informational Memory Protocol file to paste as a User Rule",
 			mcpPath:     cursorMCPPath,
 			mcpFormat:   mcpServersObject,
 			instructions: []instrSurface{
-				{path: cursorRulesPath, style: wholeFile, body: cursorRulesBody()},
+				{path: cursorMemoryProtocolPath, style: wholeFile, body: memoryProtocolMarkdown},
 			},
 			postInstall: []string{
 				"Restart Cursor so MCP config is reloaded",
 				"Verify ~/.cursor/mcp.json includes mcpServers.engram",
-				"Verify ~/.cursor/rules/engram.mdc exists (always-applied rule)",
+				"NOTE: Cursor does NOT read global rule files from the filesystem — .mdc files outside a project are silently ignored",
+				"Open ~/.cursor/engram-memory-protocol.md and copy its contents",
+				"In Cursor, open Settings → Rules → User Rules and paste the copied contents",
 			},
 		},
 		{
@@ -159,13 +161,6 @@ func agentAdapters() []agentAdapter {
 			},
 		},
 	}
-}
-
-// cursorRulesBody wraps the Memory Protocol in the YAML frontmatter Cursor needs
-// for an always-applied rule (alwaysApply:true ignores globs and attaches the rule
-// regardless of context).
-func cursorRulesBody() string {
-	return "---\ndescription: Engram persistent memory protocol\nalwaysApply: true\n---\n\n" + memoryProtocolMarkdown
 }
 
 // vscodeInstructionsBody wraps the Memory Protocol in the frontmatter VS Code
@@ -237,9 +232,14 @@ func cursorMCPPath() string {
 	return filepath.Join(home, ".cursor", "mcp.json")
 }
 
-func cursorRulesPath() string {
+// cursorMemoryProtocolPath returns the path to the informational Memory Protocol
+// file for Cursor. Cursor does not read global rule files from the filesystem;
+// .mdc files with alwaysApply outside a project are silently ignored. This file
+// is intended to be opened by the user and its contents pasted into
+// Settings → Rules → User Rules inside Cursor.
+func cursorMemoryProtocolPath() string {
 	home, _ := userHome()
-	return filepath.Join(home, ".cursor", "rules", "engram.mdc")
+	return filepath.Join(home, ".cursor", "engram-memory-protocol.md")
 }
 
 // ─── VS Code (Copilot) paths ─────────────────────────────────────────────────

--- a/internal/setup/registry_test.go
+++ b/internal/setup/registry_test.go
@@ -28,7 +28,7 @@ func declarativeAgents() []declarativeAgent {
 		{"windsurf", windsurfMCPPath, "mcpServers", mcpServersObject, windsurfRulesPath, markerBlock},
 		{"qwen", qwenSettingsPath, "mcpServers", mcpServersObject, qwenContextPath, markerBlock},
 		{"kiro", kiroMCPPath, "mcpServers", mcpServersObject, kiroSteeringPath, markerBlock},
-		{"cursor", cursorMCPPath, "mcpServers", mcpServersObject, cursorRulesPath, wholeFile},
+		{"cursor", cursorMCPPath, "mcpServers", mcpServersObject, cursorMemoryProtocolPath, wholeFile},
 		{"vscode-copilot", vscodeMCPPath, "servers", serversObject, vscodePromptPath, wholeFile},
 		{"kilocode", kilocodeConfigPath, "mcp", opencodeObject, kilocodeAgentsPath, markerBlock},
 	}
@@ -180,16 +180,38 @@ func TestInstallDeclarativeAgentsRegisterMCPAndInstructions(t *testing.T) {
 	}
 }
 
-func TestCursorAndVSCodeInstructionsCarryFrontmatter(t *testing.T) {
-	stubRegistryEnv(t)
+func TestCursorMemoryProtocolHasNoFrontmatter(t *testing.T) {
+	home := stubRegistryEnv(t)
 
 	if _, err := Install("cursor"); err != nil {
 		t.Fatalf("Install(cursor): %v", err)
 	}
-	cursorRaw, _ := os.ReadFile(cursorRulesPath())
-	if !strings.Contains(string(cursorRaw), "alwaysApply: true") {
-		t.Errorf("cursor .mdc missing alwaysApply frontmatter")
+
+	// The old .mdc path must NOT exist — we no longer write a global rule file.
+	oldMDCPath := filepath.Join(home, ".cursor", "rules", "engram.mdc")
+	if _, err := os.Stat(oldMDCPath); err == nil {
+		t.Errorf("cursor: ~/.cursor/rules/engram.mdc should not be written (Cursor ignores global rule files)")
 	}
+
+	// The new informational file must exist, contain the protocol, and have no YAML frontmatter.
+	protocolRaw, err := os.ReadFile(cursorMemoryProtocolPath())
+	if err != nil {
+		t.Fatalf("cursor: memory protocol file not written at %s: %v", cursorMemoryProtocolPath(), err)
+	}
+	content := string(protocolRaw)
+	if !strings.Contains(content, "Engram Persistent Memory") {
+		t.Errorf("cursor: memory protocol file missing expected content")
+	}
+	if strings.Contains(content, "alwaysApply") {
+		t.Errorf("cursor: memory protocol file must not contain alwaysApply frontmatter")
+	}
+	if strings.HasPrefix(content, "---") {
+		t.Errorf("cursor: memory protocol file must not start with YAML frontmatter")
+	}
+}
+
+func TestVSCodeInstructionsCarryFrontmatter(t *testing.T) {
+	stubRegistryEnv(t)
 
 	if _, err := Install("vscode-copilot"); err != nil {
 		t.Fatalf("Install(vscode-copilot): %v", err)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #521

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- `engram setup cursor` wrote `~/.cursor/rules/engram.mdc` as an always-applied global rule, but **Cursor does not read global rule files** — `.mdc`/`alwaysApply` only work at the project level; global "User Rules" are Settings-only plain text with no filesystem path. The Memory Protocol was therefore silently never applied.
- Now it writes the Memory Protocol (plain, no frontmatter) to an **informational** file `~/.cursor/engram-memory-protocol.md`, and the post-install steps tell the user to paste it as a **User Rule** in Settings → Rules. MCP registration (`~/.cursor/mcp.json`) is unchanged.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/setup/agents.go` | Cursor adapter writes informational `engram-memory-protocol.md` instead of the unread `.mdc`; updated description + postInstall; new `cursorMemoryProtocolPath`; removed dead `cursorRulesBody`/`cursorRulesPath` |
| `internal/setup/registry_test.go` | Tests assert the `.mdc` is NOT written and the new plain file exists (no `alwaysApply` frontmatter); VS Code frontmatter test split out |

## 🧪 Test Plan

- [x] `go test ./internal/setup/...`, `go vet`, `go build ./...`, `gofmt` all clean
- [x] Verified Cursor's rule model against docs/forum: global rule files are not read (open feature request for `~/.cursor/rules` global support)

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changed**
  * Cursor integration now provides a Memory Protocol markdown file for manual copy/paste configuration instead of automatically installing rule files, giving users more control over their setup.

* **Tests**
  * Updated integration tests to verify the new memory protocol behavior and confirm the removal of legacy automatic rule installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->