### PR TITLE
fix(store): reject empty sync fields

### DIFF
--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Gentleman-Programming/engram/internal/project"
 	"github.com/Gentleman-Programming/engram/internal/store"
 	mcppkg "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 func newMCPTestStore(t *testing.T) *store.Store {
@@ -292,6 +293,71 @@ func TestHandleSaveRejectsMissingContent(t *testing.T) {
 	}
 	if len(obs) != 0 {
 		t.Fatalf("expected no observation to be written, got %#v", obs)
+	}
+}
+
+func TestSaveHandlersExposeStoreAdmissionErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		handler   server.ToolHandlerFunc
+		arguments map[string]any
+		wantError string
+		countRows func(*store.Store) (int, error)
+	}{
+		{
+			name:      "observation title",
+			arguments: map[string]any{"title": " \t\n ", "content": "valid content", "project": "engram"},
+			wantError: "Failed to save: observation title is required",
+			countRows: func(s *store.Store) (int, error) {
+				var count int
+				err := s.DB().QueryRow(`SELECT count(*) FROM observations`).Scan(&count)
+				return count, err
+			},
+		},
+		{
+			name:      "prompt content",
+			arguments: map[string]any{"content": " \t\n ", "project": "engram"},
+			wantError: "Failed to save prompt: prompt content is required",
+			countRows: func(s *store.Store) (int, error) {
+				var count int
+				err := s.DB().QueryRow(`SELECT count(*) FROM user_prompts`).Scan(&count)
+				return count, err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newMCPTestStore(t)
+			if tc.name == "observation title" {
+				tc.handler = handleSave(s, MCPConfig{}, nil)
+			} else {
+				tc.handler = handleSavePrompt(s, MCPConfig{}, nil)
+			}
+
+			before, err := tc.countRows(s)
+			if err != nil {
+				t.Fatalf("count rows before invalid write: %v", err)
+			}
+			res, err := tc.handler(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: tc.arguments}})
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatalf("expected tool error, got %q", callResultText(t, res))
+			}
+			if got := callResultText(t, res); got != tc.wantError {
+				t.Fatalf("expected error %q, got %q", tc.wantError, got)
+			}
+
+			after, err := tc.countRows(s)
+			if err != nil {
+				t.Fatalf("count rows after invalid write: %v", err)
+			}
+			if after != before {
+				t.Fatalf("invalid write persisted a primary row: %d->%d", before, after)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -7442,7 +7442,7 @@ func seedMCPMatchModeFixture(t *testing.T, s *store.Store) {
 		t.Fatalf("create session: %v", err)
 	}
 	obs := []store.AddObservationParams{
-		{SessionID: "s-mcp-matchmode", Type: "decision", Title: "Auth session middleware", Content: "", Project: "engram", Scope: "project"},
+		{SessionID: "s-mcp-matchmode", Type: "decision", Title: "Auth session middleware", Content: "request routing layer", Project: "engram", Scope: "project"},
 		{SessionID: "s-mcp-matchmode", Type: "decision", Title: "Compliance audit notes", Content: "session policy", Project: "engram", Scope: "project"},
 		{SessionID: "s-mcp-matchmode", Type: "decision", Title: "OAuth tokens", Content: "auth and compliance", Project: "engram", Scope: "project"},
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -338,7 +338,8 @@ func (s *Server) handleAddObservation(w http.ResponseWriter, r *http.Request) {
 	id, err := s.store.AddObservation(body)
 	if err != nil {
 		switch {
-		case errors.Is(err, store.ErrObservationTitleRequired):
+		case errors.Is(err, store.ErrObservationTitleRequired),
+			errors.Is(err, store.ErrObservationContentRequired):
 			jsonError(w, http.StatusBadRequest, err.Error())
 		default:
 			jsonError(w, http.StatusInternalServerError, err.Error())
@@ -471,7 +472,8 @@ func (s *Server) handleUpdateObservation(w http.ResponseWriter, r *http.Request)
 	obs, err := s.store.UpdateObservation(id, body)
 	if err != nil {
 		switch {
-		case errors.Is(err, store.ErrObservationTitleRequired):
+		case errors.Is(err, store.ErrObservationTitleRequired),
+			errors.Is(err, store.ErrObservationContentRequired):
 			jsonError(w, http.StatusBadRequest, err.Error())
 		default:
 			jsonError(w, http.StatusNotFound, err.Error())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -337,7 +337,12 @@ func (s *Server) handleAddObservation(w http.ResponseWriter, r *http.Request) {
 
 	id, err := s.store.AddObservation(body)
 	if err != nil {
-		jsonError(w, http.StatusInternalServerError, err.Error())
+		switch {
+		case errors.Is(err, store.ErrObservationTitleRequired):
+			jsonError(w, http.StatusBadRequest, err.Error())
+		default:
+			jsonError(w, http.StatusInternalServerError, err.Error())
+		}
 		return
 	}
 
@@ -465,7 +470,12 @@ func (s *Server) handleUpdateObservation(w http.ResponseWriter, r *http.Request)
 
 	obs, err := s.store.UpdateObservation(id, body)
 	if err != nil {
-		jsonError(w, http.StatusNotFound, err.Error())
+		switch {
+		case errors.Is(err, store.ErrObservationTitleRequired):
+			jsonError(w, http.StatusBadRequest, err.Error())
+		default:
+			jsonError(w, http.StatusNotFound, err.Error())
+		}
 		return
 	}
 
@@ -626,7 +636,12 @@ func (s *Server) handleAddPrompt(w http.ResponseWriter, r *http.Request) {
 
 	id, err := s.store.AddPrompt(body)
 	if err != nil {
-		jsonError(w, http.StatusInternalServerError, err.Error())
+		switch {
+		case errors.Is(err, store.ErrPromptContentRequired):
+			jsonError(w, http.StatusBadRequest, err.Error())
+		default:
+			jsonError(w, http.StatusInternalServerError, err.Error())
+		}
 		return
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -349,6 +349,64 @@ func TestAdditionalServerErrorBranches(t *testing.T) {
 	}
 }
 
+func TestWriteHandlersRejectWhitespaceOnlyRequiredFields(t *testing.T) {
+	st := newServerTestStore(t)
+	srv := New(st, 0)
+	h := srv.Handler()
+
+	if err := st.CreateSession("s-whitespace", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	observationID, err := st.AddObservation(store.AddObservationParams{
+		SessionID: "s-whitespace",
+		Type:      "decision",
+		Title:     "Original title",
+		Content:   "Original content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	assertBadRequest := func(method, path, body string) {
+		t.Helper()
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %s %s, got %d body=%s", method, path, rec.Code, rec.Body.String())
+		}
+	}
+
+	assertBadRequest(http.MethodPost, "/observations", `{"session_id":"s-whitespace","type":"decision","title":" \t\n ","content":"Invalid observation","project":"engram"}`)
+	assertBadRequest(http.MethodPatch, fmt.Sprintf("/observations/%d", observationID), `{"title":" \t\n "}`)
+	assertBadRequest(http.MethodPost, "/prompts", `{"session_id":"s-whitespace","content":" \t\n ","project":"engram"}`)
+
+	var observationCount, promptCount int
+	if err := st.DB().QueryRow(`SELECT count(*) FROM observations`).Scan(&observationCount); err != nil {
+		t.Fatalf("count observations: %v", err)
+	}
+	if observationCount != 1 {
+		t.Fatalf("expected invalid observation create not to persist, got %d observations", observationCount)
+	}
+	if err := st.DB().QueryRow(`SELECT count(*) FROM user_prompts`).Scan(&promptCount); err != nil {
+		t.Fatalf("count prompts: %v", err)
+	}
+	if promptCount != 0 {
+		t.Fatalf("expected invalid prompt create not to persist, got %d prompts", promptCount)
+	}
+
+	observation, err := st.GetObservation(observationID)
+	if err != nil {
+		t.Fatalf("get seeded observation: %v", err)
+	}
+	if observation.Title != "Original title" {
+		t.Fatalf("expected invalid observation update not to persist, got title %q", observation.Title)
+	}
+}
+
 func TestHandleReviewListAndMarkReviewed(t *testing.T) {
 	st := newServerTestStore(t)
 	srv := New(st, 0)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -381,7 +381,9 @@ func TestWriteHandlersRejectWhitespaceOnlyRequiredFields(t *testing.T) {
 	}
 
 	assertBadRequest(http.MethodPost, "/observations", `{"session_id":"s-whitespace","type":"decision","title":" \t\n ","content":"Invalid observation","project":"engram"}`)
+	assertBadRequest(http.MethodPost, "/observations", `{"session_id":"s-whitespace","type":"decision","title":"Valid title","content":" \t\n ","project":"engram"}`)
 	assertBadRequest(http.MethodPatch, fmt.Sprintf("/observations/%d", observationID), `{"title":" \t\n "}`)
+	assertBadRequest(http.MethodPatch, fmt.Sprintf("/observations/%d", observationID), `{"content":" \t\n "}`)
 	assertBadRequest(http.MethodPost, "/prompts", `{"session_id":"s-whitespace","content":" \t\n ","project":"engram"}`)
 
 	var observationCount, promptCount int
@@ -404,6 +406,9 @@ func TestWriteHandlersRejectWhitespaceOnlyRequiredFields(t *testing.T) {
 	}
 	if observation.Title != "Original title" {
 		t.Fatalf("expected invalid observation update not to persist, got title %q", observation.Title)
+	}
+	if observation.Content != "Original content" {
+		t.Fatalf("expected invalid observation update not to persist, got content %q", observation.Content)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -43,14 +43,16 @@ var sqliteWriteRetryBackoffs = []time.Duration{
 	50 * time.Millisecond,
 }
 
-// Sentinel errors returned by delete operations so callers can use errors.Is.
+// Sentinel errors returned by Store operations so callers can use errors.Is.
 var (
-	ErrSessionNotFound        = errors.New("session not found")
-	ErrSessionHasObservations = errors.New("session still has observations")
-	ErrSessionDeleteBlocked   = errors.New("session deletion is blocked while cloud sync enrollment is active")
-	ErrObservationNotFound    = errors.New("observation not found")
-	ErrPromptNotFound         = errors.New("prompt not found")
-	ErrProjectNotFound        = errors.New("project not found")
+	ErrSessionNotFound          = errors.New("session not found")
+	ErrSessionHasObservations   = errors.New("session still has observations")
+	ErrSessionDeleteBlocked     = errors.New("session deletion is blocked while cloud sync enrollment is active")
+	ErrObservationNotFound      = errors.New("observation not found")
+	ErrPromptNotFound           = errors.New("prompt not found")
+	ErrProjectNotFound          = errors.New("project not found")
+	ErrObservationTitleRequired = errors.New("observation title is required")
+	ErrPromptContentRequired    = errors.New("prompt content is required")
 )
 
 // Sentinel errors for relation sync apply path (Phase 2).
@@ -2255,6 +2257,9 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 	// Strip <private>...</private> tags before persisting ANYTHING
 	title := stripPrivateTags(p.Title)
 	content := stripPrivateTags(p.Content)
+	if title == "" {
+		return 0, ErrObservationTitleRequired
+	}
 
 	if len(content) > s.cfg.MaxObservationLength {
 		content = content[:s.cfg.MaxObservationLength] + "... [truncated]"
@@ -2551,6 +2556,9 @@ func (s *Store) AddPrompt(p AddPromptParams) (int64, error) {
 	p.Project, _ = NormalizeProject(p.Project)
 
 	content := s.preparePromptContent(p.Content)
+	if content == "" {
+		return 0, ErrPromptContentRequired
+	}
 
 	var promptID int64
 	err := s.withTx(func(tx *sql.Tx) error {
@@ -2590,6 +2598,9 @@ func (s *Store) AddPrompt(p AddPromptParams) (int64, error) {
 func (s *Store) AddPromptIfMissing(p AddPromptParams) (int64, bool, error) {
 	p.Project, _ = NormalizeProject(p.Project)
 	content := s.preparePromptContent(p.Content)
+	if content == "" {
+		return 0, false, ErrPromptContentRequired
+	}
 
 	var promptID int64
 	inserted := false
@@ -2862,6 +2873,10 @@ func (s *Store) GetObservation(id int64) (*Observation, error) {
 }
 
 func (s *Store) UpdateObservation(id int64, p UpdateObservationParams) (*Observation, error) {
+	if p.Title != nil && stripPrivateTags(*p.Title) == "" {
+		return nil, ErrObservationTitleRequired
+	}
+
 	var updated *Observation
 	err := s.withTx(func(tx *sql.Tx) error {
 		obs, err := s.getObservationTx(tx, id)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -45,14 +45,15 @@ var sqliteWriteRetryBackoffs = []time.Duration{
 
 // Sentinel errors returned by Store operations so callers can use errors.Is.
 var (
-	ErrSessionNotFound          = errors.New("session not found")
-	ErrSessionHasObservations   = errors.New("session still has observations")
-	ErrSessionDeleteBlocked     = errors.New("session deletion is blocked while cloud sync enrollment is active")
-	ErrObservationNotFound      = errors.New("observation not found")
-	ErrPromptNotFound           = errors.New("prompt not found")
-	ErrProjectNotFound          = errors.New("project not found")
-	ErrObservationTitleRequired = errors.New("observation title is required")
-	ErrPromptContentRequired    = errors.New("prompt content is required")
+	ErrSessionNotFound            = errors.New("session not found")
+	ErrSessionHasObservations     = errors.New("session still has observations")
+	ErrSessionDeleteBlocked       = errors.New("session deletion is blocked while cloud sync enrollment is active")
+	ErrObservationNotFound        = errors.New("observation not found")
+	ErrPromptNotFound             = errors.New("prompt not found")
+	ErrProjectNotFound            = errors.New("project not found")
+	ErrObservationTitleRequired   = errors.New("observation title is required")
+	ErrObservationContentRequired = errors.New("observation content is required")
+	ErrPromptContentRequired      = errors.New("prompt content is required")
 )
 
 // Sentinel errors for relation sync apply path (Phase 2).
@@ -2260,6 +2261,9 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 	if title == "" {
 		return 0, ErrObservationTitleRequired
 	}
+	if content == "" {
+		return 0, ErrObservationContentRequired
+	}
 
 	if len(content) > s.cfg.MaxObservationLength {
 		content = content[:s.cfg.MaxObservationLength] + "... [truncated]"
@@ -2875,6 +2879,9 @@ func (s *Store) GetObservation(id int64) (*Observation, error) {
 func (s *Store) UpdateObservation(id int64, p UpdateObservationParams) (*Observation, error) {
 	if p.Title != nil && stripPrivateTags(*p.Title) == "" {
 		return nil, ErrObservationTitleRequired
+	}
+	if p.Content != nil && stripPrivateTags(*p.Content) == "" {
+		return nil, ErrObservationContentRequired
 	}
 
 	var updated *Observation

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -221,22 +221,27 @@ func TestUpdateObservationRejectsBlankTitleBeforePersistenceAndSync(t *testing.T
 }
 
 func TestAddPromptRejectsBlankContentBeforePersistenceAndSync(t *testing.T) {
+	type addResult struct {
+		err      error
+		inserted *bool
+	}
+
 	for _, tc := range []struct {
 		name string
-		add  func(*Store) error
+		add  func(*Store) addResult
 	}{
 		{
 			name: "add prompt",
-			add: func(s *Store) error {
+			add: func(s *Store) addResult {
 				_, err := s.AddPrompt(AddPromptParams{SessionID: "s-prompt-admission", Content: " \t\n ", Project: "engram"})
-				return err
+				return addResult{err: err}
 			},
 		},
 		{
 			name: "add prompt if missing",
-			add: func(s *Store) error {
-				_, _, err := s.AddPromptIfMissing(AddPromptParams{SessionID: "s-prompt-admission", Content: " \t\n ", Project: "engram"})
-				return err
+			add: func(s *Store) addResult {
+				_, inserted, err := s.AddPromptIfMissing(AddPromptParams{SessionID: "s-prompt-admission", Content: " \t\n ", Project: "engram"})
+				return addResult{err: err, inserted: &inserted}
 			},
 		},
 	} {
@@ -254,9 +259,12 @@ func TestAddPromptRejectsBlankContentBeforePersistenceAndSync(t *testing.T) {
 				t.Fatalf("count sync mutations before invalid write: %v", err)
 			}
 
-			err := tc.add(s)
-			if !errors.Is(err, ErrPromptContentRequired) {
-				t.Fatalf("expected ErrPromptContentRequired, got %v", err)
+			result := tc.add(s)
+			if !errors.Is(result.err, ErrPromptContentRequired) {
+				t.Fatalf("expected ErrPromptContentRequired, got %v", result.err)
+			}
+			if result.inserted != nil && *result.inserted {
+				t.Fatal("expected invalid AddPromptIfMissing call not to insert")
 			}
 
 			var promptsAfter, mutationsAfter int

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -220,6 +220,112 @@ func TestUpdateObservationRejectsBlankTitleBeforePersistenceAndSync(t *testing.T
 	}
 }
 
+func TestAddObservationRejectsBlankContentBeforePersistenceAndSync(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-content-admission", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	seedID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-content-admission",
+		Type:      "decision",
+		Title:     "Existing title",
+		Content:   "Existing content",
+		Project:   "engram",
+		Scope:     "project",
+		TopicKey:  "architecture/content-admission",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	var observationsBefore, mutationsBefore int
+	if err := s.db.QueryRow(`SELECT count(*) FROM observations`).Scan(&observationsBefore); err != nil {
+		t.Fatalf("count observations before invalid write: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count sync mutations before invalid write: %v", err)
+	}
+
+	_, err = s.AddObservation(AddObservationParams{
+		SessionID: "s-content-admission",
+		Type:      "decision",
+		Title:     "Replacement title",
+		Content:   " \t\n ",
+		Project:   "engram",
+		Scope:     "project",
+		TopicKey:  "architecture/content-admission",
+	})
+	if !errors.Is(err, ErrObservationContentRequired) {
+		t.Fatalf("expected ErrObservationContentRequired, got %v", err)
+	}
+
+	var observationsAfter, mutationsAfter int
+	if err := s.db.QueryRow(`SELECT count(*) FROM observations`).Scan(&observationsAfter); err != nil {
+		t.Fatalf("count observations after invalid write: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count sync mutations after invalid write: %v", err)
+	}
+	if observationsAfter != observationsBefore || mutationsAfter != mutationsBefore {
+		t.Fatalf("invalid observation changed persistence: observations %d->%d, mutations %d->%d", observationsBefore, observationsAfter, mutationsBefore, mutationsAfter)
+	}
+
+	seed, err := s.GetObservation(seedID)
+	if err != nil {
+		t.Fatalf("get seeded observation: %v", err)
+	}
+	if seed.Title != "Existing title" || seed.Content != "Existing content" {
+		t.Fatalf("invalid topic-key upsert changed existing observation: %#v", seed)
+	}
+}
+
+func TestUpdateObservationRejectsBlankContentBeforePersistenceAndSync(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-update-content-admission", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-update-content-admission",
+		Type:      "decision",
+		Title:     "Original title",
+		Content:   "Original content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	var mutationsBefore int
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count sync mutations before invalid update: %v", err)
+	}
+
+	blankContent := " \t\n "
+	_, err = s.UpdateObservation(id, UpdateObservationParams{Content: &blankContent})
+	if !errors.Is(err, ErrObservationContentRequired) {
+		t.Fatalf("expected ErrObservationContentRequired, got %v", err)
+	}
+
+	var mutationsAfter int
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count sync mutations after invalid update: %v", err)
+	}
+	if mutationsAfter != mutationsBefore {
+		t.Fatalf("invalid observation update enqueued a sync mutation: %d->%d", mutationsBefore, mutationsAfter)
+	}
+
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("get seeded observation: %v", err)
+	}
+	if obs.Content != "Original content" {
+		t.Fatalf("invalid update changed content to %q", obs.Content)
+	}
+}
+
 func TestAddPromptRejectsBlankContentBeforePersistenceAndSync(t *testing.T) {
 	type addResult struct {
 		err      error
@@ -8804,7 +8910,7 @@ func TestMostRecentActiveSessionScopedByProject(t *testing.T) {
 // seedMatchModeFixture creates a session and three observations with partial
 // token overlap — no single observation contains all three query tokens.
 //
-//	obs1: title "Auth session middleware"       content ""
+//	obs1: title "Auth session middleware"       content "request routing layer"
 //	obs2: title "Compliance audit notes"        content "session policy"
 //	obs3: title "OAuth tokens"                  content "auth and compliance"
 func seedMatchModeFixture(t *testing.T, s *Store) {
@@ -8813,7 +8919,7 @@ func seedMatchModeFixture(t *testing.T, s *Store) {
 		t.Fatalf("create session: %v", err)
 	}
 	obs := []AddObservationParams{
-		{SessionID: "s-matchmode", Type: "decision", Title: "Auth session middleware", Content: "", Project: "engram", Scope: "project"},
+		{SessionID: "s-matchmode", Type: "decision", Title: "Auth session middleware", Content: "request routing layer", Project: "engram", Scope: "project"},
 		{SessionID: "s-matchmode", Type: "decision", Title: "Compliance audit notes", Content: "session policy", Project: "engram", Scope: "project"},
 		{SessionID: "s-matchmode", Type: "decision", Title: "OAuth tokens", Content: "auth and compliance", Project: "engram", Scope: "project"},
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -114,6 +114,165 @@ func TestAddObservationDeduplicatesWithinWindow(t *testing.T) {
 	}
 }
 
+func TestAddObservationRejectsBlankTitleBeforePersistenceAndSync(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-admission", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	seedID, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-admission",
+		Type:      "decision",
+		Title:     "Existing title",
+		Content:   "Existing content",
+		Project:   "engram",
+		Scope:     "project",
+		TopicKey:  "architecture/admission",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	var observationsBefore, mutationsBefore int
+	if err := s.db.QueryRow(`SELECT count(*) FROM observations`).Scan(&observationsBefore); err != nil {
+		t.Fatalf("count observations before invalid write: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count sync mutations before invalid write: %v", err)
+	}
+
+	_, err = s.AddObservation(AddObservationParams{
+		SessionID: "s-admission",
+		Type:      "decision",
+		Title:     " \t\n ",
+		Content:   "Replacement content",
+		Project:   "engram",
+		Scope:     "project",
+		TopicKey:  "architecture/admission",
+	})
+	if !errors.Is(err, ErrObservationTitleRequired) {
+		t.Fatalf("expected ErrObservationTitleRequired, got %v", err)
+	}
+
+	var observationsAfter, mutationsAfter int
+	if err := s.db.QueryRow(`SELECT count(*) FROM observations`).Scan(&observationsAfter); err != nil {
+		t.Fatalf("count observations after invalid write: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count sync mutations after invalid write: %v", err)
+	}
+	if observationsAfter != observationsBefore || mutationsAfter != mutationsBefore {
+		t.Fatalf("invalid observation changed persistence: observations %d->%d, mutations %d->%d", observationsBefore, observationsAfter, mutationsBefore, mutationsAfter)
+	}
+
+	seed, err := s.GetObservation(seedID)
+	if err != nil {
+		t.Fatalf("get seeded observation: %v", err)
+	}
+	if seed.Title != "Existing title" || seed.Content != "Existing content" {
+		t.Fatalf("invalid topic-key upsert changed existing observation: %#v", seed)
+	}
+}
+
+func TestUpdateObservationRejectsBlankTitleBeforePersistenceAndSync(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-update-admission", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-update-admission",
+		Type:      "decision",
+		Title:     "Original title",
+		Content:   "Original content",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("seed observation: %v", err)
+	}
+
+	var mutationsBefore int
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count sync mutations before invalid update: %v", err)
+	}
+
+	blankTitle := " \t\n "
+	_, err = s.UpdateObservation(id, UpdateObservationParams{Title: &blankTitle})
+	if !errors.Is(err, ErrObservationTitleRequired) {
+		t.Fatalf("expected ErrObservationTitleRequired, got %v", err)
+	}
+
+	var mutationsAfter int
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count sync mutations after invalid update: %v", err)
+	}
+	if mutationsAfter != mutationsBefore {
+		t.Fatalf("invalid observation update enqueued a sync mutation: %d->%d", mutationsBefore, mutationsAfter)
+	}
+
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("get seeded observation: %v", err)
+	}
+	if obs.Title != "Original title" {
+		t.Fatalf("invalid update changed title to %q", obs.Title)
+	}
+}
+
+func TestAddPromptRejectsBlankContentBeforePersistenceAndSync(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		add  func(*Store) error
+	}{
+		{
+			name: "add prompt",
+			add: func(s *Store) error {
+				_, err := s.AddPrompt(AddPromptParams{SessionID: "s-prompt-admission", Content: " \t\n ", Project: "engram"})
+				return err
+			},
+		},
+		{
+			name: "add prompt if missing",
+			add: func(s *Store) error {
+				_, _, err := s.AddPromptIfMissing(AddPromptParams{SessionID: "s-prompt-admission", Content: " \t\n ", Project: "engram"})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			if err := s.CreateSession("s-prompt-admission", "engram", "/tmp/engram"); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+
+			var promptsBefore, mutationsBefore int
+			if err := s.db.QueryRow(`SELECT count(*) FROM user_prompts`).Scan(&promptsBefore); err != nil {
+				t.Fatalf("count prompts before invalid write: %v", err)
+			}
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+				t.Fatalf("count sync mutations before invalid write: %v", err)
+			}
+
+			err := tc.add(s)
+			if !errors.Is(err, ErrPromptContentRequired) {
+				t.Fatalf("expected ErrPromptContentRequired, got %v", err)
+			}
+
+			var promptsAfter, mutationsAfter int
+			if err := s.db.QueryRow(`SELECT count(*) FROM user_prompts`).Scan(&promptsAfter); err != nil {
+				t.Fatalf("count prompts after invalid write: %v", err)
+			}
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+				t.Fatalf("count sync mutations after invalid write: %v", err)
+			}
+			if promptsAfter != promptsBefore || mutationsAfter != mutationsBefore {
+				t.Fatalf("invalid prompt changed persistence: prompts %d->%d, mutations %d->%d", promptsBefore, promptsAfter, mutationsBefore, mutationsAfter)
+			}
+		})
+	}
+}
+
 func TestScopeFiltersSearchAndContext(t *testing.T) {
 	s := newTestStore(t)
 


### PR DESCRIPTION
## Linked Issues

Closes #686
Closes #695

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Rejects blank normalized observation titles and prompt content at the Store admission boundary.
- Keeps invalid writes from reaching persistence or the sync journal.
- Returns HTTP 400 for these client admission errors while preserving existing mappings for other failures.

## Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Add stable admission errors and validate required fields before transactions. |
| `internal/store/store_test.go` | Prove invalid create, upsert, update, and prompt writes leave rows and sync mutations unchanged, including `inserted == false`. |
| `internal/mcp/mcp_test.go` | Prove MCP handlers expose Store admission failures without persistence. |
| `internal/server/server.go` | Map Store admission errors to HTTP 400. |
| `internal/server/server_test.go` | Prove whitespace-only writes return 400 and do not persist. |

## Test Plan

- [x] Focused Store admission tests
- [x] `go test ./internal/mcp -run TestSaveHandlersExposeStoreAdmissionErrors -count=1`
- [x] `go test ./internal/mcp`
- [x] `go test ./internal/server -count=1`
- [x] `go vet ./internal/server ./internal/store`
- [x] `gofmt` and `git diff --check`
- [ ] `go test ./internal/store -count=1` - blocked by pre-existing Windows TempDir cleanup failures in `TestMigrate_Idempotent` and `TestNewErrorBranches`

---

## Contributor Checklist

- [x] I linked approved issues above (`Closes #686`, `Closes #695`)
- [x] I added exactly one `type:*` label to this PR
- [x] I ran relevant unit tests locally
- [ ] I ran the full E2E suite locally
- [x] Docs updated (not required; no public contract changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## Notes for Reviewers

Validation lives in Store so every live-write caller receives the same canonical invariant. Import, repair, and cloud-apply semantics are intentionally unchanged.

Native RDD completed an independent four-lens review and approved the exact committed tree `4138cd52bd8254d5a2000784c78da31072181fa6` without blocking findings. Delivery remains governed by ordinary repository policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to prevent observations with blank titles or content from being created or updated.
  - Added validation to prevent prompts with blank content from being created.
  - Invalid submissions now return a clear client error instead of an internal server error.
  - Rejected changes no longer create or modify stored records.
- **Tests**
  - Expanded coverage for whitespace-only fields across observation and prompt workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->