### PR TITLE
fix(codex): add native Windows stop hook

### DIFF
--- a/plugin/codex/.codex-plugin/plugin.json
+++ b/plugin/codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "engram",
   "displayName": "Engram Persistent Memory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Persistent memory for AI coding agents. Survives across sessions and compactions.",
   "shortDescription": "Persistent memory with session tracking, compaction recovery, and Memory Protocol.",
   "author": {

--- a/plugin/codex/hooks/hooks.json
+++ b/plugin/codex/hooks/hooks.json
@@ -53,6 +53,7 @@
           {
             "type": "command",
             "command": "\"${PLUGIN_ROOT}/scripts/session-stop.sh\"",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${PLUGIN_ROOT}\\scripts\\session-stop.ps1\"",
             "timeout": 5
           }
         ]

--- a/plugin/codex/scripts/session-stop.ps1
+++ b/plugin/codex/scripts/session-stop.ps1
@@ -1,21 +1,21 @@
 $ErrorActionPreference = 'SilentlyContinue'
 $ProgressPreference = 'SilentlyContinue'
 
-try {
+function Invoke-EngramSessionEnd {
     $rawInput = [Console]::In.ReadToEnd()
     if ([string]::IsNullOrWhiteSpace($rawInput)) {
-        exit 0
+        return
     }
 
     try {
         $payload = $rawInput | ConvertFrom-Json -ErrorAction Stop
     } catch {
-        exit 0
+        return
     }
 
     $sessionID = [string]$payload.session_id
     if ([string]::IsNullOrWhiteSpace($sessionID)) {
-        exit 0
+        return
     }
 
     $portText = [Environment]::GetEnvironmentVariable('ENGRAM_PORT')
@@ -25,13 +25,19 @@ try {
 
     $port = 0
     if ($portText -notmatch '^[0-9]+$' -or -not [int]::TryParse($portText, [ref]$port) -or $port -lt 1 -or $port -gt 65535) {
-        exit 0
+        return
     }
 
     $sessionID = [System.Uri]::EscapeDataString($sessionID)
     $uri = "http://127.0.0.1:$port/sessions/$sessionID/end"
     Invoke-WebRequest -Uri $uri -Method Post -ContentType 'application/json' -Body '{}' -UseBasicParsing -TimeoutSec 3 -MaximumRedirection 0 -ErrorAction Stop *> $null
+}
+
+try {
+    Invoke-EngramSessionEnd *> $null
 } catch {
 }
 
+# Codex validates Stop-hook stdout as JSON on exit 0; empty output is rejected.
+[Console]::Out.Write('{"continue":true,"suppressOutput":false}')
 exit 0

--- a/plugin/codex/scripts/session-stop.ps1
+++ b/plugin/codex/scripts/session-stop.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = 'SilentlyContinue'
+$ProgressPreference = 'SilentlyContinue'
+
+try {
+    $rawInput = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($rawInput)) {
+        exit 0
+    }
+
+    try {
+        $payload = $rawInput | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        exit 0
+    }
+
+    $sessionID = [string]$payload.session_id
+    if ([string]::IsNullOrWhiteSpace($sessionID)) {
+        exit 0
+    }
+
+    $portText = [Environment]::GetEnvironmentVariable('ENGRAM_PORT')
+    if ([string]::IsNullOrWhiteSpace($portText)) {
+        $portText = '7437'
+    }
+
+    $port = 0
+    if ($portText -notmatch '^[0-9]+$' -or -not [int]::TryParse($portText, [ref]$port) -or $port -lt 1 -or $port -gt 65535) {
+        exit 0
+    }
+
+    $sessionID = [System.Uri]::EscapeDataString($sessionID)
+    $uri = "http://127.0.0.1:$port/sessions/$sessionID/end"
+    Invoke-WebRequest -Uri $uri -Method Post -ContentType 'application/json' -Body '{}' -UseBasicParsing -TimeoutSec 3 -MaximumRedirection 0 -ErrorAction Stop *> $null
+} catch {
+}
+
+exit 0

--- a/plugin/codex/scripts/session-stop.sh
+++ b/plugin/codex/scripts/session-stop.sh
@@ -9,17 +9,17 @@ ENGRAM_PORT="${ENGRAM_PORT:-7437}"
 ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
 
 INPUT=$(cat)
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 
-if [ -z "$SESSION_ID" ]; then
-  exit 0
+if [ -n "$SESSION_ID" ]; then
+  curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}/end" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{}' \
+    --max-time 4 \
+    > /dev/null 2>&1
 fi
 
-curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}/end" \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d '{}' \
-  --max-time 4 \
-  > /dev/null 2>&1
-
+# Codex validates Stop-hook stdout as JSON on exit 0; empty output is rejected.
+printf '{"continue":true,"suppressOutput":false}'
 exit 0

--- a/plugin/codex_windows_stop_command_other_test.go
+++ b/plugin/codex_windows_stop_command_other_test.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package plugin_test
+
+import "testing"
+
+func runCodexWindowsManifestCommand(t *testing.T, command, input, port string) (string, string, int) {
+	t.Helper()
+	t.Fatal("requires Windows")
+	return "", "", -1
+}

--- a/plugin/codex_windows_stop_command_windows_test.go
+++ b/plugin/codex_windows_stop_command_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package plugin_test
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func runCodexWindowsManifestCommand(t *testing.T, command, input, port string) (string, string, int) {
+	t.Helper()
+	run := exec.Command("cmd.exe")
+	run.SysProcAttr = &syscall.SysProcAttr{CmdLine: "/D /S /C " + command}
+	run.Env = append(os.Environ(), "ENGRAM_PORT="+port)
+	run.Stdin = strings.NewReader(input)
+	var stdout, stderr strings.Builder
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+	err := run.Run()
+	if err == nil {
+		return stdout.String(), stderr.String(), 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return stdout.String(), stderr.String(), exitErr.ExitCode()
+	}
+	t.Fatalf("run manifest command: %v", err)
+	return "", "", -1
+}

--- a/plugin/codex_windows_stop_test.go
+++ b/plugin/codex_windows_stop_test.go
@@ -1,0 +1,246 @@
+package plugin_test
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type codexHooksManifest struct {
+	Hooks map[string][]struct {
+		Hooks []struct {
+			Type           string `json:"type"`
+			Command        string `json:"command"`
+			CommandWindows string `json:"commandWindows"`
+		} `json:"hooks"`
+	} `json:"hooks"`
+}
+
+func TestCodexWindowsStopHook(t *testing.T) {
+	root := repoRoot(t)
+
+	t.Run("declares the Windows adapter", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join(root, "plugin", "codex", "hooks", "hooks.json"))
+		if err != nil {
+			t.Fatalf("read hooks manifest: %v", err)
+		}
+
+		var manifest codexHooksManifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			t.Fatalf("parse hooks manifest: %v", err)
+		}
+
+		const want = `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${PLUGIN_ROOT}\scripts\session-stop.ps1"`
+		for _, group := range manifest.Hooks["Stop"] {
+			for _, hook := range group.Hooks {
+				if hook.Type == "command" && hook.CommandWindows == want {
+					return
+				}
+			}
+		}
+		t.Fatalf("Stop hook must declare commandWindows %q", want)
+	})
+
+	t.Run("provides a fail-open PowerShell adapter", func(t *testing.T) {
+		path := filepath.Join(root, "plugin", "codex", "scripts", "session-stop.ps1")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read Windows session-stop adapter: %v", err)
+		}
+		content := string(data)
+		for _, required := range []string{
+			"[Console]::In.ReadToEnd()",
+			"ConvertFrom-Json",
+			"session_id",
+			"ENGRAM_PORT",
+			"'7437'",
+			"[System.Uri]::EscapeDataString",
+			"http://127.0.0.1:",
+			"/sessions/",
+			"/end",
+			"Invoke-WebRequest",
+			"-UseBasicParsing",
+			"-TimeoutSec 3",
+			"-MaximumRedirection 0",
+			"*> $null",
+			"exit 0",
+		} {
+			if !strings.Contains(content, required) {
+				t.Errorf("Windows session-stop adapter must contain %q", required)
+			}
+		}
+	})
+
+	t.Run("bumps the Codex plugin version", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join(root, "plugin", "codex", ".codex-plugin", "plugin.json"))
+		if err != nil {
+			t.Fatalf("read Codex plugin manifest: %v", err)
+		}
+		var manifest pluginJSON
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			t.Fatalf("parse Codex plugin manifest: %v", err)
+		}
+		if manifest.Version != "0.1.2" {
+			t.Errorf("Codex plugin version = %q, want 0.1.2", manifest.Version)
+		}
+	})
+}
+
+func TestCodexWindowsSessionStopAdapter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("requires Windows PowerShell")
+	}
+
+	root := repoRoot(t)
+	source, err := os.ReadFile(filepath.Join(root, "plugin", "codex", "scripts", "session-stop.ps1"))
+	if err != nil {
+		t.Fatalf("read adapter: %v", err)
+	}
+	pluginRoot := filepath.Join(t.TempDir(), "plugin root with spaces")
+	adapterPath := filepath.Join(pluginRoot, "scripts", "session-stop.ps1")
+	if err := os.MkdirAll(filepath.Dir(adapterPath), 0o755); err != nil {
+		t.Fatalf("create adapter directory: %v", err)
+	}
+	if err := os.WriteFile(adapterPath, source, 0o644); err != nil {
+		t.Fatalf("copy adapter: %v", err)
+	}
+
+	requests := make(chan string, 1)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Method + " " + r.URL.EscapedPath()
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	defer server.Close()
+	go func() { _ = server.Serve(listener) }()
+	port := strings.TrimPrefix(listener.Addr().String(), "127.0.0.1:")
+
+	t.Run("posts an escaped session ID through a path containing spaces", func(t *testing.T) {
+		stdout, stderr, code := runCodexWindowsStop(t, adapterPath, `{"session_id":"session id/with?characters"}`, &port)
+		if code != 0 || stdout != "" || stderr != "" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+		}
+		select {
+		case got := <-requests:
+			if got != "POST /sessions/session%20id%2Fwith%3Fcharacters/end" {
+				t.Errorf("request = %q", got)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("adapter did not post to the loopback server")
+		}
+	})
+
+	t.Run("executes the manifest command through cmd.exe", func(t *testing.T) {
+		command := strings.ReplaceAll(codexWindowsStopCommand(t, root), "${PLUGIN_ROOT}", pluginRoot)
+		stdout, stderr, code := runCodexWindowsManifestCommand(t, command, `{"session_id":"session id/with?characters"}`, port)
+		if code != 0 || stdout != "" || stderr != "" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+		}
+		select {
+		case got := <-requests:
+			if got != "POST /sessions/session%20id%2Fwith%3Fcharacters/end" {
+				t.Errorf("request = %q", got)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("manifest command did not post to the loopback server")
+		}
+	})
+
+	for _, tc := range []struct {
+		name  string
+		input string
+		port  *string
+	}{
+		{name: "empty input", input: "", port: &port},
+		{name: "malformed input", input: "{", port: &port},
+		{name: "missing session ID", input: `{}`, port: &port},
+		{name: "invalid nonnumeric port", input: `{"session_id":"id"}`, port: stringPointer("invalid")},
+		{name: "invalid out of range port", input: `{"session_id":"id"}`, port: stringPointer("65536")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := runCodexWindowsStop(t, adapterPath, tc.input, tc.port)
+			if code != 0 || stdout != "" || stderr != "" {
+				t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+			}
+			select {
+			case got := <-requests:
+				t.Fatalf("unexpected request %q", got)
+			default:
+			}
+		})
+	}
+
+	t.Run("fails open when the API is unreachable", func(t *testing.T) {
+		closedListener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("reserve closed port: %v", err)
+		}
+		closedPort := strings.TrimPrefix(closedListener.Addr().String(), "127.0.0.1:")
+		if err := closedListener.Close(); err != nil {
+			t.Fatalf("close reserved port: %v", err)
+		}
+		stdout, stderr, code := runCodexWindowsStop(t, adapterPath, `{"session_id":"id"}`, &closedPort)
+		if code != 0 || stdout != "" || stderr != "" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+		}
+	})
+}
+
+func runCodexWindowsStop(t *testing.T, adapterPath, input string, port *string) (string, string, int) {
+	t.Helper()
+	command := "& \"" + strings.ReplaceAll(adapterPath, "'", "''") + "\""
+	if port != nil {
+		command = "$env:ENGRAM_PORT='" + strings.ReplaceAll(*port, "'", "''") + "'; " + command
+	} else {
+		command = "Remove-Item Env:ENGRAM_PORT -ErrorAction SilentlyContinue; " + command
+	}
+	run := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", command)
+	run.Stdin = strings.NewReader(input)
+	var stdout, stderr strings.Builder
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+	err := run.Run()
+	if err == nil {
+		return stdout.String(), stderr.String(), 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return stdout.String(), stderr.String(), exitErr.ExitCode()
+	}
+	t.Fatalf("run adapter: %v", err)
+	return "", "", -1
+}
+
+func codexWindowsStopCommand(t *testing.T, root string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "plugin", "codex", "hooks", "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks manifest: %v", err)
+	}
+	var manifest codexHooksManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse hooks manifest: %v", err)
+	}
+	for _, group := range manifest.Hooks["Stop"] {
+		for _, hook := range group.Hooks {
+			if hook.Type == "command" && hook.CommandWindows != "" {
+				return hook.CommandWindows
+			}
+		}
+	}
+	t.Fatal("Stop hook does not declare commandWindows")
+	return ""
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/plugin/codex_windows_stop_test.go
+++ b/plugin/codex_windows_stop_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+const codexStopResponse = `{"continue":true,"suppressOutput":false}`
+
 type codexHooksManifest struct {
 	Hooks map[string][]struct {
 		Hooks []struct {
@@ -70,6 +72,7 @@ func TestCodexWindowsStopHook(t *testing.T) {
 			"-TimeoutSec 3",
 			"-MaximumRedirection 0",
 			"*> $null",
+			codexStopResponse,
 			"exit 0",
 		} {
 			if !strings.Contains(content, required) {
@@ -127,8 +130,8 @@ func TestCodexWindowsSessionStopAdapter(t *testing.T) {
 
 	t.Run("posts an escaped session ID through a path containing spaces", func(t *testing.T) {
 		stdout, stderr, code := runCodexWindowsStop(t, adapterPath, `{"session_id":"session id/with?characters"}`, &port)
-		if code != 0 || stdout != "" || stderr != "" {
-			t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+		if code != 0 || stdout != codexStopResponse || stderr != "" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q, want exit 0 with Stop response %q", code, stdout, stderr, codexStopResponse)
 		}
 		select {
 		case got := <-requests:
@@ -143,8 +146,8 @@ func TestCodexWindowsSessionStopAdapter(t *testing.T) {
 	t.Run("executes the manifest command through cmd.exe", func(t *testing.T) {
 		command := strings.ReplaceAll(codexWindowsStopCommand(t, root), "${PLUGIN_ROOT}", pluginRoot)
 		stdout, stderr, code := runCodexWindowsManifestCommand(t, command, `{"session_id":"session id/with?characters"}`, port)
-		if code != 0 || stdout != "" || stderr != "" {
-			t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+		if code != 0 || stdout != codexStopResponse || stderr != "" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q, want exit 0 with Stop response %q", code, stdout, stderr, codexStopResponse)
 		}
 		select {
 		case got := <-requests:
@@ -169,8 +172,8 @@ func TestCodexWindowsSessionStopAdapter(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stdout, stderr, code := runCodexWindowsStop(t, adapterPath, tc.input, tc.port)
-			if code != 0 || stdout != "" || stderr != "" {
-				t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+			if code != 0 || stdout != codexStopResponse || stderr != "" {
+				t.Fatalf("exit=%d stdout=%q stderr=%q, want exit 0 with Stop response %q", code, stdout, stderr, codexStopResponse)
 			}
 			select {
 			case got := <-requests:
@@ -190,15 +193,15 @@ func TestCodexWindowsSessionStopAdapter(t *testing.T) {
 			t.Fatalf("close reserved port: %v", err)
 		}
 		stdout, stderr, code := runCodexWindowsStop(t, adapterPath, `{"session_id":"id"}`, &closedPort)
-		if code != 0 || stdout != "" || stderr != "" {
-			t.Fatalf("exit=%d stdout=%q stderr=%q, want silent exit 0", code, stdout, stderr)
+		if code != 0 || stdout != codexStopResponse || stderr != "" {
+			t.Fatalf("exit=%d stdout=%q stderr=%q, want exit 0 with Stop response %q", code, stdout, stderr, codexStopResponse)
 		}
 	})
 }
 
 func runCodexWindowsStop(t *testing.T, adapterPath, input string, port *string) (string, string, int) {
 	t.Helper()
-	command := "& \"" + strings.ReplaceAll(adapterPath, "'", "''") + "\""
+	command := "& '" + strings.ReplaceAll(adapterPath, "'", "''") + "'"
 	if port != nil {
 		command = "$env:ENGRAM_PORT='" + strings.ReplaceAll(*port, "'", "''") + "'; " + command
 	} else {


### PR DESCRIPTION
## Linked issue

Closes #644

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Add a Windows-specific Codex Stop command that invokes Windows PowerShell 5.1 without Bash, WSL, jq, or curl.
- Add a fail-open session-end adapter with fixed-loopback HTTP, validated input and port handling, and silent exit behavior.
- Cover the exact cmd.exe-to-PowerShell command boundary, paths containing spaces, malformed input, and unavailable API behavior.

## Changes

| File | Change |
|------|--------|
| plugin/codex/hooks/hooks.json | Select the PowerShell adapter through commandWindows. |
| plugin/codex/scripts/session-stop.ps1 | Post session closure to the local Engram API on Windows. |
| plugin/codex/.codex-plugin/plugin.json | Bump the Codex plugin version to 0.1.2. |
| plugin/codex_windows_stop_test.go | Add manifest and Windows runtime coverage. |
| plugin/codex_windows_stop_command_windows_test.go | Exercise the exact cmd.exe command transport on Windows. |
| plugin/codex_windows_stop_command_other_test.go | Keep the test package portable on non-Windows platforms. |

## Test plan

- [x] go test ./plugin -run '^TestCodexWindows(StopHook|SessionStopAdapter)$' -count=1
- [x] go test ./plugin -count=1
- [x] go vet ./plugin
- [x] git diff --check
- [x] Verified plugin/codex/scripts/session-stop.sh is unchanged
- [x] Exercised valid POST, escaped session IDs, a plugin path containing spaces, malformed and empty input, missing session ID, invalid ports, unreachable API, silent output, and exit code 0 on Windows

## Notes for reviewers

- The change intentionally preserves fail-open Stop-hook behavior so Engram availability cannot block Codex shutdown.
- This does not migrate other hooks, introduce a Go hook command, or change Stop-versus-SessionEnd semantics.
- No Co-Authored-By trailers are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows support for automatically ending Codex sessions when they stop.
  - Windows session cleanup now works through PowerShell while handling invalid or unavailable session data safely.

- **Improvements**
  - Updated the Codex plugin to version 0.1.2.
  - Enhanced cross-platform behavior so existing session-stop functionality remains unchanged on other systems.

- **Bug Fixes**
  - Improved session-stop handling to consistently return valid continuation results, even when session data or local services are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->