### PR TITLE
fix(plugin): use canonical project resolution

### DIFF
--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2368,40 +2368,27 @@ func TestClaudeCodeUserPromptHookUsesCurrentMCPServerID(t *testing.T) {
 	}
 }
 
-func TestClaudeCodeUserPromptHookDefersProjectDetectionUntilNeeded(t *testing.T) {
+func TestClaudeCodeUserPromptHookUsesProcessLocalFallbackKeyAndCanonicalResolution(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "plugin", "claude-code", "scripts", "user-prompt-submit.sh"))
 	if err != nil {
 		t.Fatalf("read user prompt hook: %v", err)
 	}
 	text := string(data)
 
-	sessionParse := strings.Index(text, "SESSION_ID=$(echo \"$INPUT\" | jq -r '.session_id // empty')")
-	if sessionParse < 0 {
-		t.Fatalf("user prompt hook missing expected session parsing structure")
-	}
-	sessionKeyBranchRel := strings.Index(text[sessionParse:], "if [ -n \"$SESSION_ID\" ]; then")
-	sessionKeyBranch := -1
-	if sessionKeyBranchRel >= 0 {
-		sessionKeyBranch = sessionParse + sessionKeyBranchRel
-	}
-	if sessionParse < 0 || sessionKeyBranch < 0 {
-		t.Fatalf("user prompt hook missing expected session parsing/keying structure")
-	}
-	if preKey := text[sessionParse:sessionKeyBranch]; strings.Contains(preKey, "detect_project") {
-		t.Fatalf("user prompt hook must not detect project before session_id-first keying")
+	if strings.Contains(text, "detect_project") {
+		t.Fatal("user prompt hook must not use Git/basename project detection")
 	}
 
-	fallbackDetect := "PROJECT=$(detect_project \"$CWD\")\n  SAFE_PROJECT="
-	if !strings.Contains(text, fallbackDetect) {
-		t.Fatalf("user prompt hook should detect project only for the no-session_id fallback key")
+	if !strings.Contains(text, "SESSION_KEY=\"engram-claude-unknown-$$-tools-loaded\"") {
+		t.Fatal("user prompt hook must use a process-local fallback key when session_id is absent")
 	}
 
 	subsequentMarker := strings.Index(text, "# SUBSEQUENT MESSAGES")
 	if subsequentMarker < 0 {
 		t.Fatalf("user prompt hook missing subsequent-message section")
 	}
-	if !strings.Contains(text[subsequentMarker:], "PROJECT=$(detect_project \"$CWD\")") {
-		t.Fatalf("user prompt hook should detect project for subsequent nudge logic after first-message handling")
+	if !strings.Contains(text[subsequentMarker:], "PROJECT=$(resolve_project \"$CWD\") || PROJECT=\"\"") {
+		t.Fatal("user prompt hook must resolve the nudge project canonically after first-message handling")
 	}
 }
 

--- a/plugin/canonical_project_resolution_test.go
+++ b/plugin/canonical_project_resolution_test.go
@@ -65,6 +65,7 @@ func TestLifecycleScriptsUseCanonicalProjectResolution(t *testing.T) {
 			{name: "empty", status: http.StatusOK, body: `{"project":"","project_source":"config"}`},
 			{name: "ambiguous", status: http.StatusOK, body: `{"project":"","project_source":"ambiguous","available_projects":["one","two"]}`},
 			{name: "invalid", status: http.StatusOK, body: `{"project":"configured-project","project_source":"unexpected"}`},
+			{name: "error hint", status: http.StatusOK, body: `{"project":"configured-project","project_source":"config","error_hint":"choose a project"}`},
 		} {
 			t.Run(agent+" fails closed when canonical resolution is "+response.name, func(t *testing.T) {
 				cwd := lifecycleProjectDirectory(t)

--- a/plugin/canonical_project_resolution_test.go
+++ b/plugin/canonical_project_resolution_test.go
@@ -1,0 +1,134 @@
+package plugin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLifecycleScriptsUseCanonicalProjectResolution(t *testing.T) {
+	bashPath := codexTestBash(t)
+	requireCodexUnixTools(t, bashPath)
+
+	for _, agent := range []string{"claude-code", "codex"} {
+		t.Run(agent+" uses configured project instead of git-derived name", func(t *testing.T) {
+			cwd := lifecycleProjectDirectory(t)
+			var requestedCWD string
+			var sessionProject string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/health":
+					w.WriteHeader(http.StatusOK)
+				case "/project/current":
+					requestedCWD = r.URL.Query().Get("cwd")
+					_, _ = w.Write([]byte(`{"project":"configured-project","project_source":"config"}`))
+				case "/sessions":
+					var payload struct {
+						Project string `json:"project"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Errorf("decode session payload: %v", err)
+					}
+					sessionProject = payload.Project
+					w.WriteHeader(http.StatusNoContent)
+				case "/context":
+					_, _ = w.Write([]byte(`{"context":""}`))
+				default:
+					t.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			runLifecycleSessionStart(t, bashPath, agent, server.URL, `{"session_id":"canonical-session","cwd":`+jsonQuote(cwd)+`}`)
+			if requestedCWD != cwd {
+				t.Fatalf("canonical request cwd = %q, want %q", requestedCWD, cwd)
+			}
+			if sessionProject != "configured-project" {
+				t.Fatalf("session project = %q, want configured project instead of git-derived", sessionProject)
+			}
+		})
+
+		for _, response := range []struct {
+			name   string
+			status int
+			body   string
+		}{
+			{name: "unavailable", status: http.StatusServiceUnavailable, body: "unavailable"},
+			{name: "malformed", status: http.StatusOK, body: "not-json"},
+			{name: "empty", status: http.StatusOK, body: `{"project":"","project_source":"config"}`},
+			{name: "ambiguous", status: http.StatusOK, body: `{"project":"","project_source":"ambiguous","available_projects":["one","two"]}`},
+			{name: "invalid", status: http.StatusOK, body: `{"project":"configured-project","project_source":"unexpected"}`},
+		} {
+			t.Run(agent+" fails closed when canonical resolution is "+response.name, func(t *testing.T) {
+				cwd := lifecycleProjectDirectory(t)
+				wroteSession := false
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/health":
+						w.WriteHeader(http.StatusOK)
+					case "/project/current":
+						w.WriteHeader(response.status)
+						_, _ = w.Write([]byte(response.body))
+					case "/sessions":
+						wroteSession = true
+						w.WriteHeader(http.StatusNoContent)
+					default:
+						t.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}))
+				defer server.Close()
+
+				runLifecycleSessionStart(t, bashPath, agent, server.URL, `{"session_id":"closed-session","cwd":`+jsonQuote(cwd)+`}`)
+				if wroteSession {
+					t.Fatal("session write must not occur when canonical project resolution fails")
+				}
+			})
+		}
+	}
+}
+
+func lifecycleProjectDirectory(t *testing.T) string {
+	t.Helper()
+	cwd := filepath.Join(t.TempDir(), "git-derived & space")
+	if err := os.MkdirAll(filepath.Join(cwd, ".engram"), 0o755); err != nil {
+		t.Fatalf("create project directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, ".engram", "config.json"), []byte(`{"project_name":"configured-project"}`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	if output, err := exec.Command("git", "-C", cwd, "init").CombinedOutput(); err != nil {
+		t.Fatalf("initialize git project: %v: %s", err, output)
+	}
+	if output, err := exec.Command("git", "-C", cwd, "remote", "add", "origin", "https://example.com/git-derived.git").CombinedOutput(); err != nil {
+		t.Fatalf("set git remote: %v: %s", err, output)
+	}
+	return cwd
+}
+
+func runLifecycleSessionStart(t *testing.T, bashPath, agent, serverURL, input string) {
+	t.Helper()
+	parsedURL, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	adapterPath := filepath.Join(repoRoot(t), "plugin", agent, "scripts", "session-start.sh")
+	run := exec.Command(bashPath, adapterPath)
+	run.Env = append(os.Environ(), "ENGRAM_PORT="+parsedURL.Port())
+	run.Stdin = strings.NewReader(input)
+	if output, err := run.CombinedOutput(); err != nil {
+		t.Fatalf("run %s session start: %v: %s", agent, err, output)
+	}
+}
+
+func jsonQuote(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/plugin/claude-code/scripts/_helpers.sh
+++ b/plugin/claude-code/scripts/_helpers.sh
@@ -2,32 +2,23 @@
 # Engram — Shared helpers for Claude Code hooks
 # WARNING: Do not read from stdin here — scripts source this before reading their hook input.
 
-# Detect project name from git remote, with fallbacks.
-# Priority: git remote origin repo name > git root basename > cwd basename
-detect_project() {
+# Resolve the project through the server, which owns project policy.
+# An unavailable, malformed, empty, or ambiguous response is not a project.
+resolve_project() {
   local dir="$1"
+  [ -n "$dir" ] || return 1
 
-  # Try git remote origin URL
-  local url
-  url=$(git -C "$dir" remote get-url origin 2>/dev/null)
-  if [ -n "$url" ]; then
-    # Handles both SSH (git@github.com:user/repo.git) and HTTPS (https://github.com/user/repo.git)
-    local name
-    name=$(echo "$url" | sed 's/\.git$//' | sed 's|.*[/:]||' | tr '[:upper:]' '[:lower:]')
-    if [ -n "$name" ]; then
-      echo "$name"
-      return
-    fi
-  fi
-
-  # Fallback: git root directory name (works in worktrees)
-  local root
-  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
-  if [ -n "$root" ]; then
-    basename "$root" | tr '[:upper:]' '[:lower:]'
-    return
-  fi
-
-  # Final fallback: cwd basename (current behavior)
-  basename "$dir" | tr '[:upper:]' '[:lower:]'
+  local encoded_cwd response
+  encoded_cwd=$(printf '%s' "$dir" | jq -sRr @uri) || return 1
+  response=$(curl -sf "${ENGRAM_URL}/project/current?cwd=${encoded_cwd}" --max-time 2 2>/dev/null) || return 1
+  printf '%s' "$response" | jq -er '
+    if (.project | type) == "string"
+      and (.project | gsub("^[[:space:]]+|[[:space:]]+$"; "") | length) > 0
+      and (.project_source | type) == "string"
+      and (.project_source as $source | ["config", "git_remote", "git_root", "git_child", "dir_basename"] | index($source) != null)
+      and (has("error_hint") | not)
+    then .project
+    else error("canonical project resolution failed")
+    end
+  ' 2>/dev/null
 }

--- a/plugin/claude-code/scripts/post-compaction.sh
+++ b/plugin/claude-code/scripts/post-compaction.sh
@@ -15,7 +15,7 @@ source "${SCRIPT_DIR}/_helpers.sh"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-PROJECT=$(detect_project "$CWD")
+PROJECT=$(resolve_project "$CWD") || PROJECT=""
 
 # Ensure session exists
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
@@ -28,8 +28,11 @@ if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
 fi
 
 # Fetch context from previous sessions
-ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
-CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+CONTEXT=""
+if [ -n "$PROJECT" ]; then
+  ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+  CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+fi
 
 # Resolve protocol verbosity mode for this slug. All slim/full branching
 # (including the engram-version floor check) lives in Go — see `engram

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -20,8 +20,6 @@ source "${SCRIPT_DIR}/_helpers.sh"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-OLD_PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
-PROJECT=$(detect_project "$CWD")
 
 # Ensure engram server is running
 if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then
@@ -29,15 +27,7 @@ if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then
   sleep 0.5
 fi
 
-# Migrate project name if it changed (one-time, idempotent)
-if [ "$OLD_PROJECT" != "$PROJECT" ] && [ -n "$OLD_PROJECT" ] && [ -n "$PROJECT" ]; then
-  curl -sf "${ENGRAM_URL}/projects/migrate" \
-    -X POST \
-    -H "Content-Type: application/json" \
-    -d "$(jq -n --arg old "$OLD_PROJECT" --arg new "$PROJECT" \
-      '{old_project: $old, new_project: $new}')" \
-    > /dev/null 2>&1
-fi
+PROJECT=$(resolve_project "$CWD") || PROJECT=""
 
 # Create session
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
@@ -134,8 +124,11 @@ if [ -f "${CWD}/.engram/manifest.json" ]; then
 fi
 
 # Fetch memory context
-ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
-CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+CONTEXT=""
+if [ -n "$PROJECT" ]; then
+  ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+  CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+fi
 
 # Resolve protocol verbosity mode for this slug. All slim/full branching
 # (including the engram-version floor check) lives in Go — see `engram

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -17,10 +17,10 @@ INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 OUTPUT=$(echo "$INPUT" | jq -r '.stdout // empty')
-PROJECT=$(detect_project "$CWD")
 
 # Nothing to capture if no output
 [ -z "$OUTPUT" ] && exit 0
+PROJECT=$(resolve_project "$CWD") || exit 0
 
 # Fire and forget — server handles extraction, dedup, and storage
 curl -sf "${ENGRAM_URL}/observations/passive" \

--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -23,19 +23,41 @@ function Write-ToolSearchMessage {
   [PSCustomObject]@{ systemMessage = $message } | ConvertTo-Json -Compress
 }
 
+function Resolve-EngramProject {
+  param(
+    [string]$EngramUrl,
+    [string]$Cwd
+  )
+  if ([string]::IsNullOrWhiteSpace($Cwd)) { return $null }
+  try {
+    $encodedCwd = [System.Uri]::EscapeDataString($Cwd)
+    $resolution = Invoke-RestMethod -Method Get -Uri "$EngramUrl/project/current?cwd=$encodedCwd" -TimeoutSec 1
+    $project = [string]$resolution.project
+    $source = [string]$resolution.project_source
+    $validSources = @('config', 'git_remote', 'git_root', 'git_child', 'dir_basename')
+    if ([string]::IsNullOrWhiteSpace($project) -or $source -notin $validSources -or $null -ne $resolution.PSObject.Properties['error_hint']) {
+      return $null
+    }
+    return $project
+  } catch {
+    return $null
+  }
+}
+
 function Invoke-EngramPromptPersist {
   param(
     [string]$EngramUrl,
     [string]$SessionId,
+    [string]$Project,
     [string]$Prompt
   )
   # Fail-silent and bounded: a short timeout keeps a slow/unreachable server
-  # from stalling prompt submission, and any error is swallowed. The server
-  # derives the prompt's project from the session, so the hook sends none.
-  if ([string]::IsNullOrWhiteSpace($Prompt) -or [string]::IsNullOrWhiteSpace($SessionId)) { return }
+  # from stalling prompt submission, and any error is swallowed.
+  if ([string]::IsNullOrWhiteSpace($Prompt) -or [string]::IsNullOrWhiteSpace($SessionId) -or [string]::IsNullOrWhiteSpace($Project)) { return }
   try {
     $body = [PSCustomObject]@{
       session_id = $SessionId
+      project    = $Project
       content    = $Prompt
     } | ConvertTo-Json -Compress
     $null = Invoke-RestMethod -Method Post -Uri "$EngramUrl/prompts" `
@@ -50,15 +72,17 @@ try {
   $inputJson = [Console]::In.ReadToEnd()
   $payload = $inputJson | ConvertFrom-Json
   $sessionID = [string]($payload.session_id)
+  $cwd       = [string]($payload.cwd)
   $prompt    = [string]($payload.prompt)
 
   if ([string]::IsNullOrWhiteSpace($sessionID)) {
     $sessionID = "windows-$PID"
   }
 
-  # Persist the prompt (fire-and-forget, fail-silent). The server derives the
-  # project from the session, so the hook does not detect it here.
-  Invoke-EngramPromptPersist -EngramUrl $engramUrl -SessionId $sessionID -Prompt $prompt
+  # Persist only after canonical server resolution; do not infer a project in
+  # the hook when the server is unavailable, invalid, or ambiguous.
+  $project = Resolve-EngramProject -EngramUrl $engramUrl -Cwd $cwd
+  Invoke-EngramPromptPersist -EngramUrl $engramUrl -SessionId $sessionID -Project $project -Prompt $prompt
 
   $safeSessionID = $sessionID -replace '[^a-zA-Z0-9_-]', '_'
   $stateFile = Join-Path ([IO.Path]::GetTempPath()) "engram-claude-$safeSessionID-tools-loaded"

--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -32,15 +32,15 @@ function Resolve-EngramProject {
   try {
     $encodedCwd = [System.Uri]::EscapeDataString($Cwd)
     $resolution = Invoke-RestMethod -Method Get -Uri "$EngramUrl/project/current?cwd=$encodedCwd" -TimeoutSec 1
-    $projectProperty = $resolution.PSObject.Properties['project']
-    $sourceProperty = $resolution.PSObject.Properties['project_source']
-    if ($null -eq $projectProperty -or $null -eq $sourceProperty -or $projectProperty.Value -isnot [string] -or $sourceProperty.Value -isnot [string]) {
+    $projectProperty = @($resolution.PSObject.Properties | Where-Object { $_.Name -ceq 'project' })
+    $sourceProperty = @($resolution.PSObject.Properties | Where-Object { $_.Name -ceq 'project_source' })
+    if ($projectProperty.Count -ne 1 -or $sourceProperty.Count -ne 1 -or $projectProperty[0].Value -isnot [string] -or $sourceProperty[0].Value -isnot [string]) {
       return $null
     }
-    $project = [string]$projectProperty.Value
-    $source = [string]$sourceProperty.Value
+    $project = $projectProperty[0].Value
+    $source = $sourceProperty[0].Value
     $validSources = @('config', 'git_remote', 'git_root', 'git_child', 'dir_basename')
-    if ([string]::IsNullOrWhiteSpace($project) -or $source -notin $validSources -or $null -ne $resolution.PSObject.Properties['error_hint']) {
+    if ([string]::IsNullOrWhiteSpace($project) -or $validSources -cnotcontains $source -or $null -ne $resolution.PSObject.Properties['error_hint']) {
       return $null
     }
     return $project

--- a/plugin/claude-code/scripts/user-prompt-submit.ps1
+++ b/plugin/claude-code/scripts/user-prompt-submit.ps1
@@ -32,8 +32,13 @@ function Resolve-EngramProject {
   try {
     $encodedCwd = [System.Uri]::EscapeDataString($Cwd)
     $resolution = Invoke-RestMethod -Method Get -Uri "$EngramUrl/project/current?cwd=$encodedCwd" -TimeoutSec 1
-    $project = [string]$resolution.project
-    $source = [string]$resolution.project_source
+    $projectProperty = $resolution.PSObject.Properties['project']
+    $sourceProperty = $resolution.PSObject.Properties['project_source']
+    if ($null -eq $projectProperty -or $null -eq $sourceProperty -or $projectProperty.Value -isnot [string] -or $sourceProperty.Value -isnot [string]) {
+      return $null
+    }
+    $project = [string]$projectProperty.Value
+    $source = [string]$sourceProperty.Value
     $validSources = @('config', 'git_remote', 'git_root', 'git_child', 'dir_basename')
     if ([string]::IsNullOrWhiteSpace($project) -or $source -notin $validSources -or $null -ne $resolution.PSObject.Properties['error_hint']) {
       return $null

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -95,24 +95,26 @@ source "${SCRIPT_DIR}/_helpers.sh"
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+PROJECT=""
 
 # ──────────────────────────────────────────────────────────────────────────────
 # PROMPT PERSIST
 #
 # Every user message is captured to POST /prompts so mem_save can attach the
-# originating prompt via SessionActivity.  Fire-and-forget: never blocks and
-# never fails the hook.
+# originating prompt via SessionActivity. The canonical project is resolved by
+# the server before this script writes. Fire-and-forget: never blocks and never
+# fails the hook.
 # ──────────────────────────────────────────────────────────────────────────────
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
 if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
   # Detached subshell so the POST never stalls the hook. The server derives the
-  # prompt's project from the session, so project lookup stays off the hot path
-  # here (the hook keys by session_id first and only resolves the project later).
+  # prompt's project from the session and rejects any mismatch.
   (
+    PROJECT=$(resolve_project "$CWD") || exit 0
     curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
       -H 'Content-Type: application/json' \
-      -d "$(jq -n --arg s "$SESSION_ID" --arg c "$PROMPT" \
-            '{session_id:$s, content:$c}')" >/dev/null 2>&1 || true
+      -d "$(jq -n --arg s "$SESSION_ID" --arg p "$PROJECT" --arg c "$PROMPT" \
+            '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
   ) &
 fi
 
@@ -163,14 +165,11 @@ OUTPUT="{}"
 # State file lives in /tmp and is keyed by session_id (falls back to project+pid).
 # ──────────────────────────────────────────────────────────────────────────────
 
-# Build a stable session key — prefer SESSION_ID, fall back to project name
+# Build a stable session key — prefer SESSION_ID, then a process-local fallback.
 if [ -n "$SESSION_ID" ]; then
   SESSION_KEY="engram-claude-${SESSION_ID}-tools-loaded"
 else
-  # No session ID available — only then detect project for the fallback state key.
-  PROJECT=$(detect_project "$CWD")
-  SAFE_PROJECT=$(printf '%s' "${PROJECT:-unknown}" | tr -cs 'a-zA-Z0-9_-' '_')
-  SESSION_KEY="engram-claude-${SAFE_PROJECT}-$$-tools-loaded"
+  SESSION_KEY="engram-claude-unknown-$$-tools-loaded"
 fi
 
 STATE_FILE="/tmp/${SESSION_KEY}"
@@ -189,9 +188,9 @@ fi
 # SUBSEQUENT MESSAGES — existing save-nudge logic
 # ──────────────────────────────────────────────────────────────────────────────
 
-# Detect project only after the first-message path has had a chance to return.
+# Resolve the project only after the first-message path has had a chance to return.
 if [ -z "${PROJECT:-}" ]; then
-  PROJECT=$(detect_project "$CWD")
+  PROJECT=$(resolve_project "$CWD") || PROJECT=""
 fi
 
 # Bail early if we can't determine the project

--- a/plugin/claude_code_windows_user_prompt_test.go
+++ b/plugin/claude_code_windows_user_prompt_test.go
@@ -20,17 +20,24 @@ func TestClaudeCodeWindowsPromptResolverRejectsMalformedCanonicalProject(t *test
 
 	for _, test := range []struct {
 		name       string
+		status     int
 		resolution string
 	}{
-		{name: "non-string project", resolution: `{"project":42,"project_source":"config"}`},
-		{name: "incorrectly cased project property", resolution: `{"Project":"canonical-project","project_source":"config"}`},
-		{name: "incorrectly cased project source property", resolution: `{"project":"canonical-project","Project_Source":"config"}`},
-		{name: "incorrectly cased project source value", resolution: `{"project":"canonical-project","project_source":"CONFIG"}`},
+		{name: "non-string project", status: http.StatusOK, resolution: `{"project":42,"project_source":"config"}`},
+		{name: "incorrectly cased project property", status: http.StatusOK, resolution: `{"Project":"canonical-project","project_source":"config"}`},
+		{name: "incorrectly cased project source property", status: http.StatusOK, resolution: `{"project":"canonical-project","Project_Source":"config"}`},
+		{name: "incorrectly cased project source value", status: http.StatusOK, resolution: `{"project":"canonical-project","project_source":"CONFIG"}`},
+		{name: "blank project", status: http.StatusOK, resolution: `{"project":"","project_source":"config"}`},
+		{name: "error hint", status: http.StatusOK, resolution: `{"project":"canonical-project","project_source":"config","error_hint":"choose a project"}`},
+		{name: "ambiguous response", status: http.StatusOK, resolution: `{"project":"","project_source":"ambiguous","available_projects":["one","two"]}`},
+		{name: "non-2xx response", status: http.StatusServiceUnavailable, resolution: `unavailable`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			var mu sync.Mutex
 			resolutionRequests := 0
 			promptWrites := 0
+			requestedCWD := ""
+			cwd := "C:/workspace/reserved &?#%+"
 			port := claudeCodeWindowsPromptServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				mu.Lock()
 				defer mu.Unlock()
@@ -38,6 +45,8 @@ func TestClaudeCodeWindowsPromptResolverRejectsMalformedCanonicalProject(t *test
 				switch r.URL.Path {
 				case "/project/current":
 					resolutionRequests++
+					requestedCWD = r.URL.Query().Get("cwd")
+					w.WriteHeader(test.status)
 					_, _ = w.Write([]byte(test.resolution))
 				case "/prompts":
 					promptWrites++
@@ -48,12 +57,15 @@ func TestClaudeCodeWindowsPromptResolverRejectsMalformedCanonicalProject(t *test
 				}
 			}))
 
-			runClaudeCodeWindowsPromptHook(t, powershellPath, adapterPath, port, "resolver-malformed", "persist this prompt")
+			runClaudeCodeWindowsPromptHook(t, powershellPath, adapterPath, port, "resolver-malformed", cwd, "persist this prompt")
 
 			mu.Lock()
 			defer mu.Unlock()
 			if resolutionRequests != 1 {
 				t.Fatalf("canonical resolution requests = %d, want 1", resolutionRequests)
+			}
+			if requestedCWD != cwd {
+				t.Fatalf("canonical request cwd = %q, want %q", requestedCWD, cwd)
 			}
 			if promptWrites != 0 {
 				t.Fatalf("prompt writes = %d, want 0 for malformed canonical project", promptWrites)
@@ -69,6 +81,8 @@ func TestClaudeCodeWindowsPromptResolverPersistsCanonicalProject(t *testing.T) {
 	var mu sync.Mutex
 	resolutionRequests := 0
 	promptWrites := 0
+	requestedCWD := ""
+	cwd := "C:/workspace/reserved &?#%+"
 	var promptPayload struct {
 		SessionID string `json:"session_id"`
 		Project   string `json:"project"`
@@ -81,6 +95,7 @@ func TestClaudeCodeWindowsPromptResolverPersistsCanonicalProject(t *testing.T) {
 		switch r.URL.Path {
 		case "/project/current":
 			resolutionRequests++
+			requestedCWD = r.URL.Query().Get("cwd")
 			_, _ = w.Write([]byte(`{"project":"canonical-project","project_source":"config"}`))
 		case "/prompts":
 			promptWrites++
@@ -97,12 +112,15 @@ func TestClaudeCodeWindowsPromptResolverPersistsCanonicalProject(t *testing.T) {
 		}
 	}))
 
-	runClaudeCodeWindowsPromptHook(t, powershellPath, adapterPath, port, "canonical-persistence", "persist this prompt")
+	runClaudeCodeWindowsPromptHook(t, powershellPath, adapterPath, port, "canonical-persistence", cwd, "persist this prompt")
 
 	mu.Lock()
 	defer mu.Unlock()
 	if resolutionRequests != 1 {
 		t.Fatalf("canonical resolution requests = %d, want 1", resolutionRequests)
+	}
+	if requestedCWD != cwd {
+		t.Fatalf("canonical request cwd = %q, want %q", requestedCWD, cwd)
 	}
 	if promptWrites != 1 {
 		t.Fatalf("prompt writes = %d, want 1", promptWrites)
@@ -130,7 +148,7 @@ func claudeCodeWindowsPromptServer(t *testing.T, handler http.Handler) string {
 	return strconv.Itoa(tcpAddr.Port)
 }
 
-func runClaudeCodeWindowsPromptHook(t *testing.T, powershellPath, adapterPath, port, sessionID, prompt string) {
+func runClaudeCodeWindowsPromptHook(t *testing.T, powershellPath, adapterPath, port, sessionID, cwd, prompt string) {
 	t.Helper()
 	stateFile := filepath.Join(os.TempDir(), "engram-claude-"+sessionID+"-tools-loaded")
 	_ = os.Remove(stateFile)
@@ -139,7 +157,15 @@ func runClaudeCodeWindowsPromptHook(t *testing.T, powershellPath, adapterPath, p
 	run := exec.Command(powershellPath, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", adapterPath)
 	run.Env = withoutEngramPort(os.Environ())
 	run.Env = append(run.Env, "ENGRAM_PORT="+port)
-	run.Stdin = strings.NewReader(`{"session_id":"` + sessionID + `","cwd":"C:/workspace","prompt":"` + prompt + `"}`)
+	input, err := json.Marshal(map[string]string{
+		"session_id": sessionID,
+		"cwd":        cwd,
+		"prompt":     prompt,
+	})
+	if err != nil {
+		t.Fatalf("marshal prompt hook input: %v", err)
+	}
+	run.Stdin = strings.NewReader(string(input))
 	if output, err := run.CombinedOutput(); err != nil {
 		t.Fatalf("run UserPromptSubmit adapter: %v: %s", err, output)
 	}

--- a/plugin/claude_code_windows_user_prompt_test.go
+++ b/plugin/claude_code_windows_user_prompt_test.go
@@ -1,0 +1,82 @@
+package plugin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestClaudeCodeWindowsPromptResolverRejectsNonStringProject(t *testing.T) {
+	powershellPath := claudeCodePowerShell(t)
+	adapterPath := filepath.Join(repoRoot(t), "plugin", "claude-code", "scripts", "user-prompt-submit.ps1")
+
+	var mu sync.Mutex
+	resolutionRequests := 0
+	promptWrites := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch r.URL.Path {
+		case "/project/current":
+			resolutionRequests++
+			_, _ = w.Write([]byte(`{"project":42,"project_source":"config"}`))
+		case "/prompts":
+			promptWrites++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	port := strings.TrimPrefix(server.URL, "http://127.0.0.1:")
+	sessionID := "resolver-type-boundary"
+	stateFile := filepath.Join(os.TempDir(), "engram-claude-"+sessionID+"-tools-loaded")
+	_ = os.Remove(stateFile)
+	t.Cleanup(func() { _ = os.Remove(stateFile) })
+
+	run := exec.Command(powershellPath, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", adapterPath)
+	run.Env = withoutEngramPort(os.Environ())
+	run.Env = append(run.Env, "ENGRAM_PORT="+port)
+	run.Stdin = strings.NewReader(`{"session_id":"` + sessionID + `","cwd":"C:/workspace","prompt":"persist this prompt"}`)
+	if output, err := run.CombinedOutput(); err != nil {
+		t.Fatalf("run UserPromptSubmit adapter: %v: %s", err, output)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if resolutionRequests != 1 {
+		t.Fatalf("canonical resolution requests = %d, want 1", resolutionRequests)
+	}
+	if promptWrites != 0 {
+		t.Fatalf("prompt writes = %d, want 0 for a non-string canonical project", promptWrites)
+	}
+}
+
+func claudeCodePowerShell(t *testing.T) string {
+	t.Helper()
+	for _, candidate := range []string{"pwsh", "powershell.exe"} {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path
+		}
+	}
+	t.Skip("requires PowerShell")
+	return ""
+}
+
+func withoutEngramPort(environment []string) []string {
+	filtered := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		if !strings.HasPrefix(strings.ToUpper(entry), "ENGRAM_PORT=") {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}

--- a/plugin/claude_code_windows_user_prompt_test.go
+++ b/plugin/claude_code_windows_user_prompt_test.go
@@ -24,6 +24,8 @@ func TestClaudeCodeWindowsPromptResolverRejectsMalformedCanonicalProject(t *test
 		resolution string
 	}{
 		{name: "non-string project", status: http.StatusOK, resolution: `{"project":42,"project_source":"config"}`},
+		{name: "malformed JSON", status: http.StatusOK, resolution: `not-json`},
+		{name: "non-string project source", status: http.StatusOK, resolution: `{"project":"canonical-project","project_source":42}`},
 		{name: "incorrectly cased project property", status: http.StatusOK, resolution: `{"Project":"canonical-project","project_source":"config"}`},
 		{name: "incorrectly cased project source property", status: http.StatusOK, resolution: `{"project":"canonical-project","Project_Source":"config"}`},
 		{name: "incorrectly cased project source value", status: http.StatusOK, resolution: `{"project":"canonical-project","project_source":"CONFIG"}`},

--- a/plugin/claude_code_windows_user_prompt_test.go
+++ b/plugin/claude_code_windows_user_prompt_test.go
@@ -1,43 +1,137 @@
 package plugin_test
 
 import (
+	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 )
 
-func TestClaudeCodeWindowsPromptResolverRejectsNonStringProject(t *testing.T) {
+func TestClaudeCodeWindowsPromptResolverRejectsMalformedCanonicalProject(t *testing.T) {
+	powershellPath := claudeCodePowerShell(t)
+	adapterPath := filepath.Join(repoRoot(t), "plugin", "claude-code", "scripts", "user-prompt-submit.ps1")
+
+	for _, test := range []struct {
+		name       string
+		resolution string
+	}{
+		{name: "non-string project", resolution: `{"project":42,"project_source":"config"}`},
+		{name: "incorrectly cased project property", resolution: `{"Project":"canonical-project","project_source":"config"}`},
+		{name: "incorrectly cased project source property", resolution: `{"project":"canonical-project","Project_Source":"config"}`},
+		{name: "incorrectly cased project source value", resolution: `{"project":"canonical-project","project_source":"CONFIG"}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var mu sync.Mutex
+			resolutionRequests := 0
+			promptWrites := 0
+			port := claudeCodeWindowsPromptServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				switch r.URL.Path {
+				case "/project/current":
+					resolutionRequests++
+					_, _ = w.Write([]byte(test.resolution))
+				case "/prompts":
+					promptWrites++
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					t.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+
+			runClaudeCodeWindowsPromptHook(t, powershellPath, adapterPath, port, "resolver-malformed", "persist this prompt")
+
+			mu.Lock()
+			defer mu.Unlock()
+			if resolutionRequests != 1 {
+				t.Fatalf("canonical resolution requests = %d, want 1", resolutionRequests)
+			}
+			if promptWrites != 0 {
+				t.Fatalf("prompt writes = %d, want 0 for malformed canonical project", promptWrites)
+			}
+		})
+	}
+}
+
+func TestClaudeCodeWindowsPromptResolverPersistsCanonicalProject(t *testing.T) {
 	powershellPath := claudeCodePowerShell(t)
 	adapterPath := filepath.Join(repoRoot(t), "plugin", "claude-code", "scripts", "user-prompt-submit.ps1")
 
 	var mu sync.Mutex
 	resolutionRequests := 0
 	promptWrites := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var promptPayload struct {
+		SessionID string `json:"session_id"`
+		Project   string `json:"project"`
+		Content   string `json:"content"`
+	}
+	port := claudeCodeWindowsPromptServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		defer mu.Unlock()
 
 		switch r.URL.Path {
 		case "/project/current":
 			resolutionRequests++
-			_, _ = w.Write([]byte(`{"project":42,"project_source":"config"}`))
+			_, _ = w.Write([]byte(`{"project":"canonical-project","project_source":"config"}`))
 		case "/prompts":
 			promptWrites++
+			if r.Method != http.MethodPost {
+				t.Errorf("prompt method = %s, want POST", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&promptPayload); err != nil {
+				t.Errorf("decode prompt payload: %v", err)
+			}
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.String())
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	defer server.Close()
 
-	port := strings.TrimPrefix(server.URL, "http://127.0.0.1:")
-	sessionID := "resolver-type-boundary"
+	runClaudeCodeWindowsPromptHook(t, powershellPath, adapterPath, port, "canonical-persistence", "persist this prompt")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if resolutionRequests != 1 {
+		t.Fatalf("canonical resolution requests = %d, want 1", resolutionRequests)
+	}
+	if promptWrites != 1 {
+		t.Fatalf("prompt writes = %d, want 1", promptWrites)
+	}
+	if promptPayload.SessionID != "canonical-persistence" || promptPayload.Project != "canonical-project" || promptPayload.Content != "persist this prompt" {
+		t.Fatalf("prompt payload = %+v, want canonical project-bearing payload", promptPayload)
+	}
+}
+
+func claudeCodeWindowsPromptServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on IPv4 loopback: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.Start()
+	t.Cleanup(server.Close)
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener address = %T, want *net.TCPAddr", listener.Addr())
+	}
+	return strconv.Itoa(tcpAddr.Port)
+}
+
+func runClaudeCodeWindowsPromptHook(t *testing.T, powershellPath, adapterPath, port, sessionID, prompt string) {
+	t.Helper()
 	stateFile := filepath.Join(os.TempDir(), "engram-claude-"+sessionID+"-tools-loaded")
 	_ = os.Remove(stateFile)
 	t.Cleanup(func() { _ = os.Remove(stateFile) })
@@ -45,18 +139,9 @@ func TestClaudeCodeWindowsPromptResolverRejectsNonStringProject(t *testing.T) {
 	run := exec.Command(powershellPath, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", adapterPath)
 	run.Env = withoutEngramPort(os.Environ())
 	run.Env = append(run.Env, "ENGRAM_PORT="+port)
-	run.Stdin = strings.NewReader(`{"session_id":"` + sessionID + `","cwd":"C:/workspace","prompt":"persist this prompt"}`)
+	run.Stdin = strings.NewReader(`{"session_id":"` + sessionID + `","cwd":"C:/workspace","prompt":"` + prompt + `"}`)
 	if output, err := run.CombinedOutput(); err != nil {
 		t.Fatalf("run UserPromptSubmit adapter: %v: %s", err, output)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if resolutionRequests != 1 {
-		t.Fatalf("canonical resolution requests = %d, want 1", resolutionRequests)
-	}
-	if promptWrites != 0 {
-		t.Fatalf("prompt writes = %d, want 0 for a non-string canonical project", promptWrites)
 	}
 }
 

--- a/plugin/codex/scripts/_helpers.sh
+++ b/plugin/codex/scripts/_helpers.sh
@@ -2,32 +2,23 @@
 # Engram — Shared helpers for Codex hooks
 # WARNING: Do not read from stdin here — scripts source this before reading their hook input.
 
-# Detect project name from git remote, with fallbacks.
-# Priority: git remote origin repo name > git root basename > cwd basename
-detect_project() {
+# Resolve the project through the server, which owns project policy.
+# An unavailable, malformed, empty, or ambiguous response is not a project.
+resolve_project() {
   local dir="$1"
+  [ -n "$dir" ] || return 1
 
-  # Try git remote origin URL
-  local url
-  url=$(git -C "$dir" remote get-url origin 2>/dev/null)
-  if [ -n "$url" ]; then
-    # Handles both SSH (git@github.com:user/repo.git) and HTTPS (https://github.com/user/repo.git)
-    local name
-    name=$(echo "$url" | sed 's/\.git$//' | sed 's|.*[/:]||' | tr '[:upper:]' '[:lower:]')
-    if [ -n "$name" ]; then
-      echo "$name"
-      return
-    fi
-  fi
-
-  # Fallback: git root directory name (works in worktrees)
-  local root
-  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
-  if [ -n "$root" ]; then
-    basename "$root" | tr '[:upper:]' '[:lower:]'
-    return
-  fi
-
-  # Final fallback: cwd basename (current behavior)
-  basename "$dir" | tr '[:upper:]' '[:lower:]'
+  local encoded_cwd response
+  encoded_cwd=$(printf '%s' "$dir" | jq -sRr @uri) || return 1
+  response=$(curl -sf "${ENGRAM_URL}/project/current?cwd=${encoded_cwd}" --max-time 2 2>/dev/null) || return 1
+  printf '%s' "$response" | jq -er '
+    if (.project | type) == "string"
+      and (.project | gsub("^[[:space:]]+|[[:space:]]+$"; "") | length) > 0
+      and (.project_source | type) == "string"
+      and (.project_source as $source | ["config", "git_remote", "git_root", "git_child", "dir_basename"] | index($source) != null)
+      and (has("error_hint") | not)
+    then .project
+    else error("canonical project resolution failed")
+    end
+  ' 2>/dev/null
 }

--- a/plugin/codex/scripts/post-compaction.sh
+++ b/plugin/codex/scripts/post-compaction.sh
@@ -15,7 +15,7 @@ source "${SCRIPT_DIR}/_helpers.sh"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-PROJECT=$(detect_project "$CWD")
+PROJECT=$(resolve_project "$CWD") || PROJECT=""
 
 # Ensure session exists
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
@@ -28,8 +28,11 @@ if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
 fi
 
 # Fetch context from previous sessions
-ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
-CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+CONTEXT=""
+if [ -n "$PROJECT" ]; then
+  ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+  CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+fi
 
 # Inject Memory Protocol + compaction instruction + context
 cat <<'PROTOCOL'

--- a/plugin/codex/scripts/session-start.sh
+++ b/plugin/codex/scripts/session-start.sh
@@ -20,8 +20,6 @@ source "${SCRIPT_DIR}/_helpers.sh"
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-OLD_PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
-PROJECT=$(detect_project "$CWD")
 
 # Ensure engram server is running
 if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then
@@ -29,15 +27,7 @@ if ! curl -sf "${ENGRAM_URL}/health" --max-time 1 > /dev/null 2>&1; then
   sleep 0.5
 fi
 
-# Migrate project name if it changed (one-time, idempotent)
-if [ "$OLD_PROJECT" != "$PROJECT" ] && [ -n "$OLD_PROJECT" ] && [ -n "$PROJECT" ]; then
-  curl -sf "${ENGRAM_URL}/projects/migrate" \
-    -X POST \
-    -H "Content-Type: application/json" \
-    -d "$(jq -n --arg old "$OLD_PROJECT" --arg new "$PROJECT" \
-      '{old_project: $old, new_project: $new}')" \
-    > /dev/null 2>&1
-fi
+PROJECT=$(resolve_project "$CWD") || PROJECT=""
 
 # Create session
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
@@ -134,8 +124,11 @@ if [ -f "${CWD}/.engram/manifest.json" ]; then
 fi
 
 # Fetch memory context
-ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
-CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+CONTEXT=""
+if [ -n "$PROJECT" ]; then
+  ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+  CONTEXT=$(curl -sf "${ENGRAM_URL}/context?project=${ENCODED_PROJECT}" --max-time 3 2>/dev/null | jq -r '.context // empty')
+fi
 
 # Inject Memory Protocol + context — stdout is returned to Codex as additionalContext
 cat <<'PROTOCOL'

--- a/plugin/codex/scripts/subagent-stop.sh
+++ b/plugin/codex/scripts/subagent-stop.sh
@@ -20,10 +20,10 @@ INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 OUTPUT=$(echo "$INPUT" | jq -r '.last_assistant_message // .stdout // empty')
-PROJECT=$(detect_project "$CWD")
 
 # Nothing to capture if no output
 [ -z "$OUTPUT" ] && exit 0
+PROJECT=$(resolve_project "$CWD") || exit 0
 
 # Post to passive capture — server handles extraction, dedup, and storage
 curl -sf "${ENGRAM_URL}/observations/passive" \

--- a/plugin/codex/scripts/user-prompt-submit.sh
+++ b/plugin/codex/scripts/user-prompt-submit.sh
@@ -28,21 +28,23 @@ source "${SCRIPT_DIR}/_helpers.sh"
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+PROJECT=""
 
 # ──────────────────────────────────────────────────────────────────────────────
 # PROMPT PERSIST
 #
 # Every user message is captured to POST /prompts so mem_save can attach the
-# originating prompt via SessionActivity. Detached subshell: never blocks and
+# originating prompt via SessionActivity. The canonical project is resolved by
+# the server before this script writes. Detached subshell: never blocks and
 # never fails the hook.
 # ──────────────────────────────────────────────────────────────────────────────
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
 if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
   (
-    _PROMPT_PROJECT=$(detect_project "$CWD")
+    PROJECT=$(resolve_project "$CWD") || exit 0
     curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
       -H 'Content-Type: application/json' \
-      -d "$(jq -n --arg s "$SESSION_ID" --arg p "${_PROMPT_PROJECT:-}" --arg c "$PROMPT" \
+      -d "$(jq -n --arg s "$SESSION_ID" --arg p "$PROJECT" --arg c "$PROMPT" \
             '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
   ) &
 fi
@@ -94,14 +96,11 @@ OUTPUT="{}"
 # State file lives in /tmp and is keyed by session_id (falls back to project+pid).
 # ──────────────────────────────────────────────────────────────────────────────
 
-# Build a stable session key — prefer SESSION_ID, fall back to project name
+# Build a stable session key — prefer SESSION_ID, then a process-local fallback.
 if [ -n "$SESSION_ID" ]; then
   SESSION_KEY="engram-codex-${SESSION_ID}-tools-loaded"
 else
-  # No session ID available — only then detect project for the fallback state key.
-  PROJECT=$(detect_project "$CWD")
-  SAFE_PROJECT=$(printf '%s' "${PROJECT:-unknown}" | tr -cs 'a-zA-Z0-9_-' '_')
-  SESSION_KEY="engram-codex-${SAFE_PROJECT}-$$-tools-loaded"
+  SESSION_KEY="engram-codex-unknown-$$-tools-loaded"
 fi
 
 STATE_FILE="/tmp/${SESSION_KEY}"
@@ -120,9 +119,9 @@ fi
 # SUBSEQUENT MESSAGES — save-nudge logic
 # ──────────────────────────────────────────────────────────────────────────────
 
-# Detect project only after the first-message path has had a chance to return.
+# Resolve the project only after the first-message path has had a chance to return.
 if [ -z "${PROJECT:-}" ]; then
-  PROJECT=$(detect_project "$CWD")
+  PROJECT=$(resolve_project "$CWD") || PROJECT=""
 fi
 
 # Bail early if we can't determine the project


### PR DESCRIPTION
## Linked Issue

Closes #555

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Resolves Claude and Codex hook projects through the canonical server endpoint.
- Removes Git/basename inference and script-side project migration.
- Fails closed when canonical resolution is unavailable, malformed, empty, ambiguous, warned, or carries non-string fields.

## Changes

| File | Change |
|------|--------|
| `plugin/claude-code/scripts` | Use URL-encoded `/project/current?cwd=` resolution before lifecycle writes and strictly validate PowerShell response types. |
| `plugin/codex/scripts` | Apply the same canonical resolution and remove inferred migration. |
| `plugin/canonical_project_resolution_test.go` | Exercise configured-vs-Git disagreement and fail-closed cases, including `error_hint`, for both agents. |
| `plugin/claude_code_windows_user_prompt_test.go` | Execute the PowerShell prompt hook and prove non-string canonical projects cannot cause prompt writes. |
| `internal/setup/setup_test.go` | Align installer assertions with canonical resolution and the process-local fallback key. |

## Test Plan

- [x] `go test ./plugin -run TestLifecycleScriptsUseCanonicalProjectResolution -count=1`
- [x] `go test ./plugin -run TestClaudeCodeWindowsPromptResolverRejectsNonStringProject -count=1`
- [x] `go test ./plugin -count=1`
- [x] `go test ./internal/server -count=1`
- [x] `go test ./internal/setup -run TestClaudeCodeUserPromptHookUsesProcessLocalFallbackKeyAndCanonicalResolution -count=1`
- [x] `go vet ./plugin`
- [x] Git Bash syntax checks for changed shell scripts
- [x] PowerShell parser validation
- [x] `gofmt` and `git diff --check`

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #555`)
- [x] I added exactly one `type:*` label to this PR
- [x] I ran relevant unit tests locally
- [ ] I ran the full E2E suite locally
- [x] Docs updated (not required; no public contract changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## Notes for Reviewers

The server remains the sole owner of project policy. Plugin scripts now transport the canonical result instead of recreating detection rules. OpenCode and Pi convergence remains tracked separately by #689.

Native RDD completed an independent four-lens review and approved the exact committed tree `246e92f7aaa0a71cf9592fbc4e4849169466f589` without blocking findings. Delivery remains governed by ordinary repository policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project names are now resolved consistently using configured project metadata.
  * Prevented prompts, session data, and context from being saved when project resolution is invalid, ambiguous, or unavailable.
  * Preserved the requested working directory during lifecycle actions.
  * Improved behavior across Claude Code, Codex, and Windows PowerShell integrations.

* **Tests**
  * Added coverage for valid, malformed, empty, ambiguous, and unavailable project-resolution responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->