### PR TITLE
fix(cloud): materialize relation mutations on chunk-ingest (WriteChunk)

### DIFF
--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -356,7 +356,7 @@ func (cs *CloudStore) indexChunkSessionsWith(ctx context.Context, execer chunkSe
 
 func materializedChunkMutations(project string, chunk engramsync.ChunkData) ([]MutationEntry, error) {
 	project = strings.TrimSpace(project)
-	entries := make([]MutationEntry, 0, len(chunk.Sessions)+len(chunk.Observations)+len(chunk.Prompts))
+	entries := make([]MutationEntry, 0, len(chunk.Sessions)+len(chunk.Observations)+len(chunk.Prompts)+len(chunk.Mutations))
 
 	for i, session := range chunk.Sessions {
 		entityKey := strings.TrimSpace(session.ID)
@@ -392,6 +392,30 @@ func materializedChunkMutations(project string, chunk engramsync.ChunkData) ([]M
 			return nil, fmt.Errorf("cloudstore: materialize chunk prompt %q: %w", entityKey, err)
 		}
 		entries = append(entries, MutationEntry{Project: project, Entity: store.SyncEntityPrompt, EntityKey: entityKey, Op: store.SyncOpUpsert, Payload: payload})
+	}
+
+	// Relations travel only as relation-entity entries in chunk.Mutations — there is no
+	// typed collection for them like Sessions/Observations/Prompts — so materialize them
+	// here to mirror the mutation-push path (#379). Session/observation/prompt mutations
+	// are already materialized from the typed collections above, so they are skipped to
+	// avoid duplicate cloud_mutations rows.
+	for i, mutation := range chunk.Mutations {
+		if strings.TrimSpace(mutation.Entity) != store.SyncEntityRelation {
+			continue
+		}
+		entityKey := strings.TrimSpace(mutation.EntityKey)
+		if entityKey == "" {
+			return nil, fmt.Errorf("cloudstore: materialize chunk: mutations[%d].entity_key is required for relation", i)
+		}
+		op := strings.TrimSpace(mutation.Op)
+		if op == "" {
+			op = store.SyncOpUpsert
+		}
+		payload := json.RawMessage(strings.TrimSpace(mutation.Payload))
+		if len(payload) == 0 {
+			payload = json.RawMessage("{}")
+		}
+		entries = append(entries, MutationEntry{Project: project, Entity: store.SyncEntityRelation, EntityKey: entityKey, Op: op, Payload: payload})
 	}
 
 	return entries, nil

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -472,6 +472,11 @@ func TestMaterializedChunkMutationsRejectsMissingSyncIDs(t *testing.T) {
 			chunk: engramsync.ChunkData{Prompts: []store.Prompt{{SessionID: "s-1"}}},
 			want:  "prompts[0].sync_id is required",
 		},
+		{
+			name:  "relation missing entity key",
+			chunk: engramsync.ChunkData{Mutations: []store.SyncMutation{{Entity: store.SyncEntityRelation}}},
+			want:  "mutations[0].entity_key is required",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -480,6 +485,111 @@ func TestMaterializedChunkMutationsRejectsMissingSyncIDs(t *testing.T) {
 				t.Fatalf("expected %q error, got %v", tt.want, err)
 			}
 		})
+	}
+}
+
+func TestMaterializedChunkMutationsCarriesRelationFromChunkMutations(t *testing.T) {
+	project := "proj-materialize-rel"
+	relationPayload := `{"sync_id":"rel-1","source_id":"obs-a","target_id":"obs-b","relation":"related","project":"proj-materialize-rel"}`
+	chunk := engramsync.ChunkData{
+		Observations: []store.Observation{{SyncID: "obs-a"}, {SyncID: "obs-b"}},
+		Mutations: []store.SyncMutation{
+			{Project: project, Entity: store.SyncEntityRelation, EntityKey: "rel-1", Op: store.SyncOpUpsert, Payload: relationPayload},
+			// A session/observation mutation that mirrors a typed row (as the push
+			// materializer emits) must NOT produce a duplicate cloud_mutations entry.
+			{Project: project, Entity: store.SyncEntityObservation, EntityKey: "obs-a", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-a"}`},
+		},
+	}
+
+	entries, err := materializedChunkMutations(project, chunk)
+	if err != nil {
+		t.Fatalf("materializedChunkMutations: %v", err)
+	}
+
+	// 2 observation upserts (from typed rows) + 1 relation (from chunk.Mutations); the
+	// duplicate observation mutation must be skipped.
+	if len(entries) != 3 {
+		t.Fatalf("expected 2 observations + 1 relation, got %d: %+v", len(entries), entries)
+	}
+
+	var relation *MutationEntry
+	for i := range entries {
+		if entries[i].Entity == store.SyncEntityRelation {
+			if relation != nil {
+				t.Fatalf("expected exactly one relation entry, got a duplicate: %+v", entries)
+			}
+			relation = &entries[i]
+		}
+	}
+	if relation == nil {
+		t.Fatalf("expected relation entry materialized from chunk.Mutations, got %+v", entries)
+	}
+	if relation.EntityKey != "rel-1" || relation.Op != store.SyncOpUpsert || relation.Project != project {
+		t.Fatalf("unexpected relation entry: %+v", *relation)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(relation.Payload, &payload); err != nil {
+		t.Fatalf("relation payload is not object JSON: %v", err)
+	}
+	if payload["sync_id"] != "rel-1" {
+		t.Fatalf("relation payload not preserved: %+v", payload)
+	}
+}
+
+func TestWriteChunkMaterializesRelationMutationIntoCloudMutations(t *testing.T) {
+	cs := openTestCloudStore(t)
+	project := "test-chunk-relation-" + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "-")
+	payload, err := chunkcodec.CanonicalizeForProject([]byte(`{
+		"observations":[
+			{"sync_id":"obs-a","session_id":"s-1","type":"decision","title":"A","content":"A","scope":"project","created_at":"2026-04-29T10:01:00Z","updated_at":"2026-04-29T10:01:00Z"},
+			{"sync_id":"obs-b","session_id":"s-1","type":"decision","title":"B","content":"B","scope":"project","created_at":"2026-04-29T10:01:00Z","updated_at":"2026-04-29T10:01:00Z"}
+		],
+		"mutations":[
+			{"entity":"relation","entity_key":"rel-1","op":"upsert","payload":"{\"sync_id\":\"rel-1\",\"source_id\":\"obs-a\",\"target_id\":\"obs-b\",\"relation\":\"related\"}"}
+		]
+	}`), project)
+	if err != nil {
+		t.Fatalf("canonicalize chunk: %v", err)
+	}
+	chunkID := chunkIDFromPayload(payload)
+
+	if err := cs.WriteChunk(context.Background(), project, chunkID, "tester", "2026-04-29T10:03:00Z", payload); err != nil {
+		t.Fatalf("WriteChunk: %v", err)
+	}
+
+	mutations, _, _, err := cs.ListMutationsSince(context.Background(), 0, 100, []string{project})
+	if err != nil {
+		t.Fatalf("ListMutationsSince: %v", err)
+	}
+	foundRelation := false
+	for _, m := range mutations {
+		if m.Entity == store.SyncEntityRelation && m.EntityKey == "rel-1" {
+			foundRelation = true
+			if m.Project != project || m.Op != store.SyncOpUpsert {
+				t.Fatalf("unexpected relation mutation: %+v", m)
+			}
+		}
+	}
+	if !foundRelation {
+		t.Fatalf("expected relation materialized into cloud_mutations, got %+v", mutations)
+	}
+
+	// Replay must stay idempotent — no duplicate relation row.
+	if err := cs.WriteChunk(context.Background(), project, chunkID, "tester", "2026-04-29T10:03:00Z", payload); err != nil {
+		t.Fatalf("replay WriteChunk: %v", err)
+	}
+	after, _, _, err := cs.ListMutationsSince(context.Background(), 0, 100, []string{project})
+	if err != nil {
+		t.Fatalf("ListMutationsSince after replay: %v", err)
+	}
+	relCount := 0
+	for _, m := range after {
+		if m.Entity == store.SyncEntityRelation && m.EntityKey == "rel-1" {
+			relCount++
+		}
+	}
+	if relCount != 1 {
+		t.Fatalf("expected exactly one relation row after replay, got %d", relCount)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #502

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Server chunk-ingest (`WriteChunk`) materialized `cloud_mutations` rows only from `chunk.Sessions/Observations/Prompts` and never iterated `chunk.Mutations`, where relations ride — so a relation uploaded via the chunk path landed in `cloud_chunks.payload` but never reached `cloud_mutations`, and mutation-pull consumers never saw it.
- Fixes it by mirroring #379 in `materializedChunkMutations`: emit relation `MutationEntry` rows from `chunk.Mutations`, skipping the typed entities already materialized above so no duplicate `cloud_mutations` rows are produced.
- This is the chunk-ingest sibling of the mutation-push gap #379 already fixed; #497 did not touch this path.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudstore/cloudstore.go` | `materializedChunkMutations` now iterates `chunk.Mutations` and emits a relation `MutationEntry` for each `relation`-entity mutation (default `upsert`, empty payload → `{}`, `entity_key` required). Session/observation/prompt mutations are skipped because they are already materialized from the typed collections, avoiding duplicate rows. Capacity hint updated. |
| `internal/cloud/cloudstore/cloudstore_test.go` | Adds `TestMaterializedChunkMutationsCarriesRelationFromChunkMutations` (unit: relation materialized, typed rows not duplicated), a `relation missing entity key` validation case, and `TestWriteChunkMaterializesRelationMutationIntoCloudMutations` (Postgres-gated end-to-end + replay idempotency). |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...` (22 packages ok, 0 failures)
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (ok)
- [x] Manually tested the affected functionality

TDD: the new unit test failed before the fix (`got 2` entries — the relation was dropped) and passes after. `go vet ./...` and `go build ./...` are clean. The end-to-end `WriteChunk → cloud_mutations` test is gated on `CLOUDSTORE_TEST_DSN` (requires Postgres) and is skipped locally without it; the unit-level coverage runs unconditionally.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #502`)
- [ ] I added exactly **one** `type:*` label to this PR — checked `type:bug` above; I have READ access only, so a maintainer may need to apply the label.
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed) — no update needed; `docs/codebase/sync-and-cloud.md:31` already documents that chunks carry the relations graph, and this fix makes the code honor that contract.
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

- The fix is deliberately scoped to relations: typed entities (session/observation/prompt) are already materialized from `chunk.Sessions/Observations/Prompts`, so the new loop filters to `store.SyncEntityRelation` to avoid duplicate `cloud_mutations` rows (the push materializer emits an observation both as a typed row and as a `chunk.Mutations` entry, so the dedup matters — covered by a test).
- Sibling issue #576 ("Cloud client import fails: relation FK precondition not met") is the **client-side import** counterpart and is independent of this change — that one is `ApplyPulledChunk` aborting a chunk on a relation FK miss instead of deferring. This PR does not touch it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relation mutations are now correctly materialized and persisted during chunk processing.
  * Invalid relation mutations missing an entity key are rejected with a clearer error.
  * Reprocessing the same chunk no longer creates duplicate relation records.
* **Tests**
  * Expanded coverage for relation-mutation materialization, validation, and idempotent writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->