### PR TITLE
feat: auto-save hooks for SessionEnd and PostToolUse events (#547)

### DIFF
--- a/internal/mcp/autosave.go
+++ b/internal/mcp/autosave.go
@@ -1,0 +1,238 @@
+// Package mcp — auto-save hook implementations.
+//
+// Auto-save hooks reduce the burden on agents to explicitly call mem_save or
+// mem_session_summary. When enabled, Engram automatically persists a
+// consolidation observation on session end, and can optionally scan tool
+// results for extractable learnings after every tool call.
+//
+// # Configuration
+//
+// Auto-save is controlled by AutoSaveConfig inside MCPConfig:
+//
+//	cfg := MCPConfig{
+//	    AutoSave: AutoSaveConfig{
+//	        Enabled:  true,
+//	        Triggers: []string{"session_end"},  // default when Enabled=true
+//	    },
+//	}
+//
+// Valid trigger values:
+//
+//	"session_end"    — consolidate and save on mem_session_end (default)
+//	"post_tool_use"  — scan every tool result for "## Key Learnings:" sections
+//
+// # Tagging
+//
+// Auto-saved observations carry ToolName="auto" so they are distinguishable
+// from explicit agent saves:
+//
+//	obs.ToolName == "auto"
+//
+// # Deduplication
+//
+// Session-end saves use a topic_key ("auto-save/session-end/<sessionID>") so
+// that calling mem_session_end twice for the same session upserts rather than
+// creates a duplicate. Post-tool-use saves delegate to PassiveCapture which
+// uses the normalized_hash column for content dedup.
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/Gentleman-Programming/engram/internal/store"
+	mcppkg "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// AutoSaveConfig controls automatic memory persistence on session lifecycle
+// events and tool completions.
+type AutoSaveConfig struct {
+	// Enabled turns auto-save on. Default: false.
+	Enabled bool `json:"enabled"`
+
+	// Triggers lists the events that trigger an auto-save.
+	// Valid values: "session_end", "post_tool_use".
+	// When Enabled is true and Triggers is empty, "session_end" is assumed.
+	Triggers []string `json:"triggers,omitempty"`
+}
+
+const (
+	// autoSaveSource is the ToolName tag written on auto-saved observations.
+	autoSaveSource = "auto"
+
+	// Trigger name constants.
+	autoSaveTriggerSessionEnd  = "session_end"
+	autoSaveTriggerPostToolUse = "post_tool_use"
+
+	// autoSaveTopicKeyPrefix is prepended to the session ID to form the
+	// topic_key used for session-end auto-saves.
+	autoSaveTopicKeyPrefix = "auto-save/session-end/"
+
+	// autoSaveMaxObservations caps how many session observations are included
+	// in a session-end consolidation summary.
+	autoSaveMaxObservations = 50
+)
+
+// hasTrigger reports whether cfg has the given trigger active.
+// When Enabled is true and Triggers is empty, only "session_end" is implied.
+func hasTrigger(cfg AutoSaveConfig, trigger string) bool {
+	if !cfg.Enabled {
+		return false
+	}
+	if len(cfg.Triggers) == 0 {
+		return trigger == autoSaveTriggerSessionEnd
+	}
+	for _, t := range cfg.Triggers {
+		if t == trigger {
+			return true
+		}
+	}
+	return false
+}
+
+// performSessionEndAutoSave saves a brief consolidation observation when a
+// session ends. It collects the session's observations, groups them by type,
+// and persists a structured summary tagged with source="auto".
+//
+// The save is idempotent: it uses a topic_key derived from the session ID so
+// that a second call (e.g. if the hook fires twice) upserts the existing row
+// rather than creating a duplicate.
+//
+// Returns nil without saving when the session has no observations.
+func performSessionEndAutoSave(s *store.Store, sessionID, project string) error {
+	observations, err := s.SessionObservations(sessionID, autoSaveMaxObservations)
+	if err != nil {
+		return fmt.Errorf("auto-save session-end: list observations: %w", err)
+	}
+	if len(observations) == 0 {
+		return nil
+	}
+
+	content := buildAutoSaveContent(sessionID, observations)
+	topicKey := autoSaveTopicKeyPrefix + sessionID
+	title := fmt.Sprintf("Auto-save: session %s (%d observations)", sessionID, len(observations))
+
+	_, err = s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "session_summary",
+		Title:     title,
+		Content:   content,
+		Project:   project,
+		Scope:     "project",
+		TopicKey:  topicKey,
+		ToolName:  autoSaveSource,
+	})
+	if err != nil {
+		return fmt.Errorf("auto-save session-end: save: %w", err)
+	}
+	return nil
+}
+
+// buildAutoSaveContent constructs the content for a session-end auto-save
+// observation. It groups observations by type and lists their titles.
+func buildAutoSaveContent(sessionID string, observations []store.Observation) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "## Auto-consolidated session summary\n\n")
+	fmt.Fprintf(&b, "Session: %s\n", sessionID)
+	fmt.Fprintf(&b, "Observations captured: %d\n\n", len(observations))
+
+	// Group by type and collect unique type names for deterministic output.
+	byType := make(map[string][]store.Observation)
+	var types []string
+	seen := make(map[string]bool)
+	for _, obs := range observations {
+		// Skip other auto-saves to avoid circular references.
+		if obs.ToolName != nil && *obs.ToolName == autoSaveSource {
+			continue
+		}
+		if !seen[obs.Type] {
+			seen[obs.Type] = true
+			types = append(types, obs.Type)
+		}
+		byType[obs.Type] = append(byType[obs.Type], obs)
+	}
+
+	// Sort types for deterministic output.
+	sort.Strings(types)
+
+	for _, typ := range types {
+		obsList := byType[typ]
+		fmt.Fprintf(&b, "### %s (%d)\n", typ, len(obsList))
+		for _, obs := range obsList {
+			fmt.Fprintf(&b, "- %s\n", obs.Title)
+		}
+		b.WriteString("\n")
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+// wrapWithPostToolUseCapture returns a ToolHandlerFunc that invokes h and,
+// after a successful (non-error) result, scans the response text for
+// "## Key Learnings:" sections. Any extracted items are persisted via
+// PassiveCapture (which deduplicates via normalized_hash).
+//
+// When the post_tool_use trigger is not enabled, h is returned unchanged.
+// Auto-save failures are logged to stderr but never propagate to the caller —
+// tool results are always returned intact.
+func wrapWithPostToolUseCapture(h server.ToolHandlerFunc, s *store.Store, cfg MCPConfig) server.ToolHandlerFunc {
+	if !hasTrigger(cfg.AutoSave, autoSaveTriggerPostToolUse) {
+		return h
+	}
+
+	return func(ctx context.Context, req mcppkg.CallToolRequest) (*mcppkg.CallToolResult, error) {
+		result, err := h(ctx, req)
+		if err != nil || result == nil || result.IsError {
+			// Don't scan error results — they're unlikely to contain learnings
+			// and we don't want to mask the original error.
+			return result, err
+		}
+
+		// Collect text content from the result.
+		var text strings.Builder
+		for _, content := range result.Content {
+			if tc, ok := mcppkg.AsTextContent(content); ok {
+				text.WriteString(tc.Text)
+				text.WriteString("\n")
+			}
+		}
+		raw := text.String()
+		if strings.TrimSpace(raw) == "" {
+			return result, nil
+		}
+
+		// Only proceed when a Key Learnings section is present — avoids
+		// unnecessary store queries for the common case.
+		if len(store.ExtractLearnings(raw)) == 0 {
+			return result, nil
+		}
+
+		// Resolve project for the capture. Tolerant: failures are non-fatal.
+		detRes, detErr := resolveWriteProjectWithProcessOverride(cfg.DefaultProject)
+		if detErr != nil {
+			fmt.Fprintf(os.Stderr, "engram: auto-save post-tool-use: project resolution failed: %v\n", detErr)
+			return result, nil
+		}
+		project, _ := store.NormalizeProject(detRes.Project)
+		sessionID := resolveFallbackSessionID(s, project)
+
+		captureResult, captureErr := s.PassiveCapture(store.PassiveCaptureParams{
+			SessionID: sessionID,
+			Content:   raw,
+			Project:   project,
+			Source:    autoSaveSource,
+		})
+		if captureErr != nil {
+			fmt.Fprintf(os.Stderr, "engram: auto-save post-tool-use: passive capture failed: %v\n", captureErr)
+		} else if captureResult != nil && captureResult.Saved > 0 {
+			fmt.Fprintf(os.Stderr, "engram: auto-save: captured %d learnings from tool result\n", captureResult.Saved)
+		}
+
+		return result, nil
+	}
+}

--- a/internal/mcp/autosave.go
+++ b/internal/mcp/autosave.go
@@ -108,15 +108,27 @@ func performSessionEndAutoSave(s *store.Store, sessionID, project string) error 
 	if err != nil {
 		return fmt.Errorf("auto-save session-end: list observations: %w", err)
 	}
-	if len(observations) == 0 {
+
+	// Count only the subset that buildAutoSaveContent will actually render
+	// (skipping prior auto-saves and personal-scope entries) so the no-op check
+	// and title reflect the saved content, not the raw fetch count.
+	n := 0
+	for _, obs := range observations {
+		if obs.ToolName != nil && *obs.ToolName == autoSaveSource {
+			continue
+		}
+		if obs.Scope == "personal" {
+			continue
+		}
+		n++
+	}
+	if n == 0 {
 		return nil
 	}
 
 	content := buildAutoSaveContent(sessionID, observations)
 	topicKey := autoSaveTopicKeyPrefix + sessionID
-	// len(observations) may be capped at autoSaveMaxObservations; the title
-	// reflects the fetched count, not necessarily the total session count.
-	title := fmt.Sprintf("Auto-save: session %s (%d observations)", sessionID, len(observations))
+	title := fmt.Sprintf("Auto-save: session %s (%d observations)", sessionID, n)
 
 	_, err = s.AddObservation(store.AddObservationParams{
 		SessionID: sessionID,

--- a/internal/mcp/autosave.go
+++ b/internal/mcp/autosave.go
@@ -152,6 +152,11 @@ func buildAutoSaveContent(sessionID string, observations []store.Observation) st
 		if obs.ToolName != nil && *obs.ToolName == autoSaveSource {
 			continue
 		}
+		// Skip personal-scope observations so they are never republished into
+		// project scope via the session-end consolidation summary.
+		if obs.Scope == "personal" {
+			continue
+		}
 		if !seen[obs.Type] {
 			seen[obs.Type] = true
 			types = append(types, obs.Type)

--- a/internal/mcp/autosave.go
+++ b/internal/mcp/autosave.go
@@ -114,6 +114,8 @@ func performSessionEndAutoSave(s *store.Store, sessionID, project string) error 
 
 	content := buildAutoSaveContent(sessionID, observations)
 	topicKey := autoSaveTopicKeyPrefix + sessionID
+	// len(observations) may be capped at autoSaveMaxObservations; the title
+	// reflects the fetched count, not necessarily the total session count.
 	title := fmt.Sprintf("Auto-save: session %s (%d observations)", sessionID, len(observations))
 
 	_, err = s.AddObservation(store.AddObservationParams{

--- a/internal/mcp/autosave_test.go
+++ b/internal/mcp/autosave_test.go
@@ -142,6 +142,67 @@ func TestPerformSessionEndAutoSaveNoObservations(t *testing.T) {
 	}
 }
 
+func TestPerformSessionEndAutoSaveAllFilteredOutNoSave(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("all-filtered-sess", "filtered-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	autoSource := autoSaveSource
+
+	// Add only auto-save observations and personal-scope observations — both are
+	// filtered out by buildAutoSaveContent, so the no-op check should catch them.
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "all-filtered-sess",
+		Type:      "session_summary",
+		Title:     "Previous auto-save",
+		Content:   "An existing auto-save that should be skipped.",
+		Project:   "filtered-proj",
+		Scope:     "project",
+		ToolName:  &autoSource,
+	})
+	if err != nil {
+		t.Fatalf("add auto-save observation: %v", err)
+	}
+	_, err = s.AddObservation(store.AddObservationParams{
+		SessionID: "all-filtered-sess",
+		Type:      "note",
+		Title:     "Private note",
+		Content:   "Personal-scope content that must never be republished.",
+		Project:   "filtered-proj",
+		Scope:     "personal",
+	})
+	if err != nil {
+		t.Fatalf("add personal-scope observation: %v", err)
+	}
+
+	// performSessionEndAutoSave must return nil without creating a new observation.
+	if err := performSessionEndAutoSave(s, "all-filtered-sess", "filtered-proj"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs, err := s.AllObservations("filtered-proj", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	// Only the 1 original auto-save (project scope) — no new auto-save created.
+	for _, o := range obs {
+		if o.ToolName == nil || *o.ToolName != autoSaveSource {
+			t.Fatalf("unexpected non-auto observation created when all input was filtered: %+v", o)
+		}
+	}
+	// Count of new auto-saves should not have grown.
+	newAutoSaves := 0
+	for _, o := range obs {
+		if o.ToolName != nil && *o.ToolName == autoSaveSource && o.Title != "Previous auto-save" {
+			newAutoSaves++
+		}
+	}
+	if newAutoSaves != 0 {
+		t.Fatalf("expected no new auto-save observation when all inputs are filtered, got %d", newAutoSaves)
+	}
+}
+
 func TestPerformSessionEndAutoSaveCreatesConsolidationObservation(t *testing.T) {
 	s := newMCPTestStore(t)
 	if err := s.CreateSession("sess-abc", "proj-x", "/tmp"); err != nil {

--- a/internal/mcp/autosave_test.go
+++ b/internal/mcp/autosave_test.go
@@ -104,6 +104,22 @@ func TestBuildAutoSaveContentSkipsAutoSavedObservations(t *testing.T) {
 	}
 }
 
+func TestBuildAutoSaveContentSkipsPersonalScopeObservations(t *testing.T) {
+	observations := []store.Observation{
+		{Type: "decision", Title: "Public decision", Scope: "project"},
+		{Type: "note", Title: "Private note", Scope: "personal"},
+	}
+
+	content := buildAutoSaveContent("sess-scope", observations)
+
+	if strings.Contains(content, "Private note") {
+		t.Fatalf("content must NOT include personal-scope titles, got: %q", content)
+	}
+	if !strings.Contains(content, "Public decision") {
+		t.Fatalf("content should include project-scope titles, got: %q", content)
+	}
+}
+
 // ─── performSessionEndAutoSave ────────────────────────────────────────────────
 
 func TestPerformSessionEndAutoSaveNoObservations(t *testing.T) {
@@ -305,6 +321,123 @@ func TestHandleSessionEndTriggersAutoSaveWhenEnabled(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected an auto-save observation after session-end, got observations: %v", obs)
+	}
+}
+
+func TestHandleSessionEndAutoSaveUsesSessionProject(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	const sessID = "sess-proj-pref"
+	const sessProj = "explicit-session-project"
+
+	if err := s.CreateSession(sessID, sessProj, "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessID,
+		Type:      "decision",
+		Title:     "Prefer session project for auto-save",
+		Content:   "The session's registered project should take precedence over CWD detection.",
+		Project:   sessProj,
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	cfg := MCPConfig{
+		AutoSave: AutoSaveConfig{
+			Enabled:  true,
+			Triggers: []string{autoSaveTriggerSessionEnd},
+		},
+	}
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSessionEnd(s, cfg, activity)
+
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":      sessID,
+		"summary": "session ended",
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", callResultText(t, res))
+	}
+
+	// Auto-save must land in the session's own project, not whatever CWD detection returned.
+	obs, err := s.AllObservations(sessProj, "project", 100)
+	if err != nil {
+		t.Fatalf("list observations for %q: %v", sessProj, err)
+	}
+	var autoObs *store.Observation
+	for i := range obs {
+		if obs[i].ToolName != nil && *obs[i].ToolName == autoSaveSource {
+			autoObs = &obs[i]
+			break
+		}
+	}
+	if autoObs == nil {
+		t.Fatalf("expected auto-save observation in session project %q", sessProj)
+	}
+	if autoObs.Project == nil || *autoObs.Project != sessProj {
+		t.Fatalf("auto-save observation Project: want %q, got %v", sessProj, autoObs.Project)
+	}
+}
+
+func TestHandleSessionEndAutoSaveErrorIsSwallowed(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	const sessID = "sess-autosave-fail"
+	const sessProj = "fail-proj"
+
+	if err := s.CreateSession(sessID, sessProj, "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessID,
+		Type:      "decision",
+		Title:     "Some decision",
+		Content:   "Content of the decision.",
+		Project:   sessProj,
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	// Sabotage the observations table so performSessionEndAutoSave returns an error.
+	// EndSession only touches the sessions and sync_mutations tables, so it still succeeds.
+	if _, dbErr := s.DB().Exec("DROP TABLE observations"); dbErr != nil {
+		t.Fatalf("drop observations table: %v", dbErr)
+	}
+
+	cfg := MCPConfig{
+		AutoSave: AutoSaveConfig{
+			Enabled:  true,
+			Triggers: []string{autoSaveTriggerSessionEnd},
+		},
+	}
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSessionEnd(s, cfg, activity)
+
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":      sessID,
+		"summary": "session ended",
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler must not propagate a Go error when auto-save fails: %v", err)
+	}
+	if res == nil || res.IsError {
+		got := "<nil result>"
+		if res != nil {
+			got = callResultText(t, res)
+		}
+		t.Fatalf("handler must return a success MCP result even when auto-save fails; got IsError=true: %s", got)
 	}
 }
 

--- a/internal/mcp/autosave_test.go
+++ b/internal/mcp/autosave_test.go
@@ -1,0 +1,545 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gentleman-Programming/engram/internal/store"
+	mcppkg "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// ─── hasTrigger ──────────────────────────────────────────────────────────────
+
+func TestHasTriggerDisabledReturnsFalse(t *testing.T) {
+	cfg := AutoSaveConfig{Enabled: false}
+	if hasTrigger(cfg, autoSaveTriggerSessionEnd) {
+		t.Fatal("expected false when Enabled=false")
+	}
+	if hasTrigger(cfg, autoSaveTriggerPostToolUse) {
+		t.Fatal("expected false when Enabled=false")
+	}
+}
+
+func TestHasTriggerEnabledEmptyTriggersDefaultsToSessionEnd(t *testing.T) {
+	cfg := AutoSaveConfig{Enabled: true}
+	if !hasTrigger(cfg, autoSaveTriggerSessionEnd) {
+		t.Fatal("expected session_end to be implied when Triggers is empty")
+	}
+	if hasTrigger(cfg, autoSaveTriggerPostToolUse) {
+		t.Fatal("expected post_tool_use to be absent when Triggers is empty")
+	}
+}
+
+func TestHasTriggerExplicitTriggers(t *testing.T) {
+	cfg := AutoSaveConfig{
+		Enabled:  true,
+		Triggers: []string{autoSaveTriggerPostToolUse},
+	}
+	if hasTrigger(cfg, autoSaveTriggerSessionEnd) {
+		t.Fatal("session_end should not be active when not in Triggers list")
+	}
+	if !hasTrigger(cfg, autoSaveTriggerPostToolUse) {
+		t.Fatal("post_tool_use should be active")
+	}
+}
+
+func TestHasTriggerBothTriggers(t *testing.T) {
+	cfg := AutoSaveConfig{
+		Enabled:  true,
+		Triggers: []string{autoSaveTriggerSessionEnd, autoSaveTriggerPostToolUse},
+	}
+	if !hasTrigger(cfg, autoSaveTriggerSessionEnd) {
+		t.Fatal("session_end should be active")
+	}
+	if !hasTrigger(cfg, autoSaveTriggerPostToolUse) {
+		t.Fatal("post_tool_use should be active")
+	}
+}
+
+// ─── buildAutoSaveContent ─────────────────────────────────────────────────────
+
+func TestBuildAutoSaveContentGroupsByType(t *testing.T) {
+	observations := []store.Observation{
+		{Type: "decision", Title: "Use JWT for auth"},
+		{Type: "bugfix", Title: "Fix N+1 query"},
+		{Type: "decision", Title: "Chose SQLite over Postgres"},
+	}
+
+	content := buildAutoSaveContent("sess-001", observations)
+
+	if !strings.Contains(content, "session: sess-001") && !strings.Contains(content, "Session: sess-001") {
+		t.Fatalf("content should include session ID, got: %q", content)
+	}
+	if !strings.Contains(content, "decision") {
+		t.Fatalf("content should include type 'decision', got: %q", content)
+	}
+	if !strings.Contains(content, "bugfix") {
+		t.Fatalf("content should include type 'bugfix', got: %q", content)
+	}
+	if !strings.Contains(content, "Use JWT for auth") {
+		t.Fatalf("content should include observation title, got: %q", content)
+	}
+	if !strings.Contains(content, "Fix N+1 query") {
+		t.Fatalf("content should include observation title, got: %q", content)
+	}
+}
+
+func TestBuildAutoSaveContentSkipsAutoSavedObservations(t *testing.T) {
+	autoSource := autoSaveSource
+	observations := []store.Observation{
+		{Type: "session_summary", Title: "Previous auto-save", ToolName: &autoSource},
+		{Type: "decision", Title: "Real decision"},
+	}
+
+	content := buildAutoSaveContent("sess-001", observations)
+
+	if strings.Contains(content, "Previous auto-save") {
+		t.Fatalf("content should NOT include previous auto-save titles, got: %q", content)
+	}
+	if !strings.Contains(content, "Real decision") {
+		t.Fatalf("content should include non-auto-save titles, got: %q", content)
+	}
+}
+
+// ─── performSessionEndAutoSave ────────────────────────────────────────────────
+
+func TestPerformSessionEndAutoSaveNoObservations(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("empty-sess", "testproject", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Should not save anything — no observations in session.
+	if err := performSessionEndAutoSave(s, "empty-sess", "testproject"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs, err := s.AllObservations("testproject", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Fatalf("expected 0 observations, got %d", len(obs))
+	}
+}
+
+func TestPerformSessionEndAutoSaveCreatesConsolidationObservation(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("sess-abc", "proj-x", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Add a couple of observations to the session.
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "sess-abc",
+		Type:      "decision",
+		Title:     "Use gRPC",
+		Content:   "We decided to use gRPC for service communication.",
+		Project:   "proj-x",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	_, err = s.AddObservation(store.AddObservationParams{
+		SessionID: "sess-abc",
+		Type:      "bugfix",
+		Title:     "Fix race condition",
+		Content:   "Fixed a race condition in the request handler.",
+		Project:   "proj-x",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	if err := performSessionEndAutoSave(s, "sess-abc", "proj-x"); err != nil {
+		t.Fatalf("auto-save: %v", err)
+	}
+
+	obs, err := s.AllObservations("proj-x", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+
+	// Expect 2 original + 1 auto-save = 3 total.
+	if len(obs) != 3 {
+		t.Fatalf("expected 3 observations (2 original + 1 auto-save), got %d", len(obs))
+	}
+
+	// Find the auto-save observation.
+	var autoSaveObs *store.Observation
+	for i := range obs {
+		if obs[i].ToolName != nil && *obs[i].ToolName == autoSaveSource {
+			autoSaveObs = &obs[i]
+			break
+		}
+	}
+	if autoSaveObs == nil {
+		t.Fatalf("expected an observation with ToolName=%q", autoSaveSource)
+	}
+	if autoSaveObs.Type != "session_summary" {
+		t.Fatalf("expected type=session_summary, got %q", autoSaveObs.Type)
+	}
+	if !strings.Contains(autoSaveObs.Content, "Use gRPC") {
+		t.Fatalf("auto-save content should reference observation titles, got: %q", autoSaveObs.Content)
+	}
+	if !strings.Contains(autoSaveObs.Content, "Fix race condition") {
+		t.Fatalf("auto-save content should reference observation titles, got: %q", autoSaveObs.Content)
+	}
+	// topic_key should be set for dedup.
+	if autoSaveObs.TopicKey == nil {
+		t.Fatalf("expected auto-save to have a topic_key for idempotency")
+	}
+	if !strings.HasPrefix(*autoSaveObs.TopicKey, autoSaveTopicKeyPrefix) {
+		t.Fatalf("expected topic_key to start with %q, got %q", autoSaveTopicKeyPrefix, *autoSaveObs.TopicKey)
+	}
+}
+
+func TestPerformSessionEndAutoSaveIsIdempotent(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("sess-dedup", "proj-y", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "sess-dedup",
+		Type:      "decision",
+		Title:     "Idempotency test decision",
+		Content:   "This is the content for the idempotency test.",
+		Project:   "proj-y",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	// Call twice — should upsert, not create two auto-save observations.
+	for i := 0; i < 2; i++ {
+		if err := performSessionEndAutoSave(s, "sess-dedup", "proj-y"); err != nil {
+			t.Fatalf("call %d: auto-save error: %v", i+1, err)
+		}
+	}
+
+	obs, err := s.AllObservations("proj-y", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+
+	// 1 original + 1 auto-save (upserted, not duplicated).
+	if len(obs) != 2 {
+		t.Fatalf("expected 2 observations (idempotent upsert), got %d", len(obs))
+	}
+
+	// Count auto-saves.
+	autoCount := 0
+	for _, o := range obs {
+		if o.ToolName != nil && *o.ToolName == autoSaveSource {
+			autoCount++
+		}
+	}
+	if autoCount != 1 {
+		t.Fatalf("expected exactly 1 auto-save observation (idempotent), got %d", autoCount)
+	}
+}
+
+// ─── handleSessionEnd with auto-save ─────────────────────────────────────────
+
+func TestHandleSessionEndTriggersAutoSaveWhenEnabled(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	// Set up a session with an observation.
+	if err := s.CreateSession("auto-sess-1", "auto-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "auto-sess-1",
+		Type:      "pattern",
+		Title:     "Use table-driven tests",
+		Content:   "Prefer table-driven tests for all handler coverage.",
+		Project:   "auto-proj",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	cfg := MCPConfig{
+		DefaultProject: "auto-proj",
+		AutoSave: AutoSaveConfig{
+			Enabled:  true,
+			Triggers: []string{autoSaveTriggerSessionEnd},
+		},
+	}
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSessionEnd(s, cfg, activity)
+
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":      "auto-sess-1",
+		"summary": "Wrapped up the testing session.",
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", callResultText(t, res))
+	}
+
+	// Verify an auto-save observation was created.
+	obs, err := s.AllObservations("auto-proj", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+
+	var found bool
+	for _, o := range obs {
+		if o.ToolName != nil && *o.ToolName == autoSaveSource {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected an auto-save observation after session-end, got observations: %v", obs)
+	}
+}
+
+func TestHandleSessionEndNoAutoSaveWhenDisabled(t *testing.T) {
+	s := newMCPTestStore(t)
+
+	if err := s.CreateSession("no-auto-sess", "no-auto-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	_, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "no-auto-sess",
+		Type:      "pattern",
+		Title:     "Some pattern",
+		Content:   "Pattern content that should not be auto-saved.",
+		Project:   "no-auto-proj",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	// AutoSave disabled (default).
+	cfg := MCPConfig{DefaultProject: "no-auto-proj"}
+	activity := NewSessionActivity(10 * time.Minute)
+	h := handleSessionEnd(s, cfg, activity)
+
+	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id": "no-auto-sess",
+	}}}
+
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", callResultText(t, res))
+	}
+
+	obs, err := s.AllObservations("no-auto-proj", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+
+	// Only the 1 original observation; no auto-save.
+	if len(obs) != 1 {
+		t.Fatalf("expected 1 observation (no auto-save), got %d", len(obs))
+	}
+	for _, o := range obs {
+		if o.ToolName != nil && *o.ToolName == autoSaveSource {
+			t.Fatalf("unexpected auto-save observation when AutoSave.Enabled=false")
+		}
+	}
+}
+
+// ─── wrapWithPostToolUseCapture ───────────────────────────────────────────────
+
+func TestWrapWithPostToolUseCapturNoOpWhenDisabled(t *testing.T) {
+	s := newMCPTestStore(t)
+	cfg := MCPConfig{} // AutoSave.Enabled=false
+
+	called := false
+	h := server.ToolHandlerFunc(func(ctx context.Context, req mcppkg.CallToolRequest) (*mcppkg.CallToolResult, error) {
+		called = true
+		return mcppkg.NewToolResultText("result"), nil
+	})
+
+	wrapped := wrapWithPostToolUseCapture(h, s, cfg)
+
+	// Wrapped function should be the same pointer when disabled (no-op).
+	// We verify by checking that the original handler is still called and
+	// no passive capture happens.
+	if err := s.CreateSession("wrap-sess", "wrap-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, err := wrapped(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected underlying handler to be called")
+	}
+
+	// No observations should have been created.
+	obs, _ := s.AllObservations("wrap-proj", "project", 100)
+	if len(obs) != 0 {
+		t.Fatalf("expected 0 observations, got %d", len(obs))
+	}
+}
+
+func TestWrapWithPostToolUseCaptureExtractsLearnings(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("ptuse-sess", "ptuse-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	cfg := MCPConfig{
+		DefaultProject: "ptuse-proj",
+		AutoSave: AutoSaveConfig{
+			Enabled:  true,
+			Triggers: []string{autoSaveTriggerPostToolUse},
+		},
+	}
+
+	// Handler that returns a result containing a Key Learnings section.
+	resultText := `Summary of work done.
+
+## Key Learnings:
+1. Always use context cancellation in long-running goroutines to avoid leaks.
+2. The normalized_hash column prevents duplicate observations from being stored.
+`
+	h := server.ToolHandlerFunc(func(ctx context.Context, req mcppkg.CallToolRequest) (*mcppkg.CallToolResult, error) {
+		return mcppkg.NewToolResultText(resultText), nil
+	})
+
+	wrapped := wrapWithPostToolUseCapture(h, s, cfg)
+	_, err := wrapped(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify learnings were captured as observations.
+	obs, err := s.AllObservations("ptuse-proj", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	if len(obs) == 0 {
+		t.Fatalf("expected captured learning observations, got none")
+	}
+
+	// All auto-captures should carry the "auto" tool name.
+	for _, o := range obs {
+		if o.ToolName == nil || *o.ToolName != autoSaveSource {
+			t.Fatalf("expected ToolName=%q, got %v", autoSaveSource, o.ToolName)
+		}
+	}
+}
+
+func TestWrapWithPostToolUseCaptureSkipsErrorResults(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("ptu-err-sess", "ptu-err-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	cfg := MCPConfig{
+		DefaultProject: "ptu-err-proj",
+		AutoSave: AutoSaveConfig{
+			Enabled:  true,
+			Triggers: []string{autoSaveTriggerPostToolUse},
+		},
+	}
+
+	// Handler that returns an error result with a Key Learnings section.
+	h := server.ToolHandlerFunc(func(ctx context.Context, req mcppkg.CallToolRequest) (*mcppkg.CallToolResult, error) {
+		r := mcppkg.NewToolResultError("## Key Learnings:\n1. Error results should not be scanned.")
+		return r, nil
+	})
+
+	wrapped := wrapWithPostToolUseCapture(h, s, cfg)
+	_, err := wrapped(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs, _ := s.AllObservations("ptu-err-proj", "project", 100)
+	if len(obs) != 0 {
+		t.Fatalf("expected 0 observations (error results skipped), got %d", len(obs))
+	}
+}
+
+func TestWrapWithPostToolUseCaptureSkipsResultsWithoutLearnings(t *testing.T) {
+	s := newMCPTestStore(t)
+	cfg := MCPConfig{
+		DefaultProject: "ptu-noop-proj",
+		AutoSave: AutoSaveConfig{
+			Enabled:  true,
+			Triggers: []string{autoSaveTriggerPostToolUse},
+		},
+	}
+
+	h := server.ToolHandlerFunc(func(ctx context.Context, req mcppkg.CallToolRequest) (*mcppkg.CallToolResult, error) {
+		return mcppkg.NewToolResultText("No learnings section here. Just plain text."), nil
+	})
+
+	wrapped := wrapWithPostToolUseCapture(h, s, cfg)
+	_, err := wrapped(context.Background(), mcppkg.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No observations created because no "## Key Learnings:" section exists.
+	if err := s.CreateSession("ptu-noop-sess", "ptu-noop-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obs, _ := s.AllObservations("ptu-noop-proj", "project", 100)
+	if len(obs) != 0 {
+		t.Fatalf("expected 0 observations, got %d", len(obs))
+	}
+}
+
+func TestWrapWithPostToolUseCaptureDeduplicates(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("ptu-dedup-sess", "ptu-dedup-proj", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	cfg := MCPConfig{
+		DefaultProject: "ptu-dedup-proj",
+		AutoSave: AutoSaveConfig{
+			Enabled:  true,
+			Triggers: []string{autoSaveTriggerPostToolUse},
+		},
+	}
+
+	resultText := `## Key Learnings:
+1. Use context.WithTimeout for all outbound HTTP requests to avoid hanging.
+`
+	h := server.ToolHandlerFunc(func(ctx context.Context, req mcppkg.CallToolRequest) (*mcppkg.CallToolResult, error) {
+		return mcppkg.NewToolResultText(resultText), nil
+	})
+	wrapped := wrapWithPostToolUseCapture(h, s, cfg)
+
+	// Call twice with the same content — second call should be a dedup.
+	for i := 0; i < 2; i++ {
+		_, err := wrapped(context.Background(), mcppkg.CallToolRequest{})
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i+1, err)
+		}
+	}
+
+	obs, err := s.AllObservations("ptu-dedup-proj", "project", 100)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	// Only 1 observation — second call deduped via normalized_hash.
+	if len(obs) != 1 {
+		t.Fatalf("expected 1 observation after dedup, got %d", len(obs))
+	}
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -56,6 +56,12 @@ type MCPConfig struct {
 	// mem_save call (REQ-001). nil means "use the store default" (3).
 	// An explicit pointer value (including 0) is forwarded directly.
 	Limit *int
+
+	// AutoSave configures automatic memory persistence on lifecycle events.
+	// When enabled, Engram saves a consolidation observation at session end
+	// (and optionally after tool calls) without requiring explicit agent saves.
+	// See AutoSaveConfig for valid trigger names and deduplication behaviour.
+	AutoSave AutoSaveConfig
 }
 
 var suggestTopicKey = store.SuggestTopicKey
@@ -290,7 +296,7 @@ func registerTools(srv *server.MCPServer, s *store.Store, cfg MCPConfig, allowli
 					mcp.Description("Max results (default: 10, max: 20)"),
 				),
 			),
-			handleSearch(s, cfg, activity),
+			wrapWithPostToolUseCapture(handleSearch(s, cfg, activity), s, cfg),
 		)
 	}
 
@@ -553,7 +559,7 @@ Examples:
 				),
 				// JW7: limit param removed — schema advertised it but handleContext never read it.
 			),
-			handleContext(s, cfg, activity),
+			wrapWithPostToolUseCapture(handleContext(s, cfg, activity), s, cfg),
 		)
 	}
 
@@ -751,7 +757,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 					mcp.Description("Source identifier (e.g. 'subagent-stop', 'session-end')"),
 				),
 			),
-			queuedWriteHandler(writeQueue, handleCapturePassive(s, cfg, activity)),
+			wrapWithPostToolUseCapture(queuedWriteHandler(writeQueue, handleCapturePassive(s, cfg, activity)), s, cfg),
 		)
 	}
 
@@ -1965,6 +1971,23 @@ func handleSessionEnd(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 
 		if err := s.EndSession(id, summary); err != nil {
 			return mcp.NewToolResultError("Failed to end session: " + err.Error()), nil
+		}
+
+		// Auto-save hook: consolidate session observations when configured.
+		// Errors are logged and swallowed — auto-save failure must not block
+		// the session-end response.
+		if hasTrigger(cfg.AutoSave, autoSaveTriggerSessionEnd) {
+			// Prefer the session's registered project over CWD detection so the
+			// auto-save lands in the same project bucket as the session itself.
+			autoSaveProject := project
+			if sess, sessErr := s.GetSession(id); sessErr == nil && sess.Project != "" {
+				if np, _ := store.NormalizeProject(sess.Project); np != "" {
+					autoSaveProject = np
+				}
+			}
+			if autoErr := performSessionEndAutoSave(s, id, autoSaveProject); autoErr != nil {
+				fmt.Fprintf(os.Stderr, "engram: auto-save session-end error (non-fatal): %v\n", autoErr)
+			}
 		}
 
 		activity.ClearSession(defaultSessionID(project))


### PR DESCRIPTION
## Summary

Adds automatic memory persistence so agents don't need to explicitly call save tools to preserve session observations.

**New: `internal/mcp/autosave.go`**
- `AutoSaveConfig` — `Enabled bool`, `Triggers []string` (default: `["session_end"]`)
- `performSessionEndAutoSave` — collects up to 50 session observations, groups by type, saves as a `session_summary` observation tagged `source:auto`. Uses `topic_key = "auto-save/session-end/<sessionID>"` for idempotent upsert
- `buildAutoSaveContent` — formats consolidation content; skips prior auto-save observations to prevent circular references
- `wrapWithPostToolUseCapture` — wraps tool handlers to extract `## Key Learnings:` sections via `PassiveCapture` (deduplicates by normalized hash); zero overhead when disabled

**Modified: `internal/mcp/mcp.go`**
- `MCPConfig.AutoSave AutoSaveConfig` field added
- `handleSessionEnd` — calls `performSessionEndAutoSave` after `EndSession`; errors are swallowed and logged to stderr so session-end never fails
- `registerTools` — wraps `mem_search`, `mem_context`, `mem_capture_passive` with `wrapWithPostToolUseCapture`

**Tests: `internal/mcp/autosave_test.go`** — 16 tests covering config logic, consolidation, idempotency, post-tool-use extraction, error-result skipping, and deduplication

Closes #547

## Test plan
- [ ] End a session with observations → auto-save observation appears in store tagged `source:auto`
- [ ] Call session-end twice → single auto-save observation (upsert, not duplicate)
- [ ] Empty session → no auto-save observation created
- [ ] Session-end never returns an error even if auto-save fails
- [ ] `AutoSave.Enabled = false` → no auto-save, no overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable automatic memory persistence, including session-end observation consolidation and optional “Key Learnings” extraction after supported memory-related tool runs.
  * Session-end autosave can be customized via triggers, with sensible defaults when autosave is enabled.
* **Bug Fixes**
  * Prevents duplicate autosaved entries via idempotent session-summary upserts and deduplicated learning captures.
  * Avoids creating autosaves when there’s nothing eligible to save, skips personal-scope items, and safely ignores autosave persistence issues without affecting the main response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->