### PR TITLE
fix(pi): recover Engram statusline after transient wake-time failures

### DIFF
--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -21,6 +21,12 @@ const CONFIGURED_ENGRAM_URL = process.env.ENGRAM_URL?.trim() || undefined;
 const ENGRAM_URL = CONFIGURED_ENGRAM_URL || `http://127.0.0.1:${ENGRAM_PORT}`;
 const ENGRAM_BIN = process.env.ENGRAM_BIN ?? "engram";
 
+const ENGRAM_FETCH_TIMEOUT_MS = 3000;
+const ENGRAM_FETCH_MAX_ATTEMPTS = 3;
+const ENGRAM_FETCH_BACKOFF_BASE_MS = 250;
+const ENGRAM_SELF_HEAL_INTERVAL_MS = 5000;
+const ENGRAM_SELF_HEAL_MAX_ATTEMPTS = 6;
+
 const ENGRAM_TOOLS = [
   "mem_search",
   "mem_save",
@@ -139,6 +145,11 @@ interface SessionContext {
   };
 }
 
+type MemoryToolContext = SessionContext & {
+  hasUI?: boolean;
+  ui?: { setStatus?: (key: string, text: string | undefined) => void };
+};
+
 interface AgentStartEvent {
   systemPrompt: string;
   prompt?: string;
@@ -161,20 +172,59 @@ class EngramHttpError extends Error {
   }
 }
 
+// Node rejects an AbortSignal.timeout() fetch with a DOMException named "TimeoutError",
+// which is an instanceof Error; a caller-supplied abort surfaces as "AbortError".
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
+}
+
+// engramFetch resolves to null on failure and ~20 call sites depend on that fallthrough —
+// ensureSession in particular must not abort a mem_save just because session creation blipped.
+// So the timeout detail travels out-of-band instead of changing what any caller receives,
+// letting executeMemoryTool tell the truth about an ambiguous write without blast radius.
+let lastFetchTimeoutMethod: string | undefined;
+
+function takeLastFetchTimeoutMethod(): string | undefined {
+  const method = lastFetchTimeoutMethod;
+  lastFetchTimeoutMethod = undefined;
+  return method;
+}
+
 async function engramFetch<TResponse = unknown>(path: string, opts: FetchOptions = {}): Promise<TResponse | null> {
+  const method = opts.method ?? "GET";
+  // This call's outcome supersedes any earlier one. A tool call can issue several fetches
+  // (mem_save creates the session, then writes the observation); without this reset a timeout
+  // on the first leg would mislabel an unrelated failure on the second as "may already have
+  // been applied", telling the agent not to retry a write that never left the machine.
+  lastFetchTimeoutMethod = undefined;
   let res: Response | undefined;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
+  let timedOut = false;
+  for (let attempt = 0; attempt < ENGRAM_FETCH_MAX_ATTEMPTS; attempt += 1) {
     try {
       res = await fetch(`${ENGRAM_URL}${redactUrlPath(path)}`, {
-        method: opts.method ?? "GET",
+        method,
         headers: opts.body ? { "Content-Type": "application/json" } : undefined,
         body: opts.body ? JSON.stringify(redactValue(opts.body)) : undefined,
+        signal: AbortSignal.timeout(ENGRAM_FETCH_TIMEOUT_MS),
       });
       break;
-    } catch {
-      if (attempt < 2) await wait(150);
+    } catch (error) {
+      // A timeout means the request may already have reached the server, so re-sending it
+      // could duplicate a non-idempotent write (mem_save and friends carry no idempotency
+      // key). Only pre-send connection failures — the macOS wake-settle case this retry
+      // exists for — are safe to repeat, and a hung server will not recover by retrying.
+      if (isTimeoutError(error)) {
+        timedOut = true;
+        break;
+      }
+      if (attempt < ENGRAM_FETCH_MAX_ATTEMPTS - 1) await wait(ENGRAM_FETCH_BACKOFF_BASE_MS * 2 ** attempt);
     }
   }
+
+  // A timeout is NOT the same failure as an unreachable server, and reporting both as "could
+  // not reach" invites the caller to retry a write whose outcome is genuinely unknown. Record
+  // which it was so the tool layer can say what we do and do not know.
+  if (timedOut) lastFetchTimeoutMethod = method;
   if (!res) return null;
 
   let data: unknown = null;
@@ -257,6 +307,48 @@ async function isEngramRunning(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function waitUnref(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+let engramSelfHealInFlight = false;
+// Keyed by session so a session that fails repeatedly is tracked once, and so a session that
+// shuts down mid-outage can be dropped instead of having its torn-down UI touched later.
+const engramSelfHealContexts = new Map<string | MemoryToolContext, MemoryToolContext>();
+
+// Pruning is by session id. A context with no resolvable session id is keyed by the ctx
+// object itself and cannot be pruned here, but it self-expires: the probe clears the whole
+// map within one cycle, and setStatus is optional-chained, so a torn-down UI is never a crash.
+function forgetSelfHealContext(sessionId: string): void {
+  engramSelfHealContexts.delete(sessionId);
+}
+
+function scheduleEngramSelfHeal(ctx: MemoryToolContext): void {
+  // Track every session that observed the outage: this module is shared by all sessions in
+  // the Pi process, so a single probe must clear the stale label on all of them, not just
+  // whichever session happened to fail first.
+  engramSelfHealContexts.set(getSessionId(ctx) ?? ctx, ctx);
+  if (engramSelfHealInFlight) return;
+  engramSelfHealInFlight = true;
+  void (async () => {
+    try {
+      for (let attempt = 0; attempt < ENGRAM_SELF_HEAL_MAX_ATTEMPTS; attempt += 1) {
+        await waitUnref(ENGRAM_SELF_HEAL_INTERVAL_MS);
+        if (await isEngramRunning()) {
+          for (const pending of engramSelfHealContexts.values()) pending.ui?.setStatus?.("engram", undefined);
+          return;
+        }
+      }
+    } finally {
+      engramSelfHealContexts.clear();
+      engramSelfHealInFlight = false;
+    }
+  })();
 }
 
 function rawBasenameProjectName(directory: string): string {
@@ -710,7 +802,17 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
   }
 }
 
-async function executeMemoryTool(toolName: string, params: Record<string, unknown>, ctx: SessionContext & { hasUI?: boolean; ui?: { setStatus?: (key: string, text: string | undefined) => void } }) {
+function unreachableMessage(timedOutMethod: string | undefined): string {
+  if (timedOutMethod && timedOutMethod !== "GET") {
+    return `gentle-engram timed out after ${ENGRAM_FETCH_TIMEOUT_MS}ms waiting for the Engram HTTP server at ${ENGRAM_URL}. The ${timedOutMethod} request may already have been applied — do NOT blindly retry it, or you may duplicate the write. Verify with mem_search or mem_doctor first.`;
+  }
+  if (timedOutMethod) {
+    return `gentle-engram timed out after ${ENGRAM_FETCH_TIMEOUT_MS}ms waiting for the Engram HTTP server at ${ENGRAM_URL}. The server accepted the connection but did not respond. Run mem_doctor or restart Engram.`;
+  }
+  return `gentle-engram could not reach the Engram HTTP server at ${ENGRAM_URL}. The Pi-native mem_* tools are registered, but the native memory provider is not currently responding. Run mem_doctor or restart Engram.`;
+}
+
+async function executeMemoryTool(toolName: string, params: Record<string, unknown>, ctx: MemoryToolContext) {
   await initOnce(ctx.cwd);
   await refreshProjectDetection(ctx.cwd);
   const action = humanToolName(toolName);
@@ -719,7 +821,7 @@ async function executeMemoryTool(toolName: string, params: Record<string, unknow
   try {
     const data = await callMemoryTool(toolName, params, ctx);
     if (data === null) {
-      throw new Error(`gentle-engram could not reach the Engram HTTP server at ${ENGRAM_URL}. The Pi-native mem_* tools are registered, but the native memory provider is not currently responding. Run mem_doctor or restart Engram.`);
+      throw new Error(unreachableMessage(takeLastFetchTimeoutMethod()));
     }
     const result = { content: [{ type: "text" as const, text: textResult(data) }], details: { data } };
     if (toolName === "mem_doctor" && data && typeof data === "object" && "status" in data && data.status === "error") {
@@ -735,6 +837,7 @@ async function executeMemoryTool(toolName: string, params: Record<string, unknow
       ? { error: message, http_status: error.status, data: error.data }
       : { error: message };
     ctx.ui?.setStatus?.("engram", `🧠 ${project} · ${errorStatusLabel(message)}`);
+    if (!(error instanceof EngramHttpError)) scheduleEngramSelfHeal(ctx);
     return { content: [{ type: "text" as const, text: message }], details, isError: true };
   }
 }
@@ -749,7 +852,7 @@ function registerMemoryTools(pi: ExtensionAPI): void {
       parameters: MEMORY_TOOL_SCHEMAS[toolName],
       renderShell: "self",
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-        return executeMemoryTool(toolName, params as Record<string, unknown>, ctx as SessionContext & { hasUI?: boolean; ui?: { setStatus?: (key: string, text: string | undefined) => void } });
+        return executeMemoryTool(toolName, params as Record<string, unknown>, ctx as MemoryToolContext);
       },
       renderCall(args) {
         return new Text(renderCallText(toolName, args), 0, 0);
@@ -772,6 +875,7 @@ export default function registerEngram(pi: ExtensionAPI) {
     if (!sessionId) return;
     toolCounts.delete(sessionId);
     forgetKnownSession(sessionId);
+    forgetSelfHealContext(sessionId);
   });
 
   pi.on("session_compact", async (event: unknown, ctx: SessionContext) => {

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -4,10 +4,10 @@ import { test } from "node:test";
 
 const source = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
 
-function extractFunctionBody(name) {
-  const signatureIndex = source.indexOf(`async function ${name}`);
+function extractFunctionBody(name, marker) {
+  const signatureIndex = source.indexOf(`function ${name}`);
   assert.notEqual(signatureIndex, -1, `${name} signature not found`);
-  const bodyStart = source.indexOf("{\n  let res", signatureIndex);
+  const bodyStart = source.indexOf(marker, signatureIndex);
   let depth = 0;
   for (let index = bodyStart; index < source.length; index += 1) {
     const char = source[index];
@@ -18,12 +18,32 @@ function extractFunctionBody(name) {
   throw new Error(`${name} body not found`);
 }
 
-function buildEngramFetchForTest() {
-  const body = extractFunctionBody("engramFetch")
+function flush(times = 2) {
+  return times <= 0
+    ? Promise.resolve()
+    : new Promise((resolve) => setTimeout(resolve, 0)).then(() => flush(times - 1));
+}
+
+function buildEngramFetchForTest({
+  wait = () => Promise.resolve(),
+  timeoutMs = 3000,
+  maxAttempts = 3,
+  backoffBaseMs = 150,
+} = {}) {
+  const body = extractFunctionBody("engramFetch", "{\n  const method")
     .replace("let res: Response | undefined;", "let res;")
     .replace("let data: unknown = null;", "let data = null;")
     .replace("return data as TResponse;", "return data;");
-  const factory = new Function("fetch", "wait", "redactUrlPath", "redactValue", "ENGRAM_URL", `
+  const factory = new Function(
+    "fetch",
+    "wait",
+    "redactUrlPath",
+    "redactValue",
+    "ENGRAM_URL",
+    "ENGRAM_FETCH_TIMEOUT_MS",
+    "ENGRAM_FETCH_MAX_ATTEMPTS",
+    "ENGRAM_FETCH_BACKOFF_BASE_MS",
+    `
     class EngramHttpError extends Error {
       constructor(message, status, data) {
         super(message);
@@ -32,17 +52,62 @@ function buildEngramFetchForTest() {
         this.data = data;
       }
     }
-    return async function engramFetch(path, opts = {}) {
+    function isTimeoutError(error) {
+      ${extractFunctionBody("isTimeoutError", "{\n  return error instanceof Error")}
+    }
+    let lastFetchTimeoutMethod;
+    const engramFetch = async function engramFetch(path, opts = {}) {
       ${body}
     };
-  `);
+    return { engramFetch, timedOutMethod: () => lastFetchTimeoutMethod };
+  `,
+  );
   return factory(
     globalThis.fetch,
-    () => Promise.resolve(),
+    wait,
     (value) => value,
     (value) => value,
     "http://127.0.0.1:7437",
+    timeoutMs,
+    maxAttempts,
+    backoffBaseMs,
   );
+}
+
+function buildScheduleEngramSelfHealForTest({ waitUnref, isEngramRunning, maxAttempts = 6 }) {
+  const body = extractFunctionBody("scheduleEngramSelfHeal", "{\n  // Track every session");
+  const forgetBody = extractFunctionBody("forgetSelfHealContext", "{\n  engramSelfHealContexts.delete");
+  const factory = new Function(
+    "waitUnref",
+    "isEngramRunning",
+    "ENGRAM_SELF_HEAL_INTERVAL_MS",
+    "ENGRAM_SELF_HEAL_MAX_ATTEMPTS",
+    `
+    let engramSelfHealInFlight = false;
+    const engramSelfHealContexts = new Map();
+    const getSessionId = (ctx) => ctx.sessionManager?.getSessionId();
+    function forgetSelfHealContext(sessionId) {
+      ${forgetBody}
+    }
+    function scheduleEngramSelfHeal(ctx) {
+      ${body}
+    }
+    return {
+      scheduleEngramSelfHeal,
+      forgetSelfHealContext,
+      isInFlight: () => engramSelfHealInFlight,
+      trackedCount: () => engramSelfHealContexts.size,
+    };
+  `,
+  );
+  return factory(waitUnref, isEngramRunning, 1, maxAttempts);
+}
+
+function sessionCtx(id, sink) {
+  return {
+    sessionManager: { getSessionId: () => id },
+    ui: { setStatus: (key, text) => sink.push([key, text]) },
+  };
 }
 
 test("mem_session_summary accepts explicit project fallback", () => {
@@ -95,11 +160,349 @@ test("native tool fetches retry transient HTTP startup failures", async () => {
     };
   };
   try {
-    const engramFetch = buildEngramFetchForTest();
+    const { engramFetch } = buildEngramFetchForTest();
     assert.deepEqual(await engramFetch("/health"), { status: "ok" });
     assert.equal(calls, 3);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("native tool fetch backs off exponentially and attaches a per-request timeout", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalAbortSignalTimeout = AbortSignal.timeout;
+  const waits = [];
+  let observedTimeoutMs;
+  AbortSignal.timeout = (ms) => {
+    observedTimeoutMs = ms;
+    return originalAbortSignalTimeout(ms);
+  };
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls < 3) throw new Error("connection refused");
+    return {
+      ok: true,
+      async json() {
+        return { status: "ok" };
+      },
+    };
+  };
+  try {
+    const { engramFetch } = buildEngramFetchForTest({
+      wait: (ms) => {
+        waits.push(ms);
+        return Promise.resolve();
+      },
+      timeoutMs: 2500,
+      backoffBaseMs: 150,
+    });
+    assert.deepEqual(await engramFetch("/health"), { status: "ok" });
+    assert.equal(calls, 3);
+    assert.deepEqual(waits, [150, 300]);
+    assert.equal(observedTimeoutMs, 2500);
+  } finally {
+    globalThis.fetch = originalFetch;
+    AbortSignal.timeout = originalAbortSignalTimeout;
+  }
+});
+
+test("a timed-out write is not re-sent, so a slow-but-applied mem_save cannot be duplicated", async () => {
+  const originalFetch = globalThis.fetch;
+  const sentBodies = [];
+  globalThis.fetch = async (_url, init) => {
+    sentBodies.push(init?.body);
+    const timeout = new Error("The operation was aborted due to timeout");
+    timeout.name = "TimeoutError";
+    throw timeout;
+  };
+  try {
+    const { engramFetch } = buildEngramFetchForTest();
+    assert.equal(await engramFetch("/observations", { method: "POST", body: { title: "t" } }), null);
+    assert.equal(sentBodies.length, 1, "a timeout must not re-send a non-idempotent write");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a timeout resolves to null like any other failure, so callers keep their fallthrough", async () => {
+  // engramFetch's return contract must NOT change: ensureSession and ~20 other call sites
+  // rely on the null fallthrough, and throwing here once aborted a mem_save before the
+  // observation write was ever attempted.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    const timeout = new Error("The operation was aborted due to timeout");
+    timeout.name = "TimeoutError";
+    throw timeout;
+  };
+  try {
+    const { engramFetch, timedOutMethod } = buildEngramFetchForTest();
+    assert.equal(await engramFetch("/sessions", { method: "POST", body: { id: "s" } }), null);
+    // The timeout detail travels out-of-band instead of through the return value.
+    assert.equal(timedOutMethod(), "POST");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a connection failure records no timeout method, so the generic message is used", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error("connection refused");
+  };
+  try {
+    const { engramFetch, timedOutMethod } = buildEngramFetchForTest();
+    assert.equal(await engramFetch("/observations", { method: "POST", body: { title: "t" } }), null);
+    assert.equal(timedOutMethod(), undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("the tool layer reports unknown write outcome instead of inviting a blind retry", () => {
+  const factory = new Function(
+    "ENGRAM_FETCH_TIMEOUT_MS",
+    "ENGRAM_URL",
+    `return function unreachableMessage(timedOutMethod) {
+      ${extractFunctionBody("unreachableMessage", "{\n  if (timedOutMethod")}
+    };`,
+  );
+  const unreachableMessage = factory(3000, "http://127.0.0.1:7437");
+
+  // A write whose outcome is genuinely unknown must not be presented as a plain outage.
+  const write = unreachableMessage("POST");
+  assert.match(write, /may already have been applied/);
+  assert.match(write, /do NOT blindly retry/);
+  assert.doesNotMatch(write, /could not reach/);
+
+  // A read carries no duplicate-write risk, so it must not carry the scary warning.
+  const read = unreachableMessage("GET");
+  assert.match(read, /did not respond/);
+  assert.doesNotMatch(read, /may already have been applied/);
+
+  // A genuine unreachable server keeps the original wording other tests pin.
+  const unreachable = unreachableMessage(undefined);
+  assert.match(unreachable, /could not reach the Engram HTTP server/);
+  assert.doesNotMatch(unreachable, /timed out/);
+});
+
+test("a session-creation timeout still lets the observation write through", async () => {
+  // Regression: when engramFetch threw on timeout, the unguarded ensureSession call in
+  // mem_save aborted the whole tool call before /observations was ever attempted, silently
+  // dropping the user's memory while telling the agent not to retry.
+  assert.match(source, /await ensureSession\(activeSessionId, activeProject\);/);
+  assert.doesNotMatch(source, /throw new EngramTimeoutError/);
+
+  const originalFetch = globalThis.fetch;
+  const paths = [];
+  globalThis.fetch = async (url, init) => {
+    const path = new URL(url).pathname;
+    paths.push(path);
+    if (path === "/sessions") {
+      const timeout = new Error("The operation was aborted due to timeout");
+      timeout.name = "TimeoutError";
+      throw timeout;
+    }
+    return { ok: true, async json() { return { id: 1 }; } };
+  };
+  try {
+    const { engramFetch } = buildEngramFetchForTest();
+    // ensureSession's own call fails soft...
+    assert.equal(await engramFetch("/sessions", { method: "POST", body: { id: "s" } }), null);
+    // ...and the observation write that follows it still lands.
+    assert.deepEqual(await engramFetch("/observations", { method: "POST", body: { title: "t" } }), { id: 1 });
+    assert.deepEqual(paths, ["/sessions", "/observations"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a timeout on the session leg does not mislabel an unrelated failure on the write leg", async () => {
+  // mem_save issues two fetches. If /sessions times out and /observations then fails for an
+  // unrelated reason, the write genuinely never reached the server — telling the agent it
+  // "may already have been applied" would suppress a retry that is both safe and necessary.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    if (new URL(url).pathname === "/sessions") {
+      const timeout = new Error("The operation was aborted due to timeout");
+      timeout.name = "TimeoutError";
+      throw timeout;
+    }
+    throw new Error("connection refused");
+  };
+  try {
+    const { engramFetch, timedOutMethod } = buildEngramFetchForTest();
+    assert.equal(await engramFetch("/sessions", { method: "POST", body: { id: "s" } }), null);
+    assert.equal(timedOutMethod(), "POST", "the session leg did time out");
+    assert.equal(await engramFetch("/observations", { method: "POST", body: { title: "t" } }), null);
+    assert.equal(timedOutMethod(), undefined, "the write leg's own failure must supersede the stale timeout");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("isTimeoutError matches what Node actually rejects with on a real AbortSignal.timeout", async () => {
+  // Pins the runtime contract the whole no-retry-on-timeout guarantee depends on: if Node
+  // ever stopped rejecting with an Error named TimeoutError, detection would silently fall
+  // through to the retry path and reactivate the duplicate-write bug.
+  const { createServer } = await import("node:http");
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const factory = new Function(`
+    return function isTimeoutError(error) {
+      ${extractFunctionBody("isTimeoutError", "{\n  return error instanceof Error")}
+    };
+  `);
+  const isTimeoutError = factory();
+  try {
+    await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(150) });
+    assert.fail("the hung server should have triggered the timeout");
+  } catch (error) {
+    assert.equal(isTimeoutError(error), true, `unrecognized timeout rejection: ${error.name}`);
+  } finally {
+    server.close();
+  }
+});
+
+test("connection failures still retry, because they never reached the server", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls < 3) throw new Error("connection refused");
+    return {
+      ok: true,
+      async json() {
+        return { status: "ok" };
+      },
+    };
+  };
+  try {
+    const { engramFetch } = buildEngramFetchForTest();
+    assert.deepEqual(await engramFetch("/observations", { method: "POST", body: { title: "t" } }), { status: "ok" });
+    assert.equal(calls, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("self-heal clears the stale engram status once the server becomes reachable again", async () => {
+  const statusCalls = [];
+  const ctx = { ui: { setStatus: (key, text) => statusCalls.push([key, text]) } };
+  const { scheduleEngramSelfHeal, isInFlight } = buildScheduleEngramSelfHealForTest({
+    waitUnref: () => Promise.resolve(),
+    isEngramRunning: async () => true,
+  });
+  scheduleEngramSelfHeal(ctx);
+  assert.equal(isInFlight(), true);
+  await flush();
+  assert.deepEqual(statusCalls, [["engram", undefined]]);
+  assert.equal(isInFlight(), false);
+});
+
+test("self-heal does not start a second probe while one is already in flight", async () => {
+  let isEngramRunningCalls = 0;
+  const { scheduleEngramSelfHeal, isInFlight } = buildScheduleEngramSelfHealForTest({
+    waitUnref: () => Promise.resolve(),
+    isEngramRunning: async () => {
+      isEngramRunningCalls += 1;
+      return isEngramRunningCalls >= 2;
+    },
+  });
+  const ctx = { ui: { setStatus: () => {} } };
+  scheduleEngramSelfHeal(ctx);
+  scheduleEngramSelfHeal(ctx);
+  await flush();
+  assert.equal(isEngramRunningCalls, 2);
+  assert.equal(isInFlight(), false);
+});
+
+test("self-heal clears the stale status on every session that observed the outage", async () => {
+  const sessionA = [];
+  const sessionB = [];
+  const { scheduleEngramSelfHeal } = buildScheduleEngramSelfHealForTest({
+    waitUnref: () => Promise.resolve(),
+    isEngramRunning: async () => true,
+  });
+  scheduleEngramSelfHeal({ ui: { setStatus: (key, text) => sessionA.push([key, text]) } });
+  scheduleEngramSelfHeal({ ui: { setStatus: (key, text) => sessionB.push([key, text]) } });
+  await flush();
+  assert.deepEqual(sessionA, [["engram", undefined]]);
+  assert.deepEqual(sessionB, [["engram", undefined]], "second session must not keep a stale error label");
+});
+
+test("a session that shuts down mid-outage is dropped instead of having its dead UI touched", async () => {
+  const alive = [];
+  const shutDown = [];
+  const { scheduleEngramSelfHeal, forgetSelfHealContext, trackedCount } = buildScheduleEngramSelfHealForTest({
+    waitUnref: () => Promise.resolve(),
+    isEngramRunning: async () => true,
+  });
+  scheduleEngramSelfHeal(sessionCtx("session-alive", alive));
+  scheduleEngramSelfHeal(sessionCtx("session-gone", shutDown));
+  forgetSelfHealContext("session-gone");
+  await flush();
+  assert.deepEqual(alive, [["engram", undefined]]);
+  assert.deepEqual(shutDown, [], "a shut-down session must not have its status touched");
+});
+
+test("repeated failures in one session are tracked once, not accumulated per tool call", async () => {
+  const sink = [];
+  const { scheduleEngramSelfHeal, trackedCount } = buildScheduleEngramSelfHealForTest({
+    waitUnref: () => Promise.resolve(),
+    isEngramRunning: async () => false,
+    maxAttempts: 1,
+  });
+  scheduleEngramSelfHeal(sessionCtx("session-a", sink));
+  scheduleEngramSelfHeal(sessionCtx("session-a", sink));
+  scheduleEngramSelfHeal(sessionCtx("session-a", sink));
+  assert.equal(trackedCount(), 1, "one session must occupy one slot regardless of failure count");
+});
+
+test("self-heal gives up after exhausting its attempt budget without clearing the status", async () => {
+  const statusCalls = [];
+  const ctx = { ui: { setStatus: (key, text) => statusCalls.push([key, text]) } };
+  const { scheduleEngramSelfHeal, isInFlight } = buildScheduleEngramSelfHealForTest({
+    waitUnref: () => Promise.resolve(),
+    isEngramRunning: async () => false,
+    maxAttempts: 2,
+  });
+  scheduleEngramSelfHeal(ctx);
+  await flush();
+  assert.deepEqual(statusCalls, []);
+  assert.equal(isInFlight(), false);
+});
+
+test("only reachability failures schedule self-heal, HTTP errors from a live server do not", () => {
+  assert.match(source, /if \(!\(error instanceof EngramHttpError\)\) scheduleEngramSelfHeal\(ctx\);/);
+});
+
+test("waitUnref schedules a background timer that does not keep the process alive", async () => {
+  const body = extractFunctionBody("waitUnref", "{\n  return new Promise");
+  const factory = new Function(`
+    return function waitUnref(ms) {
+      ${body}
+    };
+  `);
+  const waitUnref = factory();
+
+  const originalSetTimeout = globalThis.setTimeout;
+  let unrefCalled = false;
+  globalThis.setTimeout = (fn, ms) => {
+    const timer = originalSetTimeout(fn, ms);
+    const originalUnref = timer.unref.bind(timer);
+    timer.unref = () => {
+      unrefCalled = true;
+      return originalUnref();
+    };
+    return timer;
+  };
+  try {
+    await waitUnref(0);
+    assert.equal(unrefCalled, true);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
   }
 });
 
@@ -113,7 +516,7 @@ test("native tool fetch preserves HTTP error status", async () => {
     },
   });
   try {
-    const engramFetch = buildEngramFetchForTest();
+    const { engramFetch } = buildEngramFetchForTest();
     await assert.rejects(
       () => engramFetch("/search"),
       (error) => error.name === "EngramHttpError" && error.status === 503 && error.message === "server warming up",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #632

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

---

## 📝 Summary

- `engramFetch` retried 3× with a flat 150ms gap (~300ms) and **no per-request timeout**. That window is shorter than the >300ms macOS loopback needs to settle after wake from sleep, and a stalled handler could hang the request indefinitely.
- The statusline error label was only overwritten by the *next* `mem_*` call, so if the model stopped calling memory tools after a failure the label stayed stale until Pi restarted — the reported symptom.
- Adds a per-request timeout with exponential backoff, a no-retry-on-timeout guarantee, honest reporting of ambiguous write outcomes, and a background self-heal probe that clears the stale label.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Per-request `AbortSignal.timeout` + exponential backoff; never retry a timeout; out-of-band timeout signal so ambiguous writes are reported honestly; background self-heal probe with per-session tracking and shutdown pruning |
| `plugin/pi/test/index-source.test.mjs` | 13 new tests covering the above, incl. a real `AbortSignal.timeout` integration test |

### Why timeouts are never retried

A timed-out request **may already have been applied**. No memory endpoint carries an idempotency key and 16 non-idempotent `POST`/`PATCH`/`DELETE` call sites share this retry path, so re-sending on timeout could duplicate a `mem_save`. Connection failures are pre-send and remain safe to repeat — and that is precisely the wake-settle case this retry exists for. A hung server does not recover by retrying anyway.

### Why the timeout signal travels out-of-band

An earlier iteration threw a distinct error on timeout. That changed `engramFetch`'s return contract, and `ensureSession` calls it unguarded — so a `/sessions` timeout aborted `mem_save` *before* the `/observations` write, silently dropping a memory while telling the agent not to retry. `engramFetch` now still resolves to `null` (every caller keeps its fallthrough) and the timeout detail is carried separately, reset at the top of each call so the last call wins.

## 🧪 Test Plan

- [x] Unit tests pass locally: `cd plugin/pi && npm test` — **42/42**
- [x] Verified empirically that Node rejects an `AbortSignal.timeout()` fetch with a `DOMException` named `TimeoutError` for which `instanceof Error` is `true`; a test now pins this runtime contract
- [x] Manually traced every `engramFetch` call site for the return-contract change

Go-only CI jobs (`go test ./...`, e2e) are unaffected — this change is confined to the Pi TypeScript plugin.

## 💬 Notes for Reviewers

This went through four review rounds; the first three each surfaced a real regression **introduced by the previous fix**, all now closed and covered by differential tests. The final 4R sweep (risk / resilience / readability / reliability) returned **no blocking findings**. Risk came back clean.

Known non-blocking follow-ups, deliberately not fixed here to keep the diff bounded:

1. **Shared timeout flag is process-wide.** `lastFetchTimeoutMethod` gives correct last-call-wins semantics for the sequential legs of one tool invocation, but offers no isolation between genuinely concurrent calls from different sessions. Flagged as `inferential` by three lenses. Removing the class of race means threading the signal through the return path — which is exactly what caused the round-3 regression above, so it deserves its own change.
2. **`extractFunctionBody` doesn't validate its marker.** On a non-matching marker it returns nearly the whole file instead of throwing, surfacing as an opaque `SyntaxError` rather than a clear diagnostic. Test-harness only.
3. **Self-heal is scheduled for local validation errors too**, not just reachability failures, so a client-side mistake can look like a healed outage.
4. **~19s worst-case latency with no status feedback** when project detection is stuck, from `detectServerProject`'s pre-existing 5-attempt loop composing with the new per-call timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Engram connection failures and request timeouts.
  * Prevented automatic retries for timed-out operations that may have changed data.
  * Added clearer error messages identifying timeout conditions.
  * Automatically clears stale connection error indicators when service connectivity is restored.
  * Improved session cleanup during recovery and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->