### PR TITLE
fix(store): prevent duplicate observations on import

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3565,12 +3565,14 @@ func (s *Store) Import(data *ExportData) (*ImportResult, error) {
 		result.SessionsImported += int(n)
 	}
 
-	// Import observations (use new IDs — AUTOINCREMENT)
+	// Import observations (use new IDs — AUTOINCREMENT, skip duplicate sync IDs)
 	for _, obs := range data.Observations {
-		_, err := s.execHook(tx,
+		syncID := normalizeExistingSyncID(obs.SyncID, "obs")
+		res, err := s.execHook(tx,
 			`INSERT INTO observations (sync_id, session_id, type, title, content, tool_name, project, scope, topic_key, normalized_hash, revision_count, duplicate_count, last_seen_at, review_after, created_at, updated_at, deleted_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			normalizeExistingSyncID(obs.SyncID, "obs"),
+			 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+			 WHERE NOT EXISTS (SELECT 1 FROM observations WHERE sync_id = ?)`,
+			syncID,
 			obs.SessionID,
 			obs.Type,
 			obs.Title,
@@ -3587,11 +3589,13 @@ func (s *Store) Import(data *ExportData) (*ImportResult, error) {
 			obs.CreatedAt,
 			obs.UpdatedAt,
 			obs.DeletedAt,
+			syncID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("import observation %d: %w", obs.ID, err)
 		}
-		result.ObservationsImported++
+		n, _ := res.RowsAffected()
+		result.ObservationsImported += int(n)
 	}
 
 	// Import prompts

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3445,6 +3445,61 @@ func TestMigrationAndHelperEdgeBranches(t *testing.T) {
 	})
 }
 
+func TestImportSkipsObservationWithExistingSyncID(t *testing.T) {
+	s := newTestStore(t)
+	now := Now()
+	project := "engram"
+	observations := make([]Observation, 3)
+	for i := range observations {
+		observations[i] = Observation{
+			SyncID:    fmt.Sprintf("obs-import-idempotent-%d", i),
+			SessionID: "import-session",
+			Type:      "bugfix",
+			Title:     fmt.Sprintf("idempotent import %d", i),
+			Content:   fmt.Sprintf("import observation %d once", i),
+			Project:   &project,
+			Scope:     "project",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+	}
+	data := &ExportData{
+		Sessions: []Session{{
+			ID:        "import-session",
+			Project:   "engram",
+			Directory: "/tmp/engram",
+			StartedAt: now,
+		}},
+		Observations: observations,
+	}
+
+	first, err := s.Import(data)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	if first.ObservationsImported != 3 {
+		t.Fatalf("first import observations = %d, want 3", first.ObservationsImported)
+	}
+
+	for attempt := 2; attempt <= 3; attempt++ {
+		result, err := s.Import(data)
+		if err != nil {
+			t.Fatalf("import attempt %d: %v", attempt, err)
+		}
+		if result.ObservationsImported != 0 {
+			t.Fatalf("import attempt %d observations = %d, want 0", attempt, result.ObservationsImported)
+		}
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM observations WHERE sync_id LIKE 'obs-import-idempotent-%'").Scan(&count); err != nil {
+		t.Fatalf("count imported observations: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("stored observations = %d, want 3", count)
+	}
+}
+
 func TestExportImportEdgeBranches(t *testing.T) {
 	t.Run("export fails when observations query fails", func(t *testing.T) {
 		s := newTestStore(t)


### PR DESCRIPTION
## Linked Issue

Closes #531

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Prevent repeated imports from inserting observations with an existing `sync_id`.
- Report only observation rows actually inserted in `ObservationsImported`.
- Add regression coverage for the reported `3 -> 6 -> 9` scenario.

## Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Insert an observation only when its normalized `sync_id` does not already exist in the import transaction. |
| `internal/store/store_test.go` | Import three observations three times and verify the store remains at three rows. |

## Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality (covered by the focused automated regression test)

Focused verification:

- `go test ./internal/store -run TestImportSkipsObservationWithExistingSyncID -count=1`
- `go vet ./internal/store`
- TDD red phase confirmed before the fix: the second import reported one imported observation instead of zero.

The full Windows unit suite currently has unrelated baseline failures in `cmd/engram`, `internal/setup`, `internal/store`, and `internal/sync`. The failing `internal/store`, `internal/setup`, and `internal/sync` cases were reproduced unchanged from a clean `origin/main` worktree at `be4b613`.

---

## Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Pending |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Pending |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | Pending maintainer permission |
| **Unit Tests** | `go test ./...` passes | Pending CI |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Pending CI |

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #531`)
- [ ] I added exactly **one** `type:*` label to this PR (pending maintainer permission)
- [ ] I ran unit tests locally: `go test ./...` (ran; pre-existing Windows failures remain)
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (not required; no user-facing workflow or API contract changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## Notes for Reviewers

This stays within the scope approved in #531: dedupe observations during import. It does not repair historical duplicates, change prompt import behavior, or implement the LWW redesign discussed in #244.

The schema currently has a non-unique index on `observations.sync_id`. The implementation therefore uses an atomic `INSERT ... SELECT ... WHERE NOT EXISTS` inside the existing import transaction rather than adding a unique constraint that could fail migration for databases already containing duplicates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate observations when importing records with an existing synchronization ID.
  - Import results now accurately report only newly added observations.
  - Repeated imports no longer create additional duplicate observation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->