### PR TITLE
fix(claude-plugin): use plugin-scoped MCP tool prefix in UserPromptSubmit hint

### DIFF
--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -19,7 +19,7 @@ function Write-EmptyHookResponse {
 }
 
 function Write-ToolSearchMessage {
-  $message = "CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:`nselect:mcp__engram__mem_save,mcp__engram__mem_search,mcp__engram__mem_context,mcp__engram__mem_session_summary,mcp__engram__mem_session_start,mcp__engram__mem_session_end,mcp__engram__mem_get_observation,mcp__engram__mem_suggest_topic_key,mcp__engram__mem_capture_passive,mcp__engram__mem_save_prompt,mcp__engram__mem_update,mcp__engram__mem_current_project,mcp__engram__mem_judge`n`nAfter loading tools, call mem_context to check for prior session history before responding."
+  $message = "CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:`nselect:mcp__plugin_engram_engram__mem_save,mcp__plugin_engram_engram__mem_search,mcp__plugin_engram_engram__mem_context,mcp__plugin_engram_engram__mem_session_summary,mcp__plugin_engram_engram__mem_session_start,mcp__plugin_engram_engram__mem_session_end,mcp__plugin_engram_engram__mem_get_observation,mcp__plugin_engram_engram__mem_suggest_topic_key,mcp__plugin_engram_engram__mem_capture_passive,mcp__plugin_engram_engram__mem_save_prompt,mcp__plugin_engram_engram__mem_update,mcp__plugin_engram_engram__mem_current_project,mcp__plugin_engram_engram__mem_judge`n`nAfter loading tools, call mem_context to check for prior session history before responding."
   [PSCustomObject]@{ systemMessage = $message } | ConvertTo-Json -Compress
 }
 

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -56,7 +56,7 @@ sanitize_session_key_part() {
 }
 
 print_toolsearch_message() {
-  printf '%s\n' '{"systemMessage":"CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:\nselect:mcp__engram__mem_save,mcp__engram__mem_search,mcp__engram__mem_context,mcp__engram__mem_session_summary,mcp__engram__mem_session_start,mcp__engram__mem_session_end,mcp__engram__mem_get_observation,mcp__engram__mem_suggest_topic_key,mcp__engram__mem_capture_passive,mcp__engram__mem_save_prompt,mcp__engram__mem_update,mcp__engram__mem_current_project,mcp__engram__mem_judge\n\nAfter loading tools, call mem_context to check for prior session history before responding."}'
+  printf '%s\n' '{"systemMessage":"CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:\nselect:mcp__plugin_engram_engram__mem_save,mcp__plugin_engram_engram__mem_search,mcp__plugin_engram_engram__mem_context,mcp__plugin_engram_engram__mem_session_summary,mcp__plugin_engram_engram__mem_session_start,mcp__plugin_engram_engram__mem_session_end,mcp__plugin_engram_engram__mem_get_observation,mcp__plugin_engram_engram__mem_suggest_topic_key,mcp__plugin_engram_engram__mem_capture_passive,mcp__plugin_engram_engram__mem_save_prompt,mcp__plugin_engram_engram__mem_update,mcp__plugin_engram_engram__mem_current_project,mcp__plugin_engram_engram__mem_judge\n\nAfter loading tools, call mem_context to check for prior session history before responding."}'
 }
 
 if is_windows_bash && [ "${ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE:-auto}" != "0" ]; then


### PR DESCRIPTION
## Problem

The UserPromptSubmit hook (`plugin/claude-code/scripts/user-prompt-submit.ps1` / `.sh`) emits a first-turn hint telling the agent to run:

```
ToolSearch select:mcp__engram__mem_save,mcp__engram__mem_search,...
```

But when engram is installed as a Claude Code **plugin** (via the marketplace), the MCP server is registered with the plugin-scoped prefix, so the actual tool names are `mcp__plugin_engram_engram__mem_*`. The `select:` query matches nothing and the agent cannot load the memory tools from the hint.

`internal/setup/setup.go` already handles both prefixes for the permissions allowlist — only the plugin hook scripts were left on the old prefix.

## Fix

Replace `mcp__engram__` with `mcp__plugin_engram_engram__` in both claude-code hook scripts (2 lines).

## Notes

- `plugin/codex/scripts/user-prompt-submit.sh` also references `mcp__engram__` — left untouched since Codex tool naming may differ; happy to update it here too if the same prefix applies.
- Verified locally on Windows 11 + Claude Code with the plugin installed from the marketplace: the corrected `select:` list loads all 13 tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tool-loading guidance so memory tools can be discovered and invoked correctly.
  * Applied the fix consistently across supported command-line environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->