### PR TITLE
fix(store/test): fix Windows SQLite teardown race in internal/store

### DIFF
--- a/internal/store/store_migration_test.go
+++ b/internal/store/store_migration_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,7 +32,11 @@ type legacyObsRow struct {
 func newTestStoreWithLegacySchema(t *testing.T, fixtureRows []legacyObsRow) *Store {
 	t.Helper()
 
-	dir := t.TempDir()
+	// os.MkdirTemp (not t.TempDir) — see closeAndRemoveStore in store_test.go.
+	dir, err := os.MkdirTemp("", "engram-legacy-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
 	dbPath := filepath.Join(dir, "engram.db")
 
 	// 1. Open raw DB and apply legacy DDL.
@@ -85,9 +90,10 @@ func newTestStoreWithLegacySchema(t *testing.T, fixtureRows []legacyObsRow) *Sto
 
 	s, err := New(cfg)
 	if err != nil {
+		removeDirWithRetry(dir)
 		t.Fatalf("newTestStoreWithLegacySchema: New(cfg): %v", err)
 	}
-	t.Cleanup(func() { _ = s.Close() })
+	t.Cleanup(func() { closeAndRemoveStore(t, dir, s) })
 
 	return s
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -27,17 +27,55 @@ func mustDefaultConfig(t *testing.T) Config {
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 	cfg := mustDefaultConfig(t)
-	cfg.DataDir = t.TempDir()
+	// os.MkdirTemp (not t.TempDir) so we own the lifecycle; avoids racing with
+	// the testing framework's auto-RemoveAll on Windows SQLite teardown.
+	dir, err := os.MkdirTemp("", "engram-test-")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	cfg.DataDir = dir
 	cfg.DedupeWindow = time.Hour
 
 	s, err := New(cfg)
 	if err != nil {
+		_ = os.RemoveAll(dir)
 		t.Fatalf("new store: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = s.Close()
-	})
+	t.Cleanup(func() { closeAndRemoveStore(t, dir, s) })
 	return s
+}
+
+// closeAndRemoveStore closes the store and best-effort removes its data dir
+// with a retry. This is a Windows SQLite teardown mitigation: even after
+// db.Close(), SQLite may retain the file handle for a noticeable window on
+// Windows, causing the testing framework's auto-TempDir RemoveAll to fail
+// with "file being used by another process". Running our own RemoveAll with
+// retry BEFORE the framework's auto-cleanup (LIFO) makes the framework's
+// call a no-op and the test passes deterministically.
+func closeAndRemoveStore(t *testing.T, dir string, s *Store) {
+	t.Helper()
+	if s != nil {
+		_ = s.Close()
+	}
+	for i := 0; i < 100; i++ {
+		if err := os.RemoveAll(dir); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Logf("closeAndRemoveStore: best-effort RemoveAll(%q) failed after retries; framework auto-cleanup may also fail", dir)
+}
+
+// removeDirWithRetry best-effort removes a directory with a retry.
+// Used by tests that open raw SQLite handles (not via Store) but still need
+// the Windows teardown-race mitigation.
+func removeDirWithRetry(dir string) {
+	for i := 0; i < 100; i++ {
+		if err := os.RemoveAll(dir); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 type fakeRows struct {
@@ -3566,7 +3604,11 @@ func TestNewErrorBranches(t *testing.T) {
 	})
 
 	t.Run("fails when migration encounters conflicting object", func(t *testing.T) {
-		dataDir := t.TempDir()
+		// os.MkdirTemp (not t.TempDir) — see closeAndRemoveStore.
+		dataDir, err := os.MkdirTemp("", "engram-mig-conflict-test-")
+		if err != nil {
+			t.Fatalf("mkdir temp: %v", err)
+		}
 		dbPath := filepath.Join(dataDir, "engram.db")
 
 		db, err := sql.Open("sqlite", dbPath)
@@ -3591,11 +3633,19 @@ func TestNewErrorBranches(t *testing.T) {
 		`)
 		if err != nil {
 			_ = db.Close()
+			removeDirWithRetry(dataDir)
 			t.Fatalf("create conflicting view: %v", err)
 		}
 		if err := db.Close(); err != nil {
+			removeDirWithRetry(dataDir)
 			t.Fatalf("close db: %v", err)
 		}
+		// Windows SQLite teardown race: register a cleanup that retries
+		// RemoveAll on the data dir before the framework's auto-cleanup runs.
+		t.Cleanup(func() {
+			_ = db.Close() // idempotent; ensure release even if path above bailed early
+			removeDirWithRetry(dataDir)
+		})
 
 		cfg := mustDefaultConfig(t)
 		cfg.DataDir = dataDir
@@ -7344,16 +7394,20 @@ func TestReadSQLiteLockSnapshotDoesNotMutateApplicationRows(t *testing.T) {
 func newTestStoreRaw(t *testing.T) *Store {
 	t.Helper()
 	cfg := mustDefaultConfig(t)
-	cfg.DataDir = t.TempDir()
+	// os.MkdirTemp (not t.TempDir) — see newTestStore.
+	dir, err := os.MkdirTemp("", "engram-test-raw-")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	cfg.DataDir = dir
 	cfg.DedupeWindow = time.Hour
 
 	s, err := newWithoutRepair(cfg)
 	if err != nil {
+		_ = os.RemoveAll(dir)
 		t.Fatalf("new raw store: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = s.Close()
-	})
+	t.Cleanup(func() { closeAndRemoveStore(t, dir, s) })
 	return s
 }
 


### PR DESCRIPTION
## Summary

Fixes Windows-specific SQLite teardown race in \internal/store\ test helpers.

## Problem

On Windows, \database/sql\ Close on a SQLite handle does not release the file handle immediately. The testing framework's auto-TempDir RemoveAll then races and fails with \ile being used by another process\, causing 2 tests to fail:

- \TestMigrate_Idempotent\ (in \internal/store\)
- \TestNewErrorBranches/fails_when_migration_encounters_conflicting_object\ (in \internal/store\)

## Fix

Two-part pattern:

1. **Replace \	.TempDir()\ with \os.MkdirTemp()\** in test helpers (\
ewTestStore\, \
ewTestStoreRaw\, \
ewTestStoreWithLegacySchema\, and the raw-db subtest of \TestNewErrorBranches\) so we own the dir lifecycle and skip the framework's auto-RemoveAll race.
2. **Retry-based cleanup** via new helpers \closeAndRemoveStore\ and \emoveDirWithRetry\ that close the store then best-effort RemoveAll with retry (100 x 50ms = 5s budget), absorbing the SQLite teardown lag.

## Validation

- \go test -run 'TestMigrate_Idempotent|TestNewErrorBranches' -count=1 ./internal/store/\ — passes
- \go test ./internal/store/ -count=1\ — full package passes (15.2s, ~50% overhead from retry budget)

## Out of scope

\internal/sync\ baseline failures (\TestManifestReadWrite\, \TestFileTransportReadManifestNotDir\) are unrelated logic bugs, not teardown races. They remain failing on main and will be addressed in a separate change.

## Related

Pre-apply audit for the upcoming \jsonl-session-tree\ change on the same branch family. Shipping this hygiene fix separately keeps the next PR's review focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store cleanup reliability to reduce leftover temporary files and database lock issues during testing.
  * Added more robust retry-based cleanup for temporary data directories, helping avoid intermittent failures on some platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->