### PR TITLE
fix(pi): bind writes to acknowledged runtime sessions

### DIFF
--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -88,7 +88,7 @@ Other write tools still primarily use cwd/repo detection unless their schema say
 
 OpenCode binds `mem_save`, `mem_save_prompt`, `mem_session_summary`, and `mem_capture_passive` to its confirmed top-level runtime session and maps subagents to their authoritative parent.
 
-Pi's native HTTP wrappers use only `ctx.sessionManager.getSessionId()` for session-attributed writes. Model-supplied session IDs are ignored, and a missing or unconfirmed runtime ID fails safely.
+Pi binds `mem_save`, `mem_save_prompt`, `mem_session_summary`, and `mem_capture_passive` to the exact `ctx.sessionManager.getSessionId()` runtime session. Those four wrappers ignore model-supplied session IDs, and a missing or unacknowledged runtime session fails safely instead of writing under a synthesized ID.
 
 To lock write tools to the canonical project for a repo, add `.engram/config.json` at the repo root:
 

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -88,6 +88,8 @@ Other write tools still primarily use cwd/repo detection unless their schema say
 
 OpenCode binds `mem_save`, `mem_save_prompt`, `mem_session_summary`, and `mem_capture_passive` to its confirmed top-level runtime session and maps subagents to their authoritative parent.
 
+Pi's native HTTP wrappers use only `ctx.sessionManager.getSessionId()` for session-attributed writes. Model-supplied session IDs are ignored, and a missing or unconfirmed runtime ID fails safely.
+
 To lock write tools to the canonical project for a repo, add `.engram/config.json` at the repo root:
 
 ```json

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -178,10 +178,9 @@ function isTimeoutError(error: unknown): boolean {
   return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
 }
 
-// engramFetch resolves to null on failure and ~20 call sites depend on that fallthrough —
-// ensureSession in particular must not abort a mem_save just because session creation blipped.
-// So the timeout detail travels out-of-band instead of changing what any caller receives,
-// letting executeMemoryTool tell the truth about an ambiguous write without blast radius.
+// engramFetch resolves to null on transport failure. Session-attributed writes
+// treat a null registration response as unacknowledged and stop before writing;
+// other callers retain the existing null fallthrough contract.
 let lastFetchTimeoutMethod: string | undefined;
 
 function takeLastFetchTimeoutMethod(): string | undefined {
@@ -420,9 +419,12 @@ const toolCounts = new Map<string, number>();
 async function ensureSession(sessionId: string, sessionProject = project): Promise<void> {
   const key = `${sessionProject}:${sessionId}`;
   if (!sessionId || knownSessions.has(key)) return;
-  knownSessions.add(key);
   const body: SessionBody = { id: sessionId, project: sessionProject, directory };
-  await engramFetch("/sessions", { method: "POST", body });
+  const acknowledgement = await engramFetch("/sessions", { method: "POST", body });
+  if (acknowledgement === null) {
+    throw new Error(`gentle-engram could not confirm session registration for Pi runtime session ${sessionId}`);
+  }
+  knownSessions.add(key);
 }
 
 async function detectServerProject(cwd: string): Promise<CurrentProjectResponse | undefined> {
@@ -507,6 +509,14 @@ function getSessionId(ctx: SessionContext): string | undefined {
   return ctx.sessionManager.getSessionId();
 }
 
+function requireRuntimeSessionID(ctx: SessionContext): string {
+  const sessionId = ctx.sessionManager.getSessionId()?.trim();
+  if (!sessionId) {
+    throw new Error("Pi runtime session ID is unavailable; session-attributed writes require a native SessionContext ID");
+  }
+  return sessionId;
+}
+
 const optionalString = (description: string) => Type.Optional(Type.String({ description }));
 const optionalNumber = (description: string) => Type.Optional(Type.Number({ description }));
 const optionalBoolean = (description: string) => Type.Optional(Type.Boolean({ description }));
@@ -525,7 +535,6 @@ const MEMORY_TOOL_SCHEMAS: Record<string, ReturnType<typeof Type.Object>> = {
     title: Type.String({ description: "Short, searchable title" }),
     content: Type.String({ description: "Structured memory content" }),
     type: optionalString("Observation type/category"),
-    session_id: optionalString("Session ID to associate with"),
     scope: optionalString("Scope: project or personal"),
     topic_key: optionalString("Stable topic key for upserts"),
     project: optionalString("Optional explicit project"),
@@ -550,12 +559,10 @@ const MEMORY_TOOL_SCHEMAS: Record<string, ReturnType<typeof Type.Object>> = {
   }),
   mem_save_prompt: Type.Object({
     content: Type.String({ description: "The user's prompt text" }),
-    session_id: optionalString("Session ID to associate with"),
     project: optionalString("Optional project"),
   }),
   mem_session_summary: Type.Object({
     content: Type.String({ description: "Full session summary" }),
-    session_id: optionalString("Session ID"),
     project: optionalString("Optional project to use when automatic detection is unavailable"),
   }),
   mem_context: Type.Object({
@@ -591,7 +598,6 @@ const MEMORY_TOOL_SCHEMAS: Record<string, ReturnType<typeof Type.Object>> = {
   }),
   mem_capture_passive: Type.Object({
     content: Type.String({ description: "Text output containing a ## Key Learnings section" }),
-    session_id: optionalString("Session ID to associate with"),
     source: optionalString("Source identifier, e.g. subagent-stop or session-end"),
   }),
   mem_review: Type.Object({
@@ -652,7 +658,7 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
   const sessionId = getSessionId(ctx);
   const requestedProject = typeof params.project === "string" && params.project ? params.project : undefined;
   const activeProject = requestedProject || project;
-  const activeSessionId = String(params.session_id || (requestedProject ? `manual-save-${requestedProject}` : sessionId) || `manual-save-${project}`);
+  const runtimeSessionForWrite = () => requireRuntimeSessionID(ctx);
 
   switch (toolName) {
     case "mem_search":
@@ -674,8 +680,9 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
       return engramFetch(`/timeline${queryString({ observation_id: params.observation_id, before: params.before, after: params.after, project: params.project })}`);
     case "mem_get_observation":
       return engramFetch(`/observations/${encodeURIComponent(String(params.id))}`);
-    case "mem_save":
+    case "mem_save": {
       if (!requestedProject) requireResolvedProject();
+      const activeSessionId = runtimeSessionForWrite();
       await ensureSession(activeSessionId, activeProject);
       return engramFetch("/observations", {
         method: "POST",
@@ -689,6 +696,7 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
           topic_key: params.topic_key,
         },
       });
+    }
     case "mem_update":
       return engramFetch(`/observations/${encodeURIComponent(String(params.id))}`, {
         method: "PATCH",
@@ -704,20 +712,23 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
       return engramFetch(`/observations/${encodeURIComponent(String(params.id))}${queryString({ hard: params.hard_delete })}`, { method: "DELETE" });
     case "mem_suggest_topic_key":
       return { topic_key: slugifyTopicKey(params) };
-    case "mem_save_prompt":
+    case "mem_save_prompt": {
       if (!requestedProject) requireResolvedProject();
-      await ensureSession(activeSessionId, activeProject);
+      const promptSessionId = runtimeSessionForWrite();
+      await ensureSession(promptSessionId, activeProject);
       return engramFetch("/prompts", {
         method: "POST",
-        body: { session_id: activeSessionId, content: params.content, project: activeProject },
+        body: { session_id: promptSessionId, content: params.content, project: activeProject },
       });
-    case "mem_session_summary":
+    }
+    case "mem_session_summary": {
       if (!requestedProject) requireResolvedProject();
-      await ensureSession(activeSessionId, activeProject);
+      const summarySessionId = runtimeSessionForWrite();
+      await ensureSession(summarySessionId, activeProject);
       return engramFetch("/observations", {
         method: "POST",
         body: {
-          session_id: activeSessionId,
+          session_id: summarySessionId,
           type: "session_summary",
           title: "Session summary",
           content: params.content,
@@ -725,6 +736,7 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
           scope: "project",
         },
       });
+    }
     case "mem_session_start":
       requireResolvedProject();
       return engramFetch("/sessions", {
@@ -749,18 +761,20 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
     }
     case "mem_doctor":
       return engramFetch(`/doctor${queryString({ project: params.project, check: params.check, cwd: params.project ? undefined : ctx.cwd })}`);
-    case "mem_capture_passive":
+    case "mem_capture_passive": {
       requireResolvedProject();
-      await ensureSession(activeSessionId);
+      const passiveSessionId = runtimeSessionForWrite();
+      await ensureSession(passiveSessionId);
       return engramFetch("/observations/passive", {
         method: "POST",
         body: {
-          session_id: activeSessionId,
+          session_id: passiveSessionId,
           content: params.content,
           project,
           source: params.source || "pi-tool",
         },
       });
+    }
     case "mem_review": {
       const action = String(params.action || "").trim();
       if (action === "list") {

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -525,9 +525,12 @@ function getSessionId(ctx: SessionContext): string | undefined {
   return ctx.sessionManager.getSessionId();
 }
 
+// The Pi runtime session ID is opaque: blankness is validated without normalizing it,
+// so registration, writes, compaction, and shutdown cleanup all key off the exact same
+// bytes. Trimming here would split that identity and strand cache entries at shutdown.
 function requireRuntimeSessionID(ctx: SessionContext): string {
-  const sessionId = ctx.sessionManager.getSessionId()?.trim();
-  if (!sessionId) {
+  const sessionId = getSessionId(ctx);
+  if (!sessionId || sessionId.trim().length === 0) {
     throw new Error("Pi runtime session ID is unavailable; session-attributed writes require a native SessionContext ID");
   }
   return sessionId;

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -414,17 +414,33 @@ let projectResolutionError: string | undefined;
 let projectDetectionPending = false;
 
 const knownSessions = new Set<string>();
+const sessionRegistrationsInFlight = new Map<string, Promise<void>>();
 const toolCounts = new Map<string, number>();
 
 async function ensureSession(sessionId: string, sessionProject = project): Promise<void> {
   const key = `${sessionProject}:${sessionId}`;
   if (!sessionId || knownSessions.has(key)) return;
-  const body: SessionBody = { id: sessionId, project: sessionProject, directory };
-  const acknowledgement = await engramFetch("/sessions", { method: "POST", body });
-  if (acknowledgement === null) {
-    throw new Error(`gentle-engram could not confirm session registration for Pi runtime session ${sessionId}`);
+
+  const existingRegistration = sessionRegistrationsInFlight.get(key);
+  if (existingRegistration) return existingRegistration;
+
+  const registration = (async () => {
+    const body: SessionBody = { id: sessionId, project: sessionProject, directory };
+    const acknowledgement = await engramFetch("/sessions", { method: "POST", body });
+    if (acknowledgement === null) {
+      throw new Error(`gentle-engram could not confirm session registration for Pi runtime session ${sessionId}`);
+    }
+    knownSessions.add(key);
+  })();
+  sessionRegistrationsInFlight.set(key, registration);
+
+  try {
+    await registration;
+  } finally {
+    if (sessionRegistrationsInFlight.get(key) === registration) {
+      sessionRegistrationsInFlight.delete(key);
+    }
   }
-  knownSessions.add(key);
 }
 
 async function detectServerProject(cwd: string): Promise<CurrentProjectResponse | undefined> {

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -914,7 +914,7 @@ export default function registerEngram(pi: ExtensionAPI) {
     await refreshProjectDetection(ctx.cwd);
     if (projectDetectionPending || projectResolutionError) return;
     const sessionId = getSessionId(ctx);
-    if (sessionId) await ensureSessionBestEffort(sessionId);
+    if (sessionId) await ensureSession(sessionId);
 
     const summary = extractCompactedSummary(event);
     if (sessionId && summary) {

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
-const source = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+const source = readFileSync(new URL("../index.ts", import.meta.url), "utf8").replaceAll("\r\n", "\n");
 
 function extractFunctionBody(name, marker) {
   const signatureIndex = source.indexOf(`function ${name}`);
@@ -103,6 +103,18 @@ function buildScheduleEngramSelfHealForTest({ waitUnref, isEngramRunning, maxAtt
   return factory(waitUnref, isEngramRunning, 1, maxAttempts);
 }
 
+function buildEnsureSessionForTest(engramFetch) {
+  const body = extractFunctionBody("ensureSession", "{\n  const key")
+    .replace("const body: SessionBody", "const body")
+  const factory = new Function("knownSessions", "engramFetch", "project", "directory", `
+    return async function ensureSession(sessionId, sessionProject = project) {
+      ${body}
+    };
+  `);
+  const knownSessions = new Set();
+  return { ensureSession: factory(knownSessions, engramFetch, "engram", "/work/engram"), knownSessions };
+}
+
 function sessionCtx(id, sink) {
   return {
     sessionManager: { getSessionId: () => id },
@@ -112,7 +124,7 @@ function sessionCtx(id, sink) {
 
 test("mem_session_summary accepts explicit project fallback", () => {
   assert.match(source, /mem_session_summary: Type\.Object\(\{[\s\S]*project: optionalString\("Optional project to use when automatic detection is unavailable"\)/);
-  assert.match(source, /case "mem_session_summary":[\s\S]*if \(!requestedProject\) requireResolvedProject\(\);[\s\S]*ensureSession\(activeSessionId, activeProject\)[\s\S]*project: activeProject/);
+  assert.match(source, /case "mem_session_summary":[\s\S]*if \(!requestedProject\) requireResolvedProject\(\);[\s\S]*ensureSession\(summarySessionId, activeProject\)[\s\S]*project: activeProject/);
 });
 
 test("mem_search exposes and forwards match_mode and all_projects", () => {
@@ -286,35 +298,32 @@ test("the tool layer reports unknown write outcome instead of inviting a blind r
   assert.doesNotMatch(unreachable, /timed out/);
 });
 
-test("a session-creation timeout still lets the observation write through", async () => {
-  // Regression: when engramFetch threw on timeout, the unguarded ensureSession call in
-  // mem_save aborted the whole tool call before /observations was ever attempted, silently
-  // dropping the user's memory while telling the agent not to retry.
-  assert.match(source, /await ensureSession\(activeSessionId, activeProject\);/);
-  assert.doesNotMatch(source, /throw new EngramTimeoutError/);
+test("session registration requires acknowledgement and failed acknowledgement remains retryable", async () => {
+  let calls = 0;
+  const { ensureSession, knownSessions } = buildEnsureSessionForTest(async () => {
+    calls += 1;
+    return calls === 1 ? null : { status: "created" };
+  });
 
-  const originalFetch = globalThis.fetch;
-  const paths = [];
-  globalThis.fetch = async (url, init) => {
-    const path = new URL(url).pathname;
-    paths.push(path);
-    if (path === "/sessions") {
-      const timeout = new Error("The operation was aborted due to timeout");
-      timeout.name = "TimeoutError";
-      throw timeout;
-    }
-    return { ok: true, async json() { return { id: 1 }; } };
-  };
-  try {
-    const { engramFetch } = buildEngramFetchForTest();
-    // ensureSession's own call fails soft...
-    assert.equal(await engramFetch("/sessions", { method: "POST", body: { id: "s" } }), null);
-    // ...and the observation write that follows it still lands.
-    assert.deepEqual(await engramFetch("/observations", { method: "POST", body: { title: "t" } }), { id: 1 });
-    assert.deepEqual(paths, ["/sessions", "/observations"]);
-  } finally {
-    globalThis.fetch = originalFetch;
+  await assert.rejects(ensureSession("runtime"), /could not confirm session registration/);
+  assert.equal(knownSessions.has("engram:runtime"), false);
+  await ensureSession("runtime");
+  assert.equal(knownSessions.has("engram:runtime"), true);
+  await ensureSession("runtime");
+  assert.equal(calls, 2);
+});
+
+test("four session-attributed writes ignore model session_id and require the Pi runtime ID", () => {
+  for (const tool of ["mem_save", "mem_save_prompt", "mem_session_summary", "mem_capture_passive"]) {
+    const schema = source.match(new RegExp(`${tool}: Type\\.Object\\(\\{([\\s\\S]*?)\\n  \\}\\),`));
+    assert.ok(schema, `${tool} schema not found`);
+    assert.doesNotMatch(schema[1], /session_id:/, `${tool} must not invite model-supplied session identity`);
   }
+  assert.match(source, /function requireRuntimeSessionID/);
+  assert.match(source, /ctx\.sessionManager\.getSessionId\(\)/);
+  assert.match(source, /Pi runtime session ID is unavailable/);
+  assert.doesNotMatch(source, /const activeSessionId = String\(params\.session_id/);
+  assert.doesNotMatch(source, /manual-save-\$\{requestedProject\}/);
 });
 
 test("a timeout on the session leg does not mislabel an unrelated failure on the write leg", async () => {

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -317,6 +317,21 @@ test("session registration requires acknowledgement and failed acknowledgement r
   assert.equal(calls, 2);
 });
 
+test("session compaction strictly registers before forwarding its summary", () => {
+  const compactStart = source.indexOf('pi.on("session_compact"');
+  const compactEnd = source.indexOf('\n  pi.on("before_agent_start"', compactStart);
+  assert.notEqual(compactStart, -1, "session_compact handler not found");
+  assert.notEqual(compactEnd, -1, "session_compact handler end not found");
+  const compactHandler = source.slice(compactStart, compactEnd);
+
+  const registration = compactHandler.indexOf("if (sessionId) await ensureSession(sessionId);");
+  const summaryPost = compactHandler.indexOf('bestEffortEngramFetch("/observations"');
+  assert.notEqual(registration, -1, "session_compact must await strict session registration");
+  assert.notEqual(summaryPost, -1, "session_compact summary post not found");
+  assert.ok(registration < summaryPost, "strict registration must precede summary forwarding");
+  assert.doesNotMatch(compactHandler, /ensureSessionBestEffort/, "session_compact must not hide registration failure");
+});
+
 test("four session-attributed writes ignore model session_id and require the Pi runtime ID", () => {
   for (const tool of ["mem_save", "mem_save_prompt", "mem_session_summary", "mem_capture_passive"]) {
     const schema = source.match(new RegExp(`${tool}: Type\\.Object\\(\\{([\\s\\S]*?)\\n  \\}\\),`));

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -105,14 +105,18 @@ function buildScheduleEngramSelfHealForTest({ waitUnref, isEngramRunning, maxAtt
 
 function buildEnsureSessionForTest(engramFetch) {
   const body = extractFunctionBody("ensureSession", "{\n  const key")
-    .replace("const body: SessionBody", "const body")
-  const factory = new Function("knownSessions", "engramFetch", "project", "directory", `
+    .replace("const body: SessionBody", "const body");
+  const factory = new Function("knownSessions", "sessionRegistrationsInFlight", "engramFetch", "project", "directory", `
     return async function ensureSession(sessionId, sessionProject = project) {
       ${body}
     };
   `);
   const knownSessions = new Set();
-  return { ensureSession: factory(knownSessions, engramFetch, "engram", "/work/engram"), knownSessions };
+  const sessionRegistrationsInFlight = new Map();
+  return {
+    ensureSession: factory(knownSessions, sessionRegistrationsInFlight, engramFetch, "engram", "/work/engram"),
+    knownSessions,
+  };
 }
 
 function sessionCtx(id, sink) {

--- a/plugin/pi/test/native-tool-contract.test.mjs
+++ b/plugin/pi/test/native-tool-contract.test.mjs
@@ -31,6 +31,40 @@ export const Type = new Proxy({}, { get: (_target, prop) => schema(String(prop))
   );
 }
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function loadPluginHarness(tag) {
+  await installRuntimeStubs();
+  const registeredTools = new Map();
+  const eventHandlers = new Map();
+  const pluginUrl = pathToFileURL(join(ROOT, "index.ts"));
+  pluginUrl.search = `?${tag}=${Date.now()}`;
+  const { default: registerEngram } = await import(pluginUrl.href);
+  registerEngram({
+    registerTool(tool) {
+      registeredTools.set(tool.name, tool);
+    },
+    on(event, handler) {
+      eventHandlers.set(event, handler);
+    },
+  });
+  return { registeredTools, eventHandlers };
+}
+
+function runtimeContext(sessionId) {
+  return {
+    cwd: ROOT,
+    sessionManager: { getSessionId: () => sessionId },
+    ui: { setStatus() {} },
+  };
+}
+
 test("registered Pi-native mem_search reports native provider transport failure", async () => {
   const originalFetch = globalThis.fetch;
   const originalUrl = process.env.ENGRAM_URL;
@@ -150,6 +184,125 @@ test("session-attributed Pi writes bind to acknowledged runtime identity and ret
     assert.equal(noRuntime.isError, true);
     assert.match(noRuntime.content[0].text, /Pi runtime session ID is unavailable/);
     assert.equal(registrationAttempts, 2, "missing runtime identity must not synthesize or register a session");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.ENGRAM_URL;
+    else process.env.ENGRAM_URL = originalUrl;
+    await rm(NODE_MODULES, { recursive: true, force: true });
+  }
+});
+
+test("parallel first-use writes share one acknowledged registration and keep it cached", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.ENGRAM_URL;
+  process.env.ENGRAM_URL = "http://127.0.0.1:17437";
+  const registrationGate = deferred();
+  let registrationAttempts = 0;
+  const writeRequests = [];
+  globalThis.fetch = async (url, init) => {
+    const path = new URL(url).pathname;
+    if (path === "/health") return { ok: true, async json() { return { status: "ok" }; } };
+    if (path === "/project/current") {
+      return { ok: true, async json() { return { project: "pi", project_source: "dir_basename", project_path: ROOT }; } };
+    }
+    if (path === "/sessions") {
+      registrationAttempts += 1;
+      await registrationGate.promise;
+      return { ok: true, status: 201, async json() { return { status: "created" }; } };
+    }
+    if (path === "/observations") {
+      writeRequests.push(JSON.parse(init.body));
+      return { ok: true, status: 201, async json() { return { id: writeRequests.length }; } };
+    }
+    return { ok: true, async json() { return {}; } };
+  };
+
+  try {
+    const { registeredTools, eventHandlers } = await loadPluginHarness("parallel-success");
+    const memSave = registeredTools.get("mem_save");
+    const ctx = runtimeContext("parallel-success-session");
+    await eventHandlers.get("session_start")({}, ctx);
+
+    const firstWrite = memSave.execute("parallel-success-1", { title: "first", content: "one" }, undefined, undefined, ctx);
+    const secondWrite = memSave.execute("parallel-success-2", { title: "second", content: "two" }, undefined, undefined, ctx);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(registrationAttempts, 1, "parallel first writes must share one registration request");
+
+    registrationGate.resolve();
+    const [firstResult, secondResult] = await Promise.all([firstWrite, secondWrite]);
+    assert.equal(firstResult.isError, undefined);
+    assert.equal(secondResult.isError, undefined);
+    assert.deepEqual(writeRequests.map((request) => request.title).sort(), ["first", "second"]);
+    assert.ok(writeRequests.every((request) => request.session_id === "parallel-success-session"));
+
+    await memSave.execute("parallel-success-cached", { title: "cached", content: "three" }, undefined, undefined, ctx);
+    assert.equal(registrationAttempts, 1, "acknowledged registration must remain cached");
+    assert.equal(writeRequests.length, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.ENGRAM_URL;
+    else process.env.ENGRAM_URL = originalUrl;
+    await rm(NODE_MODULES, { recursive: true, force: true });
+  }
+});
+
+test("shared registration failure rejects parallel writes and a later call retries", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.ENGRAM_URL;
+  process.env.ENGRAM_URL = "http://127.0.0.1:17437";
+  const registrationGate = deferred();
+  let registrationAttempts = 0;
+  let registrationShouldFail = true;
+  const writeRequests = [];
+  globalThis.fetch = async (url, init) => {
+    const path = new URL(url).pathname;
+    if (path === "/health") return { ok: true, async json() { return { status: "ok" }; } };
+    if (path === "/project/current") {
+      return { ok: true, async json() { return { project: "pi", project_source: "dir_basename", project_path: ROOT }; } };
+    }
+    if (path === "/sessions") {
+      registrationAttempts += 1;
+      if (registrationShouldFail) {
+        await registrationGate.promise;
+        return { ok: false, status: 503, async json() { return { error: "registration unavailable" }; } };
+      }
+      return { ok: true, status: 201, async json() { return { status: "created" }; } };
+    }
+    if (path === "/observations") {
+      writeRequests.push(JSON.parse(init.body));
+      return { ok: true, status: 201, async json() { return { id: writeRequests.length }; } };
+    }
+    return { ok: true, async json() { return {}; } };
+  };
+
+  try {
+    const { registeredTools, eventHandlers } = await loadPluginHarness("parallel-failure");
+    const memSave = registeredTools.get("mem_save");
+    const ctx = runtimeContext("parallel-failure-session");
+    await eventHandlers.get("session_start")({}, ctx);
+
+    const firstWrite = memSave.execute("parallel-failure-1", { title: "first", content: "one" }, undefined, undefined, ctx);
+    const secondWrite = memSave.execute("parallel-failure-2", { title: "second", content: "two" }, undefined, undefined, ctx);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(registrationAttempts, 1, "parallel failed writes must share one registration request");
+
+    registrationGate.resolve();
+    const [firstResult, secondResult] = await Promise.all([firstWrite, secondWrite]);
+    assert.equal(firstResult.isError, true);
+    assert.equal(secondResult.isError, true);
+    assert.match(firstResult.content[0].text, /registration unavailable/);
+    assert.match(secondResult.content[0].text, /registration unavailable/);
+    assert.equal(writeRequests.length, 0, "failed registration must stop every waiting write");
+
+    registrationShouldFail = false;
+    const retryResult = await memSave.execute("parallel-failure-retry", { title: "retry", content: "three" }, undefined, undefined, ctx);
+    assert.equal(retryResult.isError, undefined);
+    assert.equal(registrationAttempts, 2, "a later write must retry failed registration");
+    assert.equal(writeRequests.length, 1);
+
+    await memSave.execute("parallel-failure-cached", { title: "cached", content: "four" }, undefined, undefined, ctx);
+    assert.equal(registrationAttempts, 2, "successful retry must remain cached");
+    assert.equal(writeRequests.length, 2);
   } finally {
     globalThis.fetch = originalFetch;
     if (originalUrl === undefined) delete process.env.ENGRAM_URL;

--- a/plugin/pi/test/native-tool-contract.test.mjs
+++ b/plugin/pi/test/native-tool-contract.test.mjs
@@ -78,3 +78,82 @@ test("registered Pi-native mem_search reports native provider transport failure"
     await rm(NODE_MODULES, { recursive: true, force: true });
   }
 });
+
+test("session-attributed Pi writes bind to acknowledged runtime identity and retry failed registration", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.ENGRAM_URL;
+  process.env.ENGRAM_URL = "http://127.0.0.1:17437";
+  let registrationAttempts = 0;
+  const observationBodies = [];
+  const sessionBodies = [];
+  globalThis.fetch = async (url, init) => {
+    const path = new URL(url).pathname;
+    if (path === "/health") return { ok: true, async json() { return { status: "ok" }; } };
+    if (path === "/project/current") {
+      return { ok: true, async json() { return { project: "pi", project_source: "dir_basename", project_path: ROOT }; } };
+    }
+    if (path === "/sessions") {
+      registrationAttempts += 1;
+      sessionBodies.push(JSON.parse(init.body));
+      if (registrationAttempts === 1) {
+        return { ok: false, status: 503, async json() { return { error: "registration unavailable" }; } };
+      }
+      return { ok: true, status: 201, async json() { return { status: "created" }; } };
+    }
+    if (path === "/observations") {
+      observationBodies.push(JSON.parse(init.body));
+      return { ok: true, status: 201, async json() { return { id: observationBodies.length }; } };
+    }
+    return { ok: true, async json() { return {}; } };
+  };
+
+  try {
+    await installRuntimeStubs();
+    const registeredTools = new Map();
+    const pluginUrl = pathToFileURL(join(ROOT, "index.ts"));
+    pluginUrl.search = `?binding=${Date.now()}`;
+    const { default: registerEngram } = await import(pluginUrl.href);
+    registerEngram({
+      registerTool(tool) { registeredTools.set(tool.name, tool); },
+      on() {},
+    });
+
+    const memSave = registeredTools.get("mem_save");
+    const ctx = {
+      cwd: ROOT,
+      sessionManager: { getSessionId: () => "runtime-session" },
+      ui: { setStatus() {} },
+    };
+    const params = { title: "runtime binding", content: "content", session_id: "model-invented" };
+
+    const failed = await memSave.execute("call-1", params, undefined, undefined, ctx);
+    assert.equal(failed.isError, true);
+    assert.equal(observationBodies.length, 0, "unacknowledged registration must stop the write");
+
+    const succeeded = await memSave.execute("call-2", params, undefined, undefined, ctx);
+    assert.equal(succeeded.isError, undefined);
+    assert.equal(registrationAttempts, 2, "failed registration must remain retryable");
+    assert.equal(sessionBodies[1].id, "runtime-session");
+    assert.equal(observationBodies[0].session_id, "runtime-session");
+    assert.notEqual(observationBodies[0].session_id, "model-invented");
+
+    await memSave.execute("call-3", params, undefined, undefined, ctx);
+    assert.equal(registrationAttempts, 2, "successful acknowledgement should be cached");
+
+    const noRuntime = await memSave.execute(
+      "call-4",
+      params,
+      undefined,
+      undefined,
+      { ...ctx, sessionManager: { getSessionId: () => undefined } },
+    );
+    assert.equal(noRuntime.isError, true);
+    assert.match(noRuntime.content[0].text, /Pi runtime session ID is unavailable/);
+    assert.equal(registrationAttempts, 2, "missing runtime identity must not synthesize or register a session");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.ENGRAM_URL;
+    else process.env.ENGRAM_URL = originalUrl;
+    await rm(NODE_MODULES, { recursive: true, force: true });
+  }
+});

--- a/plugin/pi/test/native-tool-contract.test.mjs
+++ b/plugin/pi/test/native-tool-contract.test.mjs
@@ -310,3 +310,63 @@ test("shared registration failure rejects parallel writes and a later call retri
     await rm(NODE_MODULES, { recursive: true, force: true });
   }
 });
+
+test("an opaque runtime session ID stays byte-identical through registration, compaction, and cleanup", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.ENGRAM_URL;
+  process.env.ENGRAM_URL = "http://127.0.0.1:17437";
+  // Pi hands out an opaque session ID. Surrounding whitespace is part of that
+  // identity, so normalizing it anywhere would split registration from
+  // compaction and strand the cache entry that shutdown tries to clear.
+  const runtimeSessionId = "  pi-runtime-session-id  ";
+  const sessionBodies = [];
+  const observationBodies = [];
+  globalThis.fetch = async (url, init) => {
+    const path = new URL(url).pathname;
+    if (path === "/health") return { ok: true, async json() { return { status: "ok" }; } };
+    if (path === "/project/current") {
+      return { ok: true, async json() { return { project: "pi", project_source: "dir_basename", project_path: ROOT }; } };
+    }
+    if (path === "/sessions") {
+      sessionBodies.push(JSON.parse(init.body));
+      return { ok: true, status: 201, async json() { return { status: "created" }; } };
+    }
+    if (path === "/observations") {
+      observationBodies.push(JSON.parse(init.body));
+      return { ok: true, status: 201, async json() { return { id: observationBodies.length }; } };
+    }
+    if (path === "/context") return { ok: true, async json() { return { context: "" }; } };
+    return { ok: true, async json() { return {}; } };
+  };
+
+  try {
+    const { registeredTools, eventHandlers } = await loadPluginHarness("exact-identity");
+    const memSave = registeredTools.get("mem_save");
+    const ctx = runtimeContext(runtimeSessionId);
+    await eventHandlers.get("session_start")({}, ctx);
+
+    const saved = await memSave.execute("exact-1", { title: "first", content: "one" }, undefined, undefined, ctx);
+    assert.equal(saved.isError, undefined);
+    assert.equal(sessionBodies.length, 1, "the first write registers the runtime session once");
+    assert.equal(sessionBodies[0].id, runtimeSessionId, "registration must use the exact runtime identity");
+    assert.equal(observationBodies[0].session_id, runtimeSessionId, "the write must use the exact runtime identity");
+
+    await eventHandlers.get("session_compact")({ summary: "compacted work" }, ctx);
+    assert.equal(sessionBodies.length, 1, "compaction must reuse the cached exact identity instead of registering again");
+    const compactionSummary = observationBodies.find((body) => body.type === "session_summary");
+    assert.ok(compactionSummary, "compaction summary not forwarded");
+    assert.equal(compactionSummary.session_id, runtimeSessionId, "compaction must attribute the summary to the exact identity");
+
+    await eventHandlers.get("session_shutdown")({}, ctx);
+
+    const afterShutdown = await memSave.execute("exact-2", { title: "second", content: "two" }, undefined, undefined, ctx);
+    assert.equal(afterShutdown.isError, undefined);
+    assert.equal(sessionBodies.length, 2, "shutdown must clear the cached entry so nothing is left behind");
+    assert.equal(sessionBodies[1].id, runtimeSessionId, "re-registration must still use the exact runtime identity");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.ENGRAM_URL;
+    else process.env.ENGRAM_URL = originalUrl;
+    await rm(NODE_MODULES, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #733

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Bind Pi session-attributed writes only to its native runtime session ID.
- Require acknowledged registration before writing and keep failed registration retryable.
- Remove model-supplied session identity from the four native write schemas.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Enforce acknowledged native runtime identity and case-local write declarations. |
| `plugin/pi/test/index-source.test.mjs` | Cover schema, acknowledgement cache, retry, and runtime identity contracts. |
| `plugin/pi/test/native-tool-contract.test.mjs` | Exercise native writes against failed and successful registration. |
| `docs/AGENT-SETUP.md` | Document Pi native runtime binding. |

## 🧪 Test Plan

- [x] `npm test` in `plugin/pi` — 44/44 pass
- [x] `npx --yes @biomejs/biome@2.5.6 lint plugin/pi/index.ts` — 0 errors
- [x] `go test -tags e2e ./internal/server/... -count=1`
- [x] `git diff --check`

---

## 🔗 Chain Context

**Strategy:** sequential PRs to `main`

```text
main
└── PR #730 OpenCode authoritative ownership
    └── Pi runtime binding 📍 (this PR, independent diff)
        └── Core attribution and lifecycle follow-up
```

- **Start:** `main` at `8058269`
- **End:** Pi writes use only acknowledged native runtime identity
- **Dependency:** no code dependency on PR #730; merge after it to preserve review order
- **Follow-up:** core cardinality, store errors, activity, and session-end semantics
- **Out of scope:** OpenCode, Go core, migrations, handles, flags, heartbeats
- **Review budget:** 204 authored changed lines
- **Rollback boundary:** revert this commit to restore only Pi binding behavior

---

## ✅ Contributor Checklist

- [x] I linked approved issue #733
- [x] I added exactly one `type:*` label
- [x] I ran Pi and affected E2E tests
- [x] Docs match this PR slice
- [x] Commit follows Conventional Commits
- [x] No `Co-Authored-By` trailers

## 💬 Notes for Reviewers

Pi native wrappers intentionally remain for their UI. This slice removes lifecycle policy from model arguments: the host runtime ID is authoritative, registration must be acknowledged, and failures stop the write without poisoning retry state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling so saved memories, prompts, summaries, and passive captures consistently use the active Pi runtime session.
  * Prevented writes when a valid runtime session cannot be confirmed, avoiding incorrectly attributed data.
  * Improved reliability when session registration fails, including safe retries and consistent behavior during compaction.
  * Prevented duplicate concurrent session registrations.

* **Documentation**
  * Clarified native session requirements and updated OpenCode setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->