### PR TITLE
fix(store): escape interior double-quotes in sanitizeFTS to prevent FTS5 crash

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6587,6 +6587,11 @@ func sanitizeFTS(query string) string {
 	for i, w := range words {
 		// Strip existing quotes to avoid double-quoting
 		w = strings.Trim(w, `"`)
+		// Double interior double-quotes: FTS5 escapes a literal " inside a
+		// quoted phrase by doubling it (""). Without this, `hello"world`
+		// becomes `"hello"world"` — an unterminated string literal that crashes
+		// the query with "SQL logic error: unterminated string". See #574.
+		w = strings.ReplaceAll(w, `"`, `""`)
 		words[i] = `"` + w + `"`
 	}
 	return strings.Join(words, " ")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8802,3 +8802,31 @@ func TestSearch_WeightedBM25Ranking(t *testing.T) {
 			results[1].ID, results[1].Title, results[1].Rank)
 	}
 }
+
+// TestSanitizeFTS verifies sanitizeFTS escapes interior double-quotes per FTS5
+// string-literal rules, preventing "unterminated string" crashes on inputs like
+// `hello"world`. See issue #574.
+func TestSanitizeFTS(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain word", "foo", `"foo"`},
+		{"multiple words", "fix auth bug", `"fix" "auth" "bug"`},
+		{"interior double-quote (the bug)", `foo"bar`, `"foo""bar"`},
+		{"already quoted", `"hello"`, `"hello"`},
+		{"multiple interior quotes", `a"b"c`, `"a""b""c"`},
+		{"just quotes", `""`, `""`},
+		{"mixed quote and plain", `hello"world test`, `"hello""world" "test"`},
+		{"empty input", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeFTS(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeFTS(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #574

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

---

## 📝 Summary

- Fixes FTS5 search crash on queries containing an interior double-quote (e.g. `hello"world` → `SQL logic error: unterminated string (1)`).
- Doubles interior " inside `sanitizeFTS` per the FTS5 string-literal escape rule ("""), so `hello"world` → `"hello""world"`.
- Adds `TestSanitizeFTS` with 8 cases (written first, failing per TDD; all pass after the fix).

---

## 🔧 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Add `strings.ReplaceAll(w, \"\", \"\"\"\")` after `Trim` in `sanitizeFTS` to escape interior double-quotes for FTS5. |
| `internal/store/store_test.go` | Add `TestSanitizeFTS` covering plain words, multiple words, single/multiple interior quotes, already-quoted, just-quotes, mixed, and empty input. |

---

## 🧪 Test Plan

- [x] New test `TestSanitizeFTS` fails on unpatched code (RED) and passes after the fix (GREEN): `go test ./internal/store/ -run TestSanitizeFTS -v`
- [x] Full store package passes (no regressions): `go test ./internal/store/`
- [x] Built binary no longer crashes: `go build -o /tmp/engram-fix ./cmd/engram && /tmp/engram-fix search 'hello"world'` → clean "No memories found" (exit 0).
- [x] Normal search still works: `/tmp/engram-fix search 'sanitizeFTS'` → returns results.

---

## ✅ Contributor Checklist

- [x] Linked an approved issue (#574)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Tests included with the fix
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query handling so text containing double quotes no longer produces malformed search expressions, resulting in more reliable search behavior.
* **Tests**
  * Added unit test coverage for search-term formatting across common scenarios, including plain terms, multi-word input, inputs with interior quotes, mixed quoted/unquoted sequences, and empty input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->