### PR TITLE
feat(cloud): add ENGRAM_CLOUD_EXTRA_HEADERS support

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1414,11 +1414,12 @@ Autosync is a background push/pull replication service that keeps your local Eng
 
 Autosync is **opt-in**. Set all three environment variables before starting `engram serve` or `engram mcp`:
 
-| Variable                | Required          | Description                                                             |
-| ----------------------- | ----------------- | ----------------------------------------------------------------------- |
-| `ENGRAM_CLOUD_AUTOSYNC` | Yes (exact `"1"`) | Enables autosync. Any other value disables it.                          |
-| `ENGRAM_CLOUD_TOKEN`    | Yes               | Bearer token for the cloud server.                                      |
-| `ENGRAM_CLOUD_SERVER`   | Yes               | Base URL of the cloud server (e.g. `https://cloud.engram.example.com`). |
+| Variable                     | Required          | Description                                                                             |
+| ----------------------------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| `ENGRAM_CLOUD_AUTOSYNC`       | Yes (exact `"1"`) | Enables autosync. Any other value disables it.                                          |
+| `ENGRAM_CLOUD_TOKEN`          | Yes               | Bearer token for the cloud server.                                                      |
+| `ENGRAM_CLOUD_SERVER`         | Yes               | Base URL of the cloud server (e.g. `https://cloud.engram.example.com`).                 |
+| `ENGRAM_CLOUD_EXTRA_HEADERS`  | No                | Comma-separated extra HTTP headers on every cloud request. Authorization key rejected.  |
 
 Example:
 
@@ -1436,6 +1437,30 @@ engram mcp
 ```
 
 Missing `ENGRAM_CLOUD_TOKEN` or `ENGRAM_CLOUD_SERVER` logs an `ERROR` and disables autosync gracefully — `engram serve` or `engram mcp` still starts.
+
+### Optional: Extra HTTP Headers
+
+`ENGRAM_CLOUD_EXTRA_HEADERS` lets you attach additional HTTP headers to every cloud sync request — useful for trace IDs, tenant routing, or proxy authentication.
+
+**Format**: comma-separated `Key: Value` pairs.
+
+```bash
+ENGRAM_CLOUD_EXTRA_HEADERS="X-Tenant-ID: acme, X-Trace-Id: deploy-42" \
+ENGRAM_CLOUD_AUTOSYNC=1 \
+ENGRAM_CLOUD_TOKEN=your-token \
+ENGRAM_CLOUD_SERVER=https://cloud.engram.example.com \
+engram serve
+```
+
+**Rules**:
+- Headers are applied after `Authorization` and cannot shadow the bearer token.
+- The `Authorization` key is rejected at parse time and logged as a warning. Use `ENGRAM_CLOUD_TOKEN` for authentication.
+- Malformed pairs (missing `:`) are skipped with a warning; remaining pairs are applied.
+- Header values are never logged. Only key names appear in startup logs.
+- Values may contain colons (e.g. URLs); only the first `:` in each pair acts as the separator.
+- Header keys are canonicalized (e.g. `x-trace-id` → `X-Trace-Id`); duplicates collapse with last-value-wins.
+
+Unset or empty: no extra headers added.
 
 ### Autosync Phase Table
 

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2733,6 +2733,10 @@ Environment:
   ENGRAM_CLOUD_MAX_PUSH_BYTES
                      Max cloud push payload bytes (default: 8388608)
   ENGRAM_CLOUD_TOKEN Bearer token required in authenticated cloud serve mode
+  ENGRAM_CLOUD_EXTRA_HEADERS
+                     Comma-separated extra HTTP headers on every cloud sync request
+                     Format: "Key: Value, Key2: Value2"
+                     Authorization key is rejected (use ENGRAM_CLOUD_TOKEN instead)
   ENGRAM_CLOUD_INSECURE_NO_AUTH
                      Set to 1 ONLY for local insecure cloud serve mode (no auth)
                      Cannot be combined with ENGRAM_CLOUD_TOKEN

--- a/internal/cloud/remote/transport.go
+++ b/internal/cloud/remote/transport.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -18,10 +19,76 @@ import (
 )
 
 type RemoteTransport struct {
-	baseURL    string
-	token      string
-	project    string
-	httpClient *http.Client
+	baseURL      string
+	token        string
+	project      string
+	httpClient   *http.Client
+	extraHeaders map[string]string
+}
+
+// parseExtraHeaders parses a comma-separated list of "Key: Value" pairs.
+// Returns nil if raw is empty or all pairs are malformed/rejected.
+// Uses strings.IndexByte so values may contain colons (e.g. URLs).
+func parseExtraHeaders(raw string) map[string]string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	pairs := strings.Split(raw, ",")
+	result := make(map[string]string, len(pairs))
+
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		idx := strings.IndexByte(pair, ':')
+		if idx < 0 {
+			log.Printf("[cloud] WARN ENGRAM_CLOUD_EXTRA_HEADERS: skipping malformed pair %q (missing colon)", pair)
+			continue
+		}
+		key := strings.TrimSpace(pair[:idx])
+		value := strings.TrimSpace(pair[idx+1:])
+		if key == "" {
+			continue
+		}
+		// Canonicalize the key (e.g. x-trace-id → X-Trace-Id).
+		canonical := http.CanonicalHeaderKey(key)
+		// Reject Authorization regardless of original casing.
+		if canonical == "Authorization" {
+			log.Printf("[cloud] WARN ENGRAM_CLOUD_EXTRA_HEADERS: refusing to override Authorization header")
+			continue
+		}
+		result[canonical] = value
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	// Log successful parse: emit sorted canonical key names (never values).
+	keys := make([]string, 0, len(result))
+	for k := range result {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	log.Printf("[cloud] ENGRAM_CLOUD_EXTRA_HEADERS: applying %d extra header(s): %s", len(result), strings.Join(keys, ", "))
+
+	return result
+}
+
+// sortStrings sorts a slice of strings in-place (insertion sort — small N, avoids importing sort).
+func sortStrings(ss []string) {
+	for i := 1; i < len(ss); i++ {
+		for j := i; j > 0 && ss[j] < ss[j-1]; j-- {
+			ss[j], ss[j-1] = ss[j-1], ss[j]
+		}
+	}
+}
+
+// applyExtraHeaders sets extra headers on the request after authorization.
+// Ranging over a nil map is legal in Go (no-op).
+func applyExtraHeaders(req *http.Request, extraHeaders map[string]string) {
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
 }
 
 type HTTPStatusError struct {
@@ -88,9 +155,10 @@ func NewRemoteTransport(baseURL, token, project string) (*RemoteTransport, error
 		return nil, fmt.Errorf("cloud: project is required")
 	}
 	return &RemoteTransport{
-		baseURL: normalized,
-		token:   strings.TrimSpace(token),
-		project: project,
+		baseURL:      normalized,
+		token:        strings.TrimSpace(token),
+		project:      project,
+		extraHeaders: parseExtraHeaders(os.Getenv("ENGRAM_CLOUD_EXTRA_HEADERS")),
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -156,6 +224,7 @@ func (rt *RemoteTransport) ReadManifest() (*engramsync.Manifest, error) {
 		return nil, fmt.Errorf("cloud: build manifest request: %w", err)
 	}
 	rt.setAuthorization(req)
+	applyExtraHeaders(req, rt.extraHeaders)
 
 	resp, err := rt.httpClient.Do(req)
 	if err != nil {
@@ -209,6 +278,7 @@ func (rt *RemoteTransport) WriteChunk(chunkID string, data []byte, entry engrams
 	}
 	req.Header.Set("Content-Type", "application/json")
 	rt.setAuthorization(req)
+	applyExtraHeaders(req, rt.extraHeaders)
 
 	resp, err := rt.httpClient.Do(req)
 	if err != nil {
@@ -232,6 +302,7 @@ func (rt *RemoteTransport) ReadChunk(chunkID string) ([]byte, error) {
 		return nil, fmt.Errorf("cloud: build pull request: %w", err)
 	}
 	rt.setAuthorization(req)
+	applyExtraHeaders(req, rt.extraHeaders)
 	resp, err := rt.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("cloud: pull chunk %s: %w", chunkID, err)
@@ -295,9 +366,10 @@ func (rt *RemoteTransport) PullMutations(_ int64, _ int) (*PullMutationsResponse
 // Unlike RemoteTransport (which handles chunk-level sync), this operates on the
 // mutation journal and supports cursor-based pull.
 type MutationTransport struct {
-	baseURL    string
-	token      string
-	httpClient *http.Client
+	baseURL      string
+	token        string
+	httpClient   *http.Client
+	extraHeaders map[string]string
 }
 
 // NewMutationTransport creates a MutationTransport. baseURL must be a valid http/https URL.
@@ -308,8 +380,9 @@ func NewMutationTransport(baseURL, token string) (*MutationTransport, error) {
 		return nil, err
 	}
 	return &MutationTransport{
-		baseURL: normalized,
-		token:   strings.TrimSpace(token),
+		baseURL:      normalized,
+		token:        strings.TrimSpace(token),
+		extraHeaders: parseExtraHeaders(os.Getenv("ENGRAM_CLOUD_EXTRA_HEADERS")),
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -337,6 +410,7 @@ func (mt *MutationTransport) PushMutations(entries []MutationEntry) ([]int64, er
 	}
 	req.Header.Set("Content-Type", "application/json")
 	mt.setAuthorization(req)
+	applyExtraHeaders(req, mt.extraHeaders)
 
 	resp, err := mt.httpClient.Do(req)
 	if err != nil {
@@ -368,6 +442,7 @@ func (mt *MutationTransport) PullMutations(sinceSeq int64, limit int) (*PullMuta
 		return nil, fmt.Errorf("cloud: build mutation pull request: %w", err)
 	}
 	mt.setAuthorization(req)
+	applyExtraHeaders(req, mt.extraHeaders)
 
 	resp, err := mt.httpClient.Do(req)
 	if err != nil {

--- a/internal/cloud/remote/transport.go
+++ b/internal/cloud/remote/transport.go
@@ -34,29 +34,41 @@ func parseExtraHeaders(raw string) map[string]string {
 		return nil
 	}
 
-	pairs := strings.Split(raw, ",")
-	result := make(map[string]string, len(pairs))
+	parts := strings.Split(raw, ",")
+	result := make(map[string]string)
+	var currentKey string
 
-	for _, pair := range pairs {
-		pair = strings.TrimSpace(pair)
-		idx := strings.IndexByte(pair, ':')
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		idx := strings.IndexByte(part, ':')
 		if idx < 0 {
-			log.Printf("[cloud] WARN ENGRAM_CLOUD_EXTRA_HEADERS: skipping malformed pair %q (missing colon)", pair)
+			if currentKey != "" {
+				result[currentKey] += ", " + part
+			} else {
+				log.Printf("[cloud] WARN ENGRAM_CLOUD_EXTRA_HEADERS: skipping malformed segment %q (missing colon)", part)
+			}
 			continue
 		}
-		key := strings.TrimSpace(pair[:idx])
-		value := strings.TrimSpace(pair[idx+1:])
+
+		key := strings.TrimSpace(part[:idx])
 		if key == "" {
+			currentKey = ""
 			continue
 		}
-		// Canonicalize the key (e.g. x-trace-id → X-Trace-Id).
+
 		canonical := http.CanonicalHeaderKey(key)
-		// Reject Authorization regardless of original casing.
 		if canonical == "Authorization" {
 			log.Printf("[cloud] WARN ENGRAM_CLOUD_EXTRA_HEADERS: refusing to override Authorization header")
+			currentKey = "" // Prevent appending trailing segments to a rejected header
 			continue
 		}
-		result[canonical] = value
+
+		currentKey = canonical
+		result[currentKey] = strings.TrimSpace(part[idx+1:])
 	}
 
 	if len(result) == 0 {

--- a/internal/cloud/remote/transport_extra_test.go
+++ b/internal/cloud/remote/transport_extra_test.go
@@ -1,0 +1,270 @@
+package remote
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	engramsync "github.com/Gentleman-Programming/engram/internal/sync"
+)
+
+// ─── NewRemoteTransport extraHeaders env wiring ──────────────────────────────
+
+func TestNewRemoteTransport_ExtraHeaders_ValidEnv(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "X-Tenant-ID: acme")
+	rt, err := NewRemoteTransport("http://localhost:8080", "token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+	if len(rt.extraHeaders) == 0 {
+		t.Fatal("expected extraHeaders to be populated from env, got empty")
+	}
+	if v, ok := rt.extraHeaders["X-Tenant-Id"]; !ok || v != "acme" {
+		t.Fatalf("expected X-Tenant-Id=acme, got %v", rt.extraHeaders)
+	}
+}
+
+func TestNewRemoteTransport_ExtraHeaders_Unset(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "")
+	rt, err := NewRemoteTransport("http://localhost:8080", "token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+	if rt.extraHeaders != nil {
+		t.Fatalf("expected extraHeaders to be nil when env not set, got %v", rt.extraHeaders)
+	}
+}
+
+func TestNewRemoteTransport_ExtraHeaders_EmptyString(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "")
+	rt, err := NewRemoteTransport("http://localhost:8080", "token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+	if rt.extraHeaders != nil {
+		t.Fatalf("expected extraHeaders=nil for empty env, got %v", rt.extraHeaders)
+	}
+}
+
+// ─── NewMutationTransport extraHeaders env wiring ────────────────────────────
+
+func TestNewMutationTransport_ExtraHeaders_ValidEnv(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "X-Tenant-ID: acme")
+	mt, err := NewMutationTransport("http://localhost:8080", "token")
+	if err != nil {
+		t.Fatalf("NewMutationTransport: %v", err)
+	}
+	if len(mt.extraHeaders) == 0 {
+		t.Fatal("expected extraHeaders to be populated from env, got empty")
+	}
+	if v, ok := mt.extraHeaders["X-Tenant-Id"]; !ok || v != "acme" {
+		t.Fatalf("expected X-Tenant-Id=acme, got %v", mt.extraHeaders)
+	}
+}
+
+func TestNewMutationTransport_ExtraHeaders_Unset(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "")
+	mt, err := NewMutationTransport("http://localhost:8080", "token")
+	if err != nil {
+		t.Fatalf("NewMutationTransport: %v", err)
+	}
+	if mt.extraHeaders != nil {
+		t.Fatalf("expected extraHeaders=nil when env not set, got %v", mt.extraHeaders)
+	}
+}
+
+// ─── HTTP header propagation: RemoteTransport ────────────────────────────────
+
+// captureHeadersServer starts a test server that captures request headers and returns 200.
+// capturedHeaders is set once the first request arrives; call the returned close func when done.
+func captureHeadersServer(t *testing.T, method, path string, responseBody string) (*httptest.Server, *http.Header, *sync.Once) {
+	t.Helper()
+	var captured http.Header
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == method && r.URL.Path == path {
+			once.Do(func() {
+				captured = r.Header.Clone()
+			})
+			if responseBody != "" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(responseBody))
+			} else {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"status":"ok"}`))
+			}
+			return
+		}
+		// Allow other paths through (e.g. push during WriteChunk test)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	return srv, &captured, &once
+}
+
+func TestRemoteTransport_ReadManifest_CarriesExtraHeaders(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "X-Tenant-ID: acme")
+
+	var capturedHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":1,"chunks":[]}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	_, err = rt.ReadManifest()
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Tenant-Id") != "acme" {
+		t.Fatalf("expected X-Tenant-Id=acme on request, got %q", capturedHeaders.Get("X-Tenant-Id"))
+	}
+}
+
+func TestRemoteTransport_WriteChunk_CarriesExtraHeaders(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "X-Tenant-ID: acme")
+
+	var capturedHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	err = rt.WriteChunk("", []byte(`{"sessions":[]}`), engramsync.ChunkEntry{CreatedBy: "test", CreatedAt: "2026-01-01T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("WriteChunk: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Tenant-Id") != "acme" {
+		t.Fatalf("expected X-Tenant-Id=acme on POST request, got %q", capturedHeaders.Get("X-Tenant-Id"))
+	}
+}
+
+func TestRemoteTransport_ReadChunk_CarriesExtraHeaders(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "X-Tenant-ID: acme")
+
+	var capturedHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		_, _ = w.Write([]byte(`{"sessions":[]}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	_, err = rt.ReadChunk("chunk-1")
+	if err != nil {
+		t.Fatalf("ReadChunk: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Tenant-Id") != "acme" {
+		t.Fatalf("expected X-Tenant-Id=acme on GET chunk request, got %q", capturedHeaders.Get("X-Tenant-Id"))
+	}
+}
+
+// TestRemoteTransport_AuthorizationNotOverwritten verifies that even if the env contains
+// "authorization: fake", the real Bearer token from ENGRAM_CLOUD_TOKEN wins.
+func TestRemoteTransport_AuthorizationNotOverwritten(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "authorization: fake")
+
+	var capturedHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":1,"chunks":[]}`))
+	}))
+	defer srv.Close()
+
+	rt, err := NewRemoteTransport(srv.URL, "real-token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	_, err = rt.ReadManifest()
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+
+	auth := capturedHeaders.Get("Authorization")
+	if auth != "Bearer real-token" {
+		t.Fatalf("expected Authorization=Bearer real-token, got %q", auth)
+	}
+}
+
+// ─── HTTP header propagation: MutationTransport ──────────────────────────────
+
+func TestMutationTransport_PushMutations_CarriesExtraHeaders(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "X-Tenant-ID: acme")
+
+	var capturedHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"accepted_seqs":[1]}`))
+	}))
+	defer srv.Close()
+
+	mt, err := NewMutationTransport(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("NewMutationTransport: %v", err)
+	}
+
+	entries := []MutationEntry{
+		{Project: "proj-a", Entity: "obs", EntityKey: "k1", Op: "upsert", Payload: json.RawMessage(`{}`)},
+	}
+	_, err = mt.PushMutations(entries)
+	if err != nil {
+		t.Fatalf("PushMutations: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Tenant-Id") != "acme" {
+		t.Fatalf("expected X-Tenant-Id=acme on push request, got %q", capturedHeaders.Get("X-Tenant-Id"))
+	}
+}
+
+func TestMutationTransport_PullMutations_CarriesExtraHeaders(t *testing.T) {
+	t.Setenv("ENGRAM_CLOUD_EXTRA_HEADERS", "X-Tenant-ID: acme")
+
+	var capturedHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"mutations":[],"has_more":false,"latest_seq":0}`))
+	}))
+	defer srv.Close()
+
+	mt, err := NewMutationTransport(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("NewMutationTransport: %v", err)
+	}
+
+	_, err = mt.PullMutations(0, 10)
+	if err != nil {
+		t.Fatalf("PullMutations: %v", err)
+	}
+
+	if capturedHeaders.Get("X-Tenant-Id") != "acme" {
+		t.Fatalf("expected X-Tenant-Id=acme on pull request, got %q", capturedHeaders.Get("X-Tenant-Id"))
+	}
+}

--- a/internal/cloud/remote/transport_headers_test.go
+++ b/internal/cloud/remote/transport_headers_test.go
@@ -1,0 +1,228 @@
+package remote
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+)
+
+// TestParseExtraHeaders_SinglePair verifies a single valid pair is parsed correctly.
+func TestParseExtraHeaders_SinglePair(t *testing.T) {
+	result := parseExtraHeaders("X-Tenant-ID: abc")
+	if result == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+	// http.CanonicalHeaderKey("X-Tenant-ID") = "X-Tenant-Id"
+	if v, ok := result["X-Tenant-Id"]; !ok || v != "abc" {
+		t.Fatalf("expected X-Tenant-Id=abc, got %v", result)
+	}
+}
+
+// TestParseExtraHeaders_MultiPair verifies two valid pairs produce a two-entry map.
+func TestParseExtraHeaders_MultiPair(t *testing.T) {
+	result := parseExtraHeaders("X-A: 1, X-B: 2")
+	if result == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(result), result)
+	}
+	if result["X-A"] != "1" {
+		t.Fatalf("expected X-A=1, got %q", result["X-A"])
+	}
+	if result["X-B"] != "2" {
+		t.Fatalf("expected X-B=2, got %q", result["X-B"])
+	}
+}
+
+// TestParseExtraHeaders_EmptyString verifies empty string returns nil.
+func TestParseExtraHeaders_EmptyString(t *testing.T) {
+	result := parseExtraHeaders("")
+	if result != nil {
+		t.Fatalf("expected nil for empty string, got %v", result)
+	}
+}
+
+// TestParseExtraHeaders_WhitespaceOnly verifies whitespace-only input returns nil.
+func TestParseExtraHeaders_WhitespaceOnly(t *testing.T) {
+	result := parseExtraHeaders("   \t  ")
+	if result != nil {
+		t.Fatalf("expected nil for whitespace-only input, got %v", result)
+	}
+}
+
+// TestParseExtraHeaders_MalformedPairSkipped verifies malformed pairs are skipped with a warning,
+// and remaining valid pairs are returned.
+func TestParseExtraHeaders_MalformedPairSkipped(t *testing.T) {
+	orig := log.Writer()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	result := parseExtraHeaders("X-A: 1, badpair, X-B: 2")
+	if result == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(result), result)
+	}
+	if result["X-A"] != "1" {
+		t.Fatalf("expected X-A=1, got %q", result["X-A"])
+	}
+	if result["X-B"] != "2" {
+		t.Fatalf("expected X-B=2, got %q", result["X-B"])
+	}
+	logOut := buf.String()
+	if logOut == "" {
+		t.Fatal("expected warning log for malformed pair, got empty")
+	}
+	// The log should reference the malformed pair "badpair"
+	if !contains(logOut, "badpair") {
+		t.Fatalf("expected log to mention 'badpair', got: %q", logOut)
+	}
+}
+
+// TestParseExtraHeaders_AllMalformed verifies all-malformed input returns nil.
+func TestParseExtraHeaders_AllMalformed(t *testing.T) {
+	orig := log.Writer()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	result := parseExtraHeaders("nocolon, alsono")
+	if result != nil {
+		t.Fatalf("expected nil for all-malformed input, got %v", result)
+	}
+}
+
+// TestParseExtraHeaders_AuthorizationRejected_ExactCase verifies exact-case "Authorization" is rejected
+// and the secret value is never logged.
+func TestParseExtraHeaders_AuthorizationRejected_ExactCase(t *testing.T) {
+	orig := log.Writer()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	result := parseExtraHeaders("Authorization: secret")
+	if result != nil {
+		t.Fatalf("expected nil when Authorization is rejected, got %v", result)
+	}
+	logOut := buf.String()
+	if contains(logOut, "secret") {
+		t.Fatalf("secret value must NOT appear in log, got: %q", logOut)
+	}
+}
+
+// TestParseExtraHeaders_AuthorizationRejected_UpperCase verifies uppercase AUTHORIZATION is rejected.
+func TestParseExtraHeaders_AuthorizationRejected_UpperCase(t *testing.T) {
+	orig := log.Writer()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	result := parseExtraHeaders("AUTHORIZATION: secret")
+	if result != nil {
+		t.Fatalf("expected nil when AUTHORIZATION is rejected, got %v", result)
+	}
+	logOut := buf.String()
+	if contains(logOut, "secret") {
+		t.Fatalf("secret value must NOT appear in log, got: %q", logOut)
+	}
+}
+
+// TestParseExtraHeaders_AuthorizationRejected_LowerCase verifies lowercase authorization is rejected.
+func TestParseExtraHeaders_AuthorizationRejected_LowerCase(t *testing.T) {
+	orig := log.Writer()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	result := parseExtraHeaders("authorization: secret")
+	if result != nil {
+		t.Fatalf("expected nil when authorization is rejected, got %v", result)
+	}
+	logOut := buf.String()
+	if contains(logOut, "secret") {
+		t.Fatalf("secret value must NOT appear in log, got: %q", logOut)
+	}
+}
+
+// TestParseExtraHeaders_WhitespaceTrim verifies leading/trailing whitespace is trimmed from keys and values.
+func TestParseExtraHeaders_WhitespaceTrim(t *testing.T) {
+	result := parseExtraHeaders("  X-Foo :  bar  ")
+	if result == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+	if v, ok := result["X-Foo"]; !ok || v != "bar" {
+		t.Fatalf("expected X-Foo=bar, got %v", result)
+	}
+}
+
+// TestParseExtraHeaders_ValueWithColon verifies values containing colons are preserved
+// (only the first colon acts as separator).
+func TestParseExtraHeaders_ValueWithColon(t *testing.T) {
+	result := parseExtraHeaders("X-Trace-Id: req:abc:123")
+	if result == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(result), result)
+	}
+	if v, ok := result["X-Trace-Id"]; !ok || v != "req:abc:123" {
+		t.Fatalf("expected X-Trace-Id=req:abc:123, got %v", result)
+	}
+}
+
+// TestParseExtraHeaders_MultiHeaderMixedValidMalformed verifies that valid pairs are kept,
+// malformed are skipped, and Authorization is rejected; only X-A and X-B survive.
+func TestParseExtraHeaders_MultiHeaderMixedValidMalformed(t *testing.T) {
+	orig := log.Writer()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	result := parseExtraHeaders("X-A: 1, nocolon, X-B: 2, Authorization: bad")
+	if result == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries (X-A, X-B), got %d: %v", len(result), result)
+	}
+	if result["X-A"] != "1" {
+		t.Fatalf("expected X-A=1, got %q", result["X-A"])
+	}
+	if result["X-B"] != "2" {
+		t.Fatalf("expected X-B=2, got %q", result["X-B"])
+	}
+	if _, ok := result["Authorization"]; ok {
+		t.Fatal("Authorization must not appear in result")
+	}
+	logOut := buf.String()
+	if contains(logOut, "bad") {
+		t.Fatalf("Authorization value must NOT appear in log, got: %q", logOut)
+	}
+}
+
+// contains is a helper to avoid importing strings in the test name collision.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// Suppress unused import warning - os is used by other tests that may reference it.
+var _ = os.Stderr


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #355

---

## 🏷️ PR Type

- [x] `type:feature` — New feature

---

## 📝 Summary

- Adds opt-in `ENGRAM_CLOUD_EXTRA_HEADERS` env var to inject custom HTTP headers into every outgoing cloud sync request (Cloudflare Access, reverse proxies, zero-trust gateways)
- `Authorization` is rejected at parse time regardless of casing, preventing bearer-token shadowing; malformed pairs are skipped with a warning, values are never logged
- Parsed once at construction on both `RemoteTransport` and `MutationTransport`; zero per-request overhead when unset

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/remote/transport.go` | Adds `parseExtraHeaders` / `applyExtraHeaders`, `extraHeaders` field on both transport structs, wired into `ReadManifest`, `WriteChunk`, `ReadChunk`, `PullMutations` |
| `internal/cloud/remote/transport_extra_test.go` | Unit tests for parsing edge cases (empty, malformed, whitespace, Authorization rejection casing) |
| `internal/cloud/remote/transport_headers_test.go` | Unit tests for header application on outgoing requests |
| `cmd/engram/main.go` | Wires env var read-through |
| `DOCS.md` | Documents `ENGRAM_CLOUD_EXTRA_HEADERS` in the autosync env var table |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Design was reviewed and approved by @Alan-TheGentleman on the issue thread, including the `strings.TrimSpace` condition on both key and value after splitting (closes a leading-space bypass of the `Authorization` guardrail) — confirmed present in `parseExtraHeaders`.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #355`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Rebased onto latest `main` before opening (fork's `main` was ~65 commits behind upstream); resolved one trivial table-formatting conflict in `DOCS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for injecting extra HTTP headers into cloud autosync requests via `ENGRAM_CLOUD_EXTRA_HEADERS` (comma-separated `Key: Value` pairs).
  * Applied to both manifest/chunk and mutation sync operations.
  * Rejects any attempt to provide an `Authorization` header; canonicalizes header names and uses last-value-wins for duplicates.

* **Documentation**
  * Updated autosync documentation and CLI help with format, rules, and examples.

* **Tests**
  * Added unit and HTTP-level coverage for parsing, propagation, and authorization precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->