### PR TITLE
fix: stamp version into cloud Docker image build

### DIFF
--- a/.github/workflows/cloud-image.yml
+++ b/.github/workflows/cloud-image.yml
@@ -72,5 +72,7 @@ jobs:
           file: docker/cloud/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -8,7 +8,12 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -o /out/engram ./cmd/engram
+
+# VERSION is injected via ldflags so `engram version` reports the release tag.
+# Defaults to "dev" for local builds; the release workflow passes the git tag.
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o /out/engram ./cmd/engram
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata


### PR DESCRIPTION
## Summary

The published cloud image reports `engram dev` instead of the release version. This injects the version into the Docker build so `engram version` matches the tag, the same way the brew/archive artifacts already do.

```console
# before
$ docker run --rm ghcr.io/gentleman-programming/engram:v1.17.0 version
engram dev
```

## Root cause

`docker/cloud/Dockerfile` compiled the binary without `-X main.version`, and from a source `COPY` rather than a versioned module, so `debug.ReadBuildInfo()` in `cmd/engram/main.go` fell back to `(devel)` and `version` stayed `dev`. `.goreleaser.yaml` injects the ldflag for brew/archives, but the cloud image is built separately by `cloud-image.yml`, which never passed the version through.

## Change

- `docker/cloud/Dockerfile`: add a `VERSION` build arg (default `dev`) and inject it via `-ldflags "-s -w -X main.version=$VERSION"`, plus `-trimpath` to match goreleaser's flags.
- `.github/workflows/cloud-image.yml`: pass `VERSION=${{ steps.meta.outputs.version }}` to the build, so release tags flow into the binary. Manual `workflow_dispatch` builds fall through to the `sha-...` metadata value.

Two files, no behavior change beyond the reported version. Local builds with no arg still report `dev`.

## Verification

Built the image locally with the arg and confirmed the binary picks it up:

```console
$ docker build -f docker/cloud/Dockerfile --build-arg VERSION=1.17.0-verify -t engram-verify .
$ docker run --rm engram-verify version
engram 1.17.0-verify
```

Closes #557


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud image builds now include release version information in the built app, making deployed builds easier to identify.
  * Build outputs are now produced in a more reproducible way.

* **Chores**
  * Updated the cloud image build process to pass version details through to the final image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->