### PR TITLE
fix(sync): order relation imports after observations

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -871,6 +871,7 @@ func orderMutationsForApply(mutations []store.SyncMutation) []store.SyncMutation
 	}
 	sessionUpserts := make([]store.SyncMutation, 0, len(mutations))
 	otherUpserts := make([]store.SyncMutation, 0, len(mutations))
+	relationUpserts := make([]store.SyncMutation, 0, len(mutations))
 	otherDeletes := make([]store.SyncMutation, 0, len(mutations))
 	sessionDeletes := make([]store.SyncMutation, 0, len(mutations))
 
@@ -882,6 +883,8 @@ func orderMutationsForApply(mutations []store.SyncMutation) []store.SyncMutation
 			sessionDeletes = append(sessionDeletes, mutation)
 		case mutation.Op == store.SyncOpDelete:
 			otherDeletes = append(otherDeletes, mutation)
+		case mutation.Entity == store.SyncEntityRelation:
+			relationUpserts = append(relationUpserts, mutation)
 		default:
 			otherUpserts = append(otherUpserts, mutation)
 		}
@@ -890,6 +893,7 @@ func orderMutationsForApply(mutations []store.SyncMutation) []store.SyncMutation
 	ordered := make([]store.SyncMutation, 0, len(mutations))
 	ordered = append(ordered, sessionUpserts...)
 	ordered = append(ordered, otherUpserts...)
+	ordered = append(ordered, relationUpserts...)
 	ordered = append(ordered, otherDeletes...)
 	ordered = append(ordered, sessionDeletes...)
 	return ordered

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2414,6 +2414,68 @@ func TestCloudImportReordersMutationsWithinChunkToAvoidFKFailures(t *testing.T) 
 	}
 }
 
+func TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk(t *testing.T) {
+	dst := newTestStore(t)
+	if err := dst.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll destination project: %v", err)
+	}
+
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-relation-before-observations"
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-24T12:00:00Z"}}}
+	chunk := ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: "rel-before-observations",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"rel-before-observations","source_id":"obs-relation-source","target_id":"obs-relation-target","relation":"compatible","judgment_status":"judged","project":"proj-a","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"}`,
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: "obs-relation-source",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"obs-relation-source","session_id":"sess-relation-order","type":"decision","title":"source","content":"source observation","project":"proj-a","scope":"project"}`,
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: "obs-relation-target",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"obs-relation-target","session_id":"sess-relation-order","type":"decision","title":"target","content":"target observation","project":"proj-a","scope":"project"}`,
+		},
+		{
+			Entity:    store.SyncEntitySession,
+			EntityKey: "sess-relation-order",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"id":"sess-relation-order","project":"proj-a","directory":"/tmp/proj-a"}`,
+		},
+	}}
+	chunkPayload, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal relation-first chunk: %v", err)
+	}
+	transport.chunks[chunkID] = chunkPayload
+
+	result, err := NewCloudWithTransport(dst, transport, "proj-a").Import()
+	if err != nil {
+		t.Fatalf("cloud import should apply observations before an earlier relation: %v", err)
+	}
+	if result.ChunksImported != 1 || result.ObservationsImported != 2 {
+		t.Fatalf("unexpected import result: %+v", result)
+	}
+	for _, syncID := range []string{"obs-relation-source", "obs-relation-target"} {
+		if _, err := dst.GetObservationBySyncID(syncID); err != nil {
+			t.Fatalf("expected referenced observation %q to be imported: %v", syncID, err)
+		}
+	}
+	relation, err := dst.GetRelation("rel-before-observations")
+	if err != nil {
+		t.Fatalf("expected relation to be imported: %v", err)
+	}
+	if relation.SourceID != "obs-relation-source" || relation.TargetID != "obs-relation-target" {
+		t.Fatalf("unexpected imported relation: %+v", relation)
+	}
+}
+
 func TestCloudImportMixedChunkAppliesDirectArrayDependenciesBeforeMutations(t *testing.T) {
 	dst := newTestStore(t)
 	if err := dst.EnrollProject("proj-a"); err != nil {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2476,6 +2476,63 @@ func TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk(t *testi
 	}
 }
 
+func TestCloudImportRollsBackRelationFirstChunkWhenEndpointIsMissing(t *testing.T) {
+	dst := newTestStore(t)
+	if err := dst.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll destination project: %v", err)
+	}
+
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-relation-missing-endpoint"
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-24T12:00:00Z"}}}
+	chunk := ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: "rel-missing-endpoint",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"rel-missing-endpoint","source_id":"obs-rollback-source","target_id":"obs-missing-target","relation":"compatible","judgment_status":"judged","project":"proj-a","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"}`,
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: "obs-rollback-source",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"obs-rollback-source","session_id":"sess-relation-rollback","type":"decision","title":"source","content":"source observation","project":"proj-a","scope":"project"}`,
+		},
+		{
+			Entity:    store.SyncEntitySession,
+			EntityKey: "sess-relation-rollback",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"id":"sess-relation-rollback","project":"proj-a","directory":"/tmp/proj-a"}`,
+		},
+	}}
+	chunkPayload, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal relation-first chunk with missing endpoint: %v", err)
+	}
+	transport.chunks[chunkID] = chunkPayload
+
+	if _, err := dst.GetObservationBySyncID("obs-missing-target"); err == nil {
+		t.Fatal("missing relation target must be absent from the destination before import")
+	}
+	if _, err := NewCloudWithTransport(dst, transport, "proj-a").Import(); !errors.Is(err, store.ErrRelationFKMissing) {
+		t.Fatalf("expected import to fail for the missing relation endpoint, got %v", err)
+	}
+
+	if _, err := dst.GetObservationBySyncID("obs-rollback-source"); err == nil {
+		t.Fatal("expected source observation upsert to roll back after failed relation import")
+	}
+	if _, err := dst.GetSession("sess-relation-rollback"); err == nil {
+		t.Fatal("expected session upsert to roll back after failed relation import")
+	}
+	synced, err := dst.GetSyncedChunks()
+	if err != nil {
+		t.Fatalf("get synced chunks: %v", err)
+	}
+	if synced[chunkID] {
+		t.Fatalf("failed chunk %q must not be marked synced", chunkID)
+	}
+}
+
 func TestCloudImportMixedChunkAppliesDirectArrayDependenciesBeforeMutations(t *testing.T) {
 	dst := newTestStore(t)
 	if err := dst.EnrollProject("proj-a"); err != nil {


### PR DESCRIPTION
## ­ƒöù Linked Issue

Closes #775

Refs #671

---

## ­ƒÅÀ´©Å PR Type

- [x] `type:bug` ÔÇö Bug fix
- [ ] `type:feature` ÔÇö New feature
- [ ] `type:docs` ÔÇö Documentation only
- [ ] `type:refactor` ÔÇö Code refactoring (no behavior change)
- [ ] `type:chore` ÔÇö Maintenance, dependencies, tooling
- [ ] `type:breaking-change` ÔÇö Breaking change

---

## ­ƒôØ Summary

- Apply relation upserts after session, observation, and prompt upserts from the same cloud chunk.
- Add a regression test where the relation appears before both referenced observations.
- Preserve existing delete ordering and keep self-relations, tombstones, and retry behavior out of scope.

## ­ƒôé Changes

| File | Change |
|------|--------|
| `internal/sync/sync.go` | Bucket relation upserts separately and append them after other upserts. |
| `internal/sync/sync_test.go` | Verify relation-first chunks import both observations and the relation successfully. |

## ­ƒº¬ Test Plan

- [x] Focused regression: `go test ./internal/sync -run '^TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk$' -count=1 -v`
- [x] Related sync ordering tests: `go test ./internal/sync -run 'TestCloudImport|TestApplyPulledChunk' -count=1`
- [x] Relation store tests: `go test ./internal/store -run '^TestRelationSync_' -count=1`
- [ ] Full local unit suite: `go test ./...` (did not complete on this Windows host; CI remains authoritative)
- [ ] E2E suite: not applicable to this internal sync ordering change

---

## ­ƒñû Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ÔÅ│ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ÔÅ│ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ÔÅ│ |
| **Unit Tests** | `go test ./...` passes | ÔÅ│ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ÔÅ│ |

---

## Ô£à Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: focused affected packages passed; full suite did not complete on this host
- [ ] I ran e2e tests locally: not applicable to this internal sync change
- [x] Docs updated (if behavior changed): no documentation change is required
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## ­ƒÆ¼ Notes for Reviewers

The frozen two-file candidate completed Gentle AI review with all four lenses approved. The commit tree exactly matches the reviewed candidate tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud imports now apply observation updates before relation updates when both appear in the same batch.
  * Relation records are resolved correctly, even when listed before their referenced observations.
  * Failed imports with missing relation endpoints now roll back related changes and remain available for retry.

* **Tests**
  * Added coverage for successful relation resolution and rollback behavior when required observations are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
