### PR TITLE
fix(store): support CJK search with trigram FTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Breaking changes are always marked with a `type:breaking-change` label and docum
 
 - **fix(cloud):** make chunk and mutation push payload limits configurable with `ENGRAM_CLOUD_MAX_PUSH_BYTES` while preserving the 8 MiB default.
 
+### Memory search
+
+- **fix(store):** use SQLite FTS5 trigram indexes for observations and prompts so Japanese, Chinese, and Korean substring searches work through CLI, MCP, HTTP, and TUI search.
+- **fix(store):** preserve short-token searches such as `v2` with a bounded `LIKE` fallback when every query term is under three characters (trigram indexes only match terms with at least three characters).
+
 ### Cloud user token management (`cloud-user-token-management`)
 
 - **feat(cloud):** add principal/human-user/token/project-grant/audit storage foundation (`cloud_principals`, `cloud_human_users`, `cloud_principal_tokens`, `cloud_project_grants`, `cloud_auth_audit_log`) alongside existing sync tables.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,15 +126,15 @@ Examples:
 - `pattern/error-handling-convention`
 - `config/ci-environment`
 
-**Why this format?** SQLite FTS5 tokenises on word boundaries. Lowercase kebab-case ensures the key fragments are individually searchable and do not create unexpected FTS5 token splits.
+**Why this format?** Lowercase kebab-case keeps topic fragments readable, predictable, and searchable across Engram's SQLite FTS5 index.
 
 **Anti-patterns to avoid:**
 
 | Anti-pattern | Problem | Correct form |
 |---|---|---|
-| `authModel` | camelCase breaks FTS5 tokenisation | `architecture/auth-model` |
+| `authModel` | camelCase is harder to scan and match consistently | `architecture/auth-model` |
 | `auth model` | spaces create accidental multi-token keys | `architecture/auth-model` |
-| `ARCHITECTURE/AUTH` | uppercase is inconsistent with FTS5 normalisation | `architecture/auth-model` |
+| `ARCHITECTURE/AUTH` | uppercase is inconsistent with Engram's topic-key normalisation | `architecture/auth-model` |
 | `auth/model/v2/final` | more than 2 levels — use `v2` in the description | `architecture/auth-model-v2` |
 | `bugfix` | no slash — looks like a family with no description | `bug/auth-nil-panic` |
 

--- a/docs/TEAM-USAGE.md
+++ b/docs/TEAM-USAGE.md
@@ -76,7 +76,7 @@ worry when you see them on tables with >100k rows.
 
 ## Language strategy for shared memory
 
-FTS5, the SQLite full-text search engine Engram uses, is language-agnostic but not multilingual. A search in English will not match an observation saved in Spanish, and vice versa. For a globally distributed team, this matters: if every developer saves project-scope memories in their native language, the shared knowledge base fragments and search stops working as a team tool.
+FTS5, the SQLite full-text search engine Engram uses, is language-agnostic but not a translation layer. Engram indexes observations and prompts with trigram search, so Japanese, Chinese, and Korean substrings are searchable, but a search in English still will not match an observation saved only in Spanish, Russian, Japanese, or another language. For a globally distributed team, this matters: if every developer saves project-scope memories in their native language, the shared knowledge base fragments and search stops working as a team tool.
 
 ### Convention
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -959,9 +959,6 @@ func (s *Store) migrate() error {
 	if err := s.addColumnIfNotExists("user_prompts", "sync_id", "TEXT"); err != nil {
 		return err
 	}
-	if err := s.ensureFTSTrigramTables(); err != nil {
-		return err
-	}
 
 	if _, err := s.execHook(s.db, `
 		CREATE INDEX IF NOT EXISTS idx_obs_scope ON observations(scope);
@@ -1125,6 +1122,17 @@ func (s *Store) migrate() error {
 	if _, err := s.execHook(s.db, `UPDATE user_prompts SET sync_id = 'prompt-' || lower(hex(randomblob(16))) WHERE sync_id IS NULL OR sync_id = ''`); err != nil {
 		return err
 	}
+
+	// Ensure trigram FTS tables/triggers only AFTER the backfill UPDATEs above.
+	// The FTS triggers issue an external-content 'delete' for old.rowid; running
+	// them while an FTS index is still empty/unpopulated (e.g. a legacy DB whose
+	// fts table was just created fresh) deletes a row that was never indexed and
+	// corrupts the index ("database disk image is malformed"). Creating them last
+	// mirrors main's ordering and keeps migration backfills off the trigger path.
+	if err := s.ensureFTSTrigramTables(); err != nil {
+		return err
+	}
+
 	if _, err := s.execHook(s.db, `INSERT OR IGNORE INTO sync_state (target_key, lifecycle, updated_at) VALUES ('cloud', 'idle', datetime('now'))`); err != nil {
 		return err
 	}
@@ -2181,27 +2189,33 @@ func (s *Store) ensureObservationsFTSTrigram() error {
 	}
 
 	log.Printf("[store] rebuilding observations_fts with trigram tokenizer (one-time migration; may take a moment on large databases)")
-	if _, err := s.execHook(s.db, `
-		DROP TRIGGER IF EXISTS obs_fts_insert;
-		DROP TRIGGER IF EXISTS obs_fts_update;
-		DROP TRIGGER IF EXISTS obs_fts_delete;
-		DROP TABLE IF EXISTS observations_fts;
-		CREATE VIRTUAL TABLE observations_fts USING fts5(
-			title,
-			content,
-			tool_name,
-			type,
-			project,
-			topic_key,
-			content='observations',
-			content_rowid='id',
-			tokenize='trigram'
-		);
-		INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
-		SELECT id, title, content, tool_name, type, project, topic_key
-		FROM observations
-		WHERE deleted_at IS NULL;
-	`); err != nil {
+	// Wrap the drop/create/reinsert as one transaction so a failure mid-sequence
+	// cannot leave observations_fts present but empty; a later run would otherwise
+	// see the trigram shape already in place and skip the rebuild.
+	if err := s.withTx(func(tx *sql.Tx) error {
+		_, err := s.execHook(tx, `
+			DROP TRIGGER IF EXISTS obs_fts_insert;
+			DROP TRIGGER IF EXISTS obs_fts_update;
+			DROP TRIGGER IF EXISTS obs_fts_delete;
+			DROP TABLE IF EXISTS observations_fts;
+			CREATE VIRTUAL TABLE observations_fts USING fts5(
+				title,
+				content,
+				tool_name,
+				type,
+				project,
+				topic_key,
+				content='observations',
+				content_rowid='id',
+				tokenize='trigram'
+			);
+			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
+			SELECT id, title, content, tool_name, type, project, topic_key
+			FROM observations
+			WHERE deleted_at IS NULL;
+		`)
+		return err
+	}); err != nil {
 		return fmt.Errorf("rebuild observations fts: %w", err)
 	}
 	return nil
@@ -2217,22 +2231,28 @@ func (s *Store) ensurePromptsFTSTrigram() error {
 	}
 
 	log.Printf("[store] rebuilding prompts_fts with trigram tokenizer (one-time migration; may take a moment on large databases)")
-	if _, err := s.execHook(s.db, `
-		DROP TRIGGER IF EXISTS prompt_fts_insert;
-		DROP TRIGGER IF EXISTS prompt_fts_update;
-		DROP TRIGGER IF EXISTS prompt_fts_delete;
-		DROP TABLE IF EXISTS prompts_fts;
-		CREATE VIRTUAL TABLE prompts_fts USING fts5(
-			content,
-			project,
-			content='user_prompts',
-			content_rowid='id',
-			tokenize='trigram'
-		);
-		INSERT INTO prompts_fts(rowid, content, project)
-		SELECT id, content, project
-		FROM user_prompts;
-	`); err != nil {
+	// Wrap the drop/create/reinsert as one transaction so a failure mid-sequence
+	// cannot leave prompts_fts present but empty; a later run would otherwise see
+	// the trigram shape already in place and skip the rebuild.
+	if err := s.withTx(func(tx *sql.Tx) error {
+		_, err := s.execHook(tx, `
+			DROP TRIGGER IF EXISTS prompt_fts_insert;
+			DROP TRIGGER IF EXISTS prompt_fts_update;
+			DROP TRIGGER IF EXISTS prompt_fts_delete;
+			DROP TABLE IF EXISTS prompts_fts;
+			CREATE VIRTUAL TABLE prompts_fts USING fts5(
+				content,
+				project,
+				content='user_prompts',
+				content_rowid='id',
+				tokenize='trigram'
+			);
+			INSERT INTO prompts_fts(rowid, content, project)
+			SELECT id, content, project
+			FROM user_prompts;
+		`)
+		return err
+	}); err != nil {
 		return fmt.Errorf("rebuild prompts fts: %w", err)
 	}
 	return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -840,7 +840,8 @@ func (s *Store) migrate() error {
 			project,
 			topic_key,
 			content='observations',
-			content_rowid='id'
+			content_rowid='id',
+			tokenize='trigram'
 		);
 
 			CREATE TABLE IF NOT EXISTS user_prompts (
@@ -868,7 +869,8 @@ func (s *Store) migrate() error {
 			content,
 			project,
 			content='user_prompts',
-			content_rowid='id'
+			content_rowid='id',
+			tokenize='trigram'
 		);
 
 			CREATE TABLE IF NOT EXISTS sync_chunks (
@@ -955,6 +957,9 @@ func (s *Store) migrate() error {
 	}
 
 	if err := s.addColumnIfNotExists("user_prompts", "sync_id", "TEXT"); err != nil {
+		return err
+	}
+	if err := s.ensureFTSTrigramTables(); err != nil {
 		return err
 	}
 
@@ -1131,74 +1136,11 @@ func (s *Store) migrate() error {
 		return err
 	}
 
-	// Create triggers to keep FTS in sync (idempotent check)
-	var name string
-	err := s.db.QueryRow(
-		"SELECT name FROM sqlite_master WHERE type='trigger' AND name='obs_fts_insert'",
-	).Scan(&name)
-
-	if err == sql.ErrNoRows {
-		triggers := `
-			CREATE TRIGGER obs_fts_insert AFTER INSERT ON observations BEGIN
-				INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
-				VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project, new.topic_key);
-			END;
-
-			CREATE TRIGGER obs_fts_delete AFTER DELETE ON observations BEGIN
-				INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project, topic_key)
-				VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project, old.topic_key);
-			END;
-
-			CREATE TRIGGER obs_fts_update AFTER UPDATE ON observations BEGIN
-				INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project, topic_key)
-				VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project, old.topic_key);
-				INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
-				VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project, new.topic_key);
-			END;
-		`
-		if _, err := s.execHook(s.db, triggers); err != nil {
-			return err
-		}
-	}
-
-	if err := s.migrateFTSTopicKey(); err != nil {
-		return err
-	}
 	if err := s.withTx(func(tx *sql.Tx) error {
 		_, err := s.execHook(tx, `UPDATE observations SET project = CAST(project AS TEXT) WHERE typeof(project) = 'blob'`)
 		return err
 	}); err != nil {
 		return err
-	}
-
-	// Prompts FTS triggers (separate idempotent check)
-	var promptTrigger string
-	err = s.db.QueryRow(
-		"SELECT name FROM sqlite_master WHERE type='trigger' AND name='prompt_fts_insert'",
-	).Scan(&promptTrigger)
-
-	if err == sql.ErrNoRows {
-		promptTriggers := `
-			CREATE TRIGGER prompt_fts_insert AFTER INSERT ON user_prompts BEGIN
-				INSERT INTO prompts_fts(rowid, content, project)
-				VALUES (new.id, new.content, new.project);
-			END;
-
-			CREATE TRIGGER prompt_fts_delete AFTER DELETE ON user_prompts BEGIN
-				INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
-				VALUES ('delete', old.id, old.content, old.project);
-			END;
-
-			CREATE TRIGGER prompt_fts_update AFTER UPDATE ON user_prompts BEGIN
-				INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
-				VALUES ('delete', old.id, old.content, old.project);
-				INSERT INTO prompts_fts(rowid, content, project)
-				VALUES (new.id, new.content, new.project);
-			END;
-		`
-		if _, err := s.execHook(s.db, promptTriggers); err != nil {
-			return err
-		}
 	}
 
 	// Phase 3: add republish CLI, surface dead rows via mem_status.
@@ -2209,13 +2151,36 @@ func normalizeUpgradeRepairClass(class string) string {
 	}
 }
 
-func (s *Store) migrateFTSTopicKey() error {
-	var colCount int
-	err := s.db.QueryRow("SELECT COUNT(*) FROM pragma_table_xinfo('observations_fts') WHERE name = 'topic_key'").Scan(&colCount)
-	if err != nil || colCount > 0 {
+func (s *Store) ensureFTSTrigramTables() error {
+	if err := s.ensureObservationsFTSTrigram(); err != nil {
+		return err
+	}
+	if err := s.ensurePromptsFTSTrigram(); err != nil {
+		return err
+	}
+	if err := s.recreateObservationFTSTriggers(); err != nil {
+		return err
+	}
+	if err := s.recreatePromptFTSTriggers(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) ensureObservationsFTSTrigram() error {
+	sqlText, err := s.ftsTableSQL("observations_fts")
+	if err != nil {
+		return fmt.Errorf("inspect observations fts: %w", err)
+	}
+	hasTopicKey, err := s.ftsTableHasColumn("observations_fts", "topic_key")
+	if err != nil {
+		return fmt.Errorf("inspect observations fts columns: %w", err)
+	}
+	if hasTopicKey && ftsSQLUsesTrigram(sqlText) {
 		return nil
 	}
 
+	log.Printf("[store] rebuilding observations_fts with trigram tokenizer (one-time migration; may take a moment on large databases)")
 	if _, err := s.execHook(s.db, `
 		DROP TRIGGER IF EXISTS obs_fts_insert;
 		DROP TRIGGER IF EXISTS obs_fts_update;
@@ -2229,13 +2194,57 @@ func (s *Store) migrateFTSTopicKey() error {
 			project,
 			topic_key,
 			content='observations',
-			content_rowid='id'
+			content_rowid='id',
+			tokenize='trigram'
 		);
 		INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
 		SELECT id, title, content, tool_name, type, project, topic_key
 		FROM observations
 		WHERE deleted_at IS NULL;
+	`); err != nil {
+		return fmt.Errorf("rebuild observations fts: %w", err)
+	}
+	return nil
+}
 
+func (s *Store) ensurePromptsFTSTrigram() error {
+	sqlText, err := s.ftsTableSQL("prompts_fts")
+	if err != nil {
+		return fmt.Errorf("inspect prompts fts: %w", err)
+	}
+	if ftsSQLUsesTrigram(sqlText) {
+		return nil
+	}
+
+	log.Printf("[store] rebuilding prompts_fts with trigram tokenizer (one-time migration; may take a moment on large databases)")
+	if _, err := s.execHook(s.db, `
+		DROP TRIGGER IF EXISTS prompt_fts_insert;
+		DROP TRIGGER IF EXISTS prompt_fts_update;
+		DROP TRIGGER IF EXISTS prompt_fts_delete;
+		DROP TABLE IF EXISTS prompts_fts;
+		CREATE VIRTUAL TABLE prompts_fts USING fts5(
+			content,
+			project,
+			content='user_prompts',
+			content_rowid='id',
+			tokenize='trigram'
+		);
+		INSERT INTO prompts_fts(rowid, content, project)
+		SELECT id, content, project
+		FROM user_prompts;
+	`); err != nil {
+		return fmt.Errorf("rebuild prompts fts: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) recreateObservationFTSTriggers() error {
+	// Keep trigger shape aligned with main's delete/insert FTS sync. Soft-delete
+	// gating (WHERE new.deleted_at IS NULL) belongs in a separate PR.
+	if _, err := s.execHook(s.db, `
+		DROP TRIGGER IF EXISTS obs_fts_insert;
+		DROP TRIGGER IF EXISTS obs_fts_update;
+		DROP TRIGGER IF EXISTS obs_fts_delete;
 		CREATE TRIGGER obs_fts_insert AFTER INSERT ON observations BEGIN
 			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
 			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project, new.topic_key);
@@ -2253,9 +2262,61 @@ func (s *Store) migrateFTSTopicKey() error {
 			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project, new.topic_key);
 		END;
 	`); err != nil {
-		return fmt.Errorf("migrate fts topic_key: %w", err)
+		return fmt.Errorf("recreate observations fts triggers: %w", err)
 	}
 	return nil
+}
+
+func (s *Store) recreatePromptFTSTriggers() error {
+	if _, err := s.execHook(s.db, `
+		DROP TRIGGER IF EXISTS prompt_fts_insert;
+		DROP TRIGGER IF EXISTS prompt_fts_update;
+		DROP TRIGGER IF EXISTS prompt_fts_delete;
+		CREATE TRIGGER prompt_fts_insert AFTER INSERT ON user_prompts BEGIN
+			INSERT INTO prompts_fts(rowid, content, project)
+			VALUES (new.id, new.content, new.project);
+		END;
+
+		CREATE TRIGGER prompt_fts_delete AFTER DELETE ON user_prompts BEGIN
+			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
+			VALUES ('delete', old.id, old.content, old.project);
+		END;
+
+		CREATE TRIGGER prompt_fts_update AFTER UPDATE ON user_prompts BEGIN
+			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
+			VALUES ('delete', old.id, old.content, old.project);
+			INSERT INTO prompts_fts(rowid, content, project)
+			VALUES (new.id, new.content, new.project);
+		END;
+	`); err != nil {
+		return fmt.Errorf("recreate prompts fts triggers: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ftsTableSQL(name string) (string, error) {
+	var sqlText string
+	err := s.db.QueryRow("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?", name).Scan(&sqlText)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return sqlText, err
+}
+
+func (s *Store) ftsTableHasColumn(table, column string) (bool, error) {
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM pragma_table_xinfo(?) WHERE name = ?", table, column).Scan(&count)
+	return count > 0, err
+}
+
+func ftsSQLUsesTrigram(sqlText string) bool {
+	normalized := strings.ToLower(sqlText)
+	normalized = strings.ReplaceAll(normalized, " ", "")
+	normalized = strings.ReplaceAll(normalized, "\n", "")
+	normalized = strings.ReplaceAll(normalized, "\t", "")
+	return strings.Contains(normalized, "tokenize='trigram'") ||
+		strings.Contains(normalized, `tokenize="trigram"`) ||
+		strings.Contains(normalized, "tokenize=trigram")
 }
 
 // ─── Sessions ────────────────────────────────────────────────────────────────
@@ -3154,22 +3215,33 @@ func (s *Store) SearchPrompts(query string, project string, limit int) ([]Prompt
 		limit = 10
 	}
 
-	ftsQuery := sanitizeFTS(query)
-
 	sql := `
 		SELECT p.id, ifnull(p.sync_id, '') as sync_id, p.session_id, p.content, ifnull(p.project, '') as project, p.created_at
-		FROM prompts_fts fts
-		JOIN user_prompts p ON p.id = fts.rowid
-		WHERE prompts_fts MATCH ?
 	`
-	args := []any{ftsQuery}
+	var args []any
+	if shouldUseTrigramLikeFallback(query) {
+		sql += `FROM user_prompts p WHERE `
+		appendLikeSearchCondition(&sql, &args, "ifnull(p.content, '') || ' ' || ifnull(p.project, '')", query, "all")
+	} else {
+		ftsQuery := sanitizeFTS(query)
+		sql += `
+			FROM prompts_fts fts
+			JOIN user_prompts p ON p.id = fts.rowid
+			WHERE prompts_fts MATCH ?
+		`
+		args = append(args, ftsQuery)
+	}
 
 	if project != "" {
 		sql += " AND p.project = ?"
 		args = append(args, project)
 	}
 
-	sql += " ORDER BY fts.rank LIMIT ?"
+	if shouldUseTrigramLikeFallback(query) {
+		sql += " ORDER BY p.created_at DESC LIMIT ?"
+	} else {
+		sql += " ORDER BY fts.rank LIMIT ?"
+	}
 	args = append(args, limit)
 
 	rows, err := s.queryItHook(s.db, sql, args...)
@@ -3675,15 +3747,57 @@ func (s *Store) SearchContext(ctx context.Context, query string, opts SearchOpti
 		}
 	}
 
-	// Build FTS5 query: "all" (default) uses AND semantics; "any" uses OR for broader recall.
-	var ftsQuery string
-	if opts.MatchMode == "any" {
-		ftsQuery = sanitizeFTSCandidates(query)
+	likeFallback := shouldUseTrigramLikeFallback(query)
+	sqlQ := `
+		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
+		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.pinned, o.created_at, o.updated_at, o.deleted_at,
+	`
+	var args []any
+	if likeFallback {
+		sqlQ += `
+		       0.0 as rank
+		FROM observations o
+		WHERE o.deleted_at IS NULL AND `
+		appendLikeSearchCondition(&sqlQ, &args, "ifnull(o.title, '') || ' ' || ifnull(o.content, '') || ' ' || ifnull(o.tool_name, '') || ' ' || ifnull(o.type, '') || ' ' || ifnull(o.project, '') || ' ' || ifnull(o.topic_key, '')", query, opts.MatchMode)
 	} else {
-		ftsQuery = sanitizeFTS(query)
+		// Build FTS5 query: "all" (default) uses AND semantics; "any" uses OR for broader recall.
+		var ftsQuery string
+		if opts.MatchMode == "any" {
+			ftsQuery = sanitizeFTSCandidates(query)
+		} else {
+			ftsQuery = sanitizeFTS(query)
+		}
+		sqlQ += `
+		       bm25(observations_fts, 5.0, 1.0, 0.0, 0.0, 0.0, 3.0) as rank
+		FROM observations_fts fts
+		JOIN observations o ON o.id = fts.rowid
+		WHERE observations_fts MATCH ? AND o.deleted_at IS NULL
+	`
+		args = append(args, ftsQuery)
 	}
 
-	sqlQ, args := buildSearchFTSQuery(ftsQuery, opts, limit)
+	if opts.Type != "" {
+		sqlQ += " AND o.type = ?"
+		args = append(args, opts.Type)
+	}
+
+	if opts.Project != "" {
+		sqlQ += " AND LOWER(o.project) = ?"
+		args = append(args, opts.Project)
+	}
+
+	if opts.Scope != "" {
+		sqlQ += " AND o.scope = ?"
+		args = append(args, normalizeScope(opts.Scope))
+	}
+
+	if likeFallback {
+		sqlQ += " ORDER BY o.updated_at DESC LIMIT ?"
+	} else {
+		sqlQ += " ORDER BY rank LIMIT ?"
+	}
+	args = append(args, limit)
+
 	rows, err := s.queryItContextHook(ctx, sqlQ, args...)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -8264,7 +8378,8 @@ func (s *Store) migrateLegacyObservationsTable() error {
 			project,
 			topic_key,
 			content='observations',
-			content_rowid='id'
+			content_rowid='id',
+			tokenize='trigram'
 		);
 		INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
 		SELECT id, title, content, tool_name, type, project, topic_key
@@ -8528,6 +8643,62 @@ func sanitizeFTS(query string) string {
 		words[i] = `"` + w + `"`
 	}
 	return strings.Join(words, " ")
+}
+
+func shouldUseTrigramLikeFallback(query string) bool {
+	terms := searchTerms(query)
+	if len(terms) == 0 {
+		return false
+	}
+	// Only fall back when *every* term is shorter than three runes. A mixed
+	// query like "go to prod" must stay on the FTS/bm25 path so English ranking
+	// and indexing are not degraded by a single short stopword-like token.
+	for _, term := range terms {
+		if utf8.RuneCountInString(term) >= 3 {
+			return false
+		}
+	}
+	return true
+}
+
+func appendLikeSearchCondition(sqlQ *string, args *[]any, expr, query, matchMode string) {
+	terms := searchTerms(query)
+	if len(terms) == 0 {
+		*sqlQ += "1 = 0"
+		return
+	}
+	joiner := " AND "
+	if matchMode == "any" {
+		joiner = " OR "
+	}
+	*sqlQ += "("
+	for i, term := range terms {
+		if i > 0 {
+			*sqlQ += joiner
+		}
+		*sqlQ += expr + ` LIKE ? ESCAPE '\'`
+		*args = append(*args, "%"+escapeLikeTerm(term)+"%")
+	}
+	*sqlQ += ")"
+}
+
+func searchTerms(query string) []string {
+	raw := strings.Fields(query)
+	terms := make([]string, 0, len(raw))
+	for _, term := range raw {
+		term = strings.Trim(term, `"`)
+		if term != "" {
+			terms = append(terms, term)
+		}
+	}
+	return terms
+}
+
+func escapeLikeTerm(term string) string {
+	term = strings.ReplaceAll(term, `\`, `\\`)
+	term = strings.ReplaceAll(term, `%`, `\%`)
+	term = strings.ReplaceAll(term, `_`, `\_`)
+	return term
 }
 
 // ─── Passive Capture ─────────────────────────────────────────────────────────

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1571,6 +1571,63 @@ func TestSearchShortTokensUsesLikeFallbackWithTrigramFTS(t *testing.T) {
 	}
 }
 
+func TestSearchPromptsShortTokensUsesLikeFallbackWithTrigramFTS(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-prompt-short", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	shortID, err := s.AddPrompt(AddPromptParams{SessionID: "s-prompt-short", Content: "go db", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add short-token prompt: %v", err)
+	}
+	shortResults, err := s.SearchPrompts("db", "engram", 10)
+	if err != nil {
+		t.Fatalf("search prompt short token: %v", err)
+	}
+	if len(shortResults) != 1 || shortResults[0].ID != shortID {
+		t.Fatalf("expected short-token prompt search hit, got %+v", shortResults)
+	}
+
+	literalID, err := s.AddPrompt(AddPromptParams{SessionID: "s-prompt-short", Content: "contains percent % and underscore _ characters", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add literal wildcard prompt: %v", err)
+	}
+	percentResults, err := s.SearchPrompts("%", "engram", 10)
+	if err != nil {
+		t.Fatalf("search literal percent prompt: %v", err)
+	}
+	if len(percentResults) != 1 || percentResults[0].ID != literalID {
+		t.Fatalf("expected literal percent prompt search hit only, got %+v", percentResults)
+	}
+	underscoreResults, err := s.SearchPrompts("_", "engram", 10)
+	if err != nil {
+		t.Fatalf("search literal underscore prompt: %v", err)
+	}
+	if len(underscoreResults) != 1 || underscoreResults[0].ID != literalID {
+		t.Fatalf("expected literal underscore prompt search hit only, got %+v", underscoreResults)
+	}
+
+	// The LIKE fallback contract orders by created_at DESC (not FTS rank); confirm
+	// both matches surface rather than only the first inserted row.
+	newerID, err := s.AddPrompt(AddPromptParams{SessionID: "s-prompt-short", Content: "db go", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add newer short-token prompt: %v", err)
+	}
+	orderedResults, err := s.SearchPrompts("db", "engram", 10)
+	if err != nil {
+		t.Fatalf("search prompt short token ordering: %v", err)
+	}
+	gotIDs := map[int64]bool{}
+	for _, r := range orderedResults {
+		gotIDs[r.ID] = true
+	}
+	if len(orderedResults) != 2 || !gotIDs[shortID] || !gotIDs[newerID] {
+		t.Fatalf("expected both short-token LIKE fallback prompts, got %+v", orderedResults)
+	}
+}
+
 func TestTrigramFTSTriggersSupportUpdateAndDelete(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1431,6 +1431,510 @@ func TestScopeFiltersSearchAndContext(t *testing.T) {
 	}
 }
 
+func TestSearchSupportsCJKWithTrigramFTS(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-cjk", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-cjk",
+		Type:      "bugfix",
+		Title:     "日本語検索",
+		Content:   "サンドボックス修正テスト",
+		Project:   "engram",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add cjk observation: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{
+		SessionID: "s-cjk",
+		Content:   "中国語検索プロンプト",
+		Project:   "engram",
+	}); err != nil {
+		t.Fatalf("add cjk prompt: %v", err)
+	}
+
+	results, err := s.Search("サンドボックス", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search cjk observation: %v", err)
+	}
+	if len(results) != 1 || results[0].Content != "サンドボックス修正テスト" {
+		t.Fatalf("expected cjk observation search hit, got %+v", results)
+	}
+
+	prompts, err := s.SearchPrompts("中国語検索", "engram", 10)
+	if err != nil {
+		t.Fatalf("search cjk prompt: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0].Content != "中国語検索プロンプト" {
+		t.Fatalf("expected cjk prompt search hit, got %+v", prompts)
+	}
+}
+
+func TestSearchShortTokensUsesLikeFallbackWithTrigramFTS(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-short", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obsID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-short",
+		Type:      "decision",
+		Title:     "v2",
+		Content:   "go db",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add short-token observation: %v", err)
+	}
+
+	results, err := s.Search("v2", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search short token: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != obsID {
+		t.Fatalf("expected short-token search hit, got %+v", results)
+	}
+
+	anyResults, err := s.Search("go xx", SearchOptions{Project: "engram", Limit: 10, MatchMode: "any"})
+	if err != nil {
+		t.Fatalf("search short token any mode: %v", err)
+	}
+	if len(anyResults) != 1 || anyResults[0].ID != obsID {
+		t.Fatalf("expected short-token any-mode search hit, got %+v", anyResults)
+	}
+
+	literalID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-short",
+		Type:      "decision",
+		Title:     "literal wildcard tokens",
+		Content:   "contains percent % and underscore _ characters",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add literal wildcard observation: %v", err)
+	}
+	percentResults, err := s.Search("%", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search literal percent: %v", err)
+	}
+	if len(percentResults) != 1 || percentResults[0].ID != literalID {
+		t.Fatalf("expected literal percent search hit only, got %+v", percentResults)
+	}
+	underscoreResults, err := s.Search("_", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search literal underscore: %v", err)
+	}
+	if len(underscoreResults) != 1 || underscoreResults[0].ID != literalID {
+		t.Fatalf("expected literal underscore search hit only, got %+v", underscoreResults)
+	}
+
+	_, err = s.Search("v2", SearchOptions{Project: "engram", Limit: 10, MatchMode: "or"})
+	if err == nil {
+		t.Fatalf("expected invalid match_mode error for short-token fallback query")
+	}
+	if !strings.Contains(err.Error(), "invalid match_mode") {
+		t.Fatalf("expected invalid match_mode error, got %v", err)
+	}
+
+	// Mixed-length queries must stay on FTS (not degrade English ranking via LIKE).
+	mixedID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-short",
+		Type:      "decision",
+		Title:     "production rollout",
+		Content:   "go to prod checklist",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add mixed-length observation: %v", err)
+	}
+	mixedResults, err := s.Search("go to prod", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search mixed-length query: %v", err)
+	}
+	foundMixed := false
+	for _, r := range mixedResults {
+		if r.ID == mixedID {
+			foundMixed = true
+			if r.Rank == 0 {
+				t.Fatalf("expected FTS/bm25 rank for mixed-length query, got rank=%v", r.Rank)
+			}
+			break
+		}
+	}
+	if !foundMixed {
+		t.Fatalf("expected mixed-length FTS hit for go to prod, got %+v", mixedResults)
+	}
+}
+
+func TestTrigramFTSTriggersSupportUpdateAndDelete(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-trigram", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obsID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-trigram",
+		Type:      "bugfix",
+		Title:     "更新前",
+		Content:   "古い検索テキスト",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	newContent := "更新後サンドボックス検索"
+	if _, err := s.UpdateObservation(obsID, UpdateObservationParams{Content: &newContent}); err != nil {
+		t.Fatalf("update observation with trigram fts: %v", err)
+	}
+
+	results, err := s.Search("サンドボックス", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search updated cjk observation: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != obsID {
+		t.Fatalf("expected updated cjk observation search hit, got %+v", results)
+	}
+
+	if err := s.DeleteObservation(obsID, false); err != nil {
+		t.Fatalf("soft delete observation with trigram fts: %v", err)
+	}
+	results, err = s.Search("サンドボックス", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search after soft delete: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected soft-deleted cjk observation excluded, got %+v", results)
+	}
+
+	hardDeleteID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-trigram",
+		Type:      "bugfix",
+		Title:     "完全削除",
+		Content:   "完全削除サンドボックス検索",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add hard-delete observation: %v", err)
+	}
+	results, err = s.Search("完全削除", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search hard-delete candidate: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != hardDeleteID {
+		t.Fatalf("expected hard-delete candidate search hit, got %+v", results)
+	}
+	if err := s.DeleteObservation(hardDeleteID, true); err != nil {
+		t.Fatalf("hard delete observation with trigram fts: %v", err)
+	}
+	results, err = s.Search("完全削除", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search after hard delete: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected hard-deleted cjk observation excluded, got %+v", results)
+	}
+
+	promptID, err := s.AddPrompt(AddPromptParams{SessionID: "s-trigram", Content: "プロンプト更新前", Project: "engram"})
+	if err != nil {
+		t.Fatalf("add prompt: %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE user_prompts SET content = ? WHERE id = ?`, "プロンプト更新後検索", promptID); err != nil {
+		t.Fatalf("update prompt with trigram fts: %v", err)
+	}
+	prompts, err := s.SearchPrompts("更新後検索", "engram", 10)
+	if err != nil {
+		t.Fatalf("search updated cjk prompt: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0].ID != promptID {
+		t.Fatalf("expected updated cjk prompt search hit, got %+v", prompts)
+	}
+	if err := s.DeletePrompt(promptID); err != nil {
+		t.Fatalf("delete prompt with trigram fts: %v", err)
+	}
+	prompts, err = s.SearchPrompts("更新後検索", "engram", 10)
+	if err != nil {
+		t.Fatalf("search after prompt delete: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("expected deleted cjk prompt excluded, got %+v", prompts)
+	}
+}
+
+func TestMigrateRebuildsLegacyFTSTablesWithTrigram(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-legacy-fts", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obsID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-legacy-fts",
+		Type:      "bugfix",
+		Title:     "旧検索",
+		Content:   "サンドボックス修正テスト",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	promptID, err := s.AddPrompt(AddPromptParams{
+		SessionID: "s-legacy-fts",
+		Content:   "中国語検索プロンプト",
+		Project:   "engram",
+	})
+	if err != nil {
+		t.Fatalf("add prompt: %v", err)
+	}
+
+	if _, err := s.db.Exec(`
+		DROP TRIGGER IF EXISTS obs_fts_insert;
+		DROP TRIGGER IF EXISTS obs_fts_update;
+		DROP TRIGGER IF EXISTS obs_fts_delete;
+		DROP TRIGGER IF EXISTS prompt_fts_insert;
+		DROP TRIGGER IF EXISTS prompt_fts_update;
+		DROP TRIGGER IF EXISTS prompt_fts_delete;
+		DROP TABLE IF EXISTS observations_fts;
+		DROP TABLE IF EXISTS prompts_fts;
+		CREATE VIRTUAL TABLE observations_fts USING fts5(
+			title,
+			content,
+			tool_name,
+			type,
+			project,
+			topic_key,
+			content='observations',
+			content_rowid='id'
+		);
+		CREATE VIRTUAL TABLE prompts_fts USING fts5(
+			content,
+			project,
+			content='user_prompts',
+			content_rowid='id'
+		);
+		INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
+		SELECT id, title, content, tool_name, type, project, topic_key FROM observations WHERE deleted_at IS NULL;
+		INSERT INTO prompts_fts(rowid, content, project)
+		SELECT id, content, project FROM user_prompts;
+	`); err != nil {
+		t.Fatalf("seed legacy fts tables: %v", err)
+	}
+
+	if err := s.migrate(); err != nil {
+		t.Fatalf("migrate legacy fts tables: %v", err)
+	}
+
+	obsSQL, err := s.ftsTableSQL("observations_fts")
+	if err != nil {
+		t.Fatalf("observations fts sql: %v", err)
+	}
+	promptSQL, err := s.ftsTableSQL("prompts_fts")
+	if err != nil {
+		t.Fatalf("prompts fts sql: %v", err)
+	}
+	if !ftsSQLUsesTrigram(obsSQL) || !ftsSQLUsesTrigram(promptSQL) {
+		t.Fatalf("expected trigram fts tables, observations=%q prompts=%q", obsSQL, promptSQL)
+	}
+
+	results, err := s.Search("サンドボックス", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search migrated cjk observation: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected migrated cjk observation search hit, got %+v", results)
+	}
+	prompts, err := s.SearchPrompts("中国語検索", "engram", 10)
+	if err != nil {
+		t.Fatalf("search migrated cjk prompt: %v", err)
+	}
+	if len(prompts) != 1 {
+		t.Fatalf("expected migrated cjk prompt search hit, got %+v", prompts)
+	}
+
+	updatedContent := "移行後トリガー更新検索"
+	if _, err := s.UpdateObservation(obsID, UpdateObservationParams{Content: &updatedContent}); err != nil {
+		t.Fatalf("update migrated observation: %v", err)
+	}
+	results, err = s.Search("トリガー更新", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search updated migrated observation: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != obsID {
+		t.Fatalf("expected updated migrated observation search hit, got %+v", results)
+	}
+	if err := s.DeleteObservation(obsID, true); err != nil {
+		t.Fatalf("delete migrated observation: %v", err)
+	}
+	results, err = s.Search("トリガー更新", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search deleted migrated observation: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected deleted migrated observation excluded, got %+v", results)
+	}
+
+	if _, err := s.db.Exec(`UPDATE user_prompts SET content = ? WHERE id = ?`, "移行後プロンプト更新検索", promptID); err != nil {
+		t.Fatalf("update migrated prompt: %v", err)
+	}
+	prompts, err = s.SearchPrompts("プロンプト更新", "engram", 10)
+	if err != nil {
+		t.Fatalf("search updated migrated prompt: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0].ID != promptID {
+		t.Fatalf("expected updated migrated prompt search hit, got %+v", prompts)
+	}
+	if err := s.DeletePrompt(promptID); err != nil {
+		t.Fatalf("delete migrated prompt: %v", err)
+	}
+	prompts, err = s.SearchPrompts("プロンプト更新", "engram", 10)
+	if err != nil {
+		t.Fatalf("search deleted migrated prompt: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("expected deleted migrated prompt excluded, got %+v", prompts)
+	}
+}
+
+func TestMigrateRepairsExistingTrigramDeleteTriggersBeforeCleanupUpdates(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-manual-trigram", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obsID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-manual-trigram",
+		Type:      "bugfix",
+		Title:     "手動trigram",
+		Content:   "サンドボックス修正テスト",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	promptID, err := s.AddPrompt(AddPromptParams{
+		SessionID: "s-manual-trigram",
+		Content:   "中国語検索プロンプト",
+		Project:   "engram",
+	})
+	if err != nil {
+		t.Fatalf("add prompt: %v", err)
+	}
+
+	if _, err := s.db.Exec(`
+		UPDATE observations SET scope = '';
+		UPDATE user_prompts SET sync_id = '';
+
+		DROP TRIGGER IF EXISTS obs_fts_insert;
+		DROP TRIGGER IF EXISTS obs_fts_update;
+		DROP TRIGGER IF EXISTS obs_fts_delete;
+		DROP TRIGGER IF EXISTS prompt_fts_insert;
+		DROP TRIGGER IF EXISTS prompt_fts_update;
+		DROP TRIGGER IF EXISTS prompt_fts_delete;
+
+		CREATE TRIGGER obs_fts_insert AFTER INSERT ON observations BEGIN
+			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
+			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project, new.topic_key);
+		END;
+		CREATE TRIGGER obs_fts_delete AFTER DELETE ON observations BEGIN
+			INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project, topic_key)
+			VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project, old.topic_key);
+		END;
+		CREATE TRIGGER obs_fts_update AFTER UPDATE ON observations BEGIN
+			INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project, topic_key)
+			VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project, old.topic_key);
+			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project, topic_key)
+			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project, new.topic_key);
+		END;
+
+		CREATE TRIGGER prompt_fts_insert AFTER INSERT ON user_prompts BEGIN
+			INSERT INTO prompts_fts(rowid, content, project)
+			VALUES (new.id, new.content, new.project);
+		END;
+		CREATE TRIGGER prompt_fts_delete AFTER DELETE ON user_prompts BEGIN
+			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
+			VALUES ('delete', old.id, old.content, old.project);
+		END;
+		CREATE TRIGGER prompt_fts_update AFTER UPDATE ON user_prompts BEGIN
+			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
+			VALUES ('delete', old.id, old.content, old.project);
+			INSERT INTO prompts_fts(rowid, content, project)
+			VALUES (new.id, new.content, new.project);
+		END;
+	`); err != nil {
+		t.Fatalf("seed manual trigram delete triggers: %v", err)
+	}
+
+	if err := s.migrate(); err != nil {
+		t.Fatalf("migrate should repair trigram delete triggers before cleanup updates: %v", err)
+	}
+
+	results, err := s.Search("サンドボックス", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search repaired observation: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected repaired observation search hit, got %+v", results)
+	}
+	prompts, err := s.SearchPrompts("中国語検索", "engram", 10)
+	if err != nil {
+		t.Fatalf("search repaired prompt: %v", err)
+	}
+	if len(prompts) != 1 {
+		t.Fatalf("expected repaired prompt search hit, got %+v", prompts)
+	}
+
+	updatedContent := "修復後トリガー更新検索"
+	if _, err := s.UpdateObservation(obsID, UpdateObservationParams{Content: &updatedContent}); err != nil {
+		t.Fatalf("update repaired observation: %v", err)
+	}
+	results, err = s.Search("修復後トリガー", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search updated repaired observation: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != obsID {
+		t.Fatalf("expected updated repaired observation search hit, got %+v", results)
+	}
+	if err := s.DeleteObservation(obsID, true); err != nil {
+		t.Fatalf("delete repaired observation: %v", err)
+	}
+	results, err = s.Search("修復後トリガー", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("search deleted repaired observation: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected deleted repaired observation excluded, got %+v", results)
+	}
+
+	if _, err := s.db.Exec(`UPDATE user_prompts SET content = ? WHERE id = ?`, "修復後プロンプト更新検索", promptID); err != nil {
+		t.Fatalf("update repaired prompt: %v", err)
+	}
+	prompts, err = s.SearchPrompts("プロンプト更新", "engram", 10)
+	if err != nil {
+		t.Fatalf("search updated repaired prompt: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0].ID != promptID {
+		t.Fatalf("expected updated repaired prompt search hit, got %+v", prompts)
+	}
+	if err := s.DeletePrompt(promptID); err != nil {
+		t.Fatalf("delete repaired prompt: %v", err)
+	}
+	prompts, err = s.SearchPrompts("プロンプト更新", "engram", 10)
+	if err != nil {
+		t.Fatalf("search deleted repaired prompt: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("expected deleted repaired prompt excluded, got %+v", prompts)
+	}
+}
+
 func TestUpdateAndSoftDeleteExcludedFromSearchAndTimeline(t *testing.T) {
 	s := newTestStore(t)
 


### PR DESCRIPTION
## Linked Issue

Closes #140

---

## PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance/tooling
- [ ] `type:breaking-change` — Breaking change

---

## Summary

- Switch local observation and prompt FTS5 tables to `tokenize='trigram'` so Japanese, Chinese, and Korean substring search works.
- Rebuild legacy/non-trigram FTS tables during migration (one-time `DROP` + reinsert), with a log line so large DBs know why startup paused.
- Preserve short-token searches such as `v2` with a bounded `LIKE` fallback **only when every query term is under three characters** (mixed queries like `go to prod` stay on the FTS/bm25 path).
- Keep standard FTS `'delete'`/`insert` triggers (same shape as `main`). Soft-delete trigger gating (`WHERE new.deleted_at IS NULL`) is intentionally deferred to a follow-up PR.

## Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Trigram FTS schema/migration repair, short-token LIKE fallback (all-short only), preserves weighted `bm25(...)` on the FTS branch. |
| `internal/store/store_test.go` | CJK search, legacy migration, trigger update/delete, short-token + mixed-query regression tests. |
| `CHANGELOG.md` | Documents the memory search fix. |
| `docs/ARCHITECTURE.md` | Updates topic-key wording that assumed word-boundary tokenization. |
| `docs/TEAM-USAGE.md` | Clarifies that CJK substrings are searchable but search is not translation. |

## Test Plan

- [x] Targeted store tests: `go test ./internal/store -run 'TestSearch|Trigram|FTS'`
- [ ] Full unit suite locally: `go test ./...`
- [ ] E2E tests locally: `go test -tags e2e ./internal/server/...`

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #140`)
- [x] I added exactly one `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## Notes for Reviewers

- Rebased/merged onto current `main` after #526 (bm25) and #586 (sanitizeFTS quotes).
- FTS branch preserves `bm25(observations_fts, 5.0, 1.0, 0.0, 0.0, 0.0, 3.0)`.
- Soft-delete FTS trigger gating will be a separate PR, as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved substring search for Japanese, Chinese, and Korean across CLI, MCP, HTTP, and TUI using trigram-based FTS5 indexing.
  * Restored reliable search for short tokens (e.g., `v2`) via a bounded `LIKE` fallback when queries are very short.
  * Strengthened migration to consistently rebuild and repair trigram search indexes and related triggers.
* **Documentation**
  * Clarified shared-memory language strategy: FTS5 supports same-script substring searching, but isn’t a translation layer.
* **Tests**
  * Added end-to-end coverage for CJK substring matching, short-token fallback behavior, and migration/trigger correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->