### PR TITLE
feat(store): SessionTurnRepository with SaveTurn, ListTurns, cycle detection (PR1b-repository)

### DIFF
--- a/internal/store/session_turns.go
+++ b/internal/store/session_turns.go
@@ -1,0 +1,449 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+// Turn is the public representation of a single row in session_turns. The
+// zero value is not meaningful — fields are populated by SaveTurn and
+// ListTurns.
+type Turn struct {
+	ID           string
+	SessionID    string
+	Project      string
+	ParentTurnID *string
+	TurnSeq      int
+	Role         string
+	ContentJSON  []byte
+	AgentName    *string
+	TokensIn     *int
+	TokensOut    *int
+	CreatedAt    int64
+	Metadata     map[string]any
+}
+
+// SaveTurnParams is the input shape for SaveTurn. ID is optional (auto-ULID
+// when empty); ParentTurnID, AgentName, TokensIn, TokensOut, Metadata are
+// all optional. SessionID, Project, Role, and ContentJSON are required.
+type SaveTurnParams struct {
+	ID           string
+	SessionID    string
+	Project      string
+	ParentTurnID *string
+	Role         string
+	ContentJSON  []byte
+	AgentName    *string
+	TokensIn     *int
+	TokensOut    *int
+	Metadata     map[string]any
+}
+
+// ListTurnsOpts controls ListTurns behavior.
+//
+//   - IncludeLegacy: include pre_tree=true synthetic turns (default false;
+//     Q1 / REQ-005 BDD-S-005.a — pre_tree rows are hidden by default).
+//   - FromTurnID: subtree filter (REQ-005 BDD-S-005.b). When set, the
+//     result is the descendants of the given turn (excluding the turn
+//     itself), still ordered by turn_seq ASC.
+//   - Limit / Offset: pagination. Limit <= 0 means unbounded.
+type ListTurnsOpts struct {
+	IncludeLegacy bool
+	FromTurnID    *string
+	Limit         int
+	Offset        int
+}
+
+// ─── SaveTurn ───────────────────────────────────────────────────────────────
+
+// validRoles is the set of allowed values for the role column (REQ-001).
+var validRoles = map[string]struct{}{
+	"user":      {},
+	"assistant": {},
+	"tool":      {},
+	"system":    {},
+}
+
+// validContentBlockTypes is the set of allowed "type" values inside a
+// content_json array element (Q2).
+var validContentBlockTypes = map[string]struct{}{
+	"text":        {},
+	"reasoning":   {},
+	"tool-call":   {},
+	"tool-result": {},
+}
+
+// SaveTurn appends a single turn to a session. Implements REQ-004 with
+// REQ-010 cycle detection and Q2 content validation. On success, the
+// returned Turn carries the assigned ID, turn_seq, and created_at.
+//
+// Concurrency: not safe under concurrent writers in this PR (the
+// UNIQUE(session_id, turn_seq) constraint + bounded retry land in PR3
+// per locked-in decision C). Single-writer transactions are atomic; if
+// a concurrent writer races the MAX(turn_seq) read, the second writer
+// may collide on PRIMARY KEY (id) at worst.
+func (s *Store) SaveTurn(ctx context.Context, params SaveTurnParams) (Turn, error) {
+	// ── Validation ──────────────────────────────────────────────────────
+	if strings.TrimSpace(params.Project) == "" {
+		return Turn{}, ErrProjectRequired
+	}
+	if _, ok := validRoles[params.Role]; !ok {
+		return Turn{}, ErrInvalidRole
+	}
+	if err := validateContentShape(params.ContentJSON); err != nil {
+		return Turn{}, err
+	}
+
+	// ── Cycle detection (REQ-010) ───────────────────────────────────────
+	// Walk the ancestor chain of params.ParentTurnID; if we ever see the
+	// would-be new id (or the new id equals the parent — self-loop), reject.
+	newID := params.ID
+	if newID == "" {
+		newID = newULID()
+	}
+	if params.ParentTurnID != nil {
+		if *params.ParentTurnID == newID {
+			return Turn{}, ErrCycleDetected
+		}
+		if err := s.detectCycle(ctx, newID, *params.ParentTurnID); err != nil {
+			return Turn{}, err
+		}
+		// BDD-S-001.b: parent must belong to the same session.
+		var parentSession string
+		err := s.db.QueryRowContext(ctx,
+			`SELECT session_id FROM session_turns WHERE id = ?`, *params.ParentTurnID,
+		).Scan(&parentSession)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				// Parent doesn't exist — surface as cycle (the parent
+				// can't anchor a valid new turn; the caller meant to
+				// reference an existing turn).
+				return Turn{}, fmt.Errorf("session_turns: parent_turn_id %q not found: %w",
+					*params.ParentTurnID, ErrCycleDetected)
+			}
+			return Turn{}, fmt.Errorf("session_turns: lookup parent: %w", err)
+		}
+		if parentSession != params.SessionID {
+			return Turn{}, ErrParentSessionMismatch
+		}
+	}
+
+	// ── Compute turn_seq inside a transaction ───────────────────────────
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Turn{}, fmt.Errorf("session_turns: begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var maxSeq sql.NullInt64
+	if err = tx.QueryRowContext(ctx,
+		`SELECT MAX(turn_seq) FROM session_turns WHERE session_id = ?`,
+		params.SessionID,
+	).Scan(&maxSeq); err != nil {
+		return Turn{}, fmt.Errorf("session_turns: max(turn_seq): %w", err)
+	}
+	nextSeq := 1
+	if maxSeq.Valid {
+		nextSeq = int(maxSeq.Int64) + 1
+	}
+
+	// ── Marshal metadata_json (nil → NULL) ─────────────────────────────
+	var metaJSON sql.NullString
+	if params.Metadata != nil {
+		b, mErr := json.Marshal(params.Metadata)
+		if mErr != nil {
+			return Turn{}, fmt.Errorf("session_turns: marshal metadata: %w", mErr)
+		}
+		metaJSON = sql.NullString{String: string(b), Valid: true}
+	}
+
+	// ── Insert ─────────────────────────────────────────────────────────
+	now := time.Now().UnixMilli()
+	if _, err = tx.ExecContext(ctx, `
+		INSERT INTO session_turns (
+			id, session_id, project, parent_turn_id, turn_seq, role,
+			content_json, agent_name, tokens_in, tokens_out, created_at, metadata_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, newID, params.SessionID, params.Project,
+		nullableStringPtr(params.ParentTurnID), nextSeq, params.Role,
+		string(params.ContentJSON), nullableStringPtr(params.AgentName),
+		nullableIntPtr(params.TokensIn), nullableIntPtr(params.TokensOut),
+		now, metaJSON,
+	); err != nil {
+		return Turn{}, fmt.Errorf("session_turns: insert: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return Turn{}, fmt.Errorf("session_turns: commit: %w", err)
+	}
+
+	// ── Build returned Turn ────────────────────────────────────────────
+	out := Turn{
+		ID:           newID,
+		SessionID:    params.SessionID,
+		Project:      params.Project,
+		ParentTurnID: params.ParentTurnID,
+		TurnSeq:      nextSeq,
+		Role:         params.Role,
+		ContentJSON:  append([]byte(nil), params.ContentJSON...),
+		AgentName:    params.AgentName,
+		TokensIn:     params.TokensIn,
+		TokensOut:    params.TokensOut,
+		CreatedAt:    now,
+		Metadata:     params.Metadata,
+	}
+	return out, nil
+}
+
+// detectCycle walks the ancestor chain of `parentID` (using a recursive
+// CTE bounded by the current session row count) and returns ErrCycleDetected
+// if `newID` is encountered. Self-references are caught by the caller
+// (SaveTurn) before this is invoked.
+func (s *Store) detectCycle(ctx context.Context, newID, parentID string) error {
+	// Bound the walk: never traverse more than the existing row count
+	// for the parent's session. This guarantees termination even on
+	// corrupted/cyclic data.
+	var sessionID string
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT session_id FROM session_turns WHERE id = ?`, parentID,
+	).Scan(&sessionID); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("session_turns: parent_turn_id %q not found: %w", parentID, ErrCycleDetected)
+		}
+		return fmt.Errorf("session_turns: detectCycle lookup parent session: %w", err)
+	}
+
+	var rowCount int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM session_turns WHERE session_id = ?`, sessionID,
+	).Scan(&rowCount); err != nil {
+		return fmt.Errorf("session_turns: detectCycle count: %w", err)
+	}
+	// Bounded recursive CTE. The bound is the existing row count of the
+	// session, which is also the maximum possible depth of a well-formed
+	// ancestor chain.
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		WITH RECURSIVE ancestors(id, depth) AS (
+			SELECT id, 0 FROM session_turns WHERE id = ?
+			UNION ALL
+			SELECT t.parent_turn_id, a.depth + 1
+			FROM session_turns t JOIN ancestors a ON t.id = a.id
+			WHERE t.parent_turn_id IS NOT NULL
+			  AND a.depth < %d
+		)
+		SELECT id FROM ancestors
+	`, rowCount+1), parentID)
+	if err != nil {
+		return fmt.Errorf("session_turns: detectCycle walk: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("session_turns: detectCycle scan: %w", err)
+		}
+		if id == newID {
+			return ErrCycleDetected
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("session_turns: detectCycle rows: %w", err)
+	}
+	return nil
+}
+
+// validateContentShape enforces Q2: content_json must be a JSON array of
+// typed blocks with a recognized "type" value. The check is intentionally
+// cheap (no full semantic validation) and runs BEFORE the INSERT so a
+// malformed payload never holds a write lock.
+func validateContentShape(content []byte) error {
+	if len(content) == 0 {
+		return fmt.Errorf("%w: empty content_json", ErrInvalidContentShape)
+	}
+	var raw []json.RawMessage
+	if err := json.Unmarshal(content, &raw); err != nil {
+		return fmt.Errorf("%w: not a JSON array (%v)", ErrInvalidContentShape, err)
+	}
+	if len(raw) == 0 {
+		return fmt.Errorf("%w: empty array", ErrInvalidContentShape)
+	}
+	for i, blk := range raw {
+		var probe struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(blk, &probe); err != nil {
+			return fmt.Errorf("%w: block %d is not an object (%v)", ErrInvalidContentShape, i, err)
+		}
+		if _, ok := validContentBlockTypes[probe.Type]; !ok {
+			return fmt.Errorf("%w: block %d has unknown type %q", ErrInvalidContentShape, i, probe.Type)
+		}
+	}
+	return nil
+}
+
+// ─── ListTurns ─────────────────────────────────────────────────────────────
+
+// ListTurns returns the turns for a session in turn_seq ASC order.
+//
+//   - Default excludes pre_tree=true rows (Q1 / BDD-S-005.a).
+//   - With IncludeLegacy=true, those rows are included.
+//   - With FromTurnID, only descendants of that turn are returned
+//     (the turn itself is NOT included — BDD-S-005.b).
+//   - Limit/Offset paginate; Limit <= 0 means unbounded.
+func (s *Store) ListTurns(ctx context.Context, sessionID string, opts ListTurnsOpts) ([]Turn, error) {
+	// Build the query in two variants: subtree (recursive CTE) and
+	// flat (whole-session) — both reuse the same filter + order.
+	var (
+		rows *sql.Rows
+		err  error
+	)
+
+	filterPreTree := "AND (metadata_json IS NULL OR json_extract(metadata_json, '$.pre_tree') IS NULL OR json_extract(metadata_json, '$.pre_tree') != 1)"
+
+	if opts.FromTurnID != nil {
+		// Subtree: descendants of opts.FromTurnID, excluding the turn itself.
+		// Bound the recursion by the current session row count for safety.
+		var rowCount int
+		if err = s.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM session_turns WHERE session_id = ?`, sessionID,
+		).Scan(&rowCount); err != nil {
+			return nil, fmt.Errorf("session_turns: ListTurns count: %w", err)
+		}
+		cte := fmt.Sprintf(`
+			WITH RECURSIVE subtree(id, depth) AS (
+				SELECT id, 0 FROM session_turns WHERE id = ?
+				UNION ALL
+				SELECT t.id, s.depth + 1
+				FROM session_turns t JOIN subtree s ON t.parent_turn_id = s.id
+				WHERE s.depth < %d
+			)
+			SELECT t.id, t.session_id, t.project, t.parent_turn_id, t.turn_seq, t.role,
+			       t.content_json, t.agent_name, t.tokens_in, t.tokens_out,
+			       t.created_at, t.metadata_json
+			FROM session_turns t JOIN subtree s ON t.id = s.id
+			WHERE t.id != ?
+			  AND t.session_id = ?
+		`, rowCount+1)
+		args := []any{*opts.FromTurnID, *opts.FromTurnID, sessionID}
+		if !opts.IncludeLegacy {
+			cte += " " + filterPreTree
+		}
+		cte += " ORDER BY t.turn_seq ASC"
+		if opts.Limit > 0 {
+			cte += fmt.Sprintf(" LIMIT %d", opts.Limit)
+		}
+		if opts.Offset > 0 {
+			cte += fmt.Sprintf(" OFFSET %d", opts.Offset)
+		}
+		rows, err = s.db.QueryContext(ctx, cte, args...)
+	} else {
+		query := `
+			SELECT id, session_id, project, parent_turn_id, turn_seq, role,
+			       content_json, agent_name, tokens_in, tokens_out,
+			       created_at, metadata_json
+			FROM session_turns
+			WHERE session_id = ?
+		`
+		args := []any{sessionID}
+		if !opts.IncludeLegacy {
+			query += " " + filterPreTree
+		}
+		query += " ORDER BY turn_seq ASC"
+		if opts.Limit > 0 {
+			query += fmt.Sprintf(" LIMIT %d", opts.Limit)
+		}
+		if opts.Offset > 0 {
+			query += fmt.Sprintf(" OFFSET %d", opts.Offset)
+		}
+		rows, err = s.db.QueryContext(ctx, query, args...)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("session_turns: ListTurns query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Turn
+	for rows.Next() {
+		t, scanErr := scanTurnRow(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("session_turns: ListTurns rows: %w", err)
+	}
+	return out, nil
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+// scanTurnRow scans one row of session_turns into a Turn. Shared by
+// ListTurns and any future read paths.
+func scanTurnRow(rows *sql.Rows) (Turn, error) {
+	var (
+		t           Turn
+		parentID    sql.NullString
+		agentName   sql.NullString
+		tokensIn    sql.NullInt64
+		tokensOut   sql.NullInt64
+		contentRaw  string
+		metadataRaw sql.NullString
+	)
+	if err := rows.Scan(
+		&t.ID, &t.SessionID, &t.Project, &parentID, &t.TurnSeq, &t.Role,
+		&contentRaw, &agentName, &tokensIn, &tokensOut,
+		&t.CreatedAt, &metadataRaw,
+	); err != nil {
+		return Turn{}, fmt.Errorf("session_turns: scan row: %w", err)
+	}
+	if parentID.Valid {
+		v := parentID.String
+		t.ParentTurnID = &v
+	}
+	if agentName.Valid {
+		v := agentName.String
+		t.AgentName = &v
+	}
+	if tokensIn.Valid {
+		v := int(tokensIn.Int64)
+		t.TokensIn = &v
+	}
+	if tokensOut.Valid {
+		v := int(tokensOut.Int64)
+		t.TokensOut = &v
+	}
+	t.ContentJSON = []byte(contentRaw)
+	if metadataRaw.Valid && strings.TrimSpace(metadataRaw.String) != "" {
+		var meta map[string]any
+		if err := json.Unmarshal([]byte(metadataRaw.String), &meta); err != nil {
+			return Turn{}, fmt.Errorf("session_turns: parse metadata_json: %w", err)
+		}
+		t.Metadata = meta
+	}
+	return t, nil
+}
+
+func nullableStringPtr(s *string) any {
+	if s == nil {
+		return nil
+	}
+	return *s
+}
+
+func nullableIntPtr(i *int) any {
+	if i == nil {
+		return nil
+	}
+	return *i
+}

--- a/internal/store/session_turns_test.go
+++ b/internal/store/session_turns_test.go
@@ -1,12 +1,18 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/quick"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -353,4 +359,493 @@ func TestMigrate_BackfillHandlesMultipleSessions(t *testing.T) {
 	if emptyContent != `[{"type":"text","text":""}]` {
 		t.Errorf("empty-summary content_json = %q, want %q", emptyContent, `[{"type":"text","text":""}]`)
 	}
+}
+
+// ─── SessionTurnRepository tests ────────────────────────────────────────────
+
+// TestSessionTurnRepository_SaveAndList covers REQ-004 (BDD-S-001.a,
+// BDD-S-004.a) and REQ-005 (BDD-S-005.a):
+//   - SaveTurn appends a turn under a session, assigns monotonic turn_seq,
+//     and returns the new id.
+//   - ListTurns returns turns for a session ordered by turn_seq.
+//   - ListTurns excludes pre_tree=true turns by default (Q1).
+//   - content_json round-trips byte-identical (BDD-S-001.a).
+func TestSessionTurnRepository_SaveAndList(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Save a root turn.
+	content := []byte(`[{"type":"text","text":"hello world"}]`)
+	saved, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID:   "s-1",
+		Project:     "proj-1",
+		Role:        "user",
+		ContentJSON: content,
+		AgentName:   strPtr("alice"),
+	})
+	if err != nil {
+		t.Fatalf("SaveTurn root: %v", err)
+	}
+	if saved.ID == "" {
+		t.Errorf("SaveTurn returned empty ID")
+	}
+	if saved.SessionID != "s-1" {
+		t.Errorf("saved.SessionID = %q, want s-1", saved.SessionID)
+	}
+	if saved.Project != "proj-1" {
+		t.Errorf("saved.Project = %q, want proj-1", saved.Project)
+	}
+	if saved.TurnSeq != 1 {
+		t.Errorf("first save: TurnSeq = %d, want 1", saved.TurnSeq)
+	}
+	if saved.ParentTurnID != nil {
+		t.Errorf("first save: ParentTurnID = %v, want nil", saved.ParentTurnID)
+	}
+	if saved.Role != "user" {
+		t.Errorf("saved.Role = %q, want user", saved.Role)
+	}
+	if !bytesEqual(saved.ContentJSON, content) {
+		t.Errorf("saved.ContentJSON = %q, want %q (byte-identical)", saved.ContentJSON, content)
+	}
+
+	// Save a child turn — must auto-assign turn_seq = MAX+1 = 2.
+	childContent := []byte(`[{"type":"reasoning","text":"thinking..."}]`)
+	parentID := saved.ID
+	saved2, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID:    "s-1",
+		Project:      "proj-1",
+		ParentTurnID: &parentID,
+		Role:         "assistant",
+		ContentJSON:  childContent,
+	})
+	if err != nil {
+		t.Fatalf("SaveTurn child: %v", err)
+	}
+	if saved2.TurnSeq != 2 {
+		t.Errorf("second save: TurnSeq = %d, want 2 (BDD-S-004.a)", saved2.TurnSeq)
+	}
+	if saved2.ParentTurnID == nil || *saved2.ParentTurnID != parentID {
+		t.Errorf("saved2.ParentTurnID = %v, want %q", saved2.ParentTurnID, parentID)
+	}
+
+	// Save a pre_tree synthetic turn manually (so we can test the default
+	// exclude behavior in ListTurns).
+	preTreeID := "01HZZZPREETREESYNTHETIC00000"
+	if _, err := s.db.Exec(
+		`INSERT INTO session_turns (id, session_id, project, parent_turn_id, turn_seq, role, content_json, agent_name, tokens_in, tokens_out, created_at, metadata_json)
+		 VALUES (?, 's-1', 'proj-1', NULL, 0, 'system', '[{"type":"text","text":"legacy"}]', 'system-migration', NULL, NULL, ?, '{"pre_tree":true}')`,
+		preTreeID, time.Now().UnixMilli(),
+	); err != nil {
+		t.Fatalf("insert pre_tree turn: %v", err)
+	}
+
+	// ListTurns default: must exclude pre_tree turns (Q1).
+	turns, err := s.ListTurns(ctx, "s-1", ListTurnsOpts{})
+	if err != nil {
+		t.Fatalf("ListTurns: %v", err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("ListTurns returned %d turns, want 2 (pre_tree excluded by default)", len(turns))
+	}
+	// Order: turn_seq ASC.
+	if turns[0].TurnSeq != 1 || turns[1].TurnSeq != 2 {
+		t.Errorf("ListTurns not ordered by turn_seq ASC: got [%d, %d], want [1, 2]", turns[0].TurnSeq, turns[1].TurnSeq)
+	}
+	// First turn content must round-trip byte-identical.
+	if !bytesEqual(turns[0].ContentJSON, content) {
+		t.Errorf("listed[0].ContentJSON = %q, want %q (BDD-S-001.a round-trip)", turns[0].ContentJSON, content)
+	}
+	// First turn must be the root.
+	if turns[0].ParentTurnID != nil {
+		t.Errorf("listed[0].ParentTurnID = %v, want nil (root)", turns[0].ParentTurnID)
+	}
+
+	// ListTurns with IncludeLegacy=true: returns the pre_tree turn too.
+	allTurns, err := s.ListTurns(ctx, "s-1", ListTurnsOpts{IncludeLegacy: true})
+	if err != nil {
+		t.Fatalf("ListTurns IncludeLegacy: %v", err)
+	}
+	if len(allTurns) != 3 {
+		t.Errorf("ListTurns IncludeLegacy returned %d turns, want 3 (pre_tree included)", len(allTurns))
+	}
+}
+
+// TestSessionTurnRepository_SaveAndList_SubtreeFilter covers BDD-S-005.b:
+// when from_turn_id is provided, the result is the subtree rooted at that
+// turn, NOT including the turn itself, ordered by turn_seq.
+func TestSessionTurnRepository_SaveAndList_SubtreeFilter(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Build a small fork topology under s-1:
+	//   t1 -> t2 -> t3 (root path)
+	//                -> t4 (fork) -> t5
+	//                -> t6 (fork) -> t7 -> t8
+	root, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "user",
+		ContentJSON: []byte(`[{"type":"text","text":"t1"}]`),
+	})
+	if err != nil {
+		t.Fatalf("save root: %v", err)
+	}
+	chain := func(parentID string, label string) (string, error) {
+		pid := parentID
+		t2, err := s.SaveTurn(ctx, SaveTurnParams{
+			SessionID: "s-1", Project: "proj-1", Role: "assistant",
+			ParentTurnID: &pid, ContentJSON: []byte(fmt.Sprintf(`[{"type":"text","text":%q}]`, label)),
+		})
+		if err != nil {
+			return "", err
+		}
+		return t2.ID, nil
+	}
+	t2, err := chain(root.ID, "t2")
+	if err != nil {
+		t.Fatalf("save t2: %v", err)
+	}
+	t3, err := chain(t2, "t3")
+	if err != nil {
+		t.Fatalf("save t3: %v", err)
+	}
+	if _, err := chain(t3, "t4"); err != nil {
+		t.Fatalf("save t4: %v", err)
+	}
+	if _, err := chain(t3, "t5"); err != nil {
+		t.Fatalf("save t5: %v", err)
+	}
+	t6, err := chain(t2, "t6")
+	if err != nil {
+		t.Fatalf("save t6: %v", err)
+	}
+	if _, err := chain(t6, "t7"); err != nil {
+		t.Fatalf("save t7: %v", err)
+	}
+
+	// Subtree at t2: descendants are t3, t4, t5, t6, t7. t2 itself is NOT
+	// included (BDD-S-005.b).
+	t2ID := t2
+	got, err := s.ListTurns(ctx, "s-1", ListTurnsOpts{FromTurnID: &t2ID})
+	if err != nil {
+		t.Fatalf("ListTurns subtree: %v", err)
+	}
+	if len(got) != 5 {
+		t.Errorf("subtree at t2 returned %d turns, want 5 (t3, t4, t5, t6, t7); got seqs=%v",
+			len(got), turnSeqs(got))
+	}
+	// Verify ordering.
+	for i := 1; i < len(got); i++ {
+		if got[i].TurnSeq <= got[i-1].TurnSeq {
+			t.Errorf("subtree not ordered by turn_seq ASC: %v", turnSeqs(got))
+			break
+		}
+	}
+}
+
+// TestSessionTurnRepository_CycleDetection covers REQ-010 (BDD-S-010.a/b):
+//   - Self-loop (parent_turn_id == id) is rejected.
+//   - Indirect cycle (A -> B -> C -> A) is rejected.
+//   - No row is written on rejection.
+func TestSessionTurnRepository_CycleDetection(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Build A -> B -> C.
+	a, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "user",
+		ContentJSON: []byte(`[{"type":"text","text":"A"}]`),
+	})
+	if err != nil {
+		t.Fatalf("save A: %v", err)
+	}
+	parentA := a.ID
+	b, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "assistant",
+		ParentTurnID: &parentA, ContentJSON: []byte(`[{"type":"text","text":"B"}]`),
+	})
+	if err != nil {
+		t.Fatalf("save B: %v", err)
+	}
+	parentB := b.ID
+	c, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "assistant",
+		ParentTurnID: &parentB, ContentJSON: []byte(`[{"type":"text","text":"C"}]`),
+	})
+	if err != nil {
+		t.Fatalf("save C: %v", err)
+	}
+
+	// BDD-S-010.a: self-loop rejected.
+	t.Run("self_loop", func(t *testing.T) {
+		aID := a.ID
+		_, err := s.SaveTurn(ctx, SaveTurnParams{
+			ID:          a.ID, // explicit same id
+			SessionID:   "s-1",
+			Project:     "proj-1",
+			ParentTurnID: &aID,
+			Role:        "user",
+			ContentJSON: []byte(`[{"type":"text","text":"loop"}]`),
+		})
+		if !errors.Is(err, ErrCycleDetected) {
+			t.Errorf("self-loop: err = %v, want ErrCycleDetected", err)
+		}
+	})
+
+	// BDD-S-010.b: indirect cycle rejected.
+	t.Run("indirect_cycle", func(t *testing.T) {
+		parentC := c.ID
+		_, err := s.SaveTurn(ctx, SaveTurnParams{
+			ID:          a.ID, // re-use A's id (would close A->B->C->A)
+			SessionID:   "s-1",
+			Project:     "proj-1",
+			ParentTurnID: &parentC,
+			Role:        "user",
+			ContentJSON: []byte(`[{"type":"text","text":"loopback"}]`),
+		})
+		if !errors.Is(err, ErrCycleDetected) {
+			t.Errorf("indirect cycle: err = %v, want ErrCycleDetected", err)
+		}
+	})
+
+	// No row was written on rejection.
+	var totalRows int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM session_turns WHERE session_id = 's-1'`).Scan(&totalRows); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if totalRows != 3 {
+		t.Errorf("after rejected cycles, session_turns has %d rows, want 3 (only A, B, C)", totalRows)
+	}
+}
+
+// TestSessionTurnRepository_Validation covers the other REQ-004 invariants:
+// project required, role must be in {user, assistant, tool, system},
+// content_json must be a JSON array of typed blocks, parent_turn_id must
+// belong to the same session.
+func TestSessionTurnRepository_Validation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Missing project.
+	_, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Role: "user",
+		ContentJSON: []byte(`[{"type":"text","text":"hi"}]`),
+	})
+	if !errors.Is(err, ErrProjectRequired) {
+		t.Errorf("missing project: err = %v, want ErrProjectRequired", err)
+	}
+
+	// Invalid role.
+	_, err = s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "robot",
+		ContentJSON: []byte(`[{"type":"text","text":"hi"}]`),
+	})
+	if !errors.Is(err, ErrInvalidRole) {
+		t.Errorf("invalid role: err = %v, want ErrInvalidRole", err)
+	}
+
+	// Malformed content_json.
+	_, err = s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "user",
+		ContentJSON: []byte(`"not-an-array"`),
+	})
+	if !errors.Is(err, ErrInvalidContentShape) {
+		t.Errorf("malformed content (not array): err = %v, want ErrInvalidContentShape", err)
+	}
+
+	// content_json is an array but contains a block with an unknown type.
+	_, err = s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "user",
+		ContentJSON: []byte(`[{"type":"mystery","data":1}]`),
+	})
+	if !errors.Is(err, ErrInvalidContentShape) {
+		t.Errorf("unknown block type: err = %v, want ErrInvalidContentShape", err)
+	}
+
+	// Parent in a different session.
+	other, err := s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-other", Project: "proj-1", Role: "user",
+		ContentJSON: []byte(`[{"type":"text","text":"other"}]`),
+	})
+	if err != nil {
+		t.Fatalf("save other: %v", err)
+	}
+	otherID := other.ID
+	_, err = s.SaveTurn(ctx, SaveTurnParams{
+		SessionID: "s-1", Project: "proj-1", Role: "assistant",
+		ParentTurnID: &otherID,
+		ContentJSON:  []byte(`[{"type":"text","text":"x"}]`),
+	})
+	if !errors.Is(err, ErrParentSessionMismatch) {
+		t.Errorf("parent from other session: err = %v, want ErrParentSessionMismatch", err)
+	}
+}
+
+// TestProperty_CycleDetectionTerminates is the property test (REQ-010
+// hardening). Two properties are asserted:
+//
+//  1. Random linear forests of up to N turns complete without infinite
+//     recursion. Each SaveTurn must terminate (the ancestor walk is
+//     bounded by the session row count, so this is structural).
+//  2. Cycle-detection on adversarial inputs (an explicit attempt to
+//     close a loop A->B->C->A) rejects in <10ms. This is the per-call
+//     budget from the spec.
+//
+// The previous TestSessionTurnRepository_CycleDetection covers the
+// acceptance cases (self-loop, indirect cycle). This test hardens the
+// cost and termination guarantee.
+func TestProperty_CycleDetectionTerminates(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const (
+		forestRuns  = 50
+		maxTurnsRun = 50
+		// Generous budget on linear forests (we just want to confirm
+		// termination, not wall-clock perf — that's covered by the
+		// 10K-turn perf test in PR3).
+		forestBudget = 200 * time.Millisecond
+		// Strict budget for the adversarial cycle-detection path,
+		// which is what REQ-010 actually constrains.
+		cycleBudget = 10 * time.Millisecond
+	)
+
+	// Seed RNG for reproducibility on this property test.
+	rng := rand.New(rand.NewSource(42))
+
+	// ── Property 1: linear forests terminate ──────────────────────────
+	for run := 0; run < forestRuns; run++ {
+		sid := fmt.Sprintf("prop-s-%d", run)
+		var prevID string
+		var maxObserved time.Duration
+		for i := 0; i < maxTurnsRun; i++ {
+			var parentPtr *string
+			if i > 0 {
+				p := prevID
+				parentPtr = &p
+			}
+			start := time.Now()
+			saved, err := s.SaveTurn(ctx, SaveTurnParams{
+				SessionID:    sid,
+				Project:      "prop-proj",
+				Role:         "user",
+				ParentTurnID: parentPtr,
+				ContentJSON:  []byte(fmt.Sprintf(`[{"type":"text","text":"%d"}]`, i)),
+			})
+			elapsed := time.Since(start)
+			if elapsed > maxObserved {
+				maxObserved = elapsed
+			}
+			if err != nil {
+				t.Fatalf("run %d turn %d: SaveTurn failed: %v", run, i, err)
+			}
+			prevID = saved.ID
+		}
+		// The chain is linear; cycle detection walks 0 ancestors per
+		// save (no ancestor equals the new id), so the per-call
+		// contribution is small. Generous budget accommodates
+		// Windows/dev-machine variance.
+		if maxObserved > forestBudget {
+			t.Errorf("run %d: max SaveTurn latency = %v, want < %v",
+				run, maxObserved, forestBudget)
+		}
+	}
+
+	// ── Property 2: cycle detection cost on adversarial input ─────────
+	// Build A->B->C and then attempt to save a turn with id=A and
+	// parent_turn_id=C. SaveTurn must reject with ErrCycleDetected in
+	// < cycleBudget. This exercises the bounded recursive CTE.
+	adversarialSessions := []string{"adv-s-1", "adv-s-2", "adv-s-3"}
+	for _, sid := range adversarialSessions {
+		a, err := s.SaveTurn(ctx, SaveTurnParams{
+			SessionID: sid, Project: "adv", Role: "user",
+			ContentJSON: []byte(`[{"type":"text","text":"A"}]`),
+		})
+		if err != nil {
+			t.Fatalf("adv %s: save A: %v", sid, err)
+		}
+		aID := a.ID
+		b, err := s.SaveTurn(ctx, SaveTurnParams{
+			SessionID: sid, Project: "adv", Role: "assistant",
+			ParentTurnID: &aID, ContentJSON: []byte(`[{"type":"text","text":"B"}]`),
+		})
+		if err != nil {
+			t.Fatalf("adv %s: save B: %v", sid, err)
+		}
+		bID := b.ID
+		c, err := s.SaveTurn(ctx, SaveTurnParams{
+			SessionID: sid, Project: "adv", Role: "assistant",
+			ParentTurnID: &bID, ContentJSON: []byte(`[{"type":"text","text":"C"}]`),
+		})
+		if err != nil {
+			t.Fatalf("adv %s: save C: %v", sid, err)
+		}
+		// Attempt to close the loop A->B->C->A.
+		cID := c.ID
+		start := time.Now()
+		_, err = s.SaveTurn(ctx, SaveTurnParams{
+			ID:           a.ID, // reuse A's id; would close the loop
+			SessionID:    sid,
+			Project:      "adv",
+			ParentTurnID: &cID,
+			Role:         "user",
+			ContentJSON:  []byte(`[{"type":"text","text":"loop"}]`),
+		})
+		elapsed := time.Since(start)
+		if !errors.Is(err, ErrCycleDetected) {
+			t.Errorf("adv %s: expected ErrCycleDetected, got %v", sid, err)
+		}
+		if elapsed > cycleBudget {
+			t.Errorf("adv %s: cycle detection latency = %v, want < %v",
+				sid, elapsed, cycleBudget)
+		}
+	}
+
+	// ── Property 3: quick.Check validates the Save path on random valid
+	// payloads. Restricted to the four valid block types so the test
+	// focuses on the Save path, not validation.
+	type validBlock struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	f := func(b validBlock) bool {
+		switch b.Type {
+		case "text", "reasoning", "tool-call", "tool-result":
+		default:
+			return true // not a failure of the property under test
+		}
+		payload, _ := json.Marshal([]validBlock{b})
+		_, err := s.SaveTurn(ctx, SaveTurnParams{
+			SessionID:   fmt.Sprintf("qk-%d", rng.Int63()),
+			Project:     "qk",
+			Role:        "user",
+			ContentJSON: payload,
+		})
+		return err == nil
+	}
+	if err := quick.Check(f, &quick.Config{MaxCount: 50}); err != nil {
+		t.Errorf("quick.Check failed: %v", err)
+	}
+}
+
+// ─── test helpers ──────────────────────────────────────────────────────────
+
+func strPtr(s string) *string { return &s }
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func turnSeqs(turns []Turn) []int {
+	out := make([]int, len(turns))
+	for i, t := range turns {
+		out[i] = t.TurnSeq
+	}
+	return out
 }

--- a/internal/store/session_turns_test.go
+++ b/internal/store/session_turns_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+// TestSessionTurnsSchema_TableAndIndexesExist asserts the v6→v7 migration
+// added the session_turns table with the spec'd columns (REQ-001), the
+// project column (locked-in decision A), and the 2 indexes
+// (session_id, turn_seq) and (parent_turn_id) per the PR1a spec.
+func TestSessionTurnsSchema_TableAndIndexesExist(t *testing.T) {
+	s := newTestStore(t)
+
+	// 1. Table exists.
+	var tableName string
+	err := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='session_turns'`,
+	).Scan(&tableName)
+	if err != nil {
+		t.Fatalf("session_turns table not found: %v", err)
+	}
+
+	// 2. Required columns exist with the spec'd types/constraints.
+	requiredCols := map[string]string{
+		"id":             "TEXT",
+		"session_id":     "TEXT",
+		"parent_turn_id": "TEXT",
+		"turn_seq":       "INTEGER",
+		"role":           "TEXT",
+		"content_json":   "TEXT",
+		"agent_name":     "TEXT",
+		"tokens_in":      "INTEGER",
+		"tokens_out":     "INTEGER",
+		"created_at":     "INTEGER",
+		"metadata_json":  "TEXT",
+		"project":        "TEXT",
+	}
+	rows, err := s.db.Query(`PRAGMA table_info(session_turns)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info(session_turns): %v", err)
+	}
+	defer rows.Close()
+	found := map[string]string{}
+	notNull := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var nn int
+		var dflt any
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &nn, &dflt, &pk); err != nil {
+			t.Fatalf("scan pragma: %v", err)
+		}
+		found[name] = typ
+		notNull[name] = nn == 1
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("pragma rows err: %v", err)
+	}
+	for col, wantType := range requiredCols {
+		gotType, ok := found[col]
+		if !ok {
+			t.Errorf("missing column %q on session_turns", col)
+			continue
+		}
+		// SQLite reports INTEGER for both INT and INTEGER; allow either way.
+		if !strings.EqualFold(gotType, wantType) {
+			t.Errorf("column %q type = %q, want %q", col, gotType, wantType)
+		}
+	}
+	// Locked-in decision A: project must be NOT NULL.
+	if !notNull["project"] {
+		t.Errorf("project column must be NOT NULL per decision A")
+	}
+	// id must be PRIMARY KEY (pk=1).
+	if found["id"] == "" {
+		t.Errorf("id column missing — cannot be primary key")
+	}
+
+	// 3. Two required indexes exist.
+	idxRows, err := s.db.Query(
+		`SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='session_turns'`,
+	)
+	if err != nil {
+		t.Fatalf("query indexes: %v", err)
+	}
+	defer idxRows.Close()
+	indexes := map[string]string{}
+	for idxRows.Next() {
+		var name, sql sql.NullString
+		if err := idxRows.Scan(&name, &sql); err != nil {
+			t.Fatalf("scan index row: %v", err)
+		}
+		if sql.Valid {
+			indexes[name.String] = sql.String
+		}
+	}
+	if err := idxRows.Err(); err != nil {
+		t.Fatalf("index rows err: %v", err)
+	}
+
+	wantIdx1 := false
+	wantIdx2 := false
+	for name, sql := range indexes {
+		upper := strings.ToUpper(sql)
+		if strings.Contains(upper, "SESSION_ID") && strings.Contains(upper, "TURN_SEQ") && !strings.Contains(upper, "PROJECT") {
+			wantIdx1 = true
+		}
+		if strings.Contains(upper, "PARENT_TURN_ID") {
+			wantIdx2 = true
+		}
+		_ = name
+	}
+	if !wantIdx1 {
+		t.Errorf("missing index on (session_id, turn_seq); indexes found: %v", indexes)
+	}
+	if !wantIdx2 {
+		t.Errorf("missing index on (parent_turn_id); indexes found: %v", indexes)
+	}
+}

--- a/internal/store/session_turns_test.go
+++ b/internal/store/session_turns_test.go
@@ -2,8 +2,13 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 // TestSessionTurnsSchema_TableAndIndexesExist asserts the v6→v7 migration
@@ -118,5 +123,234 @@ func TestSessionTurnsSchema_TableAndIndexesExist(t *testing.T) {
 	}
 	if !wantIdx2 {
 		t.Errorf("missing index on (parent_turn_id); indexes found: %v", indexes)
+	}
+}
+
+// newTestStoreFromV6Database creates a fresh v6 schema (sessions table only —
+// NO session_turns) populated with the given session rows, then opens the
+// store via New(cfg) so that migrate() runs the v6→v7 step under test.
+// Each sessionRow is (id, project, summary).
+//
+// Mirrors newTestStoreWithLegacySchema from store_migration_test.go but
+// uses a minimal legacy DDL that contains only the sessions table (the
+// rest of the v6 schema is irrelevant for the session_turns backfill test).
+type v6SessionRow struct {
+	id      string
+	project string
+	summary string
+}
+
+func newTestStoreFromV6Database(t *testing.T, sessionRows []v6SessionRow) *Store {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "engram-v6-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	dbPath := filepath.Join(dir, "engram.db")
+
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+
+	if _, err := raw.Exec("PRAGMA journal_mode = WAL"); err != nil {
+		raw.Close()
+		t.Fatalf("WAL pragma: %v", err)
+	}
+	if _, err := raw.Exec("PRAGMA foreign_keys = ON"); err != nil {
+		raw.Close()
+		t.Fatalf("foreign_keys pragma: %v", err)
+	}
+
+	// Minimal v6 DDL — just the sessions table. No session_turns, no
+	// memory_relations, no FTS. This is the schema as it existed before
+	// the jsonl-session-tree change.
+	v6DDL := `
+		CREATE TABLE IF NOT EXISTS sessions (
+			id         TEXT PRIMARY KEY,
+			project    TEXT NOT NULL,
+			directory  TEXT NOT NULL DEFAULT '/tmp',
+			started_at TEXT NOT NULL DEFAULT (datetime('now')),
+			ended_at   TEXT,
+			summary    TEXT
+		);
+	`
+	if _, err := raw.Exec(v6DDL); err != nil {
+		raw.Close()
+		t.Fatalf("apply v6 DDL: %v", err)
+	}
+
+	for _, row := range sessionRows {
+		var summary any
+		if row.summary != "" {
+			summary = row.summary
+		} else {
+			summary = nil
+		}
+		if _, err := raw.Exec(
+			`INSERT INTO sessions (id, project, directory, summary) VALUES (?, ?, ?, ?)`,
+			row.id, row.project, "/tmp", summary,
+		); err != nil {
+			raw.Close()
+			t.Fatalf("insert session %q: %v", row.id, err)
+		}
+	}
+
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw db: %v", err)
+	}
+
+	cfg := mustDefaultConfig(t)
+	cfg.DataDir = dir
+	s, err := New(cfg)
+	if err != nil {
+		removeDirWithRetry(dir)
+		t.Fatalf("New(cfg) on v6 db: %v", err)
+	}
+	t.Cleanup(func() { closeAndRemoveStore(t, dir, s) })
+	return s
+}
+
+// TestMigrate_BackfillsSyntheticTurns covers REQ-003 BDD-S-003.a: a v6
+// sessions row must produce exactly one synthetic session_turns row with
+// role=system, turn_seq=1, parent_turn_id=NULL, agent_name=system-migration,
+// metadata.pre_tree=true, and content_json carrying the verbatim summary
+// text wrapped as a single typed text block.
+func TestMigrate_BackfillsSyntheticTurns(t *testing.T) {
+	s := newTestStoreFromV6Database(t, []v6SessionRow{
+		{id: "legacy-1", project: "proj-legacy", summary: "prior work notes"},
+	})
+
+	var (
+		gotID, gotSessionID, gotProject, gotRole, gotAgent, gotContent string
+		gotParent                                                       sql.NullString
+		gotSeq                                                           int
+		gotMetadata                                                      sql.NullString
+	)
+	err := s.db.QueryRow(
+		`SELECT id, session_id, project, parent_turn_id, turn_seq, role,
+		        content_json, agent_name, metadata_json
+		 FROM session_turns WHERE session_id = ? ORDER BY turn_seq ASC`,
+		"legacy-1",
+	).Scan(
+		&gotID, &gotSessionID, &gotProject, &gotParent, &gotSeq, &gotRole,
+		&gotContent, &gotAgent, &gotMetadata,
+	)
+	if err != nil {
+		t.Fatalf("query synthetic turn for legacy-1: %v", err)
+	}
+
+	if gotSessionID != "legacy-1" {
+		t.Errorf("session_id = %q, want %q", gotSessionID, "legacy-1")
+	}
+	if gotProject != "proj-legacy" {
+		t.Errorf("project = %q, want %q", gotProject, "proj-legacy")
+	}
+	if gotParent.Valid {
+		t.Errorf("parent_turn_id = %q, want NULL (root turn)", gotParent.String)
+	}
+	if gotSeq != 1 {
+		t.Errorf("turn_seq = %d, want 1", gotSeq)
+	}
+	if gotRole != "system" {
+		t.Errorf("role = %q, want %q", gotRole, "system")
+	}
+	if gotAgent != "system-migration" {
+		t.Errorf("agent_name = %q, want %q", gotAgent, "system-migration")
+	}
+
+	// content_json MUST round-trip the verbatim summary as a typed text block.
+	wantContent := `[{"type":"text","text":"prior work notes"}]`
+	if gotContent != wantContent {
+		t.Errorf("content_json = %q, want %q", gotContent, wantContent)
+	}
+
+	// metadata.pre_tree MUST be true.
+	if !gotMetadata.Valid {
+		t.Fatalf("metadata_json is NULL; want JSON with pre_tree=true")
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(gotMetadata.String), &meta); err != nil {
+		t.Fatalf("unmarshal metadata_json: %v", err)
+	}
+	if preTree, _ := meta["pre_tree"].(bool); !preTree {
+		t.Errorf("metadata.pre_tree = %v, want true (meta=%v)", meta["pre_tree"], meta)
+	}
+
+	// BDD-S-003.b: re-running migrate() must NOT insert a second synthetic turn.
+	if err := s.migrate(); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	var count int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM session_turns WHERE session_id = ?`,
+		"legacy-1",
+	).Scan(&count); err != nil {
+		t.Fatalf("count after second migrate: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("re-running migrate inserted duplicate turns: count = %d, want 1", count)
+	}
+}
+
+// TestMigrate_BackfillHandlesMultipleSessions verifies the backfill loop
+// processes every existing sessions row (not just one), each producing
+// exactly one synthetic turn, and skips sessions that were created AFTER
+// the v7 migration ran (no spurious backfill on freshly created sessions).
+func TestMigrate_BackfillHandlesMultipleSessions(t *testing.T) {
+	s := newTestStoreFromV6Database(t, []v6SessionRow{
+		{id: "legacy-A", project: "proj-A", summary: "summary A"},
+		{id: "legacy-B", project: "proj-B", summary: ""}, // empty summary
+		{id: "legacy-C", project: "proj-A", summary: "summary C"},
+	})
+
+	rows, err := s.db.Query(
+		`SELECT session_id, project FROM session_turns
+		 WHERE role = 'system' AND json_extract(metadata_json, '$.pre_tree') = 1
+		 ORDER BY session_id`,
+	)
+	if err != nil {
+		t.Fatalf("query backfilled turns: %v", err)
+	}
+	defer rows.Close()
+
+	type pair struct{ sessionID, project string }
+	var got []pair
+	for rows.Next() {
+		var p pair
+		if err := rows.Scan(&p.sessionID, &p.project); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, p)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows err: %v", err)
+	}
+	want := []pair{
+		{"legacy-A", "proj-A"},
+		{"legacy-B", "proj-B"},
+		{"legacy-C", "proj-A"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d backfilled turns, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("backfilled[%d] = %+v, want %+v", i, got[i], w)
+		}
+	}
+
+	// Sessions without summary still get a synthetic turn, but content_json
+	// carries an empty text block (still a valid typed-block array).
+	var emptyContent string
+	if err := s.db.QueryRow(
+		`SELECT content_json FROM session_turns WHERE session_id = ?`,
+		"legacy-B",
+	).Scan(&emptyContent); err != nil {
+		t.Fatalf("query empty-summary turn: %v", err)
+	}
+	if emptyContent != `[{"type":"text","text":""}]` {
+		t.Errorf("empty-summary content_json = %q, want %q", emptyContent, `[{"type":"text","text":""}]`)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1121,6 +1121,15 @@ func (s *Store) migrate() error {
 		return err
 	}
 
+	// Backfill (REQ-003, BDD-S-003.a/b): for every pre-tree sessions row,
+	// insert exactly one synthetic turn carrying the prior summary text as
+	// a typed text block. Idempotent — re-runs insert nothing because the
+	// per-row guard (session_id, turn_seq=1, role='system',
+	// metadata.pre_tree=true) finds an existing row.
+	if err := s.backfillSessionTurns(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1092,6 +1092,35 @@ func (s *Store) migrate() error {
 		return err
 	}
 
+	// ── Phase: jsonl-session-tree (PR1a) — session_turns table + indexes ──
+	// One row per turn. parent_turn_id links turns into a tree (NULL for root).
+	// No UNIQUE(session_id, turn_seq) here — that lands in PR3 along with
+	// the concurrent-save retry policy (locked-in decision C).
+	// Locked-in decision A: explicit project column (denormalized, NOT NULL).
+	// UNIQUE on id is implicit (TEXT PRIMARY KEY).
+	if _, err := s.execHook(s.db, `
+		CREATE TABLE IF NOT EXISTS session_turns (
+			id             TEXT    PRIMARY KEY,
+			session_id     TEXT    NOT NULL,
+			project        TEXT    NOT NULL,
+			parent_turn_id TEXT,
+			turn_seq       INTEGER NOT NULL,
+			role           TEXT    NOT NULL,
+			content_json   TEXT    NOT NULL,
+			agent_name     TEXT,
+			tokens_in      INTEGER,
+			tokens_out     INTEGER,
+			created_at     INTEGER NOT NULL,
+			metadata_json  TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_session_turns_session_seq
+			ON session_turns(session_id, turn_seq);
+		CREATE INDEX IF NOT EXISTS idx_session_turns_parent
+			ON session_turns(parent_turn_id);
+	`); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/store/store_migration_test.go
+++ b/internal/store/store_migration_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,7 +32,11 @@ type legacyObsRow struct {
 func newTestStoreWithLegacySchema(t *testing.T, fixtureRows []legacyObsRow) *Store {
 	t.Helper()
 
-	dir := t.TempDir()
+	// os.MkdirTemp (not t.TempDir) — see closeAndRemoveStore in store_test.go.
+	dir, err := os.MkdirTemp("", "engram-legacy-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
 	dbPath := filepath.Join(dir, "engram.db")
 
 	// 1. Open raw DB and apply legacy DDL.
@@ -85,9 +90,10 @@ func newTestStoreWithLegacySchema(t *testing.T, fixtureRows []legacyObsRow) *Sto
 
 	s, err := New(cfg)
 	if err != nil {
+		removeDirWithRetry(dir)
 		t.Fatalf("newTestStoreWithLegacySchema: New(cfg): %v", err)
 	}
-	t.Cleanup(func() { _ = s.Close() })
+	t.Cleanup(func() { closeAndRemoveStore(t, dir, s) })
 
 	return s
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -27,17 +27,55 @@ func mustDefaultConfig(t *testing.T) Config {
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 	cfg := mustDefaultConfig(t)
-	cfg.DataDir = t.TempDir()
+	// os.MkdirTemp (not t.TempDir) so we own the lifecycle; avoids racing with
+	// the testing framework's auto-RemoveAll on Windows SQLite teardown.
+	dir, err := os.MkdirTemp("", "engram-test-")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	cfg.DataDir = dir
 	cfg.DedupeWindow = time.Hour
 
 	s, err := New(cfg)
 	if err != nil {
+		_ = os.RemoveAll(dir)
 		t.Fatalf("new store: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = s.Close()
-	})
+	t.Cleanup(func() { closeAndRemoveStore(t, dir, s) })
 	return s
+}
+
+// closeAndRemoveStore closes the store and best-effort removes its data dir
+// with a retry. This is a Windows SQLite teardown mitigation: even after
+// db.Close(), SQLite may retain the file handle for a noticeable window on
+// Windows, causing the testing framework's auto-TempDir RemoveAll to fail
+// with "file being used by another process". Running our own RemoveAll with
+// retry BEFORE the framework's auto-cleanup (LIFO) makes the framework's
+// call a no-op and the test passes deterministically.
+func closeAndRemoveStore(t *testing.T, dir string, s *Store) {
+	t.Helper()
+	if s != nil {
+		_ = s.Close()
+	}
+	for i := 0; i < 100; i++ {
+		if err := os.RemoveAll(dir); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Logf("closeAndRemoveStore: best-effort RemoveAll(%q) failed after retries; framework auto-cleanup may also fail", dir)
+}
+
+// removeDirWithRetry best-effort removes a directory with a retry.
+// Used by tests that open raw SQLite handles (not via Store) but still need
+// the Windows teardown-race mitigation.
+func removeDirWithRetry(dir string) {
+	for i := 0; i < 100; i++ {
+		if err := os.RemoveAll(dir); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 type fakeRows struct {
@@ -3566,7 +3604,11 @@ func TestNewErrorBranches(t *testing.T) {
 	})
 
 	t.Run("fails when migration encounters conflicting object", func(t *testing.T) {
-		dataDir := t.TempDir()
+		// os.MkdirTemp (not t.TempDir) — see closeAndRemoveStore.
+		dataDir, err := os.MkdirTemp("", "engram-mig-conflict-test-")
+		if err != nil {
+			t.Fatalf("mkdir temp: %v", err)
+		}
 		dbPath := filepath.Join(dataDir, "engram.db")
 
 		db, err := sql.Open("sqlite", dbPath)
@@ -3591,11 +3633,19 @@ func TestNewErrorBranches(t *testing.T) {
 		`)
 		if err != nil {
 			_ = db.Close()
+			removeDirWithRetry(dataDir)
 			t.Fatalf("create conflicting view: %v", err)
 		}
 		if err := db.Close(); err != nil {
+			removeDirWithRetry(dataDir)
 			t.Fatalf("close db: %v", err)
 		}
+		// Windows SQLite teardown race: register a cleanup that retries
+		// RemoveAll on the data dir before the framework's auto-cleanup runs.
+		t.Cleanup(func() {
+			_ = db.Close() // idempotent; ensure release even if path above bailed early
+			removeDirWithRetry(dataDir)
+		})
 
 		cfg := mustDefaultConfig(t)
 		cfg.DataDir = dataDir
@@ -7344,16 +7394,20 @@ func TestReadSQLiteLockSnapshotDoesNotMutateApplicationRows(t *testing.T) {
 func newTestStoreRaw(t *testing.T) *Store {
 	t.Helper()
 	cfg := mustDefaultConfig(t)
-	cfg.DataDir = t.TempDir()
+	// os.MkdirTemp (not t.TempDir) — see newTestStore.
+	dir, err := os.MkdirTemp("", "engram-test-raw-")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	cfg.DataDir = dir
 	cfg.DedupeWindow = time.Hour
 
 	s, err := newWithoutRepair(cfg)
 	if err != nil {
+		_ = os.RemoveAll(dir)
 		t.Fatalf("new raw store: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = s.Close()
-	})
+	t.Cleanup(func() { closeAndRemoveStore(t, dir, s) })
 	return s
 }
 

--- a/internal/store/ulid.go
+++ b/internal/store/ulid.go
@@ -1,0 +1,171 @@
+package store
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ulidAlphabet is Crockford base32. Excludes I, L, O, U to avoid
+// confusion with digits and accidental obscenities.
+const ulidAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// newULID returns a 26-character Crockford-base32 ULID: 10 chars of
+// millisecond timestamp (big-endian) + 16 chars of crypto-random
+// entropy. Sortable by time, unique to 80 bits of randomness.
+func newULID() string {
+	var b [16]byte
+	ms := uint64(time.Now().UnixMilli())
+	binary.BigEndian.PutUint16(b[0:2], uint16(ms>>32))
+	binary.BigEndian.PutUint32(b[2:6], uint32(ms))
+	if _, err := rand.Read(b[6:]); err != nil {
+		// crypto/rand failure is exceptional; fall back to a time-derived
+		// filler so the migration still produces a unique-enough id
+		// (collision requires multiple failures within the same ms).
+		fallback := uint64(time.Now().UnixNano())
+		binary.BigEndian.PutUint64(b[6:], fallback)
+	}
+
+	out := make([]byte, 26)
+	// Encode the first 6 bytes (48 bits timestamp) as 10 base32 chars.
+	var acc uint64
+	var bits int
+	idx := 0
+	for i := 0; i < 6; i++ {
+		acc = (acc << 8) | uint64(b[i])
+		bits += 8
+		for bits >= 5 {
+			bits -= 5
+			out[idx] = ulidAlphabet[(acc>>bits)&0x1F]
+			idx++
+		}
+	}
+	// Encode the remaining 10 bytes (80 bits) as 16 base32 chars.
+	acc = 0
+	bits = 0
+	for i := 6; i < 16; i++ {
+		acc = (acc << 8) | uint64(b[i])
+		bits += 8
+		for bits >= 5 {
+			bits -= 5
+			out[idx] = ulidAlphabet[(acc>>bits)&0x1F]
+			idx++
+		}
+	}
+	// Drain any leftover bits (80 % 5 == 0, so this is a no-op in practice).
+	for bits > 0 {
+		bits -= 5
+		out[idx] = ulidAlphabet[(acc>>bits)&0x1F]
+		idx++
+	}
+	return string(out[:idx])
+}
+
+// backfillSessionTurns is the v6→v7 backfill: for every row in sessions,
+// insert exactly one synthetic session_turns row carrying the prior summary
+// (or an empty typed text block if the summary is NULL) and the
+// `pre_tree=true` metadata flag. Idempotent — re-runs insert nothing
+// because the per-row guard finds an existing synthetic turn.
+//
+// REQ-003 (BDD-S-003.a, BDD-S-003.b).
+func (s *Store) backfillSessionTurns() error {
+	rows, err := s.db.Query(`SELECT id, project, summary FROM sessions`)
+	if err != nil {
+		return fmt.Errorf("backfill: scan sessions: %w", err)
+	}
+	defer rows.Close()
+
+	type sessionRow struct {
+		id      string
+		project string
+		summary string
+	}
+	var sessions []sessionRow
+	for rows.Next() {
+		var sr sessionRow
+		var summary sql.NullString
+		if err := rows.Scan(&sr.id, &sr.project, &summary); err != nil {
+			return fmt.Errorf("backfill: scan session row: %w", err)
+		}
+		if summary.Valid {
+			sr.summary = summary.String
+		}
+		sessions = append(sessions, sr)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("backfill: iterate sessions: %w", err)
+	}
+
+	nowMs := time.Now().UnixMilli()
+	for _, sr := range sessions {
+		// Idempotency guard: skip if a synthetic turn already exists for
+		// this session_id. Guards against re-running migrate() on a v7 DB.
+		var existing int
+		err := s.db.QueryRow(
+			`SELECT COUNT(*) FROM session_turns
+			 WHERE session_id = ?
+			   AND turn_seq = 1
+			   AND role = 'system'
+			   AND json_extract(metadata_json, '$.pre_tree') = 1`,
+			sr.id,
+		).Scan(&existing)
+		if err != nil {
+			return fmt.Errorf("backfill: idempotency check for %q: %w", sr.id, err)
+		}
+		if existing > 0 {
+			continue
+		}
+
+		// Build content_json: a JSON array containing one typed text block
+		// with the summary text verbatim. json.Marshal handles escaping
+		// (quotes, newlines, control chars) correctly.
+		summaryJSON, err := json.Marshal(sr.summary)
+		if err != nil {
+			return fmt.Errorf("backfill: marshal summary for %q: %w", sr.id, err)
+		}
+		contentJSON := fmt.Sprintf(`[{"type":"text","text":%s}]`, string(summaryJSON))
+
+		metaJSON := `{"pre_tree":true,"migrated_from_session_summary":true}`
+
+		turnID := newULID()
+		if _, err := s.execHook(s.db, `
+			INSERT INTO session_turns (
+				id, session_id, project, parent_turn_id, turn_seq, role,
+				content_json, agent_name, tokens_in, tokens_out, created_at, metadata_json
+			) VALUES (?, ?, ?, NULL, 1, 'system', ?, 'system-migration', NULL, NULL, ?, ?)
+		`, turnID, sr.id, sr.project, contentJSON, nowMs, metaJSON); err != nil {
+			return fmt.Errorf("backfill: insert synthetic turn for %q: %w", sr.id, err)
+		}
+	}
+	return nil
+}
+
+// sentinel errors for the session_turns subsystem. Public so callers can
+// use errors.Is to discriminate failure modes (e.g., cycle vs invalid
+// content vs missing parent).
+var (
+	// ErrCycleDetected is returned by SaveTurn when the requested
+	// parent_turn_id (or any of its ancestors) would create a cycle
+	// (REQ-010).
+	ErrCycleDetected = errors.New("session_turns: cycle detected in parent_turn_id chain")
+
+	// ErrInvalidContentShape is returned by SaveTurn when content_json
+	// is not a valid JSON array of typed blocks (REQ-004 / Q2).
+	ErrInvalidContentShape = errors.New("session_turns: content_json must be a JSON array of typed blocks")
+
+	// ErrParentSessionMismatch is returned by SaveTurn when the supplied
+	// parent_turn_id belongs to a different session_id (BDD-S-001.b).
+	ErrParentSessionMismatch = errors.New("session_turns: parent_turn_id belongs to a different session")
+
+	// ErrProjectRequired is returned by SaveTurn when the project field
+	// is empty (locked-in decision A).
+	ErrProjectRequired = errors.New("session_turns: project is required")
+
+	// ErrInvalidRole is returned by SaveTurn when role is not one of
+	// user, assistant, tool, system (REQ-001).
+	ErrInvalidRole = errors.New("session_turns: role must be one of user|assistant|tool|system")
+)


### PR DESCRIPTION
## Summary

Adds the `SessionTurnRepository` for the `session_turns` table — implements `SaveTurn` (append + cycle detection + content validation) and `ListTurns` (whole-session and subtree filters with pre_tree exclusion by default).

This is part 2 of 2 for the jsonl-session-tree change. Part 1 (schema + backfill) is in PR #551, which must merge first.

## What's in this PR

- **`internal/store/session_turns.go`** (449 LOC):
  - `Turn` struct, `SaveTurnParams`, `ListTurnsOpts` (public types)
  - `SaveTurn(ctx, params)` — appends a turn, validates content shape (Q2 typed blocks), enforces cycle detection (REQ-010) via bounded recursive CTE, parent-session mismatch check (BDD-S-001.b), and computes `turn_seq` inside a transaction
  - `ListTurns(ctx, sessionID, opts)` — flat or subtree query, excludes `pre_tree=true` rows by default (REQ-005 / BDD-S-005.a, BDD-S-005.b), supports `Limit`/`Offset`
  - Sentinel errors for `errors.Is` discrimination: `ErrCycleDetected`, `ErrInvalidContentShape`, `ErrParentSessionMismatch`, `ErrProjectRequired`, `ErrInvalidRole`

## What's NOT in this PR (intentional, future PRs)

- `mem_session_fork` (PR2)
- `mem_session_rewind` branch mode (PR2)
- `mem_session_summary` rewire + CLI surface + `sdd-apply` integration (PR3)
- `UNIQUE(session_id, turn_seq)` constraint + concurrent-save retry policy (locked-in decision C, lands in PR3)

## Dependencies

- **Blocked by:** PR #551 (PR1a-schema: `session_turns` table). Merge that first.
- **Also transitively blocked by:** PR #550 (hygiene: `cb71911`).

## Validation

- `go build ./...` OK
- `go test ./internal/store/... -count=1` OK (15s)
- 5 new tests:
  - `TestSessionTurnRepository_SaveAndList` (REQ-004 / REQ-005 happy path)
  - `TestSessionTurnRepository_SaveAndList_SubtreeFilter` (BDD-S-005.b)
  - `TestSessionTurnRepository_CycleDetection` (REQ-010 — direct cycle + self-loop)
  - `TestSessionTurnRepository_Validation` (Q2 typed blocks)
  - `TestProperty_CycleDetectionTerminates` (property-based — random forest never infinite-loops)

## Note on base branch

Base is `main` rather than `codex/jsonl-session-tree-pr1a-schema` because we're working from a fork and the schema branch only exists on the fork. The chain is documented in commit history. Once #550 and #551 merge to upstream `main`, this PR's diff against main shrinks to just the repository commit (`d33418e`).

## Out of scope

- `ulid.go` naming is suboptimal (mixes ULID + backfill + sentinel errors) — flagged for future refactor
- The custom ULID implementation could be replaced by `github.com/oklog/ulid/v2` in a follow-up; current implementation is intentionally time-sortable, which UUIDs are not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for saving and browsing session turns, including threaded replies and chronological ordering.
  * Session history can now be viewed as a full conversation or as a branch from a selected turn.
  * Legacy sessions are automatically brought into the new turn-based format.

* **Bug Fixes**
  * Improved validation to prevent invalid turn data from being saved.
  * Fixed cycle-related issues so circular turn references are rejected safely.
  * Improved reliability of test and cleanup handling on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->