### PR TITLE
feat: opt-in ingestion scrub + per-memory local_only sync control

### DIFF
--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Gentleman-Programming/engram/internal/cloud/cloudstore"
 	"github.com/Gentleman-Programming/engram/internal/cloud/constants"
 	"github.com/Gentleman-Programming/engram/internal/project"
+	"github.com/Gentleman-Programming/engram/internal/scrub"
 )
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -199,6 +200,56 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Sensitive-data scrub (opt-in via ENGRAM_SCRUB). Runs BEFORE InsertMutationBatch
+	// — and therefore before FTS5 indexing — so nothing sensitive is ever persisted
+	// or made searchable. Findings carry NO matched value, so this is audit-safe.
+	if mode := scrub.ModeFromEnv(); mode != scrub.ModeOff {
+		var blocked []map[string]any
+		for i, entry := range req.Entries {
+			findings := scrub.Scan(entry.Payload)
+			if len(findings) == 0 {
+				continue
+			}
+			cats := make([]string, 0, len(findings))
+			entryBlocks := false
+			for _, f := range findings {
+				cats = append(cats, string(f.Category)+":"+f.Detector)
+				if f.Blocks(mode) {
+					entryBlocks = true
+				}
+			}
+			log.Printf("cloudserver: scrub %s flagged entry %d (entity=%s, blocks=%t): %s",
+				scrubModeName(mode), i, entry.Entity, entryBlocks, strings.Join(cats, ","))
+			if entryBlocks {
+				blocked = append(blocked, map[string]any{
+					"index":      i,
+					"entity":     entry.Entity,
+					"categories": cats,
+				})
+			}
+		}
+		if len(blocked) > 0 {
+			// Best-effort audit (no sensitive content recorded).
+			if auditor, ok := s.store.(interface {
+				InsertAuditEntry(ctx context.Context, entry cloudstore.AuditEntry) error
+			}); ok {
+				_ = auditor.InsertAuditEntry(r.Context(), cloudstore.AuditEntry{
+					Project:    primaryProject,
+					Action:     "scrub_blocked",
+					Outcome:    "rejected",
+					EntryCount: len(blocked),
+					ReasonCode: "scrub_blocked",
+				})
+			}
+			jsonResponse(w, http.StatusUnprocessableEntity, map[string]any{
+				"error":       "sensitive data detected; batch rejected",
+				"reason_code": "scrub_blocked",
+				"blocked":     blocked,
+			})
+			return
+		}
+	}
+
 	acceptedSeqs, err := ms.InsertMutationBatch(r.Context(), req.Entries)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("insert mutations: %v", err), http.StatusInternalServerError)
@@ -339,6 +390,18 @@ func validateRelationPayload(payload json.RawMessage) (string, bool) {
 // payload validation is a breaking change and must not be done here.
 func validateLegacyPayload(_ string, _ json.RawMessage) (string, bool) {
 	return "", true
+}
+
+// scrubModeName renders the scrub mode for log lines.
+func scrubModeName(m scrub.Mode) string {
+	switch m {
+	case scrub.ModeParanoid:
+		return "paranoid"
+	case scrub.ModeStrict:
+		return "strict"
+	default:
+		return "warn"
+	}
 }
 
 // validateMutationEntry dispatches to the correct validator for the entry's

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -363,6 +363,9 @@ Examples:
 				mcp.WithBoolean("capture_prompt",
 					mcp.Description("Automatically capture the current user prompt when available (default: true). Set false for SDD artifacts or automated saves."),
 				),
+				mcp.WithBoolean("local_only",
+					mcp.Description("When true, save this observation locally only — never enqueue it for cloud sync. If the observation was previously synced, a delete tombstone is enqueued to remove it from the cloud."),
+				),
 			),
 			queuedWriteHandler(writeQueue, handleSave(s, cfg, activity)),
 		)
@@ -1195,6 +1198,7 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 		projectChoiceReason, _ := req.GetArguments()["project_choice_reason"].(string)
 		recoveryToken, _ := req.GetArguments()["recovery_token"].(string)
 		capturePrompt := boolArg(req, "capture_prompt", true)
+		localOnly := boolArg(req, "local_only", false)
 		recoverySessionID := sessionID
 		if strings.TrimSpace(recoverySessionID) == "" {
 			recoverySessionID = defaultSessionID("")
@@ -1260,6 +1264,7 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 			Project:   project,
 			Scope:     scope,
 			TopicKey:  topicKey,
+			LocalOnly: localOnly,
 		})
 		if err != nil {
 			return mcp.NewToolResultError("Failed to save: " + err.Error()), nil

--- a/internal/scrub/adversarial_test.go
+++ b/internal/scrub/adversarial_test.go
@@ -1,0 +1,117 @@
+package scrub
+
+import "testing"
+
+// TestAdversarial asserts the security contract against evasion / coverage cases
+// using only generic, non-proprietary examples.
+//
+// tier "high"      → must produce a finding that blocks ModeStrict.
+// tier "heuristic" → must be detected (blocks ModeParanoid) but NOT ModeStrict,
+//
+//	because the shape is indistinguishable from benign data
+//	(e.g. a 64-hex secret vs a sha256 digest).
+//
+// tier "undetectable" → documents a known gap: not caught by shape alone.
+func TestAdversarial(t *testing.T) {
+	cases := []struct {
+		tier string
+		desc string
+		in   string
+	}{
+		// PAN — all high-confidence (Luhn-validated), evasions must still block.
+		{"high", "contiguous valid visa", "4111111111111111"},
+		{"high", "spaced groups", "4111 1111 1111 1111"},
+		{"high", "dash groups", "4111-1111-1111-1111"},
+		{"high", "dot separators", "4111.1111.1111.1111"},
+		{"high", "amex 15-digit", "378282246310005"},
+		{"high", "padded with extra leading digits", "00004111111111111111"},
+		{"high", "letter-glued prefix", "ref4111111111111111"},
+		{"high", "fullwidth digits", "４１１１１１１１１１１１１１１１"},
+
+		// Card data — generic high-confidence.
+		{"high", "track2 data (ISO standard)", "5500000000000004=2705"},
+		{"high", "cvc by field name", `{"cvc":"123"}`},
+		{"high", "card_number by field name", "card_number: 4111111111111111"},
+
+		// Secrets — well-known provider shapes.
+		{"high", "stripe live key", "sk_live_abcdef0123456789"}, //gitleaks:allow (synthetic test fixture)
+		{"high", "postgres conn string (no dot host)", "postgres://admin:S3cretPass@localhost:5432/db"},
+		{"high", "password assignment", "password: hunter2SuperSecretValue"},
+		{"high", "bearer header", "Authorization: Bearer abc123def456ghi789jkl"},
+
+		// PII — email + CURP are high-confidence (generic synthetic samples).
+		{"high", "email", "alice@example.com"},
+		{"high", "CURP uppercase", "XEXX800101HDFGHJ05"},
+		{"high", "CURP lowercase", "xexx800101hdfghj05"},
+
+		// Heuristic — detectable but shape-ambiguous, block only in paranoid.
+		{"heuristic", "generic 64-hex api key", "a3f9c1d4e5b6a7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2"}, //gitleaks:allow (synthetic test fixture)
+		{"heuristic", "base64-wrapped secret", "c2tfbGl2ZV9hYmNkZWYwMTIzNDU2Nzg5cXdlcnR5"},                          //gitleaks:allow (synthetic test fixture)
+		{"heuristic", "RFC lowercase", "xexx800101ab1"},
+		{"heuristic", "mexican phone", "55 1234 5678"},
+		{"heuristic", "clabe 18-digit value", "002010077777777771"},
+		{"heuristic", "mongo objectid (synthetic)", "0123456789abcdef01234567"},
+
+		// Undetectable by shape alone — documented gap.
+		{"undetectable", "bare standalone CVV", "the code is 123"},
+	}
+
+	for _, c := range cases {
+		findings := Scan([]byte(c.in))
+		blocksStrict, blocksParanoid := false, false
+		for _, f := range findings {
+			if f.Blocks(ModeStrict) {
+				blocksStrict = true
+			}
+			if f.Blocks(ModeParanoid) {
+				blocksParanoid = true
+			}
+		}
+		switch c.tier {
+		case "high":
+			if !blocksStrict {
+				t.Errorf("HIGH must block strict but did not: %q (findings=%v)", c.desc, findings)
+			}
+		case "heuristic":
+			if blocksStrict {
+				t.Errorf("HEURISTIC must NOT block strict: %q (findings=%v)", c.desc, findings)
+			}
+			if !blocksParanoid {
+				t.Errorf("HEURISTIC must block paranoid (be detected): %q", c.desc)
+			}
+		case "undetectable":
+			if blocksStrict {
+				t.Logf("note: %q unexpectedly blocked strict (acceptable)", c.desc)
+			}
+		}
+	}
+}
+
+// TestCustomPatterns proves operators can add deployment-specific detectors via
+// config WITHOUT any organization-specific pattern living in this OSS code. Uses
+// a fictional "acme_" prefix purely as an example.
+func TestCustomPatterns(t *testing.T) {
+	t.Cleanup(func() { _ = SetCustomPatterns(nil) })
+
+	// Before: a fictional internal id is not detected by the generic engine.
+	if got := Scan([]byte("ref acme_7f3a9c1d in note")); len(got) != 0 {
+		t.Fatalf("expected no findings before custom patterns, got %+v", got)
+	}
+
+	err := SetCustomPatterns([]CustomPattern{
+		{Name: "acme_resource_id", Category: "internal_id", Severity: "heuristic", Regex: `\bacme_[0-9a-f]{8}\b`},
+		{Name: "acme_secret_field", Category: "secret", Severity: "high", Regex: `(?i)\bacme_token\b\s*[:=]\s*\S`},
+	})
+	if err != nil {
+		t.Fatalf("SetCustomPatterns: %v", err)
+	}
+
+	id := Scan([]byte("ref acme_7f3a9c1d in note"))
+	if len(id) == 0 || id[0].Detector != "acme_resource_id" || id[0].Blocks(ModeStrict) {
+		t.Fatalf("expected heuristic custom id finding, got %+v", id)
+	}
+	sec := Scan([]byte("acme_token = abc123"))
+	if len(sec) == 0 || !sec[0].Blocks(ModeStrict) {
+		t.Fatalf("expected high custom secret finding to block strict, got %+v", sec)
+	}
+}

--- a/internal/scrub/config.go
+++ b/internal/scrub/config.go
@@ -1,0 +1,116 @@
+package scrub
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// EnvCustomPatterns names an env var holding a path to a JSON file of extra,
+// deployment-specific detectors. This lets operators add organization-specific
+// patterns (internal ID formats, proprietary field names, issued-token prefixes)
+// WITHOUT placing any of that in this open-source code. The file lives only in
+// the operator's private deployment.
+//
+// File format: a JSON array of objects:
+//
+//	[
+//	  {"name":"acme_resource_id","category":"internal_id","severity":"heuristic","regex":"\\bacme_[0-9a-f]{12}\\b"},
+//	  {"name":"acme_field","category":"cardholder_data","severity":"high","regex":"(?i)\\bsecret_field\\b\\s*[:=]\\s*\\S"}
+//	]
+const EnvCustomPatterns = "ENGRAM_SCRUB_PATTERNS"
+
+// CustomPattern is an operator-supplied detector loaded from config.
+type CustomPattern struct {
+	Name     string `json:"name"`
+	Category string `json:"category"` // cardholder_data | secret | pii | internal_id
+	Severity string `json:"severity"` // "high" | "heuristic" (default heuristic)
+	Regex    string `json:"regex"`
+}
+
+type compiledCustom struct {
+	name string
+	cat  Category
+	sev  Severity
+	re   *regexp.Regexp
+}
+
+var (
+	customMu   sync.RWMutex
+	customComp []compiledCustom
+	customOnce sync.Once
+)
+
+func severityFromString(s string) Severity {
+	if strings.EqualFold(strings.TrimSpace(s), "high") {
+		return SeverityHigh
+	}
+	return SeverityHeuristic
+}
+
+func compileCustom(ps []CustomPattern) ([]compiledCustom, error) {
+	out := make([]compiledCustom, 0, len(ps))
+	for _, p := range ps {
+		re, err := regexp.Compile(p.Regex)
+		if err != nil {
+			return nil, fmt.Errorf("custom scrub pattern %q: %w", p.Name, err)
+		}
+		cat := Category(strings.TrimSpace(p.Category))
+		if cat == "" {
+			cat = CategorySecret
+		}
+		name := strings.TrimSpace(p.Name)
+		if name == "" {
+			name = "custom"
+		}
+		out = append(out, compiledCustom{name: name, cat: cat, sev: severityFromString(p.Severity), re: re})
+	}
+	return out, nil
+}
+
+// SetCustomPatterns compiles and installs the active custom detectors. Passing
+// nil clears them. Used by the env loader and by tests.
+func SetCustomPatterns(ps []CustomPattern) error {
+	comp, err := compileCustom(ps)
+	if err != nil {
+		return err
+	}
+	customMu.Lock()
+	customComp = comp
+	customMu.Unlock()
+	return nil
+}
+
+// LoadCustomPatternsFromEnv reads ENGRAM_SCRUB_PATTERNS (if set) and installs the
+// patterns. It is safe to call repeatedly; failures are returned, not panicked.
+func LoadCustomPatternsFromEnv() error {
+	path := strings.TrimSpace(os.Getenv(EnvCustomPatterns))
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", EnvCustomPatterns, err)
+	}
+	var ps []CustomPattern
+	if err := json.Unmarshal(data, &ps); err != nil {
+		return fmt.Errorf("parse %s: %w", EnvCustomPatterns, err)
+	}
+	return SetCustomPatterns(ps)
+}
+
+func customFindings(s string) []Finding {
+	customOnce.Do(func() { _ = LoadCustomPatternsFromEnv() })
+	customMu.RLock()
+	defer customMu.RUnlock()
+	var out []Finding
+	for _, c := range customComp {
+		if c.re.MatchString(s) {
+			out = append(out, Finding{c.cat, c.name, c.sev})
+		}
+	}
+	return out
+}

--- a/internal/scrub/falsepos_test.go
+++ b/internal/scrub/falsepos_test.go
@@ -1,0 +1,47 @@
+package scrub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFalsePositives feeds realistic, NON-sensitive dev-memory content and
+// reports what trips. These SHOULD ideally be clean; anything flagged here is a
+// false positive that, in strict mode, would block a legitimate save.
+func TestFalsePositives(t *testing.T) {
+	cases := []struct {
+		desc string
+		in   string
+	}{
+		{"plain architecture note", "Refactored ChargeService to batch queries; root cause was an N+1 in the listing path."},
+		{"git short sha", "Fixed in commit a1b2c3d4e on main."},
+		{"git full sha (40 hex)", "Regression introduced by 0a1b2c3d4e5f60718293a4b5c6d7e8f901234567."},
+		{"sha256 digest (64 hex)", "artifact sha256 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{"uuid", "trace id 550e8400-e29b-41d4-a716-446655440000 in the logs"},
+		{"version + PR ref", "PR #42 bumps some-library to 1.2.3."},
+		{"internal url", "evidence served by https://internal-services.example.com/svc/charges/chargebacks"},
+		{"topic key", "stored under topic_key architecture/auth-model for the upsert path"},
+		{"prose with numbers", "The retry budget is 3 attempts over 800ms with exponential backoff and jitter."},
+	}
+	for _, c := range cases {
+		got := Scan([]byte(c.in))
+		blocksStrict := false
+		tags := make([]string, 0, len(got))
+		for _, f := range got {
+			tags = append(tags, string(f.Category)+":"+f.Detector)
+			if f.Blocks(ModeStrict) {
+				blocksStrict = true
+			}
+		}
+		// The contract: legit dev content must NEVER block in strict mode.
+		if blocksStrict {
+			t.Errorf("FALSE POSITIVE blocks strict: %q -> %s", c.desc, strings.Join(tags, ","))
+			continue
+		}
+		if len(got) == 0 {
+			t.Logf("CLEAN              %s", c.desc)
+		} else {
+			t.Logf("heuristic-only(ok) %-26s -> %s", c.desc, strings.Join(tags, ","))
+		}
+	}
+}

--- a/internal/scrub/scrub.go
+++ b/internal/scrub/scrub.go
@@ -1,0 +1,335 @@
+// Package scrub provides deterministic, fail-closed detection of sensitive data
+// (cardholder data, secrets, PII, internal identifiers) at the cloud ingestion
+// boundary.
+//
+// Scan reports findings WITHOUT the matched values, so callers can reject or
+// audit a mutation batch without ever logging the sensitive content itself.
+//
+// # Design and limitations (READ THIS before trusting it)
+//
+// These detectors are deterministic (normalization + regex + Luhn + Shannon
+// entropy), not an ML classifier. They are a defense-in-depth layer to stop
+// ACCIDENTAL leakage — they are NOT a PCI compliance boundary on their own.
+// A regex/entropy scrubber will always have evasions. Known limitations:
+//
+//   - CVV/CVC has no intrinsic shape (any 3–4 digits). Only the CONTEXTUAL form
+//     ("cvv: 123") is detectable; a bare standalone CVV cannot be caught.
+//   - High-entropy detection has false positives (hashes, long IDs) and, in
+//     fail-closed strict mode, that is intentional — it rejects the save.
+//   - Data that is encoded/compressed/encrypted BEFORE reaching Scan is opaque.
+//     The cloud ingest path passes plaintext JSON, so that holds there; do not
+//     reuse Scan on already-encoded payloads.
+//
+// The only real guarantee for true cardholder data is never writing it into the
+// system at all. Scan reduces accidental exposure; it does not replace that.
+package scrub
+
+import (
+	"math"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Mode controls enforcement. It is read from ENGRAM_SCRUB and defaults to Off
+// so the feature is opt-in and never changes behavior for existing deployments.
+type Mode int
+
+const (
+	// ModeOff disables scanning entirely (default).
+	ModeOff Mode = iota
+	// ModeWarn scans and reports findings but does not block the write.
+	ModeWarn
+	// ModeStrict blocks the write on HIGH-severity findings; heuristic findings
+	// are logged but do not block (preserves usability for normal dev notes).
+	ModeStrict
+	// ModeParanoid blocks the write on ANY finding, including heuristic ones.
+	ModeParanoid
+)
+
+// ModeFromEnv resolves the enforcement mode from ENGRAM_SCRUB.
+// Accepted: "" / "off" → Off, "warn" → Warn, "strict" → Strict, "paranoid" → Paranoid.
+func ModeFromEnv() Mode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ENGRAM_SCRUB"))) {
+	case "warn":
+		return ModeWarn
+	case "strict":
+		return ModeStrict
+	case "paranoid":
+		return ModeParanoid
+	default:
+		return ModeOff
+	}
+}
+
+// Severity tiers a finding by detection confidence so callers can block on
+// high-confidence hits without being swamped by heuristic false positives.
+type Severity int
+
+const (
+	// SeverityHeuristic is FP-prone (entropy, long hex, bare IDs, phone, RFC).
+	SeverityHeuristic Severity = iota
+	// SeverityHigh is high-confidence (Luhn PAN, keys, tokens, conn strings, email).
+	SeverityHigh
+)
+
+// Blocks reports whether a finding should block a write under the given mode.
+func (f Finding) Blocks(m Mode) bool {
+	switch m {
+	case ModeParanoid:
+		return true
+	case ModeStrict:
+		return f.Severity == SeverityHigh
+	default:
+		return false
+	}
+}
+
+// Category classifies a finding without exposing the matched value.
+type Category string
+
+const (
+	CategoryPAN    Category = "cardholder_data" // PAN (Luhn-validated)
+	CategoryCVV    Category = "cardholder_data" // contextual CVV/CVC
+	CategorySecret Category = "secret"          // keys, tokens, private keys, conn strings
+	CategoryPII    Category = "pii"             // email, RFC, CURP, phone
+	CategoryID     Category = "internal_id"     // live production identifiers
+)
+
+// Finding describes a single detection. It carries NO matched value — only the
+// category, detector name, and severity — so it is safe to log and audit.
+type Finding struct {
+	Category Category
+	Detector string
+	Severity Severity
+}
+
+var (
+	// PAN candidate: a digit followed by 12+ more digits, allowing common
+	// separators (space, dash, dot, NBSP) BUT NOT requiring word boundaries —
+	// so "ref4111..." and "4111.1111..." are still found. Luhn (below) and a
+	// sliding window over long runs remove false positives / catch padding.
+	rePANCandidate = regexp.MustCompile(`[0-9](?:[ \-.\x{00A0}]?[0-9]){12,}`)
+
+	rePrivateKey = regexp.MustCompile(`-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----`)
+	reJWT        = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b`)
+	reAWSKey     = regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`)
+	// Well-known provider token prefixes (Stripe, GitHub, Slack, OpenAI, Google).
+	// Organization-specific prefixes belong in custom patterns (see config.go).
+	reTokenPrefix = regexp.MustCompile(`\b(?:sk_live_|rk_live_|sk-|xox[baprs]-|ghp_|gho_|github_pat_|AIza)[A-Za-z0-9_\-]{10,}\b`)
+	// Track 2 data: {PAN}={YYYY}{MM} — ISO card standard, highly distinctive.
+	reTrack2 = regexp.MustCompile(`\b\d{15,16}=\d{4}\b`)
+	// CLABE — Mexican 18-digit interbank account number (financial PII).
+	reCLABE = regexp.MustCompile(`\b\d{18}\b`)
+	// Generic cardholder field names paired with a value (e.g. "cvc": 123).
+	// Deployment-specific field names belong in custom patterns (see config.go).
+	reSensitiveField = regexp.MustCompile(`(?i)\b(?:card_?number|cardholder|pan|cvc|cvv2?)\b\s*["']?\s*[:=]\s*["']?\S`)
+	// scheme://user:password@host  (postgres, mysql, mongodb, redis, amqp, http…)
+	reConnString = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.\-]*://[^\s:/@]+:[^\s:/@]+@`)
+	reBearer     = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._\-]{12,}`)
+	// key-value secret assignment: password / api_key / token / secret = <value>
+	reKVSecret = regexp.MustCompile(`(?i)\b(?:password|passwd|pwd|secret|api[_-]?key|apikey|access[_-]?token|auth[_-]?token|client[_-]?secret|private[_-]?key|token)\b["']?\s*[:=]\s*["']?[^\s"',}]{6,}`)
+	// Candidate high-entropy tokens (base64/base64url-ish) and long hex blobs.
+	reEntropyTok = regexp.MustCompile(`[A-Za-z0-9+/=_\-]{20,}`)
+	reLongHex    = regexp.MustCompile(`\b[0-9a-fA-F]{32,}\b`)
+
+	reEmail = regexp.MustCompile(`\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`)
+	// Mexican RFC (12/13) and CURP (18), case-insensitive (agents may lowercase).
+	reRFC  = regexp.MustCompile(`(?i)\b[A-ZÑ&]{3,4}\d{6}[A-Z0-9]{3}\b`)
+	reCURP = regexp.MustCompile(`(?i)\b[A-Z]{4}\d{6}[HM][A-Z]{5}[0-9A-Z]\d\b`)
+	// Mexican phone: +52 prefixed, or a separator-grouped 10-digit number.
+	rePhoneMX = regexp.MustCompile(`(?:\+?52[ \-.]?)?(?:\(?\d{2,3}\)?[ \-.])\d{3,4}[ \-.]?\d{4}\b`)
+	// Contextual CVV/CVC: the keyword adjacent to 3–4 digits.
+	reCVVCtx = regexp.MustCompile(`(?i)\b(?:cvv2?|cvc2?|cvn|cid|security\s*code|c[oó]digo\s*de\s*seguridad)\b\W{0,4}\d{3,4}\b`)
+	// Mongo ObjectId — 24-char hex, a common record-identifier shape.
+	reObjectID = regexp.MustCompile(`\b[0-9a-f]{24}\b`)
+)
+
+// Scan inspects raw bytes (typically a mutation payload) and returns every
+// distinct finding. An empty slice means no sensitive data was detected.
+// Scan never returns the matched substring.
+func Scan(b []byte) []Finding {
+	s := normalize(string(b))
+	var out []Finding
+
+	// High-confidence detectors — block in strict. Near-zero false positives.
+	if detectPAN(s) {
+		out = append(out, Finding{CategoryPAN, "luhn_pan", SeverityHigh})
+	}
+	if reTrack2.MatchString(s) {
+		out = append(out, Finding{CategoryPAN, "track2", SeverityHigh})
+	}
+	if reCVVCtx.MatchString(s) {
+		out = append(out, Finding{CategoryCVV, "cvv_contextual", SeverityHigh})
+	}
+	if reSensitiveField.MatchString(s) { // generic cardholder field names
+		out = append(out, Finding{CategoryPAN, "sensitive_field", SeverityHigh})
+	}
+	for _, d := range []struct {
+		re   *regexp.Regexp
+		name string
+	}{
+		{rePrivateKey, "private_key"},
+		{reJWT, "jwt"},
+		{reAWSKey, "aws_access_key"},
+		{reTokenPrefix, "token_prefix"},
+		{reConnString, "connection_string"},
+		{reBearer, "bearer_token"},
+		{reKVSecret, "kv_secret"},
+	} {
+		if d.re.MatchString(s) {
+			out = append(out, Finding{CategorySecret, d.name, SeverityHigh})
+		}
+	}
+	if reEmail.MatchString(s) {
+		out = append(out, Finding{CategoryPII, "email", SeverityHigh})
+	}
+	if reCURP.MatchString(s) { // 18-char structured — low FP
+		out = append(out, Finding{CategoryPII, "curp", SeverityHigh})
+	}
+
+	// Heuristic detectors — FP-prone (git SHAs, hashes, UUIDs, slugs match
+	// entropy/hex; random tokens match RFC/ObjectId). Logged in strict, block
+	// only in paranoid.
+	if detectHighEntropy(s) {
+		out = append(out, Finding{CategorySecret, "high_entropy", SeverityHeuristic})
+	}
+	if reLongHex.MatchString(s) {
+		out = append(out, Finding{CategorySecret, "long_hex", SeverityHeuristic})
+	}
+	if reRFC.MatchString(s) {
+		out = append(out, Finding{CategoryPII, "rfc", SeverityHeuristic})
+	}
+	if rePhoneMX.MatchString(s) {
+		out = append(out, Finding{CategoryPII, "phone_mx", SeverityHeuristic})
+	}
+	if reCLABE.MatchString(s) {
+		out = append(out, Finding{CategoryPII, "clabe", SeverityHeuristic})
+	}
+	if reObjectID.MatchString(s) {
+		out = append(out, Finding{CategoryID, "mongo_objectid", SeverityHeuristic})
+	}
+
+	// Deployment-specific detectors loaded from config (kept out of this OSS code).
+	out = append(out, customFindings(s)...)
+
+	return out
+}
+
+// normalize folds full-width ASCII digits (U+FF10–U+FF19) to their ASCII form so
+// detectors cannot be evaded with Unicode digit homoglyphs.
+func normalize(s string) string {
+	if !strings.ContainsRune(s, '０') && !containsFullwidthDigit(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r >= '０' && r <= '９' {
+			b.WriteRune('0' + (r - '０'))
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func containsFullwidthDigit(s string) bool {
+	for _, r := range s {
+		if r >= '０' && r <= '９' {
+			return true
+		}
+	}
+	return false
+}
+
+// detectPAN strips separators from every candidate run and Luhn-checks it.
+// For runs longer than a PAN it slides a 13–19 digit window, so a PAN padded
+// with extra digits ("0000"+PAN) is still caught.
+func detectPAN(s string) bool {
+	for _, cand := range rePANCandidate.FindAllString(s, -1) {
+		d := stripNonDigits(cand)
+		n := len(d)
+		switch {
+		case n >= 13 && n <= 19:
+			if luhnValid(d) {
+				return true
+			}
+		case n > 19 && n <= 128: // bounded sliding window
+			for start := 0; start+13 <= n; start++ {
+				for l := 13; l <= 19 && start+l <= n; l++ {
+					if luhnValid(d[start : start+l]) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func stripNonDigits(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteByte(byte(r))
+		}
+	}
+	return b.String()
+}
+
+// luhnValid runs the Luhn checksum over a pure-digit string of PAN length.
+func luhnValid(d string) bool {
+	if len(d) < 13 || len(d) > 19 {
+		return false
+	}
+	sum := 0
+	double := false
+	for i := len(d) - 1; i >= 0; i-- {
+		n := int(d[i] - '0')
+		if double {
+			n *= 2
+			if n > 9 {
+				n -= 9
+			}
+		}
+		sum += n
+		double = !double
+	}
+	return sum%10 == 0
+}
+
+// detectHighEntropy flags base64/base64url-ish tokens of length >= 20 whose
+// Shannon entropy per character is high enough to look like a random secret.
+// Threshold ~3.5 bits/char clears English prose and repeated padding while
+// catching random keys; in strict mode any false positive simply blocks the save.
+func detectHighEntropy(s string) bool {
+	for _, tok := range reEntropyTok.FindAllString(s, -1) {
+		if shannonBits(tok) >= 3.5 {
+			return true
+		}
+	}
+	return false
+}
+
+func shannonBits(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	var freq [256]float64
+	n := 0.0
+	for i := 0; i < len(s); i++ {
+		freq[s[i]]++
+		n++
+	}
+	h := 0.0
+	for _, c := range freq {
+		if c == 0 {
+			continue
+		}
+		p := c / n
+		h -= p * math.Log2(p)
+	}
+	return h
+}

--- a/internal/scrub/scrub_test.go
+++ b/internal/scrub/scrub_test.go
@@ -1,0 +1,92 @@
+package scrub
+
+import (
+	"os"
+	"testing"
+)
+
+func hasCategory(fs []Finding, c Category) bool {
+	for _, f := range fs {
+		if f.Category == c {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScan_PAN(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		// 4111 1111 1111 1111 is the canonical Visa test PAN (valid Luhn).
+		{"visa test pan", "card 4111111111111111 charged", true},
+		{"pan grouped spaces", "4111 1111 1111 1111", true},
+		{"pan grouped dashes", "5500-0000-0000-0004", true}, // valid Luhn Mastercard test
+		// A 16-digit Mongo-ish order id that fails Luhn must NOT trip PAN.
+		{"order id not luhn", "order 1234567890123456 ok", false},
+		{"short digit run", "ref 12345678 ok", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := hasCategory(Scan([]byte(c.in)), CategoryPAN)
+			if got != c.want {
+				t.Fatalf("PAN detection = %v, want %v (in=%q)", got, c.want, c.in)
+			}
+		})
+	}
+}
+
+func TestScan_Secrets(t *testing.T) {
+	cases := map[string]string{
+		"private key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...",
+		"jwt":         "token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dummysig",
+		"aws key":     "AKIAIOSFODNN7EXAMPLE",
+		"stripe key":  "sk_live_abcdef0123456789", //gitleaks:allow (synthetic test fixture)
+		"github pat":  "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !hasCategory(Scan([]byte(in)), CategorySecret) {
+				t.Fatalf("expected secret finding for %q", in)
+			}
+		})
+	}
+}
+
+func TestScan_PII(t *testing.T) {
+	cases := map[string]struct {
+		in   string
+		want bool
+	}{
+		"email":          {"contact alice@example.com please", true},
+		"curp":           {"CURP XEXX800101HDFGHJ05 found", true},
+		"plain sentence": {"this is a normal architecture note about retries", false},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := hasCategory(Scan([]byte(c.in)), CategoryPII); got != c.want {
+				t.Fatalf("PII detection = %v, want %v (in=%q)", got, c.want, c.in)
+			}
+		})
+	}
+}
+
+func TestScan_CleanContentNoFindings(t *testing.T) {
+	clean := `{"title":"Fixed N+1 in charge listing","content":"Batched the query with includes; root cause was per-row lookups."}`
+	if fs := Scan([]byte(clean)); len(fs) != 0 {
+		t.Fatalf("expected no findings on clean content, got %+v", fs)
+	}
+}
+
+func TestModeFromEnv(t *testing.T) {
+	cases := map[string]Mode{"": ModeOff, "off": ModeOff, "warn": ModeWarn, "strict": ModeStrict, "STRICT": ModeStrict}
+	for in, want := range cases {
+		t.Setenv("ENGRAM_SCRUB", in)
+		if got := ModeFromEnv(); got != want {
+			t.Fatalf("ModeFromEnv(%q) = %v, want %v", in, got, want)
+		}
+	}
+	_ = os.Unsetenv("ENGRAM_SCRUB")
+}

--- a/internal/store/local_only_test.go
+++ b/internal/store/local_only_test.go
@@ -1,0 +1,491 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// countPendingObsMutations returns the total number of unacked sync_mutations rows
+// for entity='observation' without enrollment filtering — used by local_only tests
+// to assert at the raw-DB level.
+func countPendingObsMutations(t *testing.T, s *Store) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(
+		`SELECT count(*) FROM sync_mutations WHERE entity = ? AND acked_at IS NULL`,
+		SyncEntityObservation,
+	).Scan(&n); err != nil {
+		t.Fatalf("countPendingObsMutations: %v", err)
+	}
+	return n
+}
+
+// countPendingObsMutationsByOp returns unacked sync_mutations rows for
+// entity='observation' filtered by op.
+func countPendingObsMutationsByOp(t *testing.T, s *Store, op string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(
+		`SELECT count(*) FROM sync_mutations WHERE entity = ? AND op = ? AND acked_at IS NULL`,
+		SyncEntityObservation, op,
+	).Scan(&n); err != nil {
+		t.Fatalf("countPendingObsMutationsByOp(%s): %v", op, err)
+	}
+	return n
+}
+
+// setupLocalOnlyStore returns a fresh store with a session.
+func setupLocalOnlyStore(t *testing.T) *Store {
+	t.Helper()
+	s := newTestStore(t)
+	if err := s.CreateSession("ses-local", "testproj", "/tmp/local"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return s
+}
+
+// ─── (a) local_only save creates NO pending sync mutation ─────────────────────
+
+func TestAddObservation_LocalOnly_NoSyncMutation(t *testing.T) {
+	s := setupLocalOnlyStore(t)
+
+	before := countPendingObsMutations(t, s)
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "decision",
+		Title:     "Private decision",
+		Content:   "This must never reach the cloud",
+		Project:   "testproj",
+		Scope:     "project",
+		LocalOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	after := countPendingObsMutations(t, s)
+	if after != before {
+		t.Errorf("expected no new sync mutations for local_only save, got %d new mutation(s)", after-before)
+	}
+}
+
+// LocalOnly observation must be persisted locally.
+func TestAddObservation_LocalOnly_PersistedLocally(t *testing.T) {
+	s := setupLocalOnlyStore(t)
+
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "decision",
+		Title:     "Private decision",
+		Content:   "This must never reach the cloud",
+		Project:   "testproj",
+		Scope:     "project",
+		LocalOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("GetObservation: %v", err)
+	}
+	if !obs.LocalOnly {
+		t.Error("expected LocalOnly=true on persisted observation")
+	}
+	if obs.Title != "Private decision" {
+		t.Errorf("unexpected title: %q", obs.Title)
+	}
+}
+
+// ─── (b) default save still enqueues upsert ───────────────────────────────────
+
+func TestAddObservation_Default_EnqueuesUpsert(t *testing.T) {
+	s := setupLocalOnlyStore(t)
+
+	before := countPendingObsMutationsByOp(t, s, SyncOpUpsert)
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "decision",
+		Title:     "Synced decision",
+		Content:   "This reaches the cloud",
+		Project:   "testproj",
+		Scope:     "project",
+		LocalOnly: false, // explicit false — same as omitting
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	after := countPendingObsMutationsByOp(t, s, SyncOpUpsert)
+	if after <= before {
+		t.Errorf("expected at least one new upsert mutation for default save, before=%d after=%d", before, after)
+	}
+}
+
+// ─── (c) flip false→true on a synced memory enqueues a delete tombstone ───────
+
+func TestAddObservation_FlipFalseToTrue_EnqueuesDeleteTombstone(t *testing.T) {
+	s := setupLocalOnlyStore(t)
+
+	// 1. Save normally (local_only=false) so the observation gets an upsert mutation.
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "decision",
+		Title:     "Flip me to local",
+		Content:   "First save — synced",
+		Project:   "testproj",
+		Scope:     "project",
+		TopicKey:  "test/flip-to-local",
+		LocalOnly: false,
+	})
+	if err != nil {
+		t.Fatalf("first AddObservation: %v", err)
+	}
+
+	beforeUpserts := countPendingObsMutationsByOp(t, s, SyncOpUpsert)
+	beforeDeletes := countPendingObsMutationsByOp(t, s, SyncOpDelete)
+
+	// 2. Save again with local_only=true — same topic_key triggers the update path.
+	_, err = s.AddObservation(AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "decision",
+		Title:     "Flip me to local",
+		Content:   "Second save — now local only",
+		Project:   "testproj",
+		Scope:     "project",
+		TopicKey:  "test/flip-to-local",
+		LocalOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("second AddObservation (flip): %v", err)
+	}
+
+	afterUpserts := countPendingObsMutationsByOp(t, s, SyncOpUpsert)
+	afterDeletes := countPendingObsMutationsByOp(t, s, SyncOpDelete)
+
+	// No new upsert mutations.
+	if afterUpserts != beforeUpserts {
+		t.Errorf("expected no new upsert mutations on flip, before=%d after=%d", beforeUpserts, afterUpserts)
+	}
+	// Exactly one new delete mutation (tombstone).
+	if afterDeletes != beforeDeletes+1 {
+		t.Errorf("expected exactly one new delete mutation on flip, before=%d after=%d", beforeDeletes, afterDeletes)
+	}
+
+	// 3. The delete mutation's entity_key must be the observation's sync_id.
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("GetObservation after flip: %v", err)
+	}
+	if !obs.LocalOnly {
+		t.Error("expected LocalOnly=true after flip")
+	}
+
+	var deleteSyncID string
+	if err := s.db.QueryRow(
+		`SELECT entity_key FROM sync_mutations WHERE entity = ? AND op = ? AND acked_at IS NULL ORDER BY seq DESC LIMIT 1`,
+		SyncEntityObservation, SyncOpDelete,
+	).Scan(&deleteSyncID); err != nil {
+		t.Fatalf("fetch delete mutation entity_key: %v", err)
+	}
+	if deleteSyncID != obs.SyncID {
+		t.Errorf("delete tombstone entity_key=%q, want obs sync_id=%q", deleteSyncID, obs.SyncID)
+	}
+}
+
+// Flip test using the dedupe path (no topic_key, same content within window).
+func TestAddObservation_FlipFalseToTrue_DedupePathEnqueuesTombstone(t *testing.T) {
+	s := setupLocalOnlyStore(t)
+
+	params := AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "bugfix",
+		Title:     "Dedupe flip test",
+		Content:   "Exact content that deduplicates",
+		Project:   "testproj",
+		Scope:     "project",
+		LocalOnly: false,
+	}
+
+	id, err := s.AddObservation(params)
+	if err != nil {
+		t.Fatalf("first AddObservation: %v", err)
+	}
+
+	beforeDeletes := countPendingObsMutationsByOp(t, s, SyncOpDelete)
+	beforeUpserts := countPendingObsMutationsByOp(t, s, SyncOpUpsert)
+
+	// Same content → dedupe path. Flip to local_only.
+	params.LocalOnly = true
+	if _, err := s.AddObservation(params); err != nil {
+		t.Fatalf("second AddObservation (flip via dedupe): %v", err)
+	}
+
+	afterDeletes := countPendingObsMutationsByOp(t, s, SyncOpDelete)
+	afterUpserts := countPendingObsMutationsByOp(t, s, SyncOpUpsert)
+
+	if afterDeletes != beforeDeletes+1 {
+		t.Errorf("expected one delete tombstone via dedupe flip, before=%d after=%d", beforeDeletes, afterDeletes)
+	}
+	if afterUpserts != beforeUpserts {
+		t.Errorf("expected no new upsert on dedupe flip, before=%d after=%d", beforeUpserts, afterUpserts)
+	}
+
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("GetObservation: %v", err)
+	}
+	if !obs.LocalOnly {
+		t.Error("expected LocalOnly=true after dedupe flip")
+	}
+}
+
+// ─── (d) delete tombstone payload is valid JSON with Deleted=true ─────────────
+
+func TestAddObservation_FlipFalseToTrue_TombstonePayloadValid(t *testing.T) {
+	s := setupLocalOnlyStore(t)
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "decision",
+		Title:     "Tombstone payload test",
+		Content:   "Check payload",
+		Project:   "testproj",
+		Scope:     "project",
+		TopicKey:  "test/tombstone-payload",
+		LocalOnly: false,
+	})
+	if err != nil {
+		t.Fatalf("first AddObservation: %v", err)
+	}
+
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "ses-local",
+		Type:      "decision",
+		Title:     "Tombstone payload test",
+		Content:   "Check payload - updated",
+		Project:   "testproj",
+		Scope:     "project",
+		TopicKey:  "test/tombstone-payload",
+		LocalOnly: true,
+	}); err != nil {
+		t.Fatalf("flip AddObservation: %v", err)
+	}
+
+	var payload string
+	if err := s.db.QueryRow(
+		`SELECT payload FROM sync_mutations WHERE entity = ? AND op = ? AND acked_at IS NULL ORDER BY seq DESC LIMIT 1`,
+		SyncEntityObservation, SyncOpDelete,
+	).Scan(&payload); err != nil {
+		t.Fatalf("fetch tombstone payload: %v", err)
+	}
+
+	var p syncObservationPayload
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		t.Fatalf("unmarshal tombstone payload: %v", err)
+	}
+	if !p.Deleted {
+		t.Error("expected tombstone payload.Deleted=true")
+	}
+	if p.SyncID == "" {
+		t.Error("expected tombstone payload.SyncID to be set")
+	}
+}
+
+// ─── (e) Migration: legacy DB gets local_only column with default 0 ───────────
+
+func TestMigration_LocalOnlyColumnAddedToLegacyDB(t *testing.T) {
+	// Build a legacy store (pre-local_only schema), then open via New() to run migrate().
+	fixtureRows := migrationFixtureRows()
+	s := newTestStoreWithLegacySchema(t, fixtureRows)
+
+	// All migrated observations must have local_only=false (default).
+	rows, err := s.db.Query(
+		`SELECT id, ifnull(local_only, 0) FROM observations WHERE deleted_at IS NULL`,
+	)
+	if err != nil {
+		t.Fatalf("query local_only: %v", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var id int64
+		var localOnly bool
+		if err := rows.Scan(&id, &localOnly); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if localOnly {
+			t.Errorf("observation id=%d has local_only=true after migration (expected false)", id)
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if count != len(fixtureRows) {
+		t.Errorf("expected %d migrated observations, got %d", len(fixtureRows), count)
+	}
+}
+
+// After migration, observations read via GetObservation have LocalOnly=false.
+func TestMigration_LocalOnly_ObservationsReadableViaStore(t *testing.T) {
+	s := newTestStoreWithLegacySchema(t, migrationFixtureRows())
+
+	// Use AllObservations to get observations (no deletion filter needed here).
+	obs, err := s.AllObservations("engram", "project", 100)
+	if err != nil {
+		t.Fatalf("AllObservations: %v", err)
+	}
+	if len(obs) == 0 {
+		t.Fatal("expected at least one observation after migration")
+	}
+	for _, o := range obs {
+		if o.LocalOnly {
+			t.Errorf("observation %q has LocalOnly=true after migration", o.SyncID)
+		}
+	}
+}
+
+// ─── (f) Migration on DB that already has local_only column is a no-op ────────
+
+func TestMigration_LocalOnly_IdempotentOnFreshDB(t *testing.T) {
+	// A fresh store already has the local_only column via CREATE TABLE.
+	// migrate() calling addColumnIfNotExists must be a no-op (not an error).
+	s := newTestStore(t)
+
+	if err := s.CreateSession("ses-idem", "idem-proj", "/tmp/idem"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "ses-idem",
+		Type:      "decision",
+		Title:     "Idempotent migration test",
+		Content:   "Should work fine",
+		Project:   "idem-proj",
+		Scope:     "project",
+		LocalOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("GetObservation: %v", err)
+	}
+	if !obs.LocalOnly {
+		t.Error("expected LocalOnly=true after fresh-DB insert")
+	}
+}
+
+// ─── Legacy DDL without local_only column (used for migration tests) ──────────
+
+// legacyDDLWithoutLocalOnly is a snapshot of the observations table DDL
+// before the local_only column was added. It is the base for testing that
+// addColumnIfNotExists runs cleanly on upgrade.
+//
+// This is NOT the full DB DDL — just the minimal schema needed to seed
+// observations for the migration test. New() / migrate() adds the rest.
+const legacyDDLWithoutLocalOnly = `
+	CREATE TABLE IF NOT EXISTS sessions (
+		id         TEXT PRIMARY KEY,
+		project    TEXT NOT NULL DEFAULT '',
+		directory  TEXT NOT NULL DEFAULT '',
+		started_at TEXT NOT NULL DEFAULT (datetime('now')),
+		ended_at   TEXT,
+		summary    TEXT
+	);
+
+	CREATE TABLE IF NOT EXISTS observations (
+		id              INTEGER PRIMARY KEY AUTOINCREMENT,
+		sync_id         TEXT,
+		session_id      TEXT    NOT NULL,
+		type            TEXT    NOT NULL,
+		title           TEXT    NOT NULL,
+		content         TEXT    NOT NULL,
+		tool_name       TEXT,
+		project         TEXT,
+		scope           TEXT    NOT NULL DEFAULT 'project',
+		topic_key       TEXT,
+		normalized_hash TEXT,
+		revision_count  INTEGER NOT NULL DEFAULT 1,
+		duplicate_count INTEGER NOT NULL DEFAULT 1,
+		last_seen_at    TEXT,
+		pinned          BOOLEAN NOT NULL DEFAULT 0,
+		created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+		updated_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+		deleted_at      TEXT,
+		FOREIGN KEY (session_id) REFERENCES sessions(id)
+	);
+`
+
+// TestMigration_LocalOnly_ColumnAddedFromPreLocalOnlySchema opens a DB without
+// the local_only column, inserts rows, then calls New() to trigger migrate() and
+// confirms the column is present and all existing rows default to 0.
+func TestMigration_LocalOnly_ColumnAddedFromPreLocalOnlySchema(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "engram.db")
+
+	// 1. Open raw DB with the legacy schema (no local_only column).
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	if _, err := raw.Exec("PRAGMA journal_mode = WAL"); err != nil {
+		raw.Close()
+		t.Fatalf("WAL pragma: %v", err)
+	}
+	if _, err := raw.Exec("PRAGMA foreign_keys = ON"); err != nil {
+		raw.Close()
+		t.Fatalf("foreign_keys pragma: %v", err)
+	}
+	if _, err := raw.Exec(legacyDDLWithoutLocalOnly); err != nil {
+		raw.Close()
+		t.Fatalf("apply legacy DDL: %v", err)
+	}
+
+	// 2. Insert one row that should receive local_only=0 after migration.
+	if _, err := raw.Exec(
+		`INSERT INTO sessions (id, project, directory) VALUES ('ses-pre-local', 'pre-local', '/tmp')`,
+	); err != nil {
+		raw.Close()
+		t.Fatalf("insert session: %v", err)
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO observations (sync_id, session_id, type, title, content, scope)
+		 VALUES ('obs-pre-local-001', 'ses-pre-local', 'decision', 'Pre-local title', 'Pre-local content', 'project')`,
+	); err != nil {
+		raw.Close()
+		t.Fatalf("insert observation: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw db: %v", err)
+	}
+
+	// 3. Open via New() — this runs migrate().
+	cfg := mustDefaultConfig(t)
+	cfg.DataDir = dir
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New(cfg) after legacy schema: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	// 4. Confirm local_only column is present and the row defaults to 0.
+	var localOnly int
+	if err := s.db.QueryRow(
+		`SELECT ifnull(local_only, 0) FROM observations WHERE sync_id = 'obs-pre-local-001'`,
+	).Scan(&localOnly); err != nil {
+		t.Fatalf("select local_only: %v", err)
+	}
+	if localOnly != 0 {
+		t.Errorf("expected local_only=0 after migration, got %d", localOnly)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -101,6 +101,7 @@ type Observation struct {
 	LastSeenAt     *string `json:"last_seen_at,omitempty"`
 	ReviewAfter    *string `json:"review_after,omitempty"`
 	Pinned         bool    `json:"-"`
+	LocalOnly      bool    `json:"local_only,omitempty"`
 	CreatedAt      string  `json:"created_at"`
 	UpdatedAt      string  `json:"updated_at"`
 	DeletedAt      *string `json:"deleted_at,omitempty"`
@@ -191,6 +192,10 @@ type AddObservationParams struct {
 	Project   string `json:"project,omitempty"`
 	Scope     string `json:"scope,omitempty"`
 	TopicKey  string `json:"topic_key,omitempty"`
+	// LocalOnly prevents this observation from being enqueued for cloud sync.
+	// When an already-synced observation is updated with LocalOnly=true, a delete
+	// tombstone is enqueued so the cloud copy is removed.
+	LocalOnly bool `json:"local_only,omitempty"`
 }
 
 type UpdateObservationParams struct {
@@ -254,7 +259,7 @@ var decayReviewAfterMonths = map[string]int{
 }
 
 const observationSelectColumns = `id, ifnull(sync_id, '') as sync_id, session_id, type, title, content, tool_name, project,
-	       scope, topic_key, revision_count, duplicate_count, last_seen_at, review_after, pinned, created_at, updated_at, deleted_at`
+	       scope, topic_key, revision_count, duplicate_count, last_seen_at, review_after, pinned, ifnull(local_only, 0) as local_only, created_at, updated_at, deleted_at`
 
 type SyncState struct {
 	TargetKey           string  `json:"target_key"`
@@ -893,6 +898,12 @@ func (s *Store) migrate() error {
 		if err := s.addColumnIfNotExists("observations", c.name, c.definition); err != nil {
 			return err
 		}
+	}
+
+	// ── local_only: per-memory cloud-sync opt-out ────────────────────────────
+	// Default 0 (sync enabled) — existing rows keep syncing; backward compatible.
+	if err := s.addColumnIfNotExists("observations", "local_only", "BOOLEAN NOT NULL DEFAULT 0"); err != nil {
+		return err
 	}
 
 	// ── Phase: memory-conflict-surfacing — B.2 ──────────────────────────────
@@ -2279,6 +2290,11 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 				topicKey, nullableString(p.Project), scope,
 			).Scan(&existingID)
 			if err == nil {
+				// Read existing to detect local_only flip before overwriting.
+				existingObs, err := s.getObservationTx(tx, existingID)
+				if err != nil {
+					return err
+				}
 				if _, err := s.execHook(tx,
 					`UPDATE observations
 					 SET type = ?,
@@ -2287,6 +2303,7 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 					     tool_name = ?,
 					     topic_key = ?,
 					     normalized_hash = ?,
+					     local_only = ?,
 					     revision_count = revision_count + 1,
 					     last_seen_at = datetime('now'),
 					     updated_at = datetime('now')
@@ -2297,6 +2314,7 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 					nullableString(p.ToolName),
 					nullableString(topicKey),
 					normHash,
+					p.LocalOnly,
 					existingID,
 				); err != nil {
 					return err
@@ -2306,6 +2324,19 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 					return err
 				}
 				observationID = existingID
+				// local_only flip false→true: tombstone the cloud copy.
+				if !existingObs.LocalOnly && p.LocalOnly {
+					return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpDelete, syncObservationPayload{
+						SyncID:    obs.SyncID,
+						SessionID: obs.SessionID,
+						Project:   obs.Project,
+						Deleted:   true,
+					})
+				}
+				// local_only: skip cloud sync.
+				if p.LocalOnly {
+					return nil
+				}
 				return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpUpsert, observationPayloadFromObservation(obs))
 			}
 			if err != sql.ErrNoRows {
@@ -2329,12 +2360,19 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 			normHash, nullableString(p.Project), scope, p.Type, title, window,
 		).Scan(&existingID)
 		if err == nil {
+			// Read existing to detect local_only flip before overwriting.
+			existingObs, err := s.getObservationTx(tx, existingID)
+			if err != nil {
+				return err
+			}
 			if _, err := s.execHook(tx,
 				`UPDATE observations
 				 SET duplicate_count = duplicate_count + 1,
+				     local_only = ?,
 				     last_seen_at = datetime('now'),
 				     updated_at = datetime('now')
 				 WHERE id = ?`,
+				p.LocalOnly,
 				existingID,
 			); err != nil {
 				return err
@@ -2344,6 +2382,19 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 				return err
 			}
 			observationID = existingID
+			// local_only flip false→true: tombstone the cloud copy.
+			if !existingObs.LocalOnly && p.LocalOnly {
+				return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpDelete, syncObservationPayload{
+					SyncID:    obs.SyncID,
+					SessionID: obs.SessionID,
+					Project:   obs.Project,
+					Deleted:   true,
+				})
+			}
+			// local_only: skip cloud sync.
+			if p.LocalOnly {
+				return nil
+			}
 			return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpUpsert, observationPayloadFromObservation(obs))
 		}
 		if err != sql.ErrNoRows {
@@ -2352,10 +2403,10 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 
 		syncID := newSyncID("obs")
 		res, err := s.execHook(tx,
-			`INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, revision_count, duplicate_count, last_seen_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, datetime('now'), datetime('now'))`,
+			`INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, local_only, revision_count, duplicate_count, last_seen_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, datetime('now'), datetime('now'))`,
 			syncID, p.SessionID, p.Type, title, content,
-			nullableString(p.ToolName), nullableString(p.Project), scope, nullableString(topicKey), normHash,
+			nullableString(p.ToolName), nullableString(p.Project), scope, nullableString(topicKey), normHash, p.LocalOnly,
 		)
 		if err != nil {
 			return err
@@ -2381,6 +2432,10 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 		obs, err = s.getObservationTx(tx, observationID)
 		if err != nil {
 			return err
+		}
+		// local_only: skip cloud sync for this observation.
+		if p.LocalOnly {
+			return nil
 		}
 		return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpUpsert, observationPayloadFromObservation(obs))
 	})
@@ -6053,7 +6108,7 @@ func scanObservationRow(scanner observationScanner, o *Observation) error {
 	return scanner.Scan(
 		&o.ID, &o.SyncID, &o.SessionID, &o.Type, &o.Title, &o.Content,
 		&o.ToolName, &o.Project, &o.Scope, &o.TopicKey, &o.RevisionCount, &o.DuplicateCount, &o.LastSeenAt, &o.ReviewAfter,
-		&o.Pinned, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
+		&o.Pinned, &o.LocalOnly, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt,
 	)
 }
 


### PR DESCRIPTION
## Summary

Two opt-in, backward-compatible features for safer memory handling, especially for teams syncing to a shared cloud:

1. **Sensitive-data scrub at the ingestion boundary** — stop secrets/PII/cardholder data from ever being persisted or indexed.
2. **Per-memory `local_only` flag** — let a memory be marked local-only so it never syncs (with a cloud tombstone if it was already synced).

Both default to existing behavior; nothing changes unless you opt in.

## 1. Ingestion scrub (`ENGRAM_SCRUB`)

A deterministic scrubber runs in the cloud mutation-push handler **before** `InsertMutationBatch` (and therefore before FTS5 indexing), so flagged data is never stored or made searchable. Findings carry no matched value, so logging/auditing is safe.

Modes (env `ENGRAM_SCRUB`, default `off`):

| Mode | Behavior |
|------|----------|
| `off` | no scanning (default) |
| `warn` | scan + log, never block |
| `strict` | block on **high-confidence** findings; log heuristic ones |
| `paranoid` | block on **any** finding |

**Confidence tiers** are the core idea: a 40-hex git SHA is structurally identical to a 40-hex secret, so entropy/hex/ID detectors are inherently false-positive-prone. They are tiered `heuristic` (logged in strict, never blocking legit dev notes), while Luhn-validated PANs, private keys, JWTs, provider tokens, connection strings, etc. are `high` and block in strict.

**Deployment-specific patterns** (internal ID prefixes, proprietary field names) load from a private config file via `ENGRAM_SCRUB_PATTERNS`, so organization specifics never live in this repo.

Detectors include: Luhn PAN (with separator/padding/full-width-digit evasion handling), track2, contextual CVV, generic card field names, private keys, JWT, AWS keys, well-known provider token prefixes, connection strings, bearer tokens, key=value secrets, email, RFC, CURP, CLABE, Mongo ObjectId, plus Shannon-entropy and long-hex heuristics.

## 2. `local_only` memories

- New `local_only` boolean column (default `false`; additive, backward-compatible migration).
- `mem_save` accepts `local_only: true`.
- `local_only` memories are never enqueued for cloud sync.
- Flipping an already-synced memory to `local_only` emits a **delete tombstone** so the cloud copy is removed and the deletion propagates to other clients on their next pull.

## Tests & evidence

New table-driven tests; all green (`go test ./internal/scrub/ ./internal/cloud/cloudserver/ ./internal/store/ ./internal/mcp/`).

- **Adversarial battery** asserts the security contract: every PAN evasion (dot/dash/space separators, leading padding, letter-glued, full-width digits) blocks `strict`; high-confidence secrets/PII block `strict`; shape-ambiguous heuristics (64-hex, base64, RFC, phone, CLABE, ObjectId) block only `paranoid`.
- **False-positive battery** asserts legit dev content (git SHAs, sha256 digests, UUIDs, internal-looking URLs, topic-key slugs) never blocks `strict`.
- **Custom-pattern test** proves config-loaded org patterns work, using a fictional `acme_` example (no real org data in the repo).
- `local_only` tests cover: no sync enqueue when set, normal sync by default, tombstone on flip, and a clean migration on a legacy DB.

## Notes

- Fully opt-in; `ENGRAM_SCRUB` unset and `local_only` unset reproduce current behavior exactly.
- The scrub is defense-in-depth to reduce accidental leakage — not a compliance boundary on its own. Limitations (e.g. standalone CVV is undetectable by shape) are documented in the `scrub` package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **local-only** save option for observations, so content can be kept on-device without syncing to cloud storage.
  * Added configurable sensitive-data scanning with support for custom pattern rules.

* **Bug Fixes**
  * Prevents sensitive content from being stored or synced when protection is enabled.
  * Improved handling when existing synced items are switched to local-only, including remote removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->