### PR TITLE
feat: add opt-in GCF output format for MCP tool responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.10
 
 require (
 	github.com/a-h/templ v0.3.1001
+	github.com/blackwell-systems/gcf-go v1.3.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -19,7 +20,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/blackwell-systems/gcf-go v1.3.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/blackwell-systems/gcf-go v1.3.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/blackwell-systems/gcf-go v1.3.1 h1:hoIm88moF2VC+b9m+C3Xx4tl625z/hSgiVuHwOvnKXs=
+github.com/blackwell-systems/gcf-go v1.3.1/go.mod h1:hYxLOn6JHzNNNH7wfgRXWETX2lMtRtjG8FEX45I6SAI=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -2868,9 +2868,10 @@ func addErrorMetadata(result *mcp.CallToolResult, metadata map[string]any) {
 	for k, v := range metadata {
 		envelope[k] = v
 	}
-	// Re-serialize with jsonMarshal so the final output stays in the
-	// user's chosen format (JSON or GCF).
-	out, err := jsonMarshal(envelope)
+	// Re-serialize with json.Marshal (not jsonMarshal) because this is an
+	// internal round-trip: we just unmarshalled JSON, so we write JSON back.
+	// Error envelopes are small and don't benefit from GCF.
+	out, err := json.Marshal(envelope)
 	if err != nil {
 		return
 	}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -2861,11 +2861,15 @@ func addErrorMetadata(result *mcp.CallToolResult, metadata map[string]any) {
 	}
 	var envelope map[string]any
 	if err := json.Unmarshal([]byte(text.Text), &envelope); err != nil {
+		// Content may be GCF-encoded; skip metadata injection rather
+		// than corrupt the output. Error metadata is best-effort.
 		return
 	}
 	for k, v := range metadata {
 		envelope[k] = v
 	}
+	// Re-serialize with jsonMarshal so the final output stays in the
+	// user's chosen format (JSON or GCF).
 	out, err := jsonMarshal(envelope)
 	if err != nil {
 		return
@@ -2907,13 +2911,22 @@ func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolRe
 	return result
 }
 
+// _gcfEnabled is resolved once at first call and cached.
+var _gcfEnabled *bool
+
 // gcfEnabled returns true when the user has opted into GCF output format.
 func gcfEnabled() bool {
-	return os.Getenv("ENGRAM_OUTPUT_FORMAT") == "gcf"
+	if _gcfEnabled == nil {
+		v := os.Getenv("ENGRAM_OUTPUT_FORMAT") == "gcf"
+		_gcfEnabled = &v
+	}
+	return *_gcfEnabled
 }
 
 // jsonMarshal marshals v to JSON, or GCF when ENGRAM_OUTPUT_FORMAT=gcf.
-// Named to allow test injection if needed.
+// This is used for final MCP tool output only. Internal round-trips
+// (e.g. addErrorMetadata) use json.Marshal directly to avoid encoding
+// in a format that json.Unmarshal cannot read back.
 func jsonMarshal(v any) ([]byte, error) {
 	if gcfEnabled() {
 		return []byte(gcf.EncodeGeneric(v)), nil

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	gcf "github.com/blackwell-systems/gcf-go"
@@ -2915,17 +2916,11 @@ func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolRe
 	return result
 }
 
-// _gcfEnabled is resolved once at first call and cached.
-var _gcfEnabled *bool
-
 // gcfEnabled returns true when the user has opted into GCF output format.
-func gcfEnabled() bool {
-	if _gcfEnabled == nil {
-		v := os.Getenv("ENGRAM_OUTPUT_FORMAT") == "gcf"
-		_gcfEnabled = &v
-	}
-	return *_gcfEnabled
-}
+// Resolved once, thread-safe via sync.OnceValue.
+var gcfEnabled = sync.OnceValue(func() bool {
+	return os.Getenv("ENGRAM_OUTPUT_FORMAT") == "gcf"
+})
 
 // jsonMarshal marshals v to JSON, or GCF when ENGRAM_OUTPUT_FORMAT=gcf.
 // This is used for final MCP tool output only. Internal round-trips

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	gcf "github.com/blackwell-systems/gcf-go"
+
 	"github.com/Gentleman-Programming/engram/internal/diagnostic"
 	projectpkg "github.com/Gentleman-Programming/engram/internal/project"
 	"github.com/Gentleman-Programming/engram/internal/store"
@@ -2905,8 +2907,17 @@ func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolRe
 	return result
 }
 
-// jsonMarshal marshals v to JSON. Named to allow test injection if needed.
+// gcfEnabled returns true when the user has opted into GCF output format.
+func gcfEnabled() bool {
+	return os.Getenv("ENGRAM_OUTPUT_FORMAT") == "gcf"
+}
+
+// jsonMarshal marshals v to JSON, or GCF when ENGRAM_OUTPUT_FORMAT=gcf.
+// Named to allow test injection if needed.
 func jsonMarshal(v any) ([]byte, error) {
+	if gcfEnabled() {
+		return []byte(gcf.EncodeGeneric(v)), nil
+	}
 	return json.Marshal(v)
 }
 

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -2906,7 +2906,10 @@ func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolRe
 	case "session_project_mismatch":
 		envelope["hint"] = "Use a project that matches the existing session, or omit session_id and write to a different project."
 	}
-	out, _ := jsonMarshal(envelope)
+	// Use json.Marshal (not jsonMarshal) because error envelopes may be
+	// round-tripped by addErrorMetadata which needs to json.Unmarshal the
+	// content to inject recovery_token and other metadata.
+	out, _ := json.Marshal(envelope)
 	result := mcp.NewToolResultText(string(out))
 	result.IsError = true
 	return result


### PR DESCRIPTION
## Summary

Adds opt-in [GCF](https://gcformat.com) encoding for MCP tool responses via `ENGRAM_OUTPUT_FORMAT=gcf`. 3 files changed, 15 lines added. Existing behavior unchanged.

## Benchmark

Tested on engram's actual response shapes (search results, session lists, timelines) using the o200k_base tokenizer:

| Response | Size | JSON | GCF | Savings |
|----------|------|------|-----|---------|
| Search results | 10 | 2,325 | 1,603 | **31%** |
| Search results | 50 | 12,249 | 8,238 | **33%** |
| Session list | 25 | 2,466 | 1,593 | **35%** |
| Session list | 50 | 4,903 | 3,144 | **36%** |
| Timeline | 20 | 4,897 | 3,369 | **31%** |

Overall: 33% fewer tokens, 9/9 GCF wins. [Benchmark script.](https://github.com/blackwell-systems/gcf/blob/main/eval/engram-token-benchmark.mjs)

## Why

Engram observations have 16 fields with optional values. In JSON, every field name repeats on every row. GCF declares them once in a header and uses positional values.

- **100% comprehension** on every frontier model tested ([2,400+ LLM evaluations](https://gcformat.com/guide/eval-results))
- **43 billion+ lossless round-trips**, zero data corruption ([verification](https://gcformat.com/guide/lossless-verification))
- **15/16 wins vs TOON** across 16 real-world datasets, 29% fewer tokens ([benchmarks](https://gcformat.com/guide/benchmarks))
- **Zero runtime dependencies** in every implementation
- [Spec v3.2 Stable](https://github.com/blackwell-systems/gcf/blob/main/SPEC.md), 174 conformance fixtures, 6 implementations
- [Whitepaper](https://gcformat.com/whitepaper) | [Tokenizer analysis](https://gcformat.com/guide/tokenizer-analysis)

Adopted by [Speakeasy](https://speakeasy.com) (Google, Verizon, Mistral AI, DocuSign), [OmniRoute](https://omniroute.online) (6.1K stars), and [others](https://gcformat.com/ecosystem/adopters).

## Usage

```bash
ENGRAM_OUTPUT_FORMAT=gcf engram mcp
```

Without the env var, behavior is identical to current (JSON output).

## What changed

- `internal/mcp/mcp.go`: `jsonMarshal` checks `ENGRAM_OUTPUT_FORMAT=gcf`, calls `gcf.EncodeGeneric` when enabled. Added `gcfEnabled()` helper. 13 lines.
- `go.mod` / `go.sum`: added `github.com/blackwell-systems/gcf-go v1.3.1`

## Notes

This PR is intentionally minimal to show the potential of GCF on engram's data shapes. Happy to refactor the integration however you'd prefer: CLI flag instead of env var, build tag to exclude the dependency, different serialization boundary, etc. The format and the savings are the point; the wiring is up to you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GCF output encoding for MCP tool results when `ENGRAM_OUTPUT_FORMAT=gcf` is enabled.
* **Bug Fixes**
  * Hardened error/metadata handling in GCF mode to avoid metadata injection when existing content can’t be safely parsed for JSON round-tripping.
  * Standardized serialization for tool responses and structured errors to keep payloads consistently parseable and readable in GCF mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->