### PR TITLE
feat(cli): add 'engram init' command to resolve ambiguous workspaces

### DIFF
--- a/cmd/engram/init.go
+++ b/cmd/engram/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 
 func cmdInit() {
 	var projectName string
-
 	if len(os.Args) > 2 {
 		projectName = os.Args[2]
 	}
@@ -32,8 +32,19 @@ func cmdInit() {
 		return
 	}
 
+	// We use DetectProjectFull to provide contextual help to the user
+	// when they didn't provide a project name explicitly.
 	if projectName == "" {
-		fmt.Printf("No git repository detected (or multiple repositories found).\n")
+		res := project.DetectProjectFull(cwd)
+		
+		if errors.Is(res.Error, project.ErrAmbiguousProject) {
+			fmt.Printf("Ambiguous workspace: Multiple git repositories detected in this directory.\n")
+		} else if res.Source == project.SourceDirBasename {
+			fmt.Printf("No git repository detected.\n")
+		} else {
+			fmt.Printf("Project detected as '%s' (source: %s).\n", res.Project, res.Source)
+		}
+
 		fmt.Printf("What should we name this project? ")
 		
 		reader := bufio.NewReader(os.Stdin)
@@ -50,14 +61,8 @@ func cmdInit() {
 		}
 	}
 
-	// Make sure the project name is valid by normalizing it
-	normalizedName := project.DetectProjectFull(cwd).Project
-	if normalizedName == "" {
-	    // If ambiguous, DetectProjectFull returns empty string for Project, so we fallback
-		normalizedName = strings.TrimSpace(strings.ToLower(projectName))
-	} else if projectName != "" {
-	    normalizedName = strings.TrimSpace(strings.ToLower(projectName))
-	}
+	// Make sure the project name is normalized (lowercase, trimmed)
+	normalizedName := strings.TrimSpace(strings.ToLower(projectName))
 
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create .engram directory: %v\n", err)

--- a/cmd/engram/init.go
+++ b/cmd/engram/init.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gentleman-Programming/engram/internal/project"
+)
+
+func cmdInit() {
+	var projectName string
+
+	if len(os.Args) > 2 {
+		projectName = os.Args[2]
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get current working directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	configDir := filepath.Join(cwd, ".engram")
+	configFile := filepath.Join(configDir, "config.json")
+
+	if _, err := os.Stat(configFile); err == nil {
+		fmt.Printf("Engram is already initialized in this directory (.engram/config.json exists).\n")
+		return
+	}
+
+	if projectName == "" {
+		fmt.Printf("No git repository detected (or multiple repositories found).\n")
+		fmt.Printf("What should we name this project? ")
+		
+		reader := bufio.NewReader(os.Stdin)
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to read input: %v\n", err)
+			os.Exit(1)
+		}
+		
+		projectName = strings.TrimSpace(input)
+		if projectName == "" {
+			fmt.Println("Project name cannot be empty. Aborting.")
+			os.Exit(1)
+		}
+	}
+
+	// Make sure the project name is valid by normalizing it
+	normalizedName := project.DetectProjectFull(cwd).Project
+	if normalizedName == "" {
+	    // If ambiguous, DetectProjectFull returns empty string for Project, so we fallback
+		normalizedName = strings.TrimSpace(strings.ToLower(projectName))
+	} else if projectName != "" {
+	    normalizedName = strings.TrimSpace(strings.ToLower(projectName))
+	}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create .engram directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	configData := map[string]string{
+		"project_name": normalizedName,
+	}
+
+	data, err := json.MarshalIndent(configData, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(configFile, data, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write config file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully initialized Engram project '%s' at %s\n", normalizedName, configFile)
+}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -650,6 +650,8 @@ func main() {
 		cmdProjects(cfg)
 	case "setup":
 		cmdSetup()
+	case "init":
+		cmdInit()
 	case "version", "--version", "-v":
 		fmt.Printf("engram %s\n", version)
 	case "help", "--help", "-h":
@@ -2304,6 +2306,7 @@ Commands:
                        --all      Scan ALL projects for similar name groups
                        --dry-run  Preview what would be merged (no changes)
   setup [agent]      Install/setup agent integration (opencode, pi, claude-code, gemini-cli, codex)
+  init [name]        Initialize an Engram project config for unversioned workspaces
   sync               Export new memories as compressed chunk to .engram/
                          --import   Import new chunks from .engram/ into local DB
                          --status   Show sync status

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -244,6 +244,17 @@ claude plugin install engram
 
 That's it. The plugin registers the MCP server, hooks, and Memory Protocol skill automatically.
 
+> **If the marketplace command fails with a schema error**
+>
+> Older Claude Code CLI versions cannot parse some plugin manifest fields and will reject `claude plugin marketplace add` with messages like `Invalid schema: plugins.0.source: Invalid input`. The fix is to update the CLI:
+>
+> ```bash
+> claude --version  # check what you have
+> claude update     # upgrade to the latest
+> ```
+>
+> Then re-run the marketplace command. If you cannot update for some reason, **Option C (Bare MCP)** below works on any Claude Code version because it does not go through the marketplace.
+
 **Option B: Plugin via `engram setup`** — same plugin, installed from the embedded binary:
 
 ```bash

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,11 +51,28 @@ git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
 go install ./cmd/engram
 # Binary goes to %GOPATH%\bin\engram.exe (typically %USERPROFILE%\go\bin\)
-
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
-$v = git describe --tags --always
-go build -ldflags="-X main.version=local-$v" -o engram.exe ./cmd/engram
 ```
+
+> **Want a real version string instead of `dev`?**
+>
+> `go install` always stamps the binary as `dev`. To get a meaningful version, pick one of these — not both. Running them both leaves two binaries on disk and `engram version` keeps reporting `dev` because PATH still resolves to the `go install` build.
+>
+> **Option B1 — version-stamped `go install` (binary stays on PATH):**
+>
+> ```powershell
+> $v = git describe --tags --always
+> go install -ldflags="-X main.version=local-$v" ./cmd/engram
+> ```
+>
+> **Option B2 — `go build` and move the result onto PATH:**
+>
+> ```powershell
+> $v = git describe --tags --always
+> go build -ldflags="-X main.version=local-$v" -o engram.exe ./cmd/engram
+> Move-Item -Force engram.exe "$env:USERPROFILE\go\bin\engram.exe"
+> ```
+>
+> After either option, `engram version` should print `local-<git-describe>` instead of `dev`.
 
 **Option C: Download the prebuilt binary**
 
@@ -104,10 +121,27 @@ Expand-Archive engram_*_windows_amd64.zip -DestinationPath "$env:USERPROFILE\bin
 git clone https://github.com/Gentleman-Programming/engram.git
 cd engram
 go install ./cmd/engram
-
-# Optional: build with version stamp (otherwise `engram version` shows "dev")
-go build -ldflags="-X main.version=local-$(git describe --tags --always)" -o engram ./cmd/engram
+# Binary goes to $GOPATH/bin (typically ~/go/bin/)
 ```
+
+> **Want a real version string instead of `dev`?**
+>
+> `go install` always stamps the binary as `dev`. To get a meaningful version, pick one of these — not both. Running them both leaves two binaries on disk and `engram version` keeps reporting `dev` because PATH still resolves to the `go install` build.
+>
+> **Option 1 — version-stamped `go install` (binary stays on PATH):**
+>
+> ```bash
+> go install -ldflags="-X main.version=local-$(git describe --tags --always)" ./cmd/engram
+> ```
+>
+> **Option 2 — `go build` and move the result onto PATH:**
+>
+> ```bash
+> go build -ldflags="-X main.version=local-$(git describe --tags --always)" -o engram ./cmd/engram
+> mv engram "$(go env GOPATH)/bin/engram"
+> ```
+>
+> After either option, `engram version` should print `local-<git-describe>` instead of `dev`.
 
 ---
 


### PR DESCRIPTION
<!-- 
  ⚠️ READ BEFORE SUBMITTING
  
  Every PR must:
  1. Link an approved issue (with status:approved label)
  2. Have exactly one type:* label
  3. Pass all 5 automated checks
  
  See CONTRIBUTING.md for the full workflow.
-->

## 🔗 Linked Issue

Closes #511

---

## 🏷️ PR Type

- [x] `type:feature` — New feature

---

## 📝 Summary

- Adds `engram init` command to bypass git-initialization workarounds.
- Prompts the user interactively if no arguments are passed.
- Uses `DetectProjectFull` to accurately warn users if they are in an ambiguous workspace.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/init.go` | Refactored detection logic, removed unneeded overwriting of variables, improved console output depending on the error type (`ErrAmbiguousProject` vs standard `SourceDirBasename`). |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Tested manually by building the binary and initializing projects in both standard directories and ambiguous workspaces.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits
