### PR TITLE
fix(store,mcp): OR-match FTS5 queries and surface recent session activity

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1716,14 +1716,17 @@ func jsonMarshal(v any) ([]byte, error) {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-// defaultSessionID returns a project-scoped default session ID.
-// If project is non-empty: "manual-save-{project}"
-// If project is empty: "manual-save"
+// defaultSessionID returns a project-scoped, date-rotating default session ID.
+// Rotating by day prevents all observations from piling up in a single June
+// session when the binary is long-lived.
+// If project is non-empty: "manual-save-{project}-{YYYY-MM-DD}"
+// If project is empty: "manual-save-{YYYY-MM-DD}"
 func defaultSessionID(project string) string {
+	date := time.Now().UTC().Format("2006-01-02")
 	if project == "" {
-		return "manual-save"
+		return "manual-save-" + date
 	}
-	return "manual-save-" + project
+	return "manual-save-" + project + "-" + date
 }
 
 func intArg(req mcp.CallToolRequest, key string, defaultVal int) int {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1748,14 +1748,16 @@ func TestReadOnlyToolAnnotations(t *testing.T) {
 // ─── Issue #25: Session collision regression tests ──────────────────────────
 
 func TestDefaultSessionIDScopedByProject(t *testing.T) {
-	if got := defaultSessionID(""); got != "manual-save" {
-		t.Fatalf("expected manual-save for empty project, got %q", got)
+	date := time.Now().UTC().Format("2006-01-02")
+
+	if got := defaultSessionID(""); got != "manual-save-"+date {
+		t.Fatalf("expected manual-save-%s for empty project, got %q", date, got)
 	}
-	if got := defaultSessionID("engram"); got != "manual-save-engram" {
-		t.Fatalf("expected manual-save-engram, got %q", got)
+	if got := defaultSessionID("engram"); got != "manual-save-engram-"+date {
+		t.Fatalf("expected manual-save-engram-%s, got %q", date, got)
 	}
-	if got := defaultSessionID("my-app"); got != "manual-save-my-app" {
-		t.Fatalf("expected manual-save-my-app, got %q", got)
+	if got := defaultSessionID("my-app"); got != "manual-save-my-app-"+date {
+		t.Fatalf("expected manual-save-my-app-%s, got %q", date, got)
 	}
 }
 
@@ -1783,10 +1785,11 @@ func TestHandleSaveCreatesProjectScopedSession(t *testing.T) {
 		t.Fatalf("save: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
 	}
 
-	// Verify session was created with auto-detected project
-	sess, err := s.GetSession("manual-save-scoped-session-project")
+	// Verify session was created with auto-detected project (date-rotated ID)
+	date := time.Now().UTC().Format("2006-01-02")
+	sess, err := s.GetSession("manual-save-scoped-session-project-" + date)
 	if err != nil {
-		t.Fatalf("expected session manual-save-scoped-session-project to exist: %v", err)
+		t.Fatalf("expected session manual-save-scoped-session-project-%s to exist: %v", date, err)
 	}
 	if sess.Project != "scoped-session-project" {
 		t.Fatalf("expected project=scoped-session-project, got %q", sess.Project)
@@ -1815,8 +1818,9 @@ func TestHandleSavePromptCreatesProjectScopedSession(t *testing.T) {
 		t.Fatalf("save prompt: err=%v isError=%v", err, res.IsError)
 	}
 
-	if _, err := s.GetSession("manual-save-prompt-project"); err != nil {
-		t.Fatalf("expected session manual-save-prompt-project: %v", err)
+	date := time.Now().UTC().Format("2006-01-02")
+	if _, err := s.GetSession("manual-save-prompt-project-" + date); err != nil {
+		t.Fatalf("expected session manual-save-prompt-project-%s: %v", date, err)
 	}
 }
 
@@ -1843,8 +1847,9 @@ func TestHandleSessionSummaryCreatesProjectScopedSession(t *testing.T) {
 		t.Fatalf("session summary: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
 	}
 
-	if _, err := s.GetSession("manual-save-summary-session-project"); err != nil {
-		t.Fatalf("expected session manual-save-summary-session-project: %v", err)
+	date := time.Now().UTC().Format("2006-01-02")
+	if _, err := s.GetSession("manual-save-summary-session-project-" + date); err != nil {
+		t.Fatalf("expected session manual-save-summary-session-project-%s: %v", date, err)
 	}
 }
 
@@ -1870,8 +1875,9 @@ func TestHandleCapturePassiveCreatesProjectScopedSession(t *testing.T) {
 		t.Fatalf("capture passive: err=%v isError=%v text=%s", err, res.IsError, callResultText(t, res))
 	}
 
-	if _, err := s.GetSession("manual-save-capture-project"); err != nil {
-		t.Fatalf("expected session manual-save-capture-project: %v", err)
+	date := time.Now().UTC().Format("2006-01-02")
+	if _, err := s.GetSession("manual-save-capture-project-" + date); err != nil {
+		t.Fatalf("expected session manual-save-capture-project-%s: %v", date, err)
 	}
 }
 
@@ -1896,10 +1902,11 @@ func TestExplicitSessionIDBypassesDefault(t *testing.T) {
 	if _, err := s.GetSession("custom-session-123"); err != nil {
 		t.Fatalf("expected custom-session-123: %v", err)
 	}
-	// The default session should NOT exist
-	_, err = s.GetSession("manual-save-myproject")
+	// The default session (new date-rotated format) should NOT exist
+	date := time.Now().UTC().Format("2006-01-02")
+	_, err = s.GetSession("manual-save-myproject-" + date)
 	if err == nil {
-		t.Fatal("manual-save-myproject should NOT exist when explicit session_id provided")
+		t.Fatal("manual-save-myproject-" + date + " should NOT exist when explicit session_id provided")
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,6 +81,7 @@ type SessionSummary struct {
 	EndedAt          *string `json:"ended_at,omitempty"`
 	Summary          *string `json:"summary,omitempty"`
 	ObservationCount int     `json:"observation_count"`
+	LastActivityAt   string  `json:"last_activity_at"`
 }
 
 type Stats struct {
@@ -1763,7 +1764,8 @@ func (s *Store) RecentSessions(project string, limit int) ([]SessionSummary, err
 
 	query := `
 		SELECT s.id, s.project, s.started_at, s.ended_at, s.summary,
-		       COUNT(o.id) as observation_count
+		       COUNT(o.id) as observation_count,
+		       MAX(COALESCE(o.created_at, s.started_at)) as last_activity_at
 		FROM sessions s
 		LEFT JOIN observations o ON o.session_id = s.id AND o.deleted_at IS NULL
 		WHERE 1=1
@@ -1787,7 +1789,7 @@ func (s *Store) RecentSessions(project string, limit int) ([]SessionSummary, err
 	var results []SessionSummary
 	for rows.Next() {
 		var ss SessionSummary
-		if err := rows.Scan(&ss.ID, &ss.Project, &ss.StartedAt, &ss.EndedAt, &ss.Summary, &ss.ObservationCount); err != nil {
+		if err := rows.Scan(&ss.ID, &ss.Project, &ss.StartedAt, &ss.EndedAt, &ss.Summary, &ss.ObservationCount, &ss.LastActivityAt); err != nil {
 			return nil, err
 		}
 		results = append(results, ss)
@@ -1803,7 +1805,8 @@ func (s *Store) AllSessions(project string, limit int) ([]SessionSummary, error)
 
 	query := `
 		SELECT s.id, s.project, s.started_at, s.ended_at, s.summary,
-		       COUNT(o.id) as observation_count
+		       COUNT(o.id) as observation_count,
+		       MAX(COALESCE(o.created_at, s.started_at)) as last_activity_at
 		FROM sessions s
 		LEFT JOIN observations o ON o.session_id = s.id AND o.deleted_at IS NULL
 		WHERE 1=1
@@ -1827,7 +1830,7 @@ func (s *Store) AllSessions(project string, limit int) ([]SessionSummary, error)
 	var results []SessionSummary
 	for rows.Next() {
 		var ss SessionSummary
-		if err := rows.Scan(&ss.ID, &ss.Project, &ss.StartedAt, &ss.EndedAt, &ss.Summary, &ss.ObservationCount); err != nil {
+		if err := rows.Scan(&ss.ID, &ss.Project, &ss.StartedAt, &ss.EndedAt, &ss.Summary, &ss.ObservationCount, &ss.LastActivityAt); err != nil {
 			return nil, err
 		}
 		results = append(results, ss)
@@ -2144,6 +2147,9 @@ func (s *Store) SearchPrompts(query string, project string, limit int) ([]Prompt
 	}
 
 	ftsQuery := sanitizeFTS(query)
+	if ftsQuery == "" {
+		return nil, nil
+	}
 
 	sql := `
 		SELECT p.id, ifnull(p.sync_id, '') as sync_id, p.session_id, p.content, ifnull(p.project, '') as project, p.created_at
@@ -2617,6 +2623,13 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 
 	// Sanitize query for FTS5 — wrap each term in quotes to avoid syntax errors
 	ftsQuery := sanitizeFTS(query)
+	if ftsQuery == "" {
+		// Empty query: skip FTS block; return directResults (topic_key hits) up to limit.
+		if len(directResults) > limit {
+			directResults = directResults[:limit]
+		}
+		return directResults, nil
+	}
 
 	sqlQ := `
 		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
@@ -2770,7 +2783,7 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 				summary = fmt.Sprintf(": %s", truncate(*sess.Summary, 200))
 			}
 			fmt.Fprintf(&b, "- **%s** (%s)%s [%d observations]\n",
-				sess.Project, sess.StartedAt, summary, sess.ObservationCount)
+				sess.Project, sess.LastActivityAt, summary, sess.ObservationCount)
 		}
 		b.WriteString("\n")
 	}
@@ -5467,16 +5480,28 @@ func stripPrivateTags(s string) string {
 	return result
 }
 
-// sanitizeFTS wraps each word in quotes so FTS5 doesn't choke on special chars.
-// "fix auth bug" → `"fix" "auth" "bug"`
+// sanitizeFTS wraps each term in quotes and joins them with OR so a query
+// matches observations sharing ANY term, ranked by relevance (BM25 via
+// ORDER BY fts.rank at the call sites). A bare space between quoted terms is
+// an implicit AND in FTS5, which made natural-language queries return nothing.
+// Empty terms are dropped and empty input yields "" — callers MUST guard
+// against passing "" to a MATCH clause (FTS5 errors on an empty match string).
+// All embedded double-quotes are stripped (not just trimmed from the ends) so a
+// term like `a"b` can't produce an unbalanced FTS5 string (`"a"b"` → syntax error).
+// Trade-off: for very long queries OR matches any obs sharing a single term;
+// BM25 (ORDER BY fts.rank) ranks fuller matches first, so recall wins over precision.
+// "fix auth bug" → `"fix" OR "auth" OR "bug"`
 func sanitizeFTS(query string) string {
 	words := strings.Fields(query)
-	for i, w := range words {
-		// Strip existing quotes to avoid double-quoting
-		w = strings.Trim(w, `"`)
-		words[i] = `"` + w + `"`
+	quoted := make([]string, 0, len(words))
+	for _, w := range words {
+		w = strings.ReplaceAll(w, `"`, "")
+		if w == "" {
+			continue
+		}
+		quoted = append(quoted, `"`+w+`"`)
 	}
-	return strings.Join(words, " ")
+	return strings.Join(quoted, " OR ")
 }
 
 // ─── Passive Capture ─────────────────────────────────────────────────────────

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5762,6 +5762,46 @@ func TestSearchNormalizesProjectFilter(t *testing.T) {
 	}
 }
 
+// TestSearchMatchesAnyTermNotAll guards against a regression where sanitizeFTS
+// joined quoted terms with a bare space, which FTS5 interprets as an implicit
+// AND. Natural-language queries (the way agents actually search) then required
+// every single term to be present in one observation and returned nothing.
+// The desired behavior is OR-of-terms ranked by relevance (BM25), so a query
+// that overlaps partially with a stored record still surfaces it.
+func TestSearchMatchesAnyTermNotAll(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s1", "engram", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "discovery",
+		Title:     "Cash session reconciliation",
+		Content:   "Implemented cash session and tip allocation for the jau-pilot restaurant.",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	// Only some of these terms appear in the stored observation ("jau-pilot",
+	// "cash", "session"); "workboard", "mario" and "deployment" do not.
+	// A conjunctive (AND) match returns 0; the relevance-ranked OR match finds it.
+	results, err := s.Search("jau-pilot workboard mario cash session deployment", SearchOptions{
+		Project: "engram",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("expected ≥1 result for a multi-term query with partial overlap, got 0 (FTS treating terms as AND?)")
+	}
+}
+
 func TestRecentObservationsNormalizesProjectFilter(t *testing.T) {
 	s := newTestStore(t)
 
@@ -7002,5 +7042,184 @@ func TestAddObservation_DecayNotAppliedToExistingRows(t *testing.T) {
 	// review_after MUST NOT have been updated by the revision (original value preserved).
 	if ra1 != ra2 {
 		t.Errorf("revision must not overwrite review_after: was %q, now %q", ra1, ra2)
+	}
+}
+
+// ─── sanitizeFTS + Search regression tests ───────────────────────────────────
+
+// TestSearchRanksFullMatchAbovePartialMatch verifies that BM25 ranks an
+// observation matching more query terms above one matching fewer terms.
+func TestSearchRanksFullMatchAbovePartialMatch(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("rank-sess", "engram", "/tmp"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Obs A: only contains "cache"
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "rank-sess",
+		Type:      "note",
+		Title:     "cache only",
+		Content:   "This observation only mentions cache.",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation A: %v", err)
+	}
+
+	// Obs B: contains "redis", "cache", and "session" — should rank higher for the 3-term query
+	_, err = s.AddObservation(AddObservationParams{
+		SessionID: "rank-sess",
+		Type:      "note",
+		Title:     "redis cache session",
+		Content:   "This observation covers redis, cache, and session management together.",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation B: %v", err)
+	}
+
+	results, err := s.Search("redis cache session", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected >=2 results, got %d", len(results))
+	}
+
+	// BM25: more negative rank = better match. results[0] should be Obs B.
+	if results[0].Rank >= results[1].Rank {
+		t.Errorf("expected results[0].Rank (%v) < results[1].Rank (%v) — full-match should rank higher",
+			results[0].Rank, results[1].Rank)
+	}
+	if !strings.Contains(results[0].Title, "redis") {
+		t.Errorf("expected full-match observation first, got title=%q", results[0].Title)
+	}
+}
+
+// TestSearchPromptsMatchesAnyTermNotAll verifies that SearchPrompts uses OR
+// semantics: a prompt is returned if it matches ANY query term, not ALL.
+func TestSearchPromptsMatchesAnyTermNotAll(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("prompt-sess", "engram", "/tmp"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	_, err := s.AddPrompt(AddPromptParams{
+		SessionID: "prompt-sess",
+		Content:   "Fix the cash session reconciliation for jau-pilot restaurant",
+		Project:   "engram",
+	})
+	if err != nil {
+		t.Fatalf("AddPrompt: %v", err)
+	}
+
+	// Query includes terms not in the prompt ("workboard", "mario") — AND would return 0
+	results, err := s.SearchPrompts("jau-pilot workboard mario cash", "engram", 10)
+	if err != nil {
+		t.Fatalf("SearchPrompts: %v", err)
+	}
+	if len(results) < 1 {
+		t.Fatalf("expected >=1 result (OR semantics), got 0 — FTS treating terms as AND?")
+	}
+}
+
+// TestSanitizeFTSEdgeCases validates sanitizeFTS output for known inputs.
+func TestSanitizeFTSEdgeCases(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"engram", `"engram"`},
+		{"jau-pilot", `"jau-pilot"`},
+		{"OR AND NOT", `"OR" OR "AND" OR "NOT"`},
+		{`"already quoted"`, `"already" OR "quoted"`},
+		{"fix auth bug", `"fix" OR "auth" OR "bug"`},
+		{`a"b`, `"ab"`},   // embedded quote stripped → no unbalanced FTS5 string
+		{`"`, ""},         // lone quote → empty term dropped
+	}
+
+	for _, tc := range cases {
+		got := sanitizeFTS(tc.input)
+		if got != tc.want {
+			t.Errorf("sanitizeFTS(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestSearchEmptyQueryDoesNotPanic verifies that Search("", ...) does not
+// panic and returns either an empty list or a nil error.
+func TestSearchEmptyQueryDoesNotPanic(t *testing.T) {
+	s := newTestStore(t)
+
+	// Must not panic; error or empty slice are both acceptable.
+	results, err := s.Search("", SearchOptions{Limit: 10})
+	_ = results
+	_ = err
+	// If we reach here, no panic occurred.
+}
+
+// TestSearchSingleTermNoRegression ensures single-term search still works
+// after the sanitizeFTS refactor.
+func TestSearchSingleTermNoRegression(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("single-sess", "engram", "/tmp"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "single-sess",
+		Type:      "note",
+		Title:     "tokenizer impl",
+		Content:   "Implemented a custom tokenizer for FTS5.",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	results, err := s.Search("tokenizer", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) < 1 {
+		t.Fatalf("expected >=1 result for single-term query, got 0")
+	}
+}
+
+// TestSearchHyphenatedTermMatchesExactly ensures hyphenated project names
+// (e.g. "jau-pilot") survive sanitizeFTS quoting and are found by Search.
+func TestSearchHyphenatedTermMatchesExactly(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("hyph-sess", "engram", "/tmp"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "hyph-sess",
+		Type:      "note",
+		Title:     "jau-pilot config",
+		Content:   "Configuration notes for the jau-pilot project.",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	results, err := s.Search("jau-pilot", SearchOptions{Project: "engram", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) < 1 {
+		t.Fatalf("expected >=1 result for hyphenated term query, got 0")
 	}
 }


### PR DESCRIPTION
## Summary

Two retrieval bugs make `mem_search` / `mem_context` unreliable for the way agents actually use them. Both are fixed here with regression tests. The two fixes are independent — happy to split into separate PRs if you prefer.

### 1. `sanitizeFTS` used an implicit AND between terms

`sanitizeFTS` wrapped each term in quotes and joined them with a bare space. FTS5 treats `"a" "b" "c"` (space-separated, no operator) as an **implicit AND**, so a multi-word natural-language query required *every* term to appear in a single observation. Descriptive queries of 5–9 words returned nothing.

```
Search("engram obsidian bridge sessions not saved")  →  0 results (pre-fix)
```

**Fix:** join terms with `OR`. The BM25 rank (`ORDER BY fts.rank`, already present in both `Store.Search` and `Store.SearchPrompts`) ranks observations matching more terms higher, so recall improves without losing relevance ordering. Two hardening changes ride along:
- embedded double-quotes are stripped (not just trimmed from the ends), so a term like `a"b` can no longer produce an unbalanced FTS5 string (`"a"b"` → syntax error);
- empty / whitespace-only queries are guarded at both call sites so they never reach an empty `MATCH` (which FTS5 rejects).

### 2. Recent sessions showed a frozen creation date instead of recent activity

`defaultSessionID` returned a static id (`manual-save-{project}`) that never rotated, so every observation saved without an explicit session id piled into one row whose `started_at` was frozen at first creation. `FormatContext` then displayed that stale date as the "recent" session — months out of date even with fresh activity.

**Fix:**
- rotate the default session id per UTC day (`manual-save-{project}-{YYYY-MM-DD}`);
- add `SessionSummary.LastActivityAt = MAX(COALESCE(o.created_at, s.started_at))` and display it in `FormatContext` instead of `started_at` (applied consistently to `RecentSessions` and `AllSessions`).

`started_at` is `NOT NULL`, so the `COALESCE` is never NULL and the scan target stays a plain `string`.

## Tests

Adds to `internal/store/store_test.go`: OR partial-match recall, BM25 full-vs-partial ranking, prompt multi-term search, and edge cases (empty query, single term, hyphenated term, embedded quote). Updates `internal/mcp/mcp_test.go` for the rotated session id. Pre-existing `TestSessionsOrderedByMostRecentActivity` already covers the recent-activity ordering.

`go build ./...` and `go vet ./internal/...` are clean. (On Windows, `TestMigrate_Idempotent` and `TestNewErrorBranches` fail only in `TempDir` cleanup — `modernc.org/sqlite` holds the db file handle past `Close()`; unrelated to this change.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now include last activity timestamp, showing when the session was most recently used.

* **Improvements**
  * Search now matches any search term in your query, returning more relevant results.
  * Enhanced search query parsing to better handle edge cases and special characters.
  * Session organization improved with daily ID rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->