### PR TITLE
fix(cli): add path-only project pruning

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1841,7 +1841,7 @@ func cmdProjects(cfg store.Config) {
 		fmt.Fprintf(os.Stderr, "unknown projects subcommand: %s\n", subCmd)
 		fmt.Fprintln(os.Stderr, "usage: engram projects list")
 		fmt.Fprintln(os.Stderr, "       engram projects consolidate [--all] [--dry-run]")
-		fmt.Fprintln(os.Stderr, "       engram projects prune [--dry-run]")
+		fmt.Fprintln(os.Stderr, "       engram projects prune [--dry-run] [--paths-only]")
 		exitFunc(1)
 	}
 }
@@ -2246,11 +2246,23 @@ func cmdProjectsConsolidate(cfg store.Config) {
 	}
 }
 
+// isPathLikeProjectName reports whether a project name is actually a filesystem
+// path (contains a path separator). Mirrors the write-boundary rejection in
+// normalizeExplicitWriteProject so cleanup targets exactly the names newer
+// versions now refuse to create. See issue #283 bug 2.
+func isPathLikeProjectName(name string) bool {
+	return strings.ContainsAny(name, `/\`)
+}
+
 func cmdProjectsPrune(cfg store.Config) {
 	dryRun := false
+	pathsOnly := false
 	for i := 3; i < len(os.Args); i++ {
-		if os.Args[i] == "--dry-run" {
+		switch os.Args[i] {
+		case "--dry-run":
 			dryRun = true
+		case "--paths-only":
+			pathsOnly = true
 		}
 	}
 
@@ -2268,13 +2280,24 @@ func cmdProjectsPrune(cfg store.Config) {
 	// Find projects with 0 observations
 	var candidates []store.ProjectStats
 	for _, ps := range allStats {
-		if ps.ObservationCount == 0 {
-			candidates = append(candidates, ps)
+		if ps.ObservationCount != 0 {
+			continue
 		}
+		// --paths-only: restrict to garbage projects whose name is a filesystem
+		// path (issue #283 bug 2). These are leftovers from older versions that
+		// fell back to using cwd as the project name when detection failed.
+		if pathsOnly && !isPathLikeProjectName(ps.Name) {
+			continue
+		}
+		candidates = append(candidates, ps)
 	}
 
 	if len(candidates) == 0 {
-		fmt.Println("No empty projects to prune.")
+		if pathsOnly {
+			fmt.Println("No path-named projects to prune.")
+		} else {
+			fmt.Println("No empty projects to prune.")
+		}
 		return
 	}
 

--- a/cmd/engram/prune_paths_test.go
+++ b/cmd/engram/prune_paths_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gentleman-Programming/engram/internal/store"
+)
+
+// TestIsPathLikeProjectName covers the detector used to single out garbage
+// "path-as-name" projects (issue #283 bug 2 leftovers). It mirrors the
+// write-boundary rejection in normalizeExplicitWriteProject: a project name that
+// contains a path separator is a filesystem path, not a real project name.
+func TestIsPathLikeProjectName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{`c:\users\foo`, true},
+		{`/home/user`, true},
+		{`c:/users/foo`, true},
+		{`\\server\share`, true},
+		{"d:\\workspace\\sub", true},
+		{"engram", false},
+		{"agent-teams-lite", false},
+		{"e3", false},
+		{"general", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isPathLikeProjectName(tc.name); got != tc.want {
+			t.Errorf("isPathLikeProjectName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestCmdProjectsPrunePathsOnlyDryRun verifies that `--paths-only` narrows the
+// prune candidate set to path-named projects with 0 observations, leaving
+// legitimate empty projects and projects with observations untouched.
+func TestCmdProjectsPrunePathsOnlyDryRun(t *testing.T) {
+	cfg := testConfig(t)
+
+	// Garbage: path-as-name project, 0 observations (only a session).
+	mustSeedSession(t, cfg, "s-garbage", `c:\users\foo`)
+	// Legitimate empty project, 0 observations — must NOT be selected by --paths-only.
+	mustSeedSession(t, cfg, "s-legit", "legit-empty")
+	// Real project with observations — never a prune candidate.
+	mustSeedObservation(t, cfg, "s-real", "realproject", "note", "title", "content", "project")
+
+	withArgs(t, "engram", "projects", "prune", "--paths-only", "--dry-run")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsPrune(cfg) })
+
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, `c:\users\foo`) {
+		t.Fatalf("expected path-named project listed, got: %q", stdout)
+	}
+	if strings.Contains(stdout, "legit-empty") {
+		t.Fatalf("legitimate empty project must NOT be listed with --paths-only, got: %q", stdout)
+	}
+	if strings.Contains(stdout, "realproject") {
+		t.Fatalf("project with observations must never be a prune candidate, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "dry-run") {
+		t.Fatalf("expected dry-run notice, got: %q", stdout)
+	}
+}
+
+// TestCmdProjectsPrunePathsOnlyDeletesOnlyPathNamed verifies the actual
+// (non-dry-run) deletion: `prune --paths-only` removes path-named empty projects
+// while leaving legitimate empty projects and projects with observations intact.
+func TestCmdProjectsPrunePathsOnlyDeletesOnlyPathNamed(t *testing.T) {
+	cfg := testConfig(t)
+
+	mustSeedSession(t, cfg, "s-garbage", `c:\users\foo`)
+	mustSeedSession(t, cfg, "s-legit", "legit-empty")
+	mustSeedObservation(t, cfg, "s-real", "realproject", "note", "title", "content", "project")
+
+	// Answer "all" to prune every (path-named) candidate.
+	oldScan := scanInputLine
+	t.Cleanup(func() { scanInputLine = oldScan })
+	scanInputLine = func(a ...any) (int, error) {
+		if ptr, ok := a[0].(*string); ok {
+			*ptr = "all"
+		}
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "projects", "prune", "--paths-only")
+	_, stderr := captureOutput(t, func() { cmdProjectsPrune(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+	// Use ListProjectsWithStats: it includes 0-observation projects (derived from
+	// sessions), so a not-pruned empty project like "legit-empty" still shows up.
+	stats, err := s.ListProjectsWithStats()
+	if err != nil {
+		t.Fatalf("ListProjectsWithStats: %v", err)
+	}
+	names := make([]string, len(stats))
+	for i, ps := range stats {
+		names[i] = ps.Name
+	}
+
+	has := func(target string) bool {
+		for _, n := range names {
+			if n == target {
+				return true
+			}
+		}
+		return false
+	}
+	if has(`c:\users\foo`) {
+		t.Fatalf("path-named project should have been pruned, still present: %v", names)
+	}
+	if !has("legit-empty") {
+		t.Fatalf("legitimate empty project must NOT be pruned by --paths-only: %v", names)
+	}
+	if !has("realproject") {
+		t.Fatalf("project with observations must remain: %v", names)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #283

---

## 🏷️ PR Type

- [x] `type:bug`: Bug fix
- [ ] `type:feature`: New feature
- [ ] `type:docs`: Documentation only
- [ ] `type:refactor`: Code refactoring (no behavior change)
- [ ] `type:chore`: Maintenance, dependencies, tooling
- [ ] `type:breaking-change`: Breaking change

---

## 📝 Summary

- Add `projects prune --paths-only` for cleaning up legacy projects whose names are filesystem paths.
- Restrict cleanup to zero-observation path-named projects while preserving legitimate empty projects.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Add the `--paths-only` flag, path-name detection, candidate filtering, and focused empty-state output. |
| `cmd/engram/prune_paths_test.go` | Cover path detection, dry-run filtering, deletion, and preservation of legitimate projects. |

## 🧪 Test Plan

- [x] Focused unit tests pass locally: `go test ./cmd/engram -run "Test(IsPathLikeProjectName|CmdProjectsPrunePathsOnly)" -count=1`
- [ ] Full unit suite: `go test ./...` (not rerun; this Windows host has a known unrelated package-suite failure and timeout)
- [ ] E2E tests: `go test -tags e2e ./internal/server/...` (not required for this CLI-only prune change)
- [x] Scoped diff verified against `main`: only `cmd/engram/main.go` and `cmd/engram/prune_paths_test.go`

---

## 🤖 Automated Checks

These run automatically and all must pass before merge:

| Check | What it verifies | Status |
|-------|------------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Pending |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Pending |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | Pending |
| **Unit Tests** | `go test ./...` passes | Pending |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Pending |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #283`)
- [ ] I added exactly one `type:*` label to this PR (requires maintainer permission)
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (not required for this focused cleanup flag)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This PR is issue #283 bug 2 and is the second independent slice of the cleanup. The grouping safeguard remains in [#445](https://github.com/Gentleman-Programming/engram/pull/445).

### Chain Context

Both slices target `main` and can merge independently.

```text
main
├── #445: grouping safeguard (bug 4)
└── 📍 #647: path-only pruning (bug 2)
```

Start state: legacy path-named projects require broad pruning that also selects legitimate empty projects.

End state: `--paths-only` selects only zero-observation projects whose names contain filesystem separators.

Prior dependency: none. This slice is independent from #445.

Out of scope: consolidation grouping and project write-boundary behavior.
