### PR TITLE
fix(opencode): handle Windows project basenames

### DIFF
--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -201,7 +201,8 @@ function stripPrivateTags(str: string): string {
 // ─── Plugin Export ───────────────────────────────────────────────────────────
 
 export const Engram: Plugin = async (ctx) => {
-  const oldProject = basename(ctx.directory)
+  // Preserve the previous plugin's key so Windows path-based records can migrate.
+  const oldProject = ctx.directory.split("/").pop() ?? "unknown"
   const project = extractProjectName(ctx.directory)
 
   // Track tool counts per session (in-memory only, not critical)

--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -154,7 +154,7 @@ async function isEngramRunning(): Promise<boolean> {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function basename(path: string): string {
-  return path.split(/[\\/]/).pop() ?? "unknown"
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? "unknown"
 }
 
 function extractProjectName(directory: string): string {

--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -153,6 +153,10 @@ async function isEngramRunning(): Promise<boolean> {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+function basename(path: string): string {
+  return path.split(/[\\/]/).pop() ?? "unknown"
+}
+
 function extractProjectName(directory: string): string {
   // Try git remote origin URL
   try {
@@ -171,12 +175,12 @@ function extractProjectName(directory: string): string {
     const result = Bun.spawnSync(["git", "-C", directory, "rev-parse", "--show-toplevel"])
     if (result.exitCode === 0) {
       const root = result.stdout?.toString().trim()
-      if (root) return root.split("/").pop() ?? "unknown"
+      if (root) return basename(root)
     }
   } catch {}
 
   // Final fallback: cwd basename
-  return directory.split("/").pop() ?? "unknown"
+  return basename(directory)
 }
 
 function truncate(str: string, max: number): string {
@@ -197,7 +201,7 @@ function stripPrivateTags(str: string): string {
 // ─── Plugin Export ───────────────────────────────────────────────────────────
 
 export const Engram: Plugin = async (ctx) => {
-  const oldProject = ctx.directory.split("/").pop() ?? "unknown"
+  const oldProject = basename(ctx.directory)
   const project = extractProjectName(ctx.directory)
 
   // Track tool counts per session (in-memory only, not critical)

--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -157,7 +157,7 @@ function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? "unknown"
 }
 
-function extractProjectName(directory: string): string {
+function extractProjectNames(directory: string): { oldProject: string; project: string } {
   // Try git remote origin URL
   try {
     const result = Bun.spawnSync(["git", "-C", directory, "remote", "get-url", "origin"])
@@ -165,7 +165,7 @@ function extractProjectName(directory: string): string {
       const url = result.stdout?.toString().trim()
       if (url) {
         const name = url.replace(/\.git$/, "").split(/[/:]/).pop()
-        if (name) return name
+        if (name) return { oldProject: name, project: name }
       }
     }
   } catch {}
@@ -175,12 +175,20 @@ function extractProjectName(directory: string): string {
     const result = Bun.spawnSync(["git", "-C", directory, "rev-parse", "--show-toplevel"])
     if (result.exitCode === 0) {
       const root = result.stdout?.toString().trim()
-      if (root) return basename(root)
+      if (root) {
+        return {
+          oldProject: root.split("/").pop() ?? "unknown",
+          project: basename(root),
+        }
+      }
     }
   } catch {}
 
   // Final fallback: cwd basename
-  return basename(directory)
+  return {
+    oldProject: directory.split("/").pop() ?? "unknown",
+    project: basename(directory),
+  }
 }
 
 function truncate(str: string, max: number): string {
@@ -201,9 +209,7 @@ function stripPrivateTags(str: string): string {
 // ─── Plugin Export ───────────────────────────────────────────────────────────
 
 export const Engram: Plugin = async (ctx) => {
-  // Preserve the previous plugin's key so Windows path-based records can migrate.
-  const oldProject = ctx.directory.split("/").pop() ?? "unknown"
-  const project = extractProjectName(ctx.directory)
+  const { oldProject, project } = extractProjectNames(ctx.directory)
 
   // Track tool counts per session (in-memory only, not critical)
   const toolCounts = new Map<string, number>()

--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -154,7 +154,8 @@ async function isEngramRunning(): Promise<boolean> {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function basename(path: string): string {
-  return path.split(/[\\/]/).filter(Boolean).pop() ?? "unknown"
+  const name = path.split(/[\\/]/).filter(Boolean).pop()
+  return name && !/^[A-Za-z]:$/.test(name) ? name : "unknown"
 }
 
 function extractProjectNames(directory: string): { oldProject: string; project: string } {

--- a/plugin/opencode/engram.test.ts
+++ b/plugin/opencode/engram.test.ts
@@ -47,6 +47,38 @@ test("uses the Windows basename in compaction recovery outside Git", async () =>
   assert.doesNotMatch(output.context.at(-1) ?? "", /C:\\Users\\Blackie/)
 })
 
+test("ignores trailing Windows separators in the basename fallback", async () => {
+  const { plugin } = await createPlugin("C:\\Users\\Blackie\\", () => ({ exitCode: 1 }))
+  const output = { context: [] as string[] }
+
+  await plugin["experimental.session.compacting"]?.(
+    { sessionID: "session-652-trailing" } as never,
+    output,
+  )
+
+  assert.match(output.context.at(-1) ?? "", /Use project: 'Blackie'/)
+})
+
+test("uses the Windows basename from the Git-root fallback", async () => {
+  const { plugin } = await createPlugin("C:\\Users\\Blackie\\project", (command) => {
+    if (command.includes("rev-parse")) {
+      return {
+        exitCode: 0,
+        stdout: Buffer.from("C:\\Users\\Blackie\\worktrees\\engram-652\n"),
+      }
+    }
+    return { exitCode: 1 }
+  })
+  const output = { context: [] as string[] }
+
+  await plugin["experimental.session.compacting"]?.(
+    { sessionID: "session-652-git-root" } as never,
+    output,
+  )
+
+  assert.match(output.context.at(-1) ?? "", /Use project: 'engram-652'/)
+})
+
 test("uses the Windows basename as old_project during migration", async () => {
   const { requests } = await createPlugin("C:\\Users\\Blackie", (command) => {
     if (command.includes("get-url")) {

--- a/plugin/opencode/engram.test.ts
+++ b/plugin/opencode/engram.test.ts
@@ -138,3 +138,21 @@ test("migrates the legacy empty POSIX key for a trailing separator", async () =>
     { old_project: "", new_project: "blackie" },
   )
 })
+
+for (const [directory, oldProject] of [["C:\\", "C:\\"], ["C:/", ""]]) {
+  test(`uses unknown for the Windows drive root ${directory}`, async () => {
+    const { plugin, requests } = await createPlugin(directory, () => ({ exitCode: 1 }))
+    const output = { context: [] as string[] }
+
+    await plugin["experimental.session.compacting"]?.(
+      { sessionID: `session-drive-root-${directory}` } as never,
+      output,
+    )
+
+    assert.match(output.context.at(-1) ?? "", /Use project: 'unknown'/)
+    assert.deepEqual(
+      requests.find(({ path }) => path === "/projects/migrate")?.body,
+      { old_project: oldProject, new_project: "unknown" },
+    )
+  })
+}

--- a/plugin/opencode/engram.test.ts
+++ b/plugin/opencode/engram.test.ts
@@ -79,7 +79,7 @@ test("uses the Windows basename from the Git-root fallback", async () => {
   assert.match(output.context.at(-1) ?? "", /Use project: 'engram-652'/)
 })
 
-test("uses the Windows basename as old_project during migration", async () => {
+test("migrates the legacy Windows project key to the remote project", async () => {
   const { requests } = await createPlugin("C:\\Users\\Blackie", (command) => {
     if (command.includes("get-url")) {
       return {
@@ -92,7 +92,7 @@ test("uses the Windows basename as old_project during migration", async () => {
 
   assert.deepEqual(
     requests.find(({ path }) => path === "/projects/migrate")?.body,
-    { old_project: "Blackie", new_project: "engram" },
+    { old_project: "C:\\Users\\Blackie", new_project: "engram" },
   )
 })
 

--- a/plugin/opencode/engram.test.ts
+++ b/plugin/opencode/engram.test.ts
@@ -129,3 +129,12 @@ test("preserves POSIX basename fallback behavior", async () => {
 
   assert.match(output.context.at(-1) ?? "", /Use project: 'blackie'/)
 })
+
+test("migrates the legacy empty POSIX key for a trailing separator", async () => {
+  const { requests } = await createPlugin("/home/blackie/", () => ({ exitCode: 1 }))
+
+  assert.deepEqual(
+    requests.find(({ path }) => path === "/projects/migrate")?.body,
+    { old_project: "", new_project: "blackie" },
+  )
+})

--- a/plugin/opencode/engram.test.ts
+++ b/plugin/opencode/engram.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Engram } from "./engram.ts"
+
+type SpawnResult = {
+  exitCode: number
+  stdout?: Buffer
+}
+
+async function createPlugin(
+  directory: string,
+  spawnSync: (command: string[]) => SpawnResult,
+) {
+  const requests: Array<{ path: string; body?: unknown }> = []
+
+  globalThis.Bun = {
+    spawnSync,
+    file: () => ({ exists: async () => false }),
+  } as typeof Bun
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input.toString())
+    const body = init?.body ? JSON.parse(init.body.toString()) : undefined
+    requests.push({ path: url.pathname, body })
+
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+  }) as typeof fetch
+
+  const plugin = await Engram({ directory } as never)
+  return { plugin, requests }
+}
+
+test("uses the Windows basename in compaction recovery outside Git", async () => {
+  const { plugin } = await createPlugin("C:\\Users\\Blackie", () => ({ exitCode: 1 }))
+  const output = { context: [] as string[] }
+
+  await plugin["experimental.session.compacting"]?.(
+    { sessionID: "session-652" } as never,
+    output,
+  )
+
+  assert.match(output.context.at(-1) ?? "", /Use project: 'Blackie'/)
+  assert.doesNotMatch(output.context.at(-1) ?? "", /C:\\Users\\Blackie/)
+})
+
+test("uses the Windows basename as old_project during migration", async () => {
+  const { requests } = await createPlugin("C:\\Users\\Blackie", (command) => {
+    if (command.includes("get-url")) {
+      return {
+        exitCode: 0,
+        stdout: Buffer.from("https://github.com/Gentleman-Programming/engram.git\n"),
+      }
+    }
+    return { exitCode: 1 }
+  })
+
+  assert.deepEqual(
+    requests.find(({ path }) => path === "/projects/migrate")?.body,
+    { old_project: "Blackie", new_project: "engram" },
+  )
+})
+
+test("preserves POSIX basename fallback behavior", async () => {
+  const { plugin } = await createPlugin("/home/blackie", () => ({ exitCode: 1 }))
+  const output = { context: [] as string[] }
+
+  await plugin["experimental.session.compacting"]?.(
+    { sessionID: "session-posix" } as never,
+    output,
+  )
+
+  assert.match(output.context.at(-1) ?? "", /Use project: 'blackie'/)
+})

--- a/plugin/opencode/engram.test.ts
+++ b/plugin/opencode/engram.test.ts
@@ -35,7 +35,7 @@ async function createPlugin(
 }
 
 test("uses the Windows basename in compaction recovery outside Git", async () => {
-  const { plugin } = await createPlugin("C:\\Users\\Blackie", () => ({ exitCode: 1 }))
+  const { plugin, requests } = await createPlugin("C:\\Users\\Blackie", () => ({ exitCode: 1 }))
   const output = { context: [] as string[] }
 
   await plugin["experimental.session.compacting"]?.(
@@ -45,10 +45,14 @@ test("uses the Windows basename in compaction recovery outside Git", async () =>
 
   assert.match(output.context.at(-1) ?? "", /Use project: 'Blackie'/)
   assert.doesNotMatch(output.context.at(-1) ?? "", /C:\\Users\\Blackie/)
+  assert.deepEqual(
+    requests.find(({ path }) => path === "/projects/migrate")?.body,
+    { old_project: "C:\\Users\\Blackie", new_project: "Blackie" },
+  )
 })
 
 test("ignores trailing Windows separators in the basename fallback", async () => {
-  const { plugin } = await createPlugin("C:\\Users\\Blackie\\", () => ({ exitCode: 1 }))
+  const { plugin, requests } = await createPlugin("C:\\Users\\Blackie\\", () => ({ exitCode: 1 }))
   const output = { context: [] as string[] }
 
   await plugin["experimental.session.compacting"]?.(
@@ -57,6 +61,10 @@ test("ignores trailing Windows separators in the basename fallback", async () =>
   )
 
   assert.match(output.context.at(-1) ?? "", /Use project: 'Blackie'/)
+  assert.deepEqual(
+    requests.find(({ path }) => path === "/projects/migrate")?.body,
+    { old_project: "C:\\Users\\Blackie\\", new_project: "Blackie" },
+  )
 })
 
 test("uses the Windows basename from the Git-root fallback", async () => {

--- a/plugin/opencode/engram.test.ts
+++ b/plugin/opencode/engram.test.ts
@@ -79,7 +79,7 @@ test("uses the Windows basename from the Git-root fallback", async () => {
   assert.match(output.context.at(-1) ?? "", /Use project: 'engram-652'/)
 })
 
-test("migrates the legacy Windows project key to the remote project", async () => {
+test("does not migrate when the legacy remote project is unchanged", async () => {
   const { requests } = await createPlugin("C:\\Users\\Blackie", (command) => {
     if (command.includes("get-url")) {
       return {
@@ -90,9 +90,23 @@ test("migrates the legacy Windows project key to the remote project", async () =
     return { exitCode: 1 }
   })
 
+  assert.equal(requests.some(({ path }) => path === "/projects/migrate"), false)
+})
+
+test("migrates the legacy Windows Git-root key from a nested directory", async () => {
+  const { requests } = await createPlugin("C:\\repos\\engram\\nested", (command) => {
+    if (command.includes("rev-parse")) {
+      return {
+        exitCode: 0,
+        stdout: Buffer.from("C:\\repos\\engram\n"),
+      }
+    }
+    return { exitCode: 1 }
+  })
+
   assert.deepEqual(
     requests.find(({ path }) => path === "/projects/migrate")?.body,
-    { old_project: "C:\\Users\\Blackie", new_project: "engram" },
+    { old_project: "C:\\repos\\engram", new_project: "engram" },
   )
 })
 

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -201,7 +201,8 @@ function stripPrivateTags(str: string): string {
 // ─── Plugin Export ───────────────────────────────────────────────────────────
 
 export const Engram: Plugin = async (ctx) => {
-  const oldProject = basename(ctx.directory)
+  // Preserve the previous plugin's key so Windows path-based records can migrate.
+  const oldProject = ctx.directory.split("/").pop() ?? "unknown"
   const project = extractProjectName(ctx.directory)
 
   // Track tool counts per session (in-memory only, not critical)

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -154,7 +154,7 @@ async function isEngramRunning(): Promise<boolean> {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function basename(path: string): string {
-  return path.split(/[\\/]/).pop() ?? "unknown"
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? "unknown"
 }
 
 function extractProjectName(directory: string): string {

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -153,6 +153,10 @@ async function isEngramRunning(): Promise<boolean> {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+function basename(path: string): string {
+  return path.split(/[\\/]/).pop() ?? "unknown"
+}
+
 function extractProjectName(directory: string): string {
   // Try git remote origin URL
   try {
@@ -171,12 +175,12 @@ function extractProjectName(directory: string): string {
     const result = Bun.spawnSync(["git", "-C", directory, "rev-parse", "--show-toplevel"])
     if (result.exitCode === 0) {
       const root = result.stdout?.toString().trim()
-      if (root) return root.split("/").pop() ?? "unknown"
+      if (root) return basename(root)
     }
   } catch {}
 
   // Final fallback: cwd basename
-  return directory.split("/").pop() ?? "unknown"
+  return basename(directory)
 }
 
 function truncate(str: string, max: number): string {
@@ -197,7 +201,7 @@ function stripPrivateTags(str: string): string {
 // ─── Plugin Export ───────────────────────────────────────────────────────────
 
 export const Engram: Plugin = async (ctx) => {
-  const oldProject = ctx.directory.split("/").pop() ?? "unknown"
+  const oldProject = basename(ctx.directory)
   const project = extractProjectName(ctx.directory)
 
   // Track tool counts per session (in-memory only, not critical)

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -157,7 +157,7 @@ function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? "unknown"
 }
 
-function extractProjectName(directory: string): string {
+function extractProjectNames(directory: string): { oldProject: string; project: string } {
   // Try git remote origin URL
   try {
     const result = Bun.spawnSync(["git", "-C", directory, "remote", "get-url", "origin"])
@@ -165,7 +165,7 @@ function extractProjectName(directory: string): string {
       const url = result.stdout?.toString().trim()
       if (url) {
         const name = url.replace(/\.git$/, "").split(/[/:]/).pop()
-        if (name) return name
+        if (name) return { oldProject: name, project: name }
       }
     }
   } catch {}
@@ -175,12 +175,20 @@ function extractProjectName(directory: string): string {
     const result = Bun.spawnSync(["git", "-C", directory, "rev-parse", "--show-toplevel"])
     if (result.exitCode === 0) {
       const root = result.stdout?.toString().trim()
-      if (root) return basename(root)
+      if (root) {
+        return {
+          oldProject: root.split("/").pop() ?? "unknown",
+          project: basename(root),
+        }
+      }
     }
   } catch {}
 
   // Final fallback: cwd basename
-  return basename(directory)
+  return {
+    oldProject: directory.split("/").pop() ?? "unknown",
+    project: basename(directory),
+  }
 }
 
 function truncate(str: string, max: number): string {
@@ -201,9 +209,7 @@ function stripPrivateTags(str: string): string {
 // ─── Plugin Export ───────────────────────────────────────────────────────────
 
 export const Engram: Plugin = async (ctx) => {
-  // Preserve the previous plugin's key so Windows path-based records can migrate.
-  const oldProject = ctx.directory.split("/").pop() ?? "unknown"
-  const project = extractProjectName(ctx.directory)
+  const { oldProject, project } = extractProjectNames(ctx.directory)
 
   // Track tool counts per session (in-memory only, not critical)
   const toolCounts = new Map<string, number>()

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -154,7 +154,8 @@ async function isEngramRunning(): Promise<boolean> {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function basename(path: string): string {
-  return path.split(/[\\/]/).filter(Boolean).pop() ?? "unknown"
+  const name = path.split(/[\\/]/).filter(Boolean).pop()
+  return name && !/^[A-Za-z]:$/.test(name) ? name : "unknown"
 }
 
 function extractProjectNames(directory: string): { oldProject: string; project: string } {


### PR DESCRIPTION
## Linked Issue

Closes #652

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

## Summary

- Derive OpenCode project basenames from both Windows and POSIX separators.
- Apply the same basename logic to Git-root fallback, cwd fallback, and project migration.
- Add runtime regressions for Windows compaction, migration, and preserved POSIX behavior.

## Changes

| File | Change |
|------|--------|
| `plugin/opencode/engram.ts` | Add separator-agnostic project basename handling. |
| `plugin/opencode/engram.test.ts` | Add Windows and POSIX runtime regression coverage. |
| `internal/setup/plugins/opencode/engram.ts` | Synchronize the embedded OpenCode plugin copy. |

## Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Additional verification:

- `node --test plugin/opencode/engram.test.ts` (3 passed)
- `node --check plugin/opencode/engram.ts`
- `node --check internal/setup/plugins/opencode/engram.ts`
- `go test ./internal/setup -run OpenCode -count=1`
- Canonical and embedded plugin copies have identical SHA-256 hashes.

`go test ./...` was attempted on Windows. It still hits unrelated existing Windows-specific failures and a `cmd/engram` timeout; the affected OpenCode-focused tests pass, and Linux CI remains authoritative for the full suite.

## Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Pending |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Pending |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | Pending |
| **Unit Tests** | `go test ./...` passes | Pending |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Pending |

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly one **type:** label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (not required; no user-facing workflow changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

## Notes for Reviewers

The bounded reliability review approved this candidate with two non-blocking warnings: trailing directory separators are not normalized, and the TypeScript regression file is not yet registered in repository CI. Both are intentionally left as follow-up scope rather than changing the frozen candidate after approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project name detection for Windows-style paths by correctly extracting the last non-empty directory segment across both `/` and `\`.
  * Made migration context derivation consistent during compaction recovery, ensuring accurate `old_project`/`project` values and correct `/projects/migrate` request behavior (including skipping migration when unchanged).
* **Tests**
  * Added coverage for `experimental.session.compacting`, validating request payloads and triggering conditions across Windows/POSIX paths and edge cases (e.g., trailing separators, nested directories, and Git-root-derived basenames).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->