### PR TITLE
fix(setup): update cursor post-install test after #522

### DIFF
--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -254,7 +254,7 @@ func TestPrintPostInstall(t *testing.T) {
 		{
 			name:    "cursor",
 			result:  &setup.Result{Agent: "cursor"},
-			expects: []string{"Restart Cursor", "~/.cursor/mcp.json", "engram.mdc"},
+			expects: []string{"Restart Cursor", "~/.cursor/mcp.json", "engram-memory-protocol.md", "User Rules"},
 		},
 		{
 			name:    "vscode-copilot",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #523

## 🏷️ PR Type
- [x] `type:bug`

## 📝 Summary
`TestPrintPostInstall/cursor` (cmd/engram/main_test.go) still asserted the removed `engram.mdc` string after #522 switched Cursor to an informational `engram-memory-protocol.md` + manual User Rule step. Updates the expectation to the current output, fixing the failing CI on main.

## 🧪 Test Plan
- [x] `go test ./cmd/engram/...` and `go build ./...` pass

## ✅ Contributor Checklist
- [x] Linked an approved issue
- [x] One type:* label
- [x] Conventional commit, no Co-Authored-By

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation tests for post-install configuration output to match current system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->