### PR TITLE
fix(pi): hide detached process windows on Windows

### DIFF
--- a/internal/project/command_other.go
+++ b/internal/project/command_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package project
+
+import (
+	"context"
+	"os/exec"
+)
+
+func newProjectCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, args...)
+}

--- a/internal/project/command_other_test.go
+++ b/internal/project/command_other_test.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package project
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestNewProjectCommandContextPreservesDefaultProcessAttributes(t *testing.T) {
+	cmd := newProjectCommandContext(context.Background(), "git", "status")
+
+	if want := []string{"git", "status"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("command arguments = %q; want %q", cmd.Args, want)
+	}
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("SysProcAttr = %#v; want nil", cmd.SysProcAttr)
+	}
+}

--- a/internal/project/command_usage_test.go
+++ b/internal/project/command_usage_test.go
@@ -1,0 +1,61 @@
+package project
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestProjectDetectionGitCommandsUsePlatformHelper(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate test source")
+	}
+
+	file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(filepath.Dir(testFile), "detect.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse detect.go: %v", err)
+	}
+
+	tests := []struct {
+		name string
+	}{
+		{name: "detectGitRootDir"},
+		{name: "detectFromGitRemote"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var function *ast.FuncDecl
+			for _, declaration := range file.Decls {
+				candidate, ok := declaration.(*ast.FuncDecl)
+				if ok && candidate.Name.Name == tt.name {
+					function = candidate
+					break
+				}
+			}
+			if function == nil {
+				t.Fatalf("function %s not found", tt.name)
+			}
+
+			helperCalls := 0
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				identifier, ok := call.Fun.(*ast.Ident)
+				if ok && identifier.Name == "newProjectCommandContext" {
+					helperCalls++
+				}
+				return true
+			})
+			if helperCalls != 1 {
+				t.Fatalf("%s uses newProjectCommandContext %d times; want 1", tt.name, helperCalls)
+			}
+		})
+	}
+}

--- a/internal/project/command_windows.go
+++ b/internal/project/command_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package project
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+func newProjectCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}

--- a/internal/project/command_windows_test.go
+++ b/internal/project/command_windows_test.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package project
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestNewProjectCommandContextHidesWindow(t *testing.T) {
+	cmd := newProjectCommandContext(context.Background(), "git", "status")
+
+	if want := []string{"git", "status"}; !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("command arguments = %q; want %q", cmd.Args, want)
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil; want Windows process attributes")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Fatal("SysProcAttr.HideWindow is false; want true")
+	}
+}

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -279,7 +278,7 @@ func detectGitRootDir(dir string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel")
+	cmd := newProjectCommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -378,7 +377,7 @@ func detectFromGitRemote(dir string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "-C", dir, "remote", "get-url", "origin")
+	cmd := newProjectCommandContext(ctx, "git", "-C", dir, "remote", "get-url", "origin")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -383,6 +383,7 @@ function spawnDetached(command: string, args: readonly string[], cwd?: string): 
     try {
       proc = spawn(command, [...args], {
         cwd,
+        windowsHide: true,
         detached: true,
         stdio: "ignore",
       });


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #599

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Hide detached Engram subprocess windows on Windows.
- Add a source regression test that protects the `windowsHide: true` spawn option.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Set `windowsHide: true` when spawning detached Engram processes. |
| `plugin/pi/test/index-source.test.mjs` | Verify detached process spawning keeps Windows console windows hidden. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality
- [x] Regression assertion passes: `cd plugin/pi && node --test test/index-source.test.mjs` (`spawnDetached hides detached process windows`)

The targeted regression assertion passes. The test file still reports two unrelated, pre-existing `Cannot use import statement outside a module` failures that reproduce on `upstream/main`.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes/Fixes/Resolves #N` | ✅ Linked |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ Maintainer action required |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ Maintainer action required |
| **Unit Tests** | `go test ./...` passes | ⏳ Workflow approval required |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ Workflow approval required |

---

## ✅ Contributor Checklist

- [ ] I linked an approved issue above (`Closes #N`) (linked, awaiting maintainer approval)
- [ ] I added exactly **one** `type:*` label to this PR (awaiting maintainer permissions)
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Documentation is not required for this internal process-launch fix
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Issue #599 is not yet labeled `status:approved`, and this fork contributor cannot add repository labels. A maintainer needs to:

1. decide whether #599 should remain separate from the related #536;
2. add `status:approved` to #599 and `type:bug` to this PR;
3. approve the pending fork workflows so CI and PR Validation can run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented console windows from appearing when background processes start on Windows.
  * Improved the Windows experience when detecting projects through Git commands.

* **Tests**
  * Added platform-specific coverage to verify hidden process windows and preserve existing command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
