### PR TITLE
fix(pi): archive current Pi compaction shape and avoid duplicate save

### DIFF
--- a/plugin/pi/compaction-recovery.js
+++ b/plugin/pi/compaction-recovery.js
@@ -1,4 +1,9 @@
 const SUMMARY_FIELD_PATHS = [
+  // Current Pi session_compact event shape:
+  //   { compactionEntry: CompactionEntry, fromExtension, reason, willRetry }
+  // where CompactionEntry.summary holds the summary text. Listed first so the
+  // documented shape wins over generic legacy fallbacks.
+  ["compactionEntry", "summary"],
   ["summary"],
   ["compactedSummary"],
   ["compacted_summary"],
@@ -47,6 +52,11 @@ export function extractCompactedSummary(event) {
   return undefined;
 }
 
+/**
+ * Manual fallback used when the compaction summary could NOT be archived to
+ * Engram during the session_compact handler (no summary extracted, no session,
+ * or the Engram write failed). Asks the agent to save it on the next turn.
+ */
 export function recoveryInstruction(project) {
   return (
     `CRITICAL INSTRUCTION FOR COMPACTED SUMMARY:\n` +
@@ -57,8 +67,30 @@ export function recoveryInstruction(project) {
   );
 }
 
-export function buildRecoveryNotice(project, context) {
-  const instruction = recoveryInstruction(project);
+/**
+ * Used when the compaction summary was already archived to Engram by
+ * gentle-engram. Still surfaces retrieved project context for continuity, but
+ * omits the manual `FIRST ACTION REQUIRED: mem_session_summary` instruction so
+ * the agent does not duplicate the save it just completed.
+ */
+function persistedAcknowledgement(project) {
+  return (
+    `Compaction recovery summary was already saved to Engram (${project}) by gentle-engram. ` +
+    `No manual mem_session_summary call is needed for this compaction. ` +
+    `Call mem_context if you need additional recent project memory.`
+  );
+}
+
+/**
+ * Build the recovery notice injected before the next agent turn.
+ *
+ * @param {string} project Engram project name.
+ * @param {string|undefined} context Retrieved Engram project context, if any.
+ * @param {boolean} [persisted=false] True when the compaction summary was
+ *   already archived to Engram; suppresses the manual save instruction.
+ */
+export function buildRecoveryNotice(project, context, persisted = false) {
+  const instruction = persisted ? persistedAcknowledgement(project) : recoveryInstruction(project);
   const trimmedContext = typeof context === "string" ? context.trim() : "";
   return trimmedContext ? `${trimmedContext}\n\n${instruction}` : instruction;
 }

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -887,8 +887,9 @@ export default function registerEngram(pi: ExtensionAPI) {
     if (sessionId) await ensureSessionBestEffort(sessionId);
 
     const summary = extractCompactedSummary(event);
+    let persistedSummary = false;
     if (sessionId && summary) {
-      await bestEffortEngramFetch("/observations", {
+      const saved = await bestEffortEngramFetch("/observations", {
         method: "POST",
         body: {
           session_id: sessionId,
@@ -900,10 +901,14 @@ export default function registerEngram(pi: ExtensionAPI) {
           topic_key: "session/compaction-recovery",
         },
       });
+      // bestEffortEngramFetch returns null on a failed/unreachable write. Treat
+      // only a confirmed response as persisted so a failed archive still falls
+      // back to the manual FIRST ACTION REQUIRED save instruction.
+      persistedSummary = saved !== null;
     }
 
     const data = await bestEffortEngramFetch<ContextResponse>(`/context?project=${encodeURIComponent(project)}`);
-    pendingRecoveryNotice = buildRecoveryNotice(project, data?.context);
+    pendingRecoveryNotice = buildRecoveryNotice(project, data?.context, persistedSummary);
   });
 
   pi.on("before_agent_start", async (event: AgentStartEvent, ctx: SessionContext) => {

--- a/plugin/pi/test/compaction-recovery.test.mjs
+++ b/plugin/pi/test/compaction-recovery.test.mjs
@@ -15,6 +15,26 @@ test("extractCompactedSummary supports top-level and nested summary fields", () 
   assert.equal(extractCompactedSummary({ compaction: { content: "content summary" } }), "content summary");
 });
 
+test("extractCompactedSummary reads the current Pi session_compact event shape", () => {
+  // Documented Pi event: { compactionEntry: CompactionEntry, ... } where
+  // CompactionEntry.summary holds the summary text.
+  assert.equal(
+    extractCompactedSummary({ compactionEntry: { summary: "native pi summary" } }),
+    "native pi summary",
+  );
+  assert.equal(
+    extractCompactedSummary({
+      compactionEntry: { summary: "  extension summary  " },
+      fromExtension: true,
+      reason: "threshold",
+      willRetry: false,
+    }),
+    "extension summary",
+  );
+  // Empty compactionEntry.summary is ignored (falls through / returns undefined).
+  assert.equal(extractCompactedSummary({ compactionEntry: { summary: "   " } }), undefined);
+});
+
 test("recoveryInstruction keeps manual FIRST ACTION REQUIRED fallback", () => {
   const notice = recoveryInstruction("engram");
   assert.match(notice, /FIRST ACTION REQUIRED/);
@@ -26,4 +46,16 @@ test("recoveryInstruction keeps manual FIRST ACTION REQUIRED fallback", () => {
 test("buildRecoveryNotice prefixes context when available", () => {
   assert.equal(buildRecoveryNotice("engram", "existing context").startsWith("existing context\n\nCRITICAL"), true);
   assert.equal(buildRecoveryNotice("engram", "").startsWith("CRITICAL"), true);
+});
+
+test("buildRecoveryNotice drops the manual save instruction once persisted", () => {
+  // Default (persisted=false): manual save instruction is present.
+  const fallback = buildRecoveryNotice("engram", undefined);
+  assert.match(fallback, /FIRST ACTION REQUIRED/);
+
+  // After a successful archive: no manual save instruction, context still surfaced.
+  const persisted = buildRecoveryNotice("engram", "recent project memory", true);
+  assert.doesNotMatch(persisted, /FIRST ACTION REQUIRED/);
+  assert.match(persisted, /recent project memory/);
+  assert.match(persisted, /already saved to Engram/);
 });


### PR DESCRIPTION
Closes #951

> Review size: 435 authored changed lines. Maintainer-approved size:exception rationale: 216 lines are executable Pi lifecycle coverage, and separating the tests from the behavior would break the cohesive verification and rollback boundary.

## Problem

`gentle-engram`'s `session_compact` handler never auto-archived the compaction summary to Engram on **current Pi**, because `extractCompactedSummary` only inspected legacy top-level / nested paths and missed Pi's documented event shape:

```ts
// Pi session_compact event (docs: docs/compaction.md)
{ compactionEntry: CompactionEntry, fromExtension, reason, willRetry }
// CompactionEntry.summary holds the summary text
```

As a result, `summary` was `undefined`, the `/observations` POST was skipped, and the agent was **always** asked to save the summary manually via the `FIRST ACTION REQUIRED: mem_session_summary` notice on the next turn — even though that was meant to be a fallback.

Separately, `buildRecoveryNotice` always appended the manual-save instruction, so once extraction is fixed the agent would duplicate the save it just completed.

## Fix

**`plugin/pi/compaction-recovery.js`**
- Add `["compactionEntry", "summary"]` as the first `SUMMARY_FIELD_PATH` so the documented event shape is extracted (legacy fallbacks are preserved).
- `buildRecoveryNotice(project, context, persisted = false)`: when `persisted`, emit a continuity-only acknowledgement (still surfaces retrieved Engram context) and **omit** the manual `FIRST ACTION REQUIRED: mem_session_summary` instruction. Default `false` keeps existing behavior for any caller.

**`plugin/pi/index.ts`**
- In `session_compact`, treat the archive POST's confirmed response as `persisted` and pass it to `buildRecoveryNotice`. `bestEffortEngramFetch` returns `null` on a failed/unreachable write, so a failed archive still falls back to the manual save instruction — only a confirmed success suppresses it.

## Behavior matrix

| summary extracted | archive succeeded | notice on next turn |
|---|---|---|
| yes | yes | context + "already saved" (no manual save) |
| yes | no (server down) | context + manual `FIRST ACTION REQUIRED` (retry) |
| no | n/a | context + manual `FIRST ACTION REQUIRED` (unchanged) |

## Tests

- `extractCompactedSummary` now covers `{ compactionEntry: { summary } }` (native + extension-provided, plus whitespace-only ignored).
- `buildRecoveryNotice(..., true)` asserts no `FIRST ACTION REQUIRED` while still surfacing context.

Full local run: `node --test plugin/pi/test/*.test.mjs` → **44 pass / 0 fail**.

Backward compatible: `buildRecoveryNotice` third arg defaults to `false`, and the new extraction path is strictly additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after session compaction by correctly recognizing current summary formats.
  * Recovery notices now accurately indicate whether the summary was saved successfully.
  * Empty summaries are handled without generating misleading recovery instructions.

* **Tests**
  * Added coverage for current compaction events, empty summaries, and saved-summary notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->