### PR TITLE
fix(mcp): track save freshness by project

### DIFF
--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -14,10 +14,11 @@ const ambiguousProjectRecoveryTTL = 5 * time.Minute
 
 // SessionActivity tracks tool call activity for save reminders and activity scores.
 type SessionActivity struct {
-	mu         sync.Mutex
-	sessions   map[string]*sessionState
-	nudgeAfter time.Duration
-	now        func() time.Time // injectable for testing
+	mu           sync.Mutex
+	sessions     map[string]*sessionState
+	projectSaves map[string]time.Time
+	nudgeAfter   time.Duration
+	now          func() time.Time // injectable for testing
 }
 
 type sessionState struct {
@@ -44,9 +45,10 @@ type ambiguousProjectRecovery struct {
 // NewSessionActivity creates a new activity tracker with the given nudge threshold.
 func NewSessionActivity(nudgeAfter time.Duration) *SessionActivity {
 	return &SessionActivity{
-		sessions:   make(map[string]*sessionState),
-		nudgeAfter: nudgeAfter,
-		now:        time.Now,
+		sessions:     make(map[string]*sessionState),
+		projectSaves: make(map[string]time.Time),
+		nudgeAfter:   nudgeAfter,
+		now:          time.Now,
 	}
 }
 
@@ -137,10 +139,36 @@ func (a *SessionActivity) ValidateAmbiguousProjectRecoveryToken(sessionID, token
 	return recovery.selectedProject == selectedProject
 }
 
-// RecordSave increments the save counter and updates lastSaveAt.
+// RecordSave increments per-session save activity only. When the project is
+// known, callers should use RecordProjectSave so project read nudges also reset.
 func (a *SessionActivity) RecordSave(sessionID string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.recordSaveLocked(sessionID)
+}
+
+// RecordProjectSave records a successful save for both the concrete MCP
+// session and the project's synthetic activity session used by read tools.
+func (a *SessionActivity) RecordProjectSave(sessionID, project string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.recordSaveLocked(sessionID)
+	if project != "" {
+		a.projectSaves[project] = a.now()
+	}
+}
+
+// RecordProjectFreshness updates project read nudges without changing any
+// session's activity score.
+func (a *SessionActivity) RecordProjectFreshness(project string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if project != "" {
+		a.projectSaves[project] = a.now()
+	}
+}
+
+func (a *SessionActivity) recordSaveLocked(sessionID string) {
 	s := a.getOrCreate(sessionID)
 	s.saveCount++
 	s.lastSaveAt = a.now()
@@ -171,42 +199,50 @@ func (a *SessionActivity) CurrentPrompt(sessionID, project string) (string, bool
 	return s.currentPrompt.content, true
 }
 
-// NudgeIfNeeded returns a reminder string if too much time has passed since
-// the last save in this session. Returns empty string if no nudge needed.
+// NudgeIfNeeded returns a per-session reminder and does not consult saves made
+// through other sessions in the same project. Project read tools should use
+// NudgeForProject. Returns empty string if no nudge is needed.
 func (a *SessionActivity) NudgeIfNeeded(sessionID string) string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	return a.nudgeIfNeededLocked(sessionID)
+}
 
+// NudgeForProject suppresses a session nudge when the project has received a
+// more recent successful save through another explicit MCP session.
+func (a *SessionActivity) NudgeForProject(sessionID, project string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if savedAt, ok := a.projectSaves[project]; ok {
+		if a.now().Sub(savedAt) < a.nudgeAfter {
+			return ""
+		}
+		delete(a.projectSaves, project)
+	}
+	return a.nudgeIfNeededLocked(sessionID)
+}
+
+func (a *SessionActivity) nudgeIfNeededLocked(sessionID string) string {
 	s, ok := a.sessions[sessionID]
 	if !ok {
 		return ""
 	}
-
 	now := a.now()
-
-	// Don't nudge if session is too young
 	if now.Sub(s.startedAt) < a.nudgeAfter {
 		return ""
 	}
-
-	// Don't nudge idle/new sessions (no saves and few tool calls)
 	if s.saveCount == 0 && s.toolCallCount <= 5 {
 		return ""
 	}
-
-	// Check time since last save (or session start if no saves yet)
 	ref := s.lastSaveAt
 	if ref.IsZero() {
 		ref = s.startedAt
 	}
-
 	elapsed := now.Sub(ref)
 	if elapsed < a.nudgeAfter {
 		return ""
 	}
-
-	minutes := int(elapsed.Minutes())
-	return fmt.Sprintf("\n\n⚠️ No mem_save calls for this project in %d minutes. Did you make any decisions, fix bugs, or discover something worth persisting?", minutes)
+	return fmt.Sprintf("\n\n⚠️ No mem_save calls for this project in %d minutes. Did you make any decisions, fix bugs, or discover something worth persisting?", int(elapsed.Minutes()))
 }
 
 // ActivityScore returns a formatted activity score string for the session.

--- a/internal/mcp/activity_test.go
+++ b/internal/mcp/activity_test.go
@@ -79,6 +79,49 @@ func TestSessionActivity_RecordSave_ResetsNudge(t *testing.T) {
 	}
 }
 
+func TestSessionActivity_ProjectSaveSuppressesNudgeWithoutMutatingDefaultScore(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	a := NewSessionActivity(10 * time.Minute)
+	a.now = func() time.Time { return now }
+
+	project := "myproject"
+	defaultSID := defaultSessionID(project)
+	for i := 0; i < 6; i++ {
+		a.RecordToolCall(defaultSID)
+	}
+	now = now.Add(15 * time.Minute)
+	if nudge := a.NudgeForProject(defaultSID, project); nudge == "" {
+		t.Fatal("expected project nudge before save")
+	}
+
+	a.RecordProjectSave("explicit-session", project)
+	if nudge := a.NudgeForProject(defaultSID, project); nudge != "" {
+		t.Fatalf("expected project save to suppress nudge, got %q", nudge)
+	}
+	if score := a.ActivityScore(defaultSID); !strings.Contains(score, "0 saves") {
+		t.Fatalf("expected default session score to remain unchanged, got %q", score)
+	}
+}
+
+func TestSessionActivity_NudgeForProjectExpiresOldProjectSave(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	a := NewSessionActivity(10 * time.Minute)
+	a.now = func() time.Time { return now }
+	project := "myproject"
+	defaultSID := defaultSessionID(project)
+	for i := 0; i < 6; i++ {
+		a.RecordToolCall(defaultSID)
+	}
+	a.RecordProjectSave("explicit-session", project)
+	now = now.Add(15 * time.Minute)
+	if nudge := a.NudgeForProject(defaultSID, project); nudge == "" {
+		t.Fatal("expected nudge after project save freshness expires")
+	}
+	if _, ok := a.projectSaves[project]; ok {
+		t.Fatal("expected expired project save entry to be removed")
+	}
+}
+
 func TestSessionActivity_ActivityScore(t *testing.T) {
 	a := NewSessionActivity(10 * time.Minute)
 	sid := "test-session"

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1139,7 +1139,7 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 			fmt.Fprintf(&b, "---\nResults above are previews (300 chars). To read the full content of a specific memory, call mem_get_observation(id: <ID>).\n")
 		}
 
-		if nudge := activity.NudgeIfNeeded(sessionID); nudge != "" {
+		if nudge := activity.NudgeForProject(sessionID, project); nudge != "" {
 			b.WriteString(nudge)
 		}
 
@@ -1287,7 +1287,7 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 		}
 
 		if activity != nil {
-			activity.RecordSave(sessionID)
+			activity.RecordProjectSave(sessionID, project)
 		}
 
 		msg := fmt.Sprintf("Memory saved: %q (%s)", title, typ)
@@ -1662,7 +1662,7 @@ func handleContext(s *store.Store, cfg MCPConfig, activity *SessionActivity) ser
 		result := fmt.Sprintf("%s\n---\nMemory stats: %d sessions, %d observations across projects: %s",
 			contextResult, stats.TotalSessions, stats.TotalObservations, projects)
 
-		if nudge := activity.NudgeIfNeeded(sessionID); nudge != "" {
+		if nudge := activity.NudgeForProject(sessionID, project); nudge != "" {
 			result += nudge
 		}
 
@@ -1921,6 +1921,7 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		if err != nil {
 			return mcp.NewToolResultError("Failed to save session summary: " + err.Error()), nil
 		}
+		activity.RecordProjectFreshness(project)
 
 		msg := fmt.Sprintf("Session summary saved for project %q", project)
 		if score := activity.ActivityScore(defaultSessionID(project)); score != "" {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -3128,6 +3128,106 @@ func TestSearchResponseIncludesNudgeAfterInactivity(t *testing.T) {
 	}
 }
 
+func TestImmediateExplicitSessionSaveSuppressesProjectSearchNudge(t *testing.T) {
+	s := newMCPTestStore(t)
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	activity := NewSessionActivity(10 * time.Minute)
+	activity.now = func() time.Time { return now }
+
+	project := "myproject"
+	s.CreateSession("explicit-session", project, "")
+	searchSessionID := defaultSessionID(project)
+	for i := 0; i < 6; i++ {
+		activity.RecordToolCall(searchSessionID)
+	}
+	now = now.Add(15 * time.Minute)
+
+	save := handleSave(s, MCPConfig{}, activity)
+	_, err := save(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"session_id": "explicit-session",
+			"project":    project,
+			"type":       "discovery",
+			"title":      "fresh memory",
+			"content":    "fresh searchable content",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("save handler error: %v", err)
+	}
+
+	search := handleSearch(s, MCPConfig{}, activity)
+	res, err := search(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"query":   "fresh memory",
+			"project": project,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("search handler error: %v", err)
+	}
+	text := callResultText(t, res)
+	if !strings.Contains(text, "fresh memory") {
+		t.Fatalf("expected fresh memory in search response, got: %q", text)
+	}
+	if strings.Contains(text, "No mem_save calls for this project") {
+		t.Fatalf("unexpected stale inactivity warning after immediate save: %q", text)
+	}
+}
+
+func TestImmediateExplicitSessionSaveSuppressesProjectContextNudge(t *testing.T) {
+	s := newMCPTestStore(t)
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	activity := NewSessionActivity(10 * time.Minute)
+	activity.now = func() time.Time { return now }
+	project := "myproject"
+	s.CreateSession("explicit-session", project, "")
+	defaultSID := defaultSessionID(project)
+	for i := 0; i < 6; i++ {
+		activity.RecordToolCall(defaultSID)
+	}
+	now = now.Add(15 * time.Minute)
+	activity.RecordProjectSave("explicit-session", project)
+
+	res, err := handleContext(s, MCPConfig{}, activity)(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": project}},
+	})
+	if err != nil {
+		t.Fatalf("context handler error: %v", err)
+	}
+	if text := callResultText(t, res); strings.Contains(text, "No mem_save calls for this project") {
+		t.Fatalf("unexpected stale context warning after save: %q", text)
+	}
+}
+
+func TestSessionSummarySuppressesProjectSearchNudge(t *testing.T) {
+	s := newMCPTestStore(t)
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	activity := NewSessionActivity(10 * time.Minute)
+	activity.now = func() time.Time { return now }
+	project := "myproject"
+	s.CreateSession("summary-session", project, "")
+	defaultSID := defaultSessionID(project)
+	for i := 0; i < 6; i++ {
+		activity.RecordToolCall(defaultSID)
+	}
+	now = now.Add(15 * time.Minute)
+
+	_, err := handleSessionSummary(s, MCPConfig{}, activity)(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"session_id": "summary-session",
+			"project":    project,
+			"content":    "## Goal\nVerify project freshness",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("summary handler error: %v", err)
+	}
+	if nudge := activity.NudgeForProject(defaultSID, project); nudge != "" {
+		t.Fatalf("unexpected stale nudge after session summary: %q", nudge)
+	}
+}
+
 func TestSessionSummaryResponseIncludesActivityScore(t *testing.T) {
 	// Set up a git repo so auto-detect returns a known project (REQ-308).
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- track recent successful saves separately at project scope for read-tool nudges
- keep per-session activity scores isolated when saves use explicit session IDs
- suppress contradictory `mem_search`/`mem_context` warnings after `mem_save` or `mem_session_summary`
- lazily expire project freshness entries after the configured nudge interval

## Root cause
`mem_save` records activity under the concrete observation session ID, while `mem_search` and `mem_context` evaluate nudges under `defaultSessionID(project)`. A fresh observation could therefore be returned together with `No mem_save calls for this project ...`.

Updating the synthetic default session would make the warning disappear, but it breaks the existing explicit-session ActivityScore contract. This change keeps project freshness as separate state instead.

Related history: #449 improved active-session routing for saves, but does not address project-level read nudges.
Related nudge issue: #668 covers client-hook timezone and first-observation behavior, not this server-side identity mismatch.

Tracked by #703. This PR remains draft until that issue receives `status:approved`; `Closes #703` will be added after approval.

## Test plan
- TDD regression: explicit-session save → immediate project search returns the observation without stale warning
- context regression: explicit-session save suppresses immediate project context warning
- session-summary regression: summary save refreshes project read activity without incrementing default-session save score
- unit coverage for expiration and session-score isolation
- targeted activity/save/nudge suite under Go 1.25 Docker
- patch applies and tests cleanly against v1.20.0; live-verified through Hermes on two hosts

## Notes
The full `internal/mcp` suite in an anonymous checkout has unrelated existing project-detection fixture failures because the checkout's detected project is not backed in test stores. The targeted affected suite is green, and the fix received two review passes with no remaining Critical or Important findings.
