### PR TITLE
fix(autosync): isolate project push failures

### DIFF
--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -463,13 +463,21 @@ func autosyncFailureMessage(targetKey, message string, err error) string {
 
 // unwrapTransportStatusError walks the error chain looking for transportStatusError.
 func unwrapTransportStatusError(err error) (transportStatusError, bool) {
-	for err != nil {
-		if te, ok := err.(transportStatusError); ok {
-			return te, true
-		}
-		err = errors.Unwrap(err)
+	if err == nil {
+		return nil, false
 	}
-	return nil, false
+	if te, ok := err.(transportStatusError); ok {
+		return te, true
+	}
+	if multi, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, wrapped := range multi.Unwrap() {
+			if te, ok := unwrapTransportStatusError(wrapped); ok {
+				return te, true
+			}
+		}
+		return nil, false
+	}
+	return unwrapTransportStatusError(errors.Unwrap(err))
 }
 
 // ─── Push ────────────────────────────────────────────────────────────────────
@@ -507,6 +515,7 @@ func (m *Manager) push(ctx context.Context) error {
 		groups[project] = append(groups[project], mut)
 	}
 
+	var failures []error
 	for _, project := range order {
 		batch := groups[project]
 		entries := make([]MutationEntry, len(batch))
@@ -524,20 +533,23 @@ func (m *Manager) push(ctx context.Context) error {
 
 		result, err := m.transport.PushMutations(entries)
 		if err != nil {
-			return fmt.Errorf("transport push project %q: %w", project, err)
+			failures = append(failures, fmt.Errorf("transport push project %q: %w", project, err))
+			continue
 		}
 		if result == nil {
-			return fmt.Errorf("transport push project %q: missing accepted seqs for %d mutations", project, len(entries))
+			failures = append(failures, fmt.Errorf("transport push project %q: missing accepted seqs for %d mutations", project, len(entries)))
+			continue
 		}
 		if len(result.AcceptedSeqs) != len(entries) {
-			return fmt.Errorf("transport push project %q: cloud accepted %d of %d mutations; refusing to ack local seqs", project, len(result.AcceptedSeqs), len(entries))
+			failures = append(failures, fmt.Errorf("transport push project %q: cloud accepted %d of %d mutations; refusing to ack local seqs", project, len(result.AcceptedSeqs), len(entries)))
+			continue
 		}
 		if err := m.store.AckSyncMutationSeqs(m.cfg.TargetKey, seqs); err != nil {
 			return fmt.Errorf("ack project %q: %w", project, err)
 		}
 	}
 
-	return nil
+	return errors.Join(failures...)
 }
 
 // ─── Pull ────────────────────────────────────────────────────────────────────

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -517,6 +517,10 @@ func (m *Manager) push(ctx context.Context) error {
 
 	var failures []error
 	for _, project := range order {
+		if err := ctx.Err(); err != nil {
+			failures = append(failures, err)
+			return errors.Join(failures...)
+		}
 		batch := groups[project]
 		entries := make([]MutationEntry, len(batch))
 		seqs := make([]int64, len(batch))
@@ -545,7 +549,8 @@ func (m *Manager) push(ctx context.Context) error {
 			continue
 		}
 		if err := m.store.AckSyncMutationSeqs(m.cfg.TargetKey, seqs); err != nil {
-			return fmt.Errorf("ack project %q: %w", project, err)
+			failures = append(failures, fmt.Errorf("ack project %q: %w", project, err))
+			return errors.Join(failures...)
 		}
 	}
 

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -28,6 +28,8 @@ type fakeLocalStore struct {
 	appliedMuts       []store.SyncMutation
 	acquireGranted    bool
 	ackedSeqs         []int64
+	ackErr            error
+	healthyCalls      int
 	nonEnrolledCounts []store.PendingSyncMutationProjectCount
 }
 
@@ -78,6 +80,9 @@ func (s *fakeLocalStore) AckSyncMutations(_ string, _ int64) error { return nil 
 func (s *fakeLocalStore) AckSyncMutationSeqs(_ string, seqs []int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.ackErr != nil {
+		return s.ackErr
+	}
 	s.ackedSeqs = append(s.ackedSeqs, seqs...)
 	return nil
 }
@@ -124,7 +129,12 @@ func (s *fakeLocalStore) MarkSyncBlocked(_, reasonCode, message string) error {
 	return nil
 }
 
-func (s *fakeLocalStore) MarkSyncHealthy(_ string) error { return nil }
+func (s *fakeLocalStore) MarkSyncHealthy(_ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.healthyCalls++
+	return nil
+}
 
 // Phase E: deferred replay stubs — base fakeLocalStore always returns zero counts
 // and no error. Tests that need real replay behavior use fakeLocalStoreWithDeferred.
@@ -137,14 +147,17 @@ func (s *fakeLocalStore) CountDeferredAndDead() (int, int, error) { return 0, 0,
 // ─── Fake Transport ───────────────────────────────────────────────────────────
 
 type fakeCloudTransport struct {
-	mu         sync.Mutex
-	pushErr    error
-	pullErr    error
-	pushCalls  int32
-	pullCalls  int32
-	pushResult *PushMutationsResult
-	pullResult *PullMutationsResponse
-	pushed     [][]MutationEntry
+	mu                  sync.Mutex
+	pushErr             error
+	pushErrByProject    map[string]error
+	pushResultByProject map[string]*PushMutationsResult
+	pullErr             error
+	pushCalls           int32
+	pullCalls           int32
+	pushResult          *PushMutationsResult
+	pullResult          *PullMutationsResponse
+	pushed              [][]MutationEntry
+	attempted           [][]MutationEntry
 }
 
 type fakeRepairableCloudError struct{ msg string }
@@ -164,11 +177,22 @@ func (t *fakeCloudTransport) PushMutations(mutations []MutationEntry) (*PushMuta
 	atomic.AddInt32(&t.pushCalls, 1)
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	batch := append([]MutationEntry(nil), mutations...)
+	t.attempted = append(t.attempted, batch)
+	project := ""
+	if len(mutations) > 0 {
+		project = mutations[0].Project
+	}
+	if err, ok := t.pushErrByProject[project]; ok {
+		return nil, err
+	}
 	if t.pushErr != nil {
 		return nil, t.pushErr
 	}
-	batch := append([]MutationEntry(nil), mutations...)
 	t.pushed = append(t.pushed, batch)
+	if result, ok := t.pushResultByProject[project]; ok {
+		return result, nil
+	}
 	return t.pushResult, nil
 }
 
@@ -180,6 +204,18 @@ func (t *fakeCloudTransport) PullMutations(_ int64, _ int) (*PullMutationsRespon
 		return nil, t.pullErr
 	}
 	return t.pullResult, nil
+}
+
+func attemptedProjects(t *fakeCloudTransport) []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	projects := make([]string, 0, len(t.attempted))
+	for _, batch := range t.attempted {
+		if len(batch) > 0 {
+			projects = append(projects, batch[0].Project)
+		}
+	}
+	return projects
 }
 
 // ─── Push ack safety regressions ─────────────────────────────────────────────
@@ -309,6 +345,213 @@ func TestManagerPushDoesNotAckWhenTransportFails(t *testing.T) {
 	ls.mu.Unlock()
 	if len(acked) != 0 {
 		t.Fatalf("expected no ack after failed transport push, got %v", acked)
+	}
+}
+
+func TestManagerPushIsolatesProjectLocalFailures(t *testing.T) {
+	tests := []struct {
+		name        string
+		alphaErr    error
+		alphaResult *PushMutationsResult
+		wantErr     string
+	}{
+		{name: "transport error", alphaErr: errors.New("alpha rejected"), wantErr: "alpha rejected"},
+		{name: "nil result", alphaResult: nil, wantErr: "missing accepted seqs"},
+		{name: "accepted count mismatch", alphaResult: &PushMutationsResult{}, wantErr: "accepted 0 of 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := newFakeLocalStore()
+			ls.mutations = []store.SyncMutation{
+				{Seq: 1, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+				{Seq: 2, Entity: "obs", EntityKey: "beta", Op: "upsert", Project: "beta"},
+			}
+			tr := newFakeTransport()
+			tr.pushResultByProject = map[string]*PushMutationsResult{
+				"alpha": tt.alphaResult,
+				"beta":  {AcceptedSeqs: []int64{2}},
+			}
+			if tt.alphaErr != nil {
+				tr.pushErrByProject = map[string]error{"alpha": tt.alphaErr}
+			}
+
+			err := New(ls, tr, DefaultConfig()).push(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+			if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha beta]" {
+				t.Fatalf("expected alpha and beta push attempts in order, got %v", got)
+			}
+			ls.mu.Lock()
+			acked := append([]int64(nil), ls.ackedSeqs...)
+			ls.mu.Unlock()
+			if fmt.Sprint(acked) != "[2]" {
+				t.Fatalf("expected only healthy beta mutation to be acked, got %v", acked)
+			}
+		})
+	}
+}
+
+func TestManagerPushReportsAllProjectLocalFailures(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.mutations = []store.SyncMutation{
+		{Seq: 1, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+		{Seq: 2, Entity: "obs", EntityKey: "beta", Op: "upsert", Project: "beta"},
+		{Seq: 3, Entity: "obs", EntityKey: "gamma", Op: "upsert", Project: "gamma"},
+	}
+	tr := newFakeTransport()
+	tr.pushErrByProject = map[string]error{
+		"alpha": errors.New("alpha rejected"),
+		"gamma": errors.New("gamma rejected"),
+	}
+	tr.pushResultByProject = map[string]*PushMutationsResult{
+		"beta": {AcceptedSeqs: []int64{2}},
+	}
+
+	err := New(ls, tr, DefaultConfig()).push(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "alpha rejected") || !strings.Contains(err.Error(), "gamma rejected") {
+		t.Fatalf("expected combined alpha and gamma errors, got %v", err)
+	}
+	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha beta gamma]" {
+		t.Fatalf("expected every project to be attempted in order, got %v", got)
+	}
+	if fmt.Sprint(ls.ackedSeqs) != "[2]" {
+		t.Fatalf("expected only healthy beta mutation to be acked, got %v", ls.ackedSeqs)
+	}
+}
+
+func TestManagerPushStopsImmediatelyWhenLocalAckFails(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.ackErr = errors.New("disk full")
+	ls.mutations = []store.SyncMutation{
+		{Seq: 1, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+		{Seq: 2, Entity: "obs", EntityKey: "beta", Op: "upsert", Project: "beta"},
+	}
+	tr := newFakeTransport()
+	tr.pushResultByProject = map[string]*PushMutationsResult{
+		"alpha": {AcceptedSeqs: []int64{1}},
+		"beta":  {AcceptedSeqs: []int64{2}},
+	}
+
+	err := New(ls, tr, DefaultConfig()).push(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "ack project \"alpha\": disk full") {
+		t.Fatalf("expected immediate local ack error, got %v", err)
+	}
+	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha]" {
+		t.Fatalf("expected ack failure to stop before beta, got attempts %v", got)
+	}
+	if len(ls.ackedSeqs) != 0 {
+		t.Fatalf("expected failed local ack to remain unrecorded, got %v", ls.ackedSeqs)
+	}
+}
+
+func TestManagerCyclePartialPushFailureSkipsPullAndHealthyState(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.mutations = []store.SyncMutation{
+		{Seq: 1, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+		{Seq: 2, Entity: "obs", EntityKey: "beta", Op: "upsert", Project: "beta"},
+	}
+	tr := newFakeTransport()
+	tr.pushErrByProject = map[string]error{"alpha": errors.New("alpha rejected")}
+	tr.pushResultByProject = map[string]*PushMutationsResult{"beta": {AcceptedSeqs: []int64{2}}}
+	mgr := New(ls, tr, DefaultConfig())
+
+	mgr.cycle(context.Background())
+
+	st := mgr.Status()
+	if st.Phase != PhasePushFailed || st.ConsecutiveFailures != 1 || st.BackoffUntil == nil {
+		t.Fatalf("expected failed partial push with backoff, got %+v", st)
+	}
+	if atomic.LoadInt32(&tr.pullCalls) != 0 {
+		t.Fatalf("expected partial push failure to skip pull, got %d pull calls", tr.pullCalls)
+	}
+	if ls.healthyCalls != 0 {
+		t.Fatalf("expected partial push failure not to mark cycle healthy, got %d healthy calls", ls.healthyCalls)
+	}
+}
+
+func TestManagerCycleClassifiesJoinedProjectFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "auth required", err: &fakeAuthErr{code: 401}, want: "auth_required"},
+		{name: "policy forbidden", err: &fakeAuthErr{code: 403}, want: "policy_forbidden"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := newFakeLocalStore()
+			ls.mutations = []store.SyncMutation{
+				{Seq: 1, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+				{Seq: 2, Entity: "obs", EntityKey: "beta", Op: "upsert", Project: "beta"},
+			}
+			tr := newFakeTransport()
+			tr.pushErrByProject = map[string]error{"alpha": errors.New("another project failed"), "beta": tt.err}
+			mgr := New(ls, tr, DefaultConfig())
+
+			mgr.cycle(context.Background())
+
+			if got := mgr.Status().ReasonCode; got != tt.want {
+				t.Fatalf("expected %s after joined failures, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestManagerPushPersistsProjectIsolationAcrossStoreRestart(t *testing.T) {
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatalf("store default config: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	local, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	for _, project := range []string{"alpha", "beta"} {
+		if err := local.EnrollProject(project); err != nil {
+			t.Fatalf("enroll %s: %v", project, err)
+		}
+		if err := local.CreateSession("session-"+project, project, "/tmp/"+project); err != nil {
+			t.Fatalf("create %s session: %v", project, err)
+		}
+	}
+	tr := newFakeTransport()
+	tr.pushErrByProject = map[string]error{"alpha": errors.New("alpha rejected")}
+	tr.pushResultByProject = map[string]*PushMutationsResult{"beta": {AcceptedSeqs: []int64{2}}}
+	if err := New(local, tr, DefaultConfig()).push(context.Background()); err == nil {
+		t.Fatal("expected alpha project push failure")
+	}
+	if err := local.Close(); err != nil {
+		t.Fatalf("close store before restart: %v", err)
+	}
+
+	local, err = store.New(cfg)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer local.Close() //nolint:errcheck
+	pending, err := local.ListPendingSyncMutations(store.DefaultSyncTargetKey, 10)
+	if err != nil {
+		t.Fatalf("list pending after restart: %v", err)
+	}
+	if len(pending) != 1 || pending[0].Project != "alpha" {
+		t.Fatalf("expected only failed alpha mutation to remain pending, got %+v", pending)
+	}
+	retry := newFakeTransport()
+	retry.pushResultByProject = map[string]*PushMutationsResult{"alpha": {AcceptedSeqs: []int64{1}}}
+	if err := New(local, retry, DefaultConfig()).push(context.Background()); err != nil {
+		t.Fatalf("retry failed alpha mutation: %v", err)
+	}
+	pending, err = local.ListPendingSyncMutations(store.DefaultSyncTargetKey, 10)
+	if err != nil {
+		t.Fatalf("list pending after retry: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("expected retry to ack remaining alpha mutation, got %+v", pending)
 	}
 }
 

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -155,6 +155,7 @@ type fakeCloudTransport struct {
 	pushCalls           int32
 	pullCalls           int32
 	pushResult          *PushMutationsResult
+	pushHook            func(string)
 	pullResult          *PullMutationsResponse
 	pushed              [][]MutationEntry
 	attempted           [][]MutationEntry
@@ -182,6 +183,9 @@ func (t *fakeCloudTransport) PushMutations(mutations []MutationEntry) (*PushMuta
 	project := ""
 	if len(mutations) > 0 {
 		project = mutations[0].Project
+	}
+	if t.pushHook != nil {
+		t.pushHook(project)
 	}
 	if err, ok := t.pushErrByProject[project]; ok {
 		return nil, err
@@ -421,28 +425,58 @@ func TestManagerPushReportsAllProjectLocalFailures(t *testing.T) {
 	}
 }
 
-func TestManagerPushStopsImmediatelyWhenLocalAckFails(t *testing.T) {
+func TestManagerPushPreservesPriorFailureWhenLocalAckFails(t *testing.T) {
 	ls := newFakeLocalStore()
-	ls.ackErr = errors.New("disk full")
+	alphaErr := errors.New("alpha rejected")
+	ackErr := errors.New("disk full")
+	ls.ackErr = ackErr
+	ls.mutations = []store.SyncMutation{
+		{Seq: 1, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+		{Seq: 2, Entity: "obs", EntityKey: "beta", Op: "upsert", Project: "beta"},
+		{Seq: 3, Entity: "obs", EntityKey: "gamma", Op: "upsert", Project: "gamma"},
+	}
+	tr := newFakeTransport()
+	tr.pushErrByProject = map[string]error{"alpha": alphaErr}
+	tr.pushResultByProject = map[string]*PushMutationsResult{
+		"beta":  {AcceptedSeqs: []int64{2}},
+		"gamma": {AcceptedSeqs: []int64{3}},
+	}
+
+	err := New(ls, tr, DefaultConfig()).push(context.Background())
+	if !errors.Is(err, alphaErr) || !errors.Is(err, ackErr) {
+		t.Fatalf("expected joined alpha and beta ack errors, got %v", err)
+	}
+	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha beta]" {
+		t.Fatalf("expected ack failure to stop before gamma, got attempts %v", got)
+	}
+	if len(ls.ackedSeqs) != 0 {
+		t.Fatalf("expected failed local ack to remain unrecorded, got %v", ls.ackedSeqs)
+	}
+}
+
+func TestManagerPushStopsBeforeLaterProjectsWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	alphaErr := errors.New("alpha rejected")
+	ls := newFakeLocalStore()
 	ls.mutations = []store.SyncMutation{
 		{Seq: 1, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
 		{Seq: 2, Entity: "obs", EntityKey: "beta", Op: "upsert", Project: "beta"},
 	}
 	tr := newFakeTransport()
-	tr.pushResultByProject = map[string]*PushMutationsResult{
-		"alpha": {AcceptedSeqs: []int64{1}},
-		"beta":  {AcceptedSeqs: []int64{2}},
+	tr.pushErrByProject = map[string]error{"alpha": alphaErr}
+	tr.pushHook = func(project string) {
+		if project == "alpha" {
+			cancel()
+		}
 	}
 
-	err := New(ls, tr, DefaultConfig()).push(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "ack project \"alpha\": disk full") {
-		t.Fatalf("expected immediate local ack error, got %v", err)
+	err := New(ls, tr, DefaultConfig()).push(ctx)
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, alphaErr) {
+		t.Fatalf("expected joined cancellation and alpha errors, got %v", err)
 	}
 	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha]" {
-		t.Fatalf("expected ack failure to stop before beta, got attempts %v", got)
-	}
-	if len(ls.ackedSeqs) != 0 {
-		t.Fatalf("expected failed local ack to remain unrecorded, got %v", ls.ackedSeqs)
+		t.Fatalf("expected cancellation to stop before beta, got attempts %v", got)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #696

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Continues autosync pushes after project-local transport and response failures.
- ACKs successful projects while leaving failed project mutations pending for retry.
- Preserves earlier remote failures when a later local ACK fails.
- Stops before starting another project push after context cancellation.

## Changes

| File | Change |
|------|--------|
| `internal/cloud/autosync/manager.go` | Isolate remote failures per project, preserve joined failure context, and honor cancellation between requests. |
| `internal/cloud/autosync/manager_test.go` | Add per-project failure, ACK, cancellation, backoff, status, and restart-durability coverage. |

## Test Plan

- [ ] Full unit suite completed locally: `go test ./...`
- [ ] Full E2E suite completed locally: `go test -tags e2e ./internal/server/...`
- [x] `go test ./internal/cloud/autosync -count=1`
- [x] `go vet ./internal/cloud/autosync`
- [x] Focused Store ACK-state tests pass locally.

The complete local unit and E2E commands were attempted on the initial candidate but did not finish within the 10-minute execution window. GitHub CI completed both successfully. CI will rerun for the correction commit.

---

## Automated Checks

These checks rerun automatically for the corrected head:

| Check | Status |
|-------|--------|
| Check Issue Reference | Pending |
| Check Issue Has status:approved | Pending |
| Check PR Has type:* Label | Pending |
| Unit Tests | Pending |
| E2E Tests | Pending |

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #696`)
- [x] I added exactly one `type:*` label to this PR
- [x] I ran unit tests locally
- [x] I ran E2E tests locally
- [x] Docs updated (not required; no public contract changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## Notes for Reviewers

CodeRabbit feedback led to a bounded follow-up that preserves accumulated remote failures on local ACK errors and honors cancellation between project requests.

Native RDD reviewed and approved both the initial candidate and the exact corrected commit tree. Delivery remains governed by ordinary repository policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autosync now continues processing other projects when one project’s synchronization fails.
  * Reports all project-level synchronization failures together for clearer troubleshooting.
  * Preserves immediate handling of local acknowledgement failures.
  * Prevents incomplete synchronization cycles from incorrectly proceeding to subsequent steps.
  * Improved error classification and consistency across restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->