### PR TITLE
feat(deploy): env.yml deployment config, Dockerfile, and ingress base-path support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS builder
-
-ARG TARGETOS
-ARG TARGETARCH
+FROM golang:1.25.10-alpine AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -o /out/engram ./cmd/engram
+RUN CGO_ENABLED=0 go build -o /out/engram ./cmd/engram
 
 RUN wget -O /out/us-west-2-bundle.pem https://truststore.pki.rds.amazonaws.com/us-west-2/us-west-2-bundle.pem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -o /out/engram ./cmd/engram
+
+RUN wget -O /out/us-west-2-bundle.pem https://truststore.pki.rds.amazonaws.com/us-west-2/us-west-2-bundle.pem
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates tzdata
+RUN adduser -D -u 10001 engram
+USER engram
+WORKDIR /home/engram
+COPY --from=builder /out/engram /usr/local/bin/engram
+COPY --from=builder /out/us-west-2-bundle.pem /app/us-west-2-bundle.pem
+
+EXPOSE 18080
+ENTRYPOINT ["engram"]
+CMD ["cloud", "serve"]

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ For authenticated mode, upgrade flow, dashboard behavior, reason codes, and full
 
 - [Engram Cloud docs landing](docs/engram-cloud/README.md)
 - [Engram Cloud quickstart](docs/engram-cloud/quickstart.md)
+- [Always-on autosync setup on macOS (launchd)](docs/engram-cloud/engram-autosync-setup.md)
 - [DOCS.md — Cloud CLI reference](DOCS.md#cloud-cli-opt-in)
 - [DOCS.md — Cloud Autosync](DOCS.md#cloud-autosync)
 
@@ -386,6 +387,7 @@ Full environment variable reference → [DOCS.md#environment-variables](DOCS.md#
 | --------------------------------------------- | ---------------------------------------------------------------------- |
 | [Installation](docs/INSTALLATION.md)          | All install methods + platform support                                 |
 | [Engram Cloud](docs/engram-cloud/README.md)   | Cloud landing page, quickstart, branding, and deep links               |
+| [macOS Autosync Setup](docs/engram-cloud/engram-autosync-setup.md) | From zero to always-on cloud autosync via launchd (install, enroll, daemon, verification) |
 | [Agent Setup](docs/AGENT-SETUP.md)            | Per-agent configuration + Memory Protocol                              |
 | [Codebase Guide](docs/CODEBASE-GUIDE.md)      | Guide to the repository structure, flows, and implementation landmarks |
 | [Architecture](docs/ARCHITECTURE.md)          | How it works + MCP tools + project structure                           |

--- a/docs/engram-cloud/README.md
+++ b/docs/engram-cloud/README.md
@@ -82,6 +82,7 @@ For a direct registry-based deploy example, use:
 | Doc | Purpose |
 |---|---|
 | [Quickstart](./quickstart.md) | One recommended path first, then authenticated mode |
+| [macOS Autosync Setup](./engram-autosync-setup.md) | From zero to always-on autosync via launchd, with the verified root cause of stale cloud copies |
 | [GHCR Compose Example](./docker-compose.ghcr.yml) | Pull-and-run deployment sample for Dokploy/Coolify/Portainer/VPS |
 | [Branding](./branding.md) | Engram Cloud visual identity, asset usage, previews |
 | [Technical Cloud Reference](../../DOCS.md#cloud-cli-opt-in) | Full CLI + env/runtime details |

--- a/docs/engram-cloud/engram-autosync-setup.md
+++ b/docs/engram-cloud/engram-autosync-setup.md
@@ -1,0 +1,219 @@
+# Engram from zero: install, cloud sync, and always-on autosync (macOS)
+
+This guide takes you from "never used Engram" to a setup where:
+
+1. Your AI agents (Claude Code, etc.) save persistent memories locally.
+2. Those memories sync to the Nauta Engram cloud.
+3. The sync keeps working even if you close every shell, log out, or reboot — via a `launchd` agent, macOS's native service manager.
+
+Everything below was verified on Engram **v1.19.0** installed via Homebrew (binary at `/opt/homebrew/bin/engram`, data at `~/.engram/`).
+
+---
+
+## How Engram works (30-second mental model)
+
+- **Saving is local and always safe.** Agent tools (`mem_save`, etc.) write straight to a SQLite database at `~/.engram/engram.db`. No daemon or network needed. You never lose a memory by closing a shell.
+- **Every save also queues a "sync mutation"** in that same database, marked unacked until it reaches the cloud.
+- **Cloud upload is a separate step.** The queue is flushed either by an explicit `engram sync --cloud --project <name>`, or automatically by the `engram serve` daemon **when autosync is enabled** (`ENGRAM_CLOUD_AUTOSYNC=1`). If neither is in place, memories pile up locally and the cloud copy goes stale — that's the problem this guide fixes.
+
+---
+
+## Step 1 — Install Engram
+
+```bash
+brew install gentleman-programming/tap/engram
+engram version   # expect v1.19.0 or newer
+```
+
+## Step 2 — Hook it into your agent (optional but recommended)
+
+For Claude Code:
+
+```bash
+engram setup claude-code
+```
+
+This registers Engram as an MCP server so tools like `mem_save` / `mem_search` are available inside your agent sessions. (Other supported agents: `engram setup <agent>` — cursor, codex, gemini-cli, etc.)
+
+## Step 3 — Point Engram at the cloud server
+
+```bash
+engram cloud config --server https://ingress.internal.getnauta.dev/api/nauta-engram/
+```
+
+This writes `~/.engram/cloud.json`. Verify with:
+
+```bash
+engram cloud status
+```
+
+You want to see `Cloud status: configured` and `Auth status: ready`.
+
+## Step 4 — Enroll your project
+
+Cloud sync is opt-in **per project**. The project name is auto-detected from the git remote of the directory you work in. This guide uses a disposable test project, `smoke-project`, so you can practice safely — swap in your real project name when you're done testing.
+
+```bash
+engram cloud enroll smoke-project
+```
+
+Repeat for any other project you want synced.
+
+## Step 5 — Smoke-test the whole pipeline once
+
+```bash
+# save something
+engram save "cloud-test" "verifying cloud sync end-to-end" --project smoke-project
+
+# push the queue to the cloud
+engram sync --cloud --project smoke-project
+```
+
+You should see `Cloud sync complete for project "smoke-project"` with a chunk id and mutation count. If this works manually, automation will work too.
+
+---
+
+## Why memories weren't reaching the cloud (root cause, verified 2026-07-10)
+
+Diagnosed in practice with `engram cloud status`, `engram doctor`, and the [official engram-cloud docs](https://github.com/Gentleman-Programming/engram/blob/main/docs/engram-cloud/quickstart.md):
+
+- **Autosync lives inside the `engram serve` daemon.** The MCP tools (`mem_save`, etc.) only write to local SQLite and enqueue mutations — they never push to the cloud themselves.
+- **The daemon wasn't running** (no process, no launchd agent), so nothing ever flushed the queue. `engram cloud status` says it directly: *"Local daemon: not running on port 7437 — run `engram serve` to resume autosync"*.
+- **`ENGRAM_CLOUD_AUTOSYNC=1` was never set.** Autosync requires three env vars — `ENGRAM_CLOUD_AUTOSYNC`, `ENGRAM_CLOUD_TOKEN`, `ENGRAM_CLOUD_SERVER` — and only the token was exported. Even a running daemon would have stayed idle.
+- The one stale chunk on the server came from the single manual `engram sync --cloud` run during Step 5.
+
+Symptom to recognize it by: `engram sync --status --cloud --project <name>` shows more local chunks than remote (e.g. `Local chunks: 5, Remote chunks: 1`).
+
+The steps below fix all three conditions permanently.
+
+## Step 6 — Export the cloud env vars for ALL sessions
+
+Two different kinds of "session" need the variables, and they do **not** share configuration:
+
+**1. Interactive shells** (terminals, and any agent session spawned from them) — add all three exports to `~/.zshrc`:
+
+```bash
+# ~/.zshrc — engram cloud sync
+export ENGRAM_CLOUD_TOKEN=<your-bearer-token>
+export ENGRAM_CLOUD_SERVER=https://ingress.internal.getnauta.dev/api/nauta-engram/
+export ENGRAM_CLOUD_AUTOSYNC=1
+```
+
+Apply and confirm:
+
+```bash
+source ~/.zshrc
+env | grep ENGRAM   # all three must appear
+```
+
+**2. launchd services** — launchd does **not** read `~/.zshrc`. The daemon plist must carry its own `EnvironmentVariables` block (included in Step 7). This is the trap that silently disables autosync if you only export in the shell.
+
+Note: `ENGRAM_CLOUD_SERVER` overlaps with `~/.engram/cloud.json` (written in Step 3), but exporting it explicitly keeps the CLI, the daemon, and future machine bootstraps consistent.
+
+## Step 7 — Run the autosync daemon, alive across reboots (launchd + KeepAlive)
+
+Running `engram serve` in a terminal works, but it dies the moment that terminal (or the agent session that spawned it) closes. The fix is a **launchd agent**: macOS starts it at login and restarts it if it ever crashes. With the autosync env vars embedded, the daemon flushes the cloud queue in the background for every enrolled project — no separate timer needed.
+
+Run this single command — it generates the plist (injecting the real token and server from your Step 6 exports, so make sure the current shell has them: `env | grep ENGRAM`) and (re)loads the agent:
+
+```bash
+cat > ~/Library/LaunchAgents/dev.engram.serve.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.engram.serve</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/engram</string>
+        <string>serve</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ENGRAM_CLOUD_AUTOSYNC</key>
+        <string>1</string>
+        <key>ENGRAM_CLOUD_TOKEN</key>
+        <string>${ENGRAM_CLOUD_TOKEN}</string>
+        <key>ENGRAM_CLOUD_SERVER</key>
+        <string>${ENGRAM_CLOUD_SERVER}</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/engram-serve.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/engram-serve.err.log</string>
+</dict>
+</plist>
+EOF
+launchctl bootout gui/$(id -u)/dev.engram.serve 2>/dev/null; \
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.engram.serve.plist
+```
+
+The heredoc is unquoted on purpose: `${ENGRAM_CLOUD_TOKEN}` and `${ENGRAM_CLOUD_SERVER}` expand from your shell, so the written plist contains the literal values (launchd can't expand variables itself). The `bootout` before `bootstrap` makes the command idempotent — safe to re-run after editing.
+
+Verify:
+
+```bash
+launchctl list | grep engram          # should show dev.engram.serve
+curl -s http://127.0.0.1:7437/health  # {"service":"engram","status":"ok",...}
+engram cloud status                   # "Local daemon: running on port 7437"
+```
+
+`KeepAlive` means launchd restarts the daemon if it dies; `RunAtLoad` means it starts at every login. No shell required, survives reboots.
+
+## Step 8 — Verify autosync end-to-end
+
+```bash
+# 1. save a memory without any daemon interaction
+engram save "autosync-test" "saved after automation setup" --project smoke-project
+
+# 2. give autosync a moment, then compare local vs remote chunks
+engram sync --status --cloud --project smoke-project
+# healthy: Local chunks == Remote chunks
+
+# 3. confirm nothing is left unacked
+sqlite3 ~/.engram/engram.db \
+  "SELECT count(*) FROM sync_mutations WHERE acked_at IS NULL AND project='smoke-project';"
+# expect: 0
+```
+
+If the queue isn't draining, check `/tmp/engram-serve.err.log` and the Troubleshooting section. You can always force a flush manually:
+
+```bash
+engram sync --cloud --project smoke-project
+```
+
+---
+
+## Day-to-day operations cheat sheet
+
+| Task | Command |
+|------|---------|
+| Is the daemon up? | `engram cloud status` or `curl -s 127.0.0.1:7437/health` |
+| What's pending upload? | `sqlite3 ~/.engram/engram.db "SELECT seq, entity, project FROM sync_mutations WHERE acked_at IS NULL;"` |
+| Local vs remote chunks | `engram sync --status --cloud --project <name>` |
+| Force a sync now | `engram sync --cloud --project <name>` |
+| Restart the daemon | `launchctl kickstart -k gui/$(id -u)/dev.engram.serve` |
+| Stop the daemon | `launchctl bootout gui/$(id -u)/dev.engram.serve` |
+| Health diagnostics | `engram doctor --json` |
+| See all projects | `engram projects list` |
+
+## Troubleshooting
+
+- **`launchctl bootstrap` says "Bootstrap failed: 5: Input/output error"** — the agent is already loaded. Unload first: `launchctl bootout gui/$(id -u)/dev.engram.serve`, then bootstrap again.
+- **Daemon runs but the queue never drains** — almost always a missing `ENGRAM_CLOUD_AUTOSYNC=1` in the plist's `EnvironmentVariables` (launchd ignores `~/.zshrc`). Confirm what the daemon actually sees: `launchctl print gui/$(id -u)/dev.engram.serve | grep -A5 environment`.
+- **Sync log shows auth errors** — re-check `engram cloud status`; the token comes from runtime cloud config, and the project must be enrolled (`engram cloud enroll <project>`).
+- **Sync fails with `blocked_unenrolled` / `paused` / `policy_forbidden`** — server-side states from the cloud control plane: enroll the project, or ask an admin to resume sync from the dashboard.
+- **After a brew upgrade the daemon disappears** — launchd points at `/opt/homebrew/bin/engram`, which is a stable symlink, so upgrades are normally fine; if the daemon is flapping, check `/tmp/engram-serve.err.log`.
+- **Memories saved but never reach the cloud** — remember: saving is local-only by design. Check the pending-queue query above, then confirm the daemon is loaded (`launchctl list | grep engram`) and autosync is enabled.
+- **Fallback if autosync misbehaves** — a timer-style launchd agent running `engram sync --cloud --project <name>` on a `StartInterval` (e.g. 900 s) also works; one agent per project, distinct `Label`s. Autosync via the daemon supersedes this approach.

--- a/env.yml
+++ b/env.yml
@@ -1,18 +1,6 @@
 ---
 - name: ENGRAM_DATABASE_URL
-  value: "postgres://{{ nauta_engram_db_user }}:{{ nauta_engram_db_password }}@{{ nauta_engram_db_host }}:{{ nauta_engram_db_port }}/{{ nauta_engram_db_name }}?sslmode=verify-full&sslrootcert=/app/us-west-2-bundle.pem"
-
-- name: ENGRAM_JWT_SECRET
-  value: "{{ nauta_engram_jwt_secret }}"
-
-- name: ENGRAM_CLOUD_TOKEN
-  value: "{{ nauta_engram_cloud_token }}"
-
-- name: ENGRAM_CLOUD_ADMIN
-  value: "{{ nauta_engram_cloud_admin }}"
-
-- name: ENGRAM_CLOUD_ALLOWED_PROJECTS
-  value: "{{ nauta_engram_cloud_allowed_projects }}"
+  value: "postgres://{{ nauta_engram_db_user }}:{{ nauta_engram_db_password }}@{{ nauta_engram_db_host }}:{{ nauta_engram_db_port }}/{{ nauta_engram_db_database }}?sslmode=verify-full&sslrootcert=/app/us-west-2-bundle.pem"
 
 - name: ENGRAM_CLOUD_HOST
   value: "0.0.0.0"

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,21 @@
+---
+- name: ENGRAM_DATABASE_URL
+  value: "postgres://{{ nauta_engram_db_user }}:{{ nauta_engram_db_password }}@{{ nauta_engram_db_host }}:{{ nauta_engram_db_port }}/{{ nauta_engram_db_name }}?sslmode=verify-full&sslrootcert=/app/us-west-2-bundle.pem"
+
+- name: ENGRAM_JWT_SECRET
+  value: "{{ nauta_engram_jwt_secret }}"
+
+- name: ENGRAM_CLOUD_TOKEN
+  value: "{{ nauta_engram_cloud_token }}"
+
+- name: ENGRAM_CLOUD_ADMIN
+  value: "{{ nauta_engram_cloud_admin }}"
+
+- name: ENGRAM_CLOUD_ALLOWED_PROJECTS
+  value: "{{ nauta_engram_cloud_allowed_projects }}"
+
+- name: ENGRAM_CLOUD_HOST
+  value: "0.0.0.0"
+
+- name: ENGRAM_PORT
+  value: "18080"

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -185,11 +185,19 @@ func (s *CloudServer) Start() error {
 	return s.listenAndServe(addr, s.Handler())
 }
 
+// ingressBasePath is the prefix under which the Nauta ingress exposes this
+// service; the ingress does not strip it, so every route must also resolve
+// beneath it.
+const ingressBasePath = "/api/nauta-engram"
+
 func (s *CloudServer) Handler() http.Handler {
 	if s.mux == nil {
 		s.routes()
 	}
-	return s.mux
+	outer := http.NewServeMux()
+	outer.Handle("/", s.mux)
+	outer.Handle(ingressBasePath+"/", http.StripPrefix(ingressBasePath, prefixRewrite(ingressBasePath, s.mux)))
+	return outer
 }
 
 func (s *CloudServer) pushBodyLimit() int64 {
@@ -202,9 +210,6 @@ func (s *CloudServer) pushBodyLimit() int64 {
 func (s *CloudServer) routes() {
 	s.mux = http.NewServeMux()
 	s.mux.HandleFunc("GET /health", s.handleHealth)
-	// Nauta ingress routes /api/nauta-engram/* to this container without
-	// stripping the prefix, and health-checks /api/nauta-engram/health.
-	s.mux.HandleFunc("GET /api/nauta-engram/health", s.handleHealth)
 	var dashboardStore dashboard.DashboardStore
 	if store, ok := s.store.(dashboard.DashboardStore); ok {
 		dashboardStore = store

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -202,6 +202,9 @@ func (s *CloudServer) pushBodyLimit() int64 {
 func (s *CloudServer) routes() {
 	s.mux = http.NewServeMux()
 	s.mux.HandleFunc("GET /health", s.handleHealth)
+	// Nauta ingress routes /api/nauta-engram/* to this container without
+	// stripping the prefix, and health-checks /api/nauta-engram/health.
+	s.mux.HandleFunc("GET /api/nauta-engram/health", s.handleHealth)
 	var dashboardStore dashboard.DashboardStore
 	if store, ok := s.store.(dashboard.DashboardStore); ok {
 		dashboardStore = store

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -74,6 +74,60 @@ func TestHandlerPushRejectsInvalidClientCreatedAt(t *testing.T) {
 	}
 }
 
+func TestHandlerServesRoutesUnderIngressBasePath(t *testing.T) {
+	srv := New(&fakeStore{}, fakeAuth{}, 0)
+
+	health := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(health, httptest.NewRequest(http.MethodGet, ingressBasePath+"/health", nil))
+	if health.Code != http.StatusOK {
+		t.Fatalf("expected %s/health=200, got %d", ingressBasePath, health.Code)
+	}
+
+	// Sync routes must resolve under the ingress prefix too — anything but 404
+	// proves the route matched (the ingress forwards without stripping the prefix).
+	manifest := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(manifest, httptest.NewRequest(http.MethodGet, ingressBasePath+"/sync/pull?project=proj-a", nil))
+	if manifest.Code == http.StatusNotFound {
+		t.Fatalf("expected %s/sync/pull to resolve, got 404 body=%q", ingressBasePath, manifest.Body.String())
+	}
+}
+
+func TestHandlerRewritesDashboardResponsesUnderIngressBasePath(t *testing.T) {
+	srv := New(&fakeStore{}, fakeAuth{}, 0)
+
+	// Unauthenticated dashboard request must redirect within the prefix, or the
+	// browser lands on a path the ingress does not route.
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ingressBasePath+"/dashboard", nil))
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect for unauthenticated %s/dashboard, got %d", ingressBasePath, rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); !strings.HasPrefix(loc, ingressBasePath+"/dashboard/login") {
+		t.Fatalf("expected Location under %s/dashboard/login, got %q", ingressBasePath, loc)
+	}
+
+	// Login page HTML must reference dashboard URLs under the prefix.
+	login := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(login, httptest.NewRequest(http.MethodGet, ingressBasePath+"/dashboard/login", nil))
+	if login.Code != http.StatusOK {
+		t.Fatalf("expected %s/dashboard/login=200, got %d", ingressBasePath, login.Code)
+	}
+	body := login.Body.String()
+	if !strings.Contains(body, `"`+ingressBasePath+`/dashboard`) {
+		t.Fatalf("expected login HTML to contain prefixed dashboard URLs, got %q", body)
+	}
+	if strings.Contains(body, `"/dashboard`) {
+		t.Fatalf("expected no unprefixed dashboard URLs in login HTML, got %q", body)
+	}
+
+	// Non-prefixed access keeps emitting unprefixed URLs.
+	direct := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(direct, httptest.NewRequest(http.MethodGet, "/dashboard", nil))
+	if loc := direct.Header().Get("Location"); !strings.HasPrefix(loc, "/dashboard/login") {
+		t.Fatalf("expected direct Location under /dashboard/login, got %q", loc)
+	}
+}
+
 func (s *fakeStore) ReadChunk(_ context.Context, _ string, chunkID string) ([]byte, error) {
 	if s.errRead != nil {
 		return nil, s.errRead

--- a/internal/cloud/cloudserver/prefix_rewrite.go
+++ b/internal/cloud/cloudserver/prefix_rewrite.go
@@ -1,0 +1,95 @@
+package cloudserver
+
+import (
+	"bytes"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// prefixRewrite wraps a handler that was mounted behind http.StripPrefix and
+// re-adds the stripped prefix to everything the browser will interpret as an
+// absolute path: redirect headers, cookie paths, and root-relative URLs inside
+// HTML bodies. Without this, handlers that emit absolute paths (the dashboard)
+// send the browser to URLs outside the ingress route.
+func prefixRewrite(prefix string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw := &prefixRewriteWriter{inner: w, prefix: prefix}
+		next.ServeHTTP(rw, r)
+		rw.finish()
+	})
+}
+
+type prefixRewriteWriter struct {
+	inner       http.ResponseWriter
+	prefix      string
+	status      int
+	wroteHeader bool
+	buffering   bool
+	buf         bytes.Buffer
+}
+
+var rewriteHeaderNames = []string{"Location", "Content-Location", "HX-Redirect", "HX-Location", "HX-Push-Url"}
+
+func (rw *prefixRewriteWriter) Header() http.Header {
+	return rw.inner.Header()
+}
+
+func (rw *prefixRewriteWriter) WriteHeader(status int) {
+	if rw.wroteHeader {
+		return
+	}
+	rw.wroteHeader = true
+	rw.status = status
+	h := rw.inner.Header()
+	for _, name := range rewriteHeaderNames {
+		if v := h.Get(name); strings.HasPrefix(v, "/") && !strings.HasPrefix(v, rw.prefix+"/") {
+			h.Set(name, rw.prefix+v)
+		}
+	}
+	cookies := h["Set-Cookie"]
+	for i, c := range cookies {
+		if !strings.Contains(c, "Path="+rw.prefix) {
+			cookies[i] = strings.Replace(c, "Path=/", "Path="+rw.prefix+"/", 1)
+		}
+	}
+	if strings.HasPrefix(h.Get("Content-Type"), "text/html") {
+		// Buffer HTML so root-relative URLs can be rewritten before sending;
+		// the declared length no longer matches, so recompute it on finish.
+		rw.buffering = true
+		h.Del("Content-Length")
+		return
+	}
+	rw.inner.WriteHeader(status)
+}
+
+func (rw *prefixRewriteWriter) Write(b []byte) (int, error) {
+	if !rw.wroteHeader {
+		rw.WriteHeader(http.StatusOK)
+	}
+	if rw.buffering {
+		return rw.buf.Write(b)
+	}
+	return rw.inner.Write(b)
+}
+
+func (rw *prefixRewriteWriter) Flush() {
+	if rw.buffering {
+		return
+	}
+	if f, ok := rw.inner.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (rw *prefixRewriteWriter) finish() {
+	if !rw.buffering {
+		return
+	}
+	// Handlers only emit root-relative URLs under /dashboard; rewriting just
+	// that path avoids mangling unrelated `"/` sequences like self-closing tags.
+	body := bytes.ReplaceAll(rw.buf.Bytes(), []byte(`"/dashboard`), []byte(`"`+rw.prefix+`/dashboard`))
+	rw.inner.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	rw.inner.WriteHeader(rw.status)
+	rw.inner.Write(body)
+}


### PR DESCRIPTION
## Summary
- Add `env.yml` deployment config wiring the Postgres URL (with RDS TLS `verify-full` via the bundled `us-west-2-bundle.pem` cert), cloud host, and port; cloud auth vars live in secrets-inventory instead of env.yml
- Add a multi-stage `Dockerfile` (Go 1.25 builder → Alpine runtime, non-root user) that bakes in the RDS CA bundle and runs `engram cloud serve` on port 18080, using legacy-builder-compatible syntax
- Serve all routes under the `/api/nauta-engram` ingress base path in addition to the root: the ingress forwards without stripping the prefix, so the handler mounts the mux under both
- Add `prefixRewrite` response wrapper that re-adds the stripped prefix to redirect headers (`Location`, HTMX headers), cookie paths, and root-relative `/dashboard` URLs in HTML bodies so the dashboard works behind the ingress
- Add a macOS always-on autosync setup guide (`docs/engram-cloud/engram-autosync-setup.md`) covering install, cloud enrollment, and a launchd agent, linked from the README and cloud docs landing

## Test plan
- [x] `cloudserver` tests cover health and sync routes resolving under the ingress prefix
- [x] Tests cover dashboard redirects, login HTML URL rewriting under the prefix, and unchanged behavior for non-prefixed access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added containerized deployment with a lightweight runtime image, non-root execution, TLS CA certificates, and timezone data.
  * Added environment-based configuration for database connection, host, and port.
  * Added support for serving the application under the `/api/nauta-engram` ingress path.
* **Bug Fixes**
  * Fixed redirects, cookies, dashboard links, health checks, and synchronization routes when accessed through the ingress path, while preserving direct (non-prefixed) access behavior.
* **Documentation**
  * Added a macOS autosync setup guide to the Cloud documentation map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->