### PR TITLE
fix(sync): isolate invalid relation imports

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4208,41 +4208,9 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 
 		applyErr := s.applyPulledMutationTx(tx, mutation)
 		if applyErr != nil {
-			// Phase E: per-entity skip+log policy (design §9).
-			// For relation FK misses, write to sync_apply_deferred and ACK the seq
-			// so the cursor can advance. All other errors propagate and halt the pull.
-			if mutation.Entity == SyncEntityRelation && errors.Is(applyErr, ErrRelationFKMissing) {
-				log.Printf("[store] ApplyPulledMutation: relation FK miss seq=%d entity_key=%s — deferring",
-					mutation.Seq, mutation.EntityKey)
-				if _, deferErr := s.execHook(tx, `
-					INSERT INTO sync_apply_deferred
-						(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
-					VALUES (?, ?, ?, 'deferred', 0, datetime('now'))
-					ON CONFLICT(sync_id) DO UPDATE SET
-						payload            = excluded.payload,
-						last_attempted_at  = datetime('now')
-				`, mutation.EntityKey, mutation.Entity, mutation.Payload); deferErr != nil {
-					return fmt.Errorf("ApplyPulledMutation: write deferred row: %w", deferErr)
-				}
-				// Fall through to advance the cursor (ACK the seq).
-			} else if mutation.Entity == SyncEntityRelation && errors.Is(applyErr, ErrApplyDead) {
-				// Payload is permanently undecodable — write directly as dead and ACK.
-				// There is no point retrying; a malformed payload will never become valid.
-				log.Printf("[store] ApplyPulledMutation: relation payload dead seq=%d entity_key=%s err=%v — marking dead",
-					mutation.Seq, mutation.EntityKey, applyErr)
-				if _, deferErr := s.execHook(tx, `
-					INSERT INTO sync_apply_deferred
-						(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
-					VALUES (?, ?, ?, 'dead', 0, datetime('now'))
-					ON CONFLICT(sync_id) DO UPDATE SET
-						payload           = excluded.payload,
-						apply_status      = 'dead',
-						last_attempted_at = datetime('now')
-				`, mutation.EntityKey, mutation.Entity, mutation.Payload); deferErr != nil {
-					return fmt.Errorf("ApplyPulledMutation: write dead row: %w", deferErr)
-				}
-				// Fall through to advance the cursor (ACK the seq).
-			} else {
+			if handled, err := s.recordRelationApplyFailureTx(tx, mutation, applyErr); err != nil {
+				return err
+			} else if !handled {
 				return applyErr
 			}
 		}
@@ -4255,6 +4223,43 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 		)
 		return err
 	})
+}
+
+// recordRelationApplyFailureTx records relation failures that are safe to
+// acknowledge while preserving the existing fail-fast behavior for other
+// entities and errors.
+func (s *Store) recordRelationApplyFailureTx(tx *sql.Tx, mutation SyncMutation, applyErr error) (bool, error) {
+	if mutation.Entity != SyncEntityRelation {
+		return false, nil
+	}
+
+	status := ""
+	switch {
+	case errors.Is(applyErr, ErrRelationFKMissing):
+		status = "deferred"
+	case errors.Is(applyErr, ErrApplyDead):
+		status = "dead"
+	default:
+		return false, nil
+	}
+
+	if _, err := s.execHook(tx, `
+		INSERT INTO sync_apply_deferred
+			(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
+		VALUES (?, ?, ?, ?, 0, datetime('now'))
+		ON CONFLICT(sync_id) DO UPDATE SET
+			payload           = excluded.payload,
+			apply_status      = CASE
+				WHEN excluded.apply_status = 'dead' THEN 'dead'
+				ELSE sync_apply_deferred.apply_status
+			END,
+			last_attempted_at = datetime('now')
+	`, mutation.EntityKey, mutation.Entity, mutation.Payload, status); err != nil {
+		return false, fmt.Errorf("write relation apply failure: %w", err)
+	}
+
+	log.Printf("[store] relation apply seq=%d entity_key=%s err=%v - marking %s", mutation.Seq, mutation.EntityKey, applyErr, status)
+	return true, nil
 }
 
 // ApplyPulledChunk atomically applies all mutations contained in a pulled chunk
@@ -4292,8 +4297,12 @@ func (s *Store) ApplyPulledChunk(targetKey, chunkID string, mutations []SyncMuta
 			mutation.Seq = seq
 			mutation.TargetKey = targetKey
 			mutation.Source = SyncSourceRemote
-			if err := s.applyPulledMutationTx(tx, mutation); err != nil {
-				return fmt.Errorf("apply chunk mutation %d: %w", i, err)
+			if applyErr := s.applyPulledMutationTx(tx, mutation); applyErr != nil {
+				if handled, err := s.recordRelationApplyFailureTx(tx, mutation, applyErr); err != nil {
+					return fmt.Errorf("apply chunk mutation %d: %w", i, err)
+				} else if !handled {
+					return fmt.Errorf("apply chunk mutation %d: %w", i, applyErr)
+				}
 			}
 		}
 
@@ -5668,7 +5677,11 @@ func (s *Store) applyRelationUpsertTx(tx *sql.Tx, mutation SyncMutation) error {
 	).Scan(&obsCount); err != nil {
 		return fmt.Errorf("applyRelationUpsertTx: check observations: %w", err)
 	}
-	if obsCount < 2 {
+	requiredObservations := 2
+	if p.SourceID == p.TargetID {
+		requiredObservations = 1
+	}
+	if obsCount < requiredObservations {
 		return ErrRelationFKMissing
 	}
 

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -140,13 +140,13 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	missingID := newSyncID("rel-missing")
 	mutations := []SyncMutation{
 		buildRelationMutation(t, syncRelationPayload{
-			SyncID: validID, SourceID: syncA, TargetID: syncB,
-			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
+			SyncID: missingID, SourceID: syncA, TargetID: missingTarget,
+			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged,
 			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
 		}),
 		buildRelationMutation(t, syncRelationPayload{
-			SyncID: missingID, SourceID: syncA, TargetID: missingTarget,
-			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged,
+			SyncID: validID, SourceID: syncA, TargetID: syncB,
+			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
 			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
 		}),
 	}

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -160,6 +160,10 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	if got := countDeferredRows(t, s, missingID); got != 1 {
 		t.Fatalf("expected missing relation to defer, got %d rows", got)
 	}
+	status, _ := getDeferredRow(t, s, missingID)
+	if status != "deferred" {
+		t.Fatalf("apply_status: want deferred, got %q", status)
+	}
 	var lastPulled int64
 	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
 		t.Fatalf("read last_pulled_seq: %v", err)

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -164,6 +164,9 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	if status != "deferred" {
 		t.Fatalf("apply_status: want deferred, got %q", status)
 	}
+	if got := countRelationRows(t, s, missingID); got != 0 {
+		t.Fatalf("expected missing relation to remain unapplied, got %d rows", got)
+	}
 	var lastPulled int64
 	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
 		t.Fatalf("read last_pulled_seq: %v", err)

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -109,6 +109,108 @@ func TestApplyPulledRelation_InsertsWhenObsExist(t *testing.T) {
 	}
 }
 
+func TestApplyPulledRelation_AllowsSelfReference(t *testing.T) {
+	s, syncA, _ := setupSyncApplyStore(t)
+
+	relSyncID := newSyncID("rel-self")
+	m := buildRelationMutation(t, syncRelationPayload{
+		SyncID:         relSyncID,
+		SourceID:       syncA,
+		TargetID:       syncA,
+		Relation:       RelationCompatible,
+		JudgmentStatus: JudgmentStatusJudged,
+		Project:        "proj-apply",
+		CreatedAt:      "2026-04-26T10:00:00Z",
+		UpdatedAt:      "2026-04-26T10:00:00Z",
+	})
+
+	if err := applyRelationMutation(t, s, m); err != nil {
+		t.Fatalf("applyPulledMutationTx: %v", err)
+	}
+	if got := countRelationRows(t, s, relSyncID); got != 1 {
+		t.Fatalf("expected 1 self-referential relation, got %d", got)
+	}
+}
+
+func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
+	s, syncA, syncB := setupSyncApplyStore(t)
+	missingTarget := "obs-ghost-" + newSyncID("x")
+
+	validID := newSyncID("rel-valid")
+	missingID := newSyncID("rel-missing")
+	mutations := []SyncMutation{
+		buildRelationMutation(t, syncRelationPayload{
+			SyncID: validID, SourceID: syncA, TargetID: syncB,
+			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
+			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
+		}),
+		buildRelationMutation(t, syncRelationPayload{
+			SyncID: missingID, SourceID: syncA, TargetID: missingTarget,
+			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged,
+			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
+		}),
+	}
+
+	if err := s.ApplyPulledChunk(DefaultSyncTargetKey, "chunk-local-relations", mutations); err != nil {
+		t.Fatalf("ApplyPulledChunk: %v", err)
+	}
+	if got := countRelationRows(t, s, validID); got != 1 {
+		t.Fatalf("expected valid relation to apply, got %d rows", got)
+	}
+	if got := countDeferredRows(t, s, missingID); got != 1 {
+		t.Fatalf("expected missing relation to defer, got %d rows", got)
+	}
+	var lastPulled int64
+	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
+		t.Fatalf("read last_pulled_seq: %v", err)
+	}
+	if lastPulled != int64(len(mutations)) {
+		t.Fatalf("last_pulled_seq: want %d, got %d", len(mutations), lastPulled)
+	}
+	chunks, err := s.GetSyncedChunksForTarget(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("read synced chunks: %v", err)
+	}
+	if !chunks["chunk-local-relations"] {
+		t.Fatal("expected chunk with deferred relation to be marked as synced")
+	}
+}
+
+func TestApplyPulledChunk_MarksMalformedRelationDeadAndContinues(t *testing.T) {
+	s, syncA, syncB := setupSyncApplyStore(t)
+	validID := newSyncID("rel-valid")
+	deadID := newSyncID("rel-dead")
+	mutations := []SyncMutation{
+		{Entity: SyncEntityRelation, EntityKey: deadID, Op: SyncOpUpsert, Payload: "not json"},
+		buildRelationMutation(t, syncRelationPayload{
+			SyncID: validID, SourceID: syncA, TargetID: syncB,
+			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
+			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
+		}),
+	}
+
+	if err := s.ApplyPulledChunk(DefaultSyncTargetKey, "chunk-dead-relation", mutations); err != nil {
+		t.Fatalf("ApplyPulledChunk: %v", err)
+	}
+	if got := countRelationRows(t, s, validID); got != 1 {
+		t.Fatalf("expected valid relation to apply, got %d rows", got)
+	}
+	var status string
+	if err := s.db.QueryRow(`SELECT apply_status FROM sync_apply_deferred WHERE sync_id = ?`, deadID).Scan(&status); err != nil {
+		t.Fatalf("read dead relation status: %v", err)
+	}
+	if status != "dead" {
+		t.Fatalf("apply_status: want dead, got %q", status)
+	}
+	var lastPulled int64
+	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
+		t.Fatalf("read last_pulled_seq: %v", err)
+	}
+	if lastPulled != int64(len(mutations)) {
+		t.Fatalf("last_pulled_seq: want %d, got %d", len(mutations), lastPulled)
+	}
+}
+
 // C.3b — ApplyPulledRelation_DefersOnFKMiss: target observation absent →
 // row written to sync_apply_deferred; no halt; seq is ACK-able.
 func TestApplyPulledRelation_DefersOnFKMiss(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix local chunk imports that stall on self-referential or permanently invalid relation mutations.
- Defer missing-endpoint relations and mark malformed relation payloads as dead while allowing the rest of the chunk to apply.
- Preserve atomic rollback for non-relation errors and keep the existing cloud import policy shared.

## Changes
- Allow a self-referential relation when its single observation exists.
- Extract relation failure recording into a transaction-scoped helper reused by `ApplyPulledMutation` and `ApplyPulledChunk`.
- Continue local chunk imports after `ErrRelationFKMissing` or `ErrApplyDead`, advance the cursor, and record the chunk as synced.
- Add regression coverage for self-relations, deferred orphan relations, dead payloads, cursor advancement, chunk registration, and existing atomic rollback.

## Validation
- [x] `go test ./... -count=1` (2368 passed)
- [x] `go test -race ./internal/store ./internal/sync ./internal/cloud/... ./internal/server/... ./internal/mcp/... -count=1` (1480 passed)
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [x] Validated an isolated SQLite backup of the active database with `quick_check` and `integrity_check`; the active database was never modified.

## Scope
This addresses the local-import side of #649. Export-side orphan generation remains covered separately by #701 and #615.

Closes #649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relation updates with missing targets are now deferred while valid updates continue processing.
  * Permanently invalid relation payloads are recorded and acknowledged without blocking other updates.
  * Self-referential relations can now be applied successfully.
  * Existing dead records are protected from being downgraded to deferred status.

* **Tests**
  * Added coverage for mixed valid and invalid relation batches, malformed payloads, self-referential relations, cursor advancement, and acknowledgment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->