### PR TITLE
fix(cloud): keep credentials out of upgrade state

### DIFF
--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -498,7 +497,7 @@ func cmdCloudUpgradeBootstrap(cfg store.Config) {
 		return
 	}
 	cc.ServerURL = validatedURL
-	if err := captureUpgradeSnapshotBeforeBootstrap(s, cfg, project); err != nil {
+	if err := captureUpgradeSnapshotBeforeBootstrap(s, project); err != nil {
 		fatal(err)
 		return
 	}
@@ -528,14 +527,14 @@ func cmdCloudUpgradeBootstrap(cfg store.Config) {
 	fmt.Printf("noop: %t\n", result.NoOp)
 }
 
-func captureUpgradeSnapshotBeforeBootstrap(s *store.Store, cfg store.Config, project string) error {
+func captureUpgradeSnapshotBeforeBootstrap(s *store.Store, project string) error {
 	state, err := s.GetCloudUpgradeState(project)
 	if err != nil {
 		return fmt.Errorf("load cloud upgrade state before bootstrap snapshot: %w", err)
 	}
 	if state != nil {
 		snapshot := state.Snapshot
-		if snapshot.CloudConfigPresent || strings.TrimSpace(snapshot.CloudConfigJSON) != "" || snapshot.ProjectEnrolled {
+		if snapshot.Captured {
 			return nil
 		}
 	}
@@ -545,15 +544,7 @@ func captureUpgradeSnapshotBeforeBootstrap(s *store.Store, cfg store.Config, pro
 		return fmt.Errorf("load project enrollment before bootstrap snapshot: %w", err)
 	}
 
-	var snapshot store.CloudUpgradeSnapshot
-	configBytes, err := os.ReadFile(cloudConfigPath(cfg))
-	if err == nil {
-		snapshot.CloudConfigPresent = true
-		snapshot.CloudConfigJSON = string(configBytes)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("read cloud config for bootstrap snapshot: %w", err)
-	}
-	snapshot.ProjectEnrolled = enrolled
+	snapshot := store.CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: enrolled}
 
 	next := store.CloudUpgradeState{Project: project, Stage: store.UpgradeStagePlanned, RepairClass: store.UpgradeRepairClassNone, Snapshot: snapshot}
 	if state != nil {
@@ -629,14 +620,6 @@ func cmdCloudUpgradeRollback(cfg store.Config) {
 		fmt.Fprintln(os.Stderr, "rollback is unavailable post-bootstrap; use explicit disconnect/unenroll flows")
 		exitFunc(1)
 		return
-	}
-	if state.Snapshot.CloudConfigPresent {
-		if err := os.WriteFile(cloudConfigPath(cfg), []byte(state.Snapshot.CloudConfigJSON), 0o644); err != nil {
-			fatal(err)
-			return
-		}
-	} else {
-		_ = os.Remove(cloudConfigPath(cfg))
 	}
 	rolledBack, err := engramsync.RollbackProject(s, engramsync.UpgradeRollbackOptions{Project: project})
 	if err != nil {

--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -533,8 +533,13 @@ func captureUpgradeSnapshotBeforeBootstrap(s *store.Store, project string) error
 		return fmt.Errorf("load cloud upgrade state before bootstrap snapshot: %w", err)
 	}
 	if state != nil {
-		snapshot := state.Snapshot
-		if snapshot.Captured {
+		if (state.Stage == store.UpgradeStageBootstrapEnrolled ||
+			state.Stage == store.UpgradeStageBootstrapPushed ||
+			state.Stage == store.UpgradeStageBootstrapVerified) &&
+			!state.Snapshot.Captured {
+			return fmt.Errorf("bootstrap checkpoint requires a captured pre-bootstrap snapshot")
+		}
+		if state.Snapshot.Captured {
 			return nil
 		}
 	}

--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -497,7 +497,8 @@ func cmdCloudUpgradeBootstrap(cfg store.Config) {
 		return
 	}
 	cc.ServerURL = validatedURL
-	if err := captureUpgradeSnapshotBeforeBootstrap(s, project); err != nil {
+	project, _, err = engramsync.CaptureUpgradeSnapshotBeforeBootstrap(s, project)
+	if err != nil {
 		fatal(err)
 		return
 	}
@@ -525,41 +526,6 @@ func cmdCloudUpgradeBootstrap(cfg store.Config) {
 	fmt.Printf("stage: %s\n", result.Stage)
 	fmt.Printf("resumed: %t\n", result.Resumed)
 	fmt.Printf("noop: %t\n", result.NoOp)
-}
-
-func captureUpgradeSnapshotBeforeBootstrap(s *store.Store, project string) error {
-	state, err := s.GetCloudUpgradeState(project)
-	if err != nil {
-		return fmt.Errorf("load cloud upgrade state before bootstrap snapshot: %w", err)
-	}
-	if state != nil {
-		if (state.Stage == store.UpgradeStageBootstrapEnrolled ||
-			state.Stage == store.UpgradeStageBootstrapPushed ||
-			state.Stage == store.UpgradeStageBootstrapVerified) &&
-			!state.Snapshot.Captured {
-			return fmt.Errorf("bootstrap checkpoint requires a captured pre-bootstrap snapshot")
-		}
-		if state.Snapshot.Captured {
-			return nil
-		}
-	}
-
-	enrolled, err := s.IsProjectEnrolled(project)
-	if err != nil {
-		return fmt.Errorf("load project enrollment before bootstrap snapshot: %w", err)
-	}
-
-	snapshot := store.CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: enrolled}
-
-	next := store.CloudUpgradeState{Project: project, Stage: store.UpgradeStagePlanned, RepairClass: store.UpgradeRepairClassNone, Snapshot: snapshot}
-	if state != nil {
-		next = *state
-		next.Snapshot = snapshot
-	}
-	if err := s.SaveCloudUpgradeState(next); err != nil {
-		return fmt.Errorf("persist pre-bootstrap rollback snapshot: %w", err)
-	}
-	return nil
 }
 
 func cmdCloudUpgradeStatus(cfg store.Config) {

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -1139,11 +1139,8 @@ func TestCmdCloudUpgradeBootstrapStatusAndRollbackSemantics(t *testing.T) {
 			if state == nil {
 				return nil, fmt.Errorf("expected pre-bootstrap state snapshot")
 			}
-			if !state.Snapshot.CloudConfigPresent {
-				return nil, fmt.Errorf("expected snapshot cloud config presence to be true")
-			}
-			if !strings.Contains(state.Snapshot.CloudConfigJSON, "cloud.example.test") {
-				return nil, fmt.Errorf("expected snapshot cloud config json to include configured server")
+			if !state.Snapshot.Captured {
+				return nil, fmt.Errorf("expected pre-bootstrap snapshot to be captured")
 			}
 			if state.Snapshot.ProjectEnrolled {
 				return nil, fmt.Errorf("expected snapshot to preserve pre-bootstrap unenrolled state")
@@ -1164,6 +1161,36 @@ func TestCmdCloudUpgradeBootstrapStatusAndRollbackSemantics(t *testing.T) {
 			t.Fatalf("expected verified bootstrap stage output, got %q", stdout)
 		}
 	})
+}
+
+func TestCmdCloudUpgradeBootstrapSnapshotExcludesCloudCredentials(t *testing.T) {
+	stubExitWithPanic(t)
+	stubRuntimeHooks(t)
+
+	const token = "test-bootstrap-token-must-not-reach-sqlite"
+	cfg := testConfig(t)
+	if err := saveCloudConfig(cfg, &cloudConfig{ServerURL: "https://cloud.example.test", Token: token}); err != nil {
+		t.Fatalf("save cloud config: %v", err)
+	}
+
+	oldBootstrap := runUpgradeBootstrap
+	runUpgradeBootstrap = func(s *store.Store, project string, _ *cloudConfig) (*engramsync.UpgradeBootstrapResult, error) {
+		var snapshotJSON string
+		if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, project).Scan(&snapshotJSON); err != nil {
+			return nil, fmt.Errorf("read persisted bootstrap snapshot: %w", err)
+		}
+		if strings.Contains(snapshotJSON, token) || strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
+			return nil, fmt.Errorf("bootstrap snapshot persisted credential material: %s", snapshotJSON)
+		}
+		return &engramsync.UpgradeBootstrapResult{Project: project, Stage: store.UpgradeStageBootstrapVerified}, nil
+	}
+	t.Cleanup(func() { runUpgradeBootstrap = oldBootstrap })
+
+	withArgs(t, "engram", "cloud", "upgrade", "bootstrap", "--project", "proj-a")
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("bootstrap should not persist cloud credentials, panic=%v stderr=%q", recovered, stderr)
+	}
 }
 
 func TestCmdCloudUpgradeRepairStatusAndRollbackBranches(t *testing.T) {
@@ -1248,8 +1275,12 @@ func TestCmdCloudUpgradeRepairStatusAndRollbackBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("rollback restores cloud config when snapshot captured it", func(t *testing.T) {
+	t.Run("rollback leaves existing cloud config in place", func(t *testing.T) {
+		const token = "test-rollback-token-must-not-reach-sqlite"
 		cfg := testConfig(t)
+		if err := saveCloudConfig(cfg, &cloudConfig{ServerURL: "https://rollback.example.test", Token: token}); err != nil {
+			t.Fatalf("seed current cloud config: %v", err)
+		}
 		s, err := store.New(cfg)
 		if err != nil {
 			t.Fatalf("open store: %v", err)
@@ -1259,9 +1290,8 @@ func TestCmdCloudUpgradeRepairStatusAndRollbackBranches(t *testing.T) {
 			Stage:       store.UpgradeStageBootstrapPushed,
 			RepairClass: store.UpgradeRepairClassRepairable,
 			Snapshot: store.CloudUpgradeSnapshot{
-				CloudConfigPresent: true,
-				CloudConfigJSON:    `{"server_url":"https://rollback.example.test"}`,
-				ProjectEnrolled:    false,
+				Captured:        true,
+				ProjectEnrolled: false,
 			},
 		}); err != nil {
 			_ = s.Close()
@@ -1279,46 +1309,23 @@ func TestCmdCloudUpgradeRepairStatusAndRollbackBranches(t *testing.T) {
 		}
 		data, err := os.ReadFile(filepath.Join(cfg.DataDir, "cloud.json"))
 		if err != nil {
-			t.Fatalf("expected restored cloud config file: %v", err)
+			t.Fatalf("read existing cloud config after rollback: %v", err)
 		}
-		if !strings.Contains(string(data), "rollback.example.test") {
-			t.Fatalf("expected restored cloud config content, got %q", string(data))
+		if !strings.Contains(string(data), "rollback.example.test") || !strings.Contains(string(data), token) {
+			t.Fatalf("expected rollback to leave existing cloud config intact, got %q", string(data))
 		}
-	})
 
-	t.Run("rollback removes cloud config when snapshot had none", func(t *testing.T) {
-		cfg := testConfig(t)
-		if err := saveCloudConfig(cfg, &cloudConfig{ServerURL: "https://cloud.example.test"}); err != nil {
-			t.Fatalf("seed current cloud config: %v", err)
-		}
-		s, err := store.New(cfg)
+		s, err = store.New(cfg)
 		if err != nil {
-			t.Fatalf("open store: %v", err)
+			t.Fatalf("reopen store: %v", err)
 		}
-		if err := s.SaveCloudUpgradeState(store.CloudUpgradeState{
-			Project:     "proj-a",
-			Stage:       store.UpgradeStageBootstrapPushed,
-			RepairClass: store.UpgradeRepairClassRepairable,
-			Snapshot: store.CloudUpgradeSnapshot{
-				CloudConfigPresent: false,
-				ProjectEnrolled:    false,
-			},
-		}); err != nil {
-			_ = s.Close()
-			t.Fatalf("seed rollback state: %v", err)
+		t.Cleanup(func() { _ = s.Close() })
+		var snapshotJSON string
+		if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, "proj-a").Scan(&snapshotJSON); err != nil {
+			t.Fatalf("read rolled back snapshot: %v", err)
 		}
-		_ = s.Close()
-
-		withArgs(t, "engram", "cloud", "upgrade", "rollback", "--project", "proj-a")
-		stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
-		if recovered != nil || stderr != "" {
-			t.Fatalf("rollback should succeed, panic=%v stderr=%q", recovered, stderr)
-		}
-		if !strings.Contains(stdout, "stage: rolled_back") {
-			t.Fatalf("expected rolled_back stage output, got %q", stdout)
-		}
-		if _, err := os.Stat(filepath.Join(cfg.DataDir, "cloud.json")); !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("expected cloud config to be removed, err=%v", err)
+		if strings.Contains(snapshotJSON, token) || strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
+			t.Fatalf("rollback state persisted credential material: %s", snapshotJSON)
 		}
 	})
 }

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -1096,7 +1096,14 @@ func TestCmdCloudUpgradeBootstrapStatusAndRollbackSemantics(t *testing.T) {
 			t.Fatalf("open store: %v", err)
 		}
 		t.Cleanup(func() { _ = s.Close() })
-		if err := s.SaveCloudUpgradeState(store.CloudUpgradeState{Project: "proj-a", Stage: store.UpgradeStageBootstrapVerified, RepairClass: store.UpgradeRepairClassReady}); err != nil {
+		if err := s.SaveCloudUpgradeState(store.CloudUpgradeState{
+			Project:     "proj-a",
+			Stage:       store.UpgradeStageBootstrapVerified,
+			RepairClass: store.UpgradeRepairClassReady,
+			Snapshot: store.CloudUpgradeSnapshot{
+				Captured: true,
+			},
+		}); err != nil {
 			t.Fatalf("seed verified state: %v", err)
 		}
 
@@ -1190,6 +1197,125 @@ func TestCmdCloudUpgradeBootstrapSnapshotExcludesCloudCredentials(t *testing.T) 
 	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
 	if recovered != nil || stderr != "" {
 		t.Fatalf("bootstrap should not persist cloud credentials, panic=%v stderr=%q", recovered, stderr)
+	}
+}
+
+func TestCmdCloudUpgradeBootstrapCapturesEnrollmentFromPreBootstrapState(t *testing.T) {
+	stubExitWithPanic(t)
+	stubRuntimeHooks(t)
+
+	for _, stage := range []string{store.UpgradeStageDoctorReady, store.UpgradeStageRepairApplied} {
+		t.Run(stage, func(t *testing.T) {
+			cfg := testConfig(t)
+			if err := saveCloudConfig(cfg, &cloudConfig{ServerURL: "https://cloud.example.test"}); err != nil {
+				t.Fatalf("save cloud config: %v", err)
+			}
+			s, err := store.New(cfg)
+			if err != nil {
+				t.Fatalf("open store: %v", err)
+			}
+			if err := s.EnrollProject("proj-a"); err != nil {
+				_ = s.Close()
+				t.Fatalf("seed enrollment: %v", err)
+			}
+			if err := s.SaveCloudUpgradeState(store.CloudUpgradeState{
+				Project:     "proj-a",
+				Stage:       stage,
+				RepairClass: store.UpgradeRepairClassReady,
+			}); err != nil {
+				_ = s.Close()
+				t.Fatalf("seed pre-bootstrap state: %v", err)
+			}
+			if err := s.Close(); err != nil {
+				t.Fatalf("close seeded store: %v", err)
+			}
+
+			oldBootstrap := runUpgradeBootstrap
+			runUpgradeBootstrap = func(s *store.Store, project string, _ *cloudConfig) (*engramsync.UpgradeBootstrapResult, error) {
+				state, err := s.GetCloudUpgradeState(project)
+				if err != nil {
+					return nil, fmt.Errorf("load captured state: %w", err)
+				}
+				if state == nil || !state.Snapshot.Captured || !state.Snapshot.ProjectEnrolled {
+					return nil, fmt.Errorf("expected enrolled pre-bootstrap snapshot, got %+v", state)
+				}
+				return &engramsync.UpgradeBootstrapResult{Project: project, Stage: store.UpgradeStageBootstrapVerified}, nil
+			}
+			t.Cleanup(func() { runUpgradeBootstrap = oldBootstrap })
+
+			withArgs(t, "engram", "cloud", "upgrade", "bootstrap", "--project", "proj-a")
+			_, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
+			if recovered != nil || stderr != "" {
+				t.Fatalf("bootstrap should capture existing enrollment, panic=%v stderr=%q", recovered, stderr)
+			}
+		})
+	}
+}
+
+func TestCmdCloudUpgradeBootstrapRejectsUncapturedPostSideEffectCheckpoints(t *testing.T) {
+	stubExitWithPanic(t)
+	stubRuntimeHooks(t)
+
+	for _, stage := range []string{
+		store.UpgradeStageBootstrapEnrolled,
+		store.UpgradeStageBootstrapPushed,
+		store.UpgradeStageBootstrapVerified,
+	} {
+		t.Run(stage, func(t *testing.T) {
+			cfg := testConfig(t)
+			if err := saveCloudConfig(cfg, &cloudConfig{ServerURL: "https://cloud.example.test"}); err != nil {
+				t.Fatalf("save cloud config: %v", err)
+			}
+			s, err := store.New(cfg)
+			if err != nil {
+				t.Fatalf("open store: %v", err)
+			}
+			if err := s.EnrollProject("proj-a"); err != nil {
+				_ = s.Close()
+				t.Fatalf("seed enrollment: %v", err)
+			}
+			if err := s.SaveCloudUpgradeState(store.CloudUpgradeState{
+				Project:     "proj-a",
+				Stage:       stage,
+				RepairClass: store.UpgradeRepairClassRepairable,
+			}); err != nil {
+				_ = s.Close()
+				t.Fatalf("seed uncaptured checkpoint: %v", err)
+			}
+			if err := s.Close(); err != nil {
+				t.Fatalf("close seeded store: %v", err)
+			}
+
+			called := false
+			oldBootstrap := runUpgradeBootstrap
+			runUpgradeBootstrap = func(*store.Store, string, *cloudConfig) (*engramsync.UpgradeBootstrapResult, error) {
+				called = true
+				return nil, nil
+			}
+			t.Cleanup(func() { runUpgradeBootstrap = oldBootstrap })
+
+			withArgs(t, "engram", "cloud", "upgrade", "bootstrap", "--project", "proj-a")
+			_, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloud(cfg) })
+			if _, ok := recovered.(exitCode); !ok {
+				t.Fatalf("expected bootstrap checkpoint rejection, got %v", recovered)
+			}
+			if !strings.Contains(stderr, "requires a captured pre-bootstrap snapshot") {
+				t.Fatalf("expected captured-snapshot guidance, got %q", stderr)
+			}
+			if called {
+				t.Fatal("bootstrap must not proceed from an uncaptured checkpoint")
+			}
+
+			s, err = store.New(cfg)
+			if err != nil {
+				t.Fatalf("reopen store: %v", err)
+			}
+			defer s.Close()
+			enrolled, err := s.IsProjectEnrolled("proj-a")
+			if err != nil || !enrolled {
+				t.Fatalf("rejected bootstrap must preserve enrollment: enrolled=%t err=%v", enrolled, err)
+			}
+		})
 	}
 }
 
@@ -1313,19 +1439,6 @@ func TestCmdCloudUpgradeRepairStatusAndRollbackBranches(t *testing.T) {
 		}
 		if !strings.Contains(string(data), "rollback.example.test") || !strings.Contains(string(data), token) {
 			t.Fatalf("expected rollback to leave existing cloud config intact, got %q", string(data))
-		}
-
-		s, err = store.New(cfg)
-		if err != nil {
-			t.Fatalf("reopen store: %v", err)
-		}
-		t.Cleanup(func() { _ = s.Close() })
-		var snapshotJSON string
-		if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, "proj-a").Scan(&snapshotJSON); err != nil {
-			t.Fatalf("read rolled back snapshot: %v", err)
-		}
-		if strings.Contains(snapshotJSON, token) || strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
-			t.Fatalf("rollback state persisted credential material: %s", snapshotJSON)
 		}
 	})
 }

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -980,6 +980,15 @@ func TestCmdCloudUpgradeDoctorRequiresProjectAndIsDeterministic(t *testing.T) {
 		if !strings.Contains(bootstrapStderr, "legacy mutation payloads require repair") {
 			t.Fatalf("expected actionable legacy-repair guidance, got %q", bootstrapStderr)
 		}
+		capturedState, err := store.New(cfg)
+		if err != nil {
+			t.Fatalf("reopen store after bootstrap preflight: %v", err)
+		}
+		defer capturedState.Close()
+		state, err := capturedState.GetCloudUpgradeState("proj-legacy")
+		if err != nil || state == nil || !state.Snapshot.Captured || !state.Snapshot.ProjectEnrolled {
+			t.Fatalf("bootstrap must capture enrollment before legacy diagnosis: state=%+v err=%v", state, err)
+		}
 	})
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1107,8 +1107,17 @@ func (s *Store) redactCloudUpgradeSnapshots() error {
 			WHEN 1 THEN CASE
 				WHEN json_type(snapshot_json, '$.cloud_config_present') IS NOT NULL
 					OR json_type(snapshot_json, '$.cloud_config_json') IS NOT NULL
-					THEN '{"captured":true,"project_enrolled":' ||
-						CASE json_extract(snapshot_json, '$.project_enrolled') WHEN 1 THEN 'true' ELSE 'false' END || '}'
+					THEN CASE
+						WHEN stage IN ('planned', 'doctor_ready', 'doctor_blocked', 'repair_applied')
+							AND (
+								json_extract(snapshot_json, '$.cloud_config_present') = 1
+								OR ifnull(json_extract(snapshot_json, '$.cloud_config_json'), '') != ''
+								OR json_extract(snapshot_json, '$.project_enrolled') = 1
+							)
+							THEN '{"captured":true,"project_enrolled":' ||
+								CASE json_extract(snapshot_json, '$.project_enrolled') WHEN 1 THEN 'true' ELSE 'false' END || '}'
+						ELSE '{"captured":false,"project_enrolled":false}'
+					END
 				ELSE '{"captured":' ||
 					CASE json_extract(snapshot_json, '$.captured') WHEN 1 THEN 'true' ELSE 'false' END ||
 					',"project_enrolled":' ||
@@ -1206,7 +1215,7 @@ func (s *Store) CanRollbackCloudUpgrade(project string) (bool, error) {
 	if state == nil {
 		return false, nil
 	}
-	return state.Stage != UpgradeStageBootstrapVerified, nil
+	return state.Snapshot.Captured && state.Stage != UpgradeStageBootstrapVerified, nil
 }
 
 func (s *Store) RollbackCloudUpgrade(project string) (CloudUpgradeState, error) {
@@ -1223,7 +1232,7 @@ func (s *Store) RollbackCloudUpgrade(project string) (CloudUpgradeState, error) 
 	if state == nil {
 		return CloudUpgradeState{}, fmt.Errorf("rollback requires existing upgrade checkpoint state")
 	}
-	if state.Stage == UpgradeStageBootstrapVerified {
+	if !state.Snapshot.Captured || state.Stage == UpgradeStageBootstrapVerified {
 		return CloudUpgradeState{}, fmt.Errorf("rollback is unavailable post-bootstrap; use explicit disconnect/unenroll flows")
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1232,7 +1232,10 @@ func (s *Store) RollbackCloudUpgrade(project string) (CloudUpgradeState, error) 
 	if state == nil {
 		return CloudUpgradeState{}, fmt.Errorf("rollback requires existing upgrade checkpoint state")
 	}
-	if !state.Snapshot.Captured || state.Stage == UpgradeStageBootstrapVerified {
+	if !state.Snapshot.Captured {
+		return CloudUpgradeState{}, fmt.Errorf("rollback requires a captured pre-bootstrap snapshot")
+	}
+	if state.Stage == UpgradeStageBootstrapVerified {
 		return CloudUpgradeState{}, fmt.Errorf("rollback is unavailable post-bootstrap; use explicit disconnect/unenroll flows")
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -311,9 +311,8 @@ const (
 )
 
 type CloudUpgradeSnapshot struct {
-	CloudConfigPresent bool   `json:"cloud_config_present"`
-	CloudConfigJSON    string `json:"cloud_config_json,omitempty"`
-	ProjectEnrolled    bool   `json:"project_enrolled"`
+	Captured        bool `json:"captured"`
+	ProjectEnrolled bool `json:"project_enrolled"`
 }
 
 type CloudUpgradeState struct {
@@ -819,6 +818,9 @@ func (s *Store) migrate() error {
 	if _, err := s.execHook(s.db, schema); err != nil {
 		return err
 	}
+	if err := s.redactCloudUpgradeSnapshots(); err != nil {
+		return err
+	}
 
 	observationColumns := []struct {
 		name       string
@@ -1098,6 +1100,26 @@ func (s *Store) migrate() error {
 	return nil
 }
 
+func (s *Store) redactCloudUpgradeSnapshots() error {
+	_, err := s.execHook(s.db, `
+		UPDATE cloud_upgrade_state
+		SET snapshot_json = CASE json_valid(snapshot_json)
+			WHEN 1 THEN CASE
+				WHEN json_type(snapshot_json, '$.cloud_config_present') IS NOT NULL
+					OR json_type(snapshot_json, '$.cloud_config_json') IS NOT NULL
+					THEN '{"captured":true,"project_enrolled":' ||
+						CASE json_extract(snapshot_json, '$.project_enrolled') WHEN 1 THEN 'true' ELSE 'false' END || '}'
+				ELSE '{"captured":' ||
+					CASE json_extract(snapshot_json, '$.captured') WHEN 1 THEN 'true' ELSE 'false' END ||
+					',"project_enrolled":' ||
+					CASE json_extract(snapshot_json, '$.project_enrolled') WHEN 1 THEN 'true' ELSE 'false' END || '}'
+			END
+			ELSE '{"captured":false,"project_enrolled":false}'
+		END
+	`)
+	return err
+}
+
 func (s *Store) SaveCloudUpgradeState(state CloudUpgradeState) error {
 	project, _ := NormalizeProject(state.Project)
 	project = strings.TrimSpace(project)
@@ -1120,7 +1142,12 @@ func (s *Store) SaveCloudUpgradeState(state CloudUpgradeState) error {
 		ON CONFLICT(project) DO UPDATE SET
 			stage = excluded.stage,
 			repair_class = excluded.repair_class,
-			snapshot_json = excluded.snapshot_json,
+			snapshot_json = CASE
+				WHEN json_extract(excluded.snapshot_json, '$.captured') = 0
+					AND json_extract(cloud_upgrade_state.snapshot_json, '$.captured') = 1
+					THEN cloud_upgrade_state.snapshot_json
+				ELSE excluded.snapshot_json
+			END,
 			last_error_code = excluded.last_error_code,
 			last_error_message = excluded.last_error_message,
 			findings_json = excluded.findings_json,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2161,7 +2161,7 @@ func TestUpgradeStateSnapshotLifecycle(t *testing.T) {
 	}
 }
 
-func TestCloudUpgradeSnapshotMigrationRedactsAndRecovers(t *testing.T) {
+func TestCloudUpgradeSnapshotMigrationRedactsAndPreservesOnlyTrustedCaptures(t *testing.T) {
 	cfg := mustDefaultConfig(t)
 	cfg.DataDir = t.TempDir()
 
@@ -2176,19 +2176,25 @@ func TestCloudUpgradeSnapshotMigrationRedactsAndRecovers(t *testing.T) {
 	const token = "test-legacy-token-must-not-remain-in-sqlite"
 	testCases := []struct {
 		project  string
+		stage    string
 		snapshot string
 		want     CloudUpgradeSnapshot
 	}{
-		{"legacy", fmt.Sprintf(`{"cloud_config_present":true,"cloud_config_json":"{\"token\":\"%s\"}","project_enrolled":true}`, token), CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: true}},
-		{"uncaptured", `{"captured":false,"project_enrolled":false}`, CloudUpgradeSnapshot{}},
-		{"malformed", `{"captured":`, CloudUpgradeSnapshot{}},
+		{"legacy-captured", UpgradeStageDoctorReady, fmt.Sprintf(`{"cloud_config_present":true,"cloud_config_json":"%s","project_enrolled":true}`, token), CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: true}},
+		{"legacy-doctor", UpgradeStageDoctorBlocked, `{"cloud_config_present":false,"project_enrolled":false}`, CloudUpgradeSnapshot{}},
+		{"legacy-repair", UpgradeStageRepairApplied, `{"cloud_config_present":false,"project_enrolled":false}`, CloudUpgradeSnapshot{}},
+		{"legacy-post-side-effect", UpgradeStageBootstrapPushed, `{"cloud_config_present":true,"project_enrolled":false}`, CloudUpgradeSnapshot{}},
+		{"current-doctor", UpgradeStageDoctorReady, `{"captured":false,"project_enrolled":false}`, CloudUpgradeSnapshot{}},
+		{"current-repair", UpgradeStageRepairApplied, `{"captured":false,"project_enrolled":false}`, CloudUpgradeSnapshot{}},
+		{"malformed-enrolled", UpgradeStageBootstrapEnrolled, `{"captured":`, CloudUpgradeSnapshot{}},
+		{"malformed-pushed", UpgradeStageBootstrapPushed, `{"captured":`, CloudUpgradeSnapshot{}},
 	}
 	raw, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
 	if err != nil {
 		t.Fatalf("open raw store: %v", err)
 	}
 	for _, tc := range testCases {
-		if _, err := raw.Exec(`INSERT INTO cloud_upgrade_state (project, snapshot_json) VALUES (?, ?)`, tc.project, tc.snapshot); err != nil {
+		if _, err := raw.Exec(`INSERT INTO cloud_upgrade_state (project, stage, snapshot_json) VALUES (?, ?, ?)`, tc.project, tc.stage, tc.snapshot); err != nil {
 			_ = raw.Close()
 			t.Fatalf("seed %s snapshot: %v", tc.project, err)
 		}
@@ -2201,17 +2207,35 @@ func TestCloudUpgradeSnapshotMigrationRedactsAndRecovers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen migrated store: %v", err)
 	}
-	t.Cleanup(func() { _ = s.Close() })
 
 	for _, tc := range testCases {
 		state, err := s.GetCloudUpgradeState(tc.project)
 		if err != nil || state == nil || state.Snapshot != tc.want {
 			t.Fatalf("migrate %s snapshot: state=%+v err=%v", tc.project, state, err)
 		}
+		if tc.want.Captured {
+			continue
+		}
+		allowed, err := s.CanRollbackCloudUpgrade(tc.project)
+		if err != nil || allowed {
+			t.Fatalf("uncaptured %s snapshot must not allow rollback: allowed=%t err=%v", tc.project, allowed, err)
+		}
 	}
 	var snapshotJSON string
-	if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, "legacy").Scan(&snapshotJSON); err != nil || strings.Contains(snapshotJSON, token) || strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
+	if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, "legacy-captured").Scan(&snapshotJSON); err != nil || strings.Contains(snapshotJSON, token) || strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
 		t.Fatalf("legacy credential material remained in snapshot: %s (%v)", snapshotJSON, err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close migrated store: %v", err)
+	}
+	s, err = New(cfg)
+	if err != nil {
+		t.Fatalf("reopen idempotently redacted store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	state, err := s.GetCloudUpgradeState("legacy-captured")
+	if err != nil || state == nil || !state.Snapshot.Captured || !state.Snapshot.ProjectEnrolled {
+		t.Fatalf("idempotent migration lost captured snapshot: state=%+v err=%v", state, err)
 	}
 }
 
@@ -2760,6 +2784,31 @@ func TestRollbackCloudUpgradeSafetyBoundary(t *testing.T) {
 		_, err := s.RollbackCloudUpgrade("rb-verified")
 		if err == nil || !strings.Contains(err.Error(), "rollback is unavailable post-bootstrap") {
 			t.Fatalf("expected loud post-boundary failure, got %v", err)
+		}
+	})
+
+	t.Run("rollback rejects uncaptured checkpoints without changing enrollment", func(t *testing.T) {
+		s := newTestStore(t)
+		if err := s.EnrollProject("rb-uncaptured"); err != nil {
+			t.Fatalf("seed enrolled project: %v", err)
+		}
+		if err := s.SaveCloudUpgradeState(CloudUpgradeState{
+			Project:     "rb-uncaptured",
+			Stage:       UpgradeStageBootstrapPushed,
+			RepairClass: UpgradeRepairClassRepairable,
+		}); err != nil {
+			t.Fatalf("seed uncaptured checkpoint: %v", err)
+		}
+
+		if _, err := s.RollbackCloudUpgrade("rb-uncaptured"); err == nil {
+			t.Fatal("expected rollback with an uncaptured snapshot to fail")
+		}
+		enrolled, err := s.IsProjectEnrolled("rb-uncaptured")
+		if err != nil {
+			t.Fatalf("verify enrollment after rejected rollback: %v", err)
+		}
+		if !enrolled {
+			t.Fatal("rejected rollback must not unenroll the project")
 		}
 	})
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2098,9 +2098,8 @@ func TestUpgradeStateSnapshotLifecycle(t *testing.T) {
 	}
 
 	snapshot := CloudUpgradeSnapshot{
-		CloudConfigPresent: true,
-		CloudConfigJSON:    `{"server_url":"https://cloud.example.test"}`,
-		ProjectEnrolled:    false,
+		Captured:        true,
+		ProjectEnrolled: false,
 	}
 	state := CloudUpgradeState{
 		Project:          project,
@@ -2124,7 +2123,7 @@ func TestUpgradeStateSnapshotLifecycle(t *testing.T) {
 	if stored.Stage != UpgradeStageBootstrapEnrolled {
 		t.Fatalf("expected stage %q, got %q", UpgradeStageBootstrapEnrolled, stored.Stage)
 	}
-	if !stored.Snapshot.CloudConfigPresent || stored.Snapshot.CloudConfigJSON == "" {
+	if !stored.Snapshot.Captured || stored.Snapshot.ProjectEnrolled {
 		t.Fatalf("expected snapshot to roundtrip, got %+v", stored.Snapshot)
 	}
 
@@ -2159,6 +2158,60 @@ func TestUpgradeStateSnapshotLifecycle(t *testing.T) {
 	}
 	if afterClear != nil {
 		t.Fatalf("expected nil upgrade state after clear, got %+v", afterClear)
+	}
+}
+
+func TestCloudUpgradeSnapshotMigrationRedactsAndRecovers(t *testing.T) {
+	cfg := mustDefaultConfig(t)
+	cfg.DataDir = t.TempDir()
+
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store before legacy seed: %v", err)
+	}
+
+	const token = "test-legacy-token-must-not-remain-in-sqlite"
+	testCases := []struct {
+		project  string
+		snapshot string
+		want     CloudUpgradeSnapshot
+	}{
+		{"legacy", fmt.Sprintf(`{"cloud_config_present":true,"cloud_config_json":"{\"token\":\"%s\"}","project_enrolled":true}`, token), CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: true}},
+		{"uncaptured", `{"captured":false,"project_enrolled":false}`, CloudUpgradeSnapshot{}},
+		{"malformed", `{"captured":`, CloudUpgradeSnapshot{}},
+	}
+	raw, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
+	if err != nil {
+		t.Fatalf("open raw store: %v", err)
+	}
+	for _, tc := range testCases {
+		if _, err := raw.Exec(`INSERT INTO cloud_upgrade_state (project, snapshot_json) VALUES (?, ?)`, tc.project, tc.snapshot); err != nil {
+			_ = raw.Close()
+			t.Fatalf("seed %s snapshot: %v", tc.project, err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw store: %v", err)
+	}
+
+	s, err = New(cfg)
+	if err != nil {
+		t.Fatalf("reopen migrated store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	for _, tc := range testCases {
+		state, err := s.GetCloudUpgradeState(tc.project)
+		if err != nil || state == nil || state.Snapshot != tc.want {
+			t.Fatalf("migrate %s snapshot: state=%+v err=%v", tc.project, state, err)
+		}
+	}
+	var snapshotJSON string
+	if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, "legacy").Scan(&snapshotJSON); err != nil || strings.Contains(snapshotJSON, token) || strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
+		t.Fatalf("legacy credential material remained in snapshot: %s (%v)", snapshotJSON, err)
 	}
 }
 
@@ -2667,9 +2720,8 @@ func TestRollbackCloudUpgradeSafetyBoundary(t *testing.T) {
 			Stage:       UpgradeStageBootstrapPushed,
 			RepairClass: UpgradeRepairClassRepairable,
 			Snapshot: CloudUpgradeSnapshot{
-				CloudConfigPresent: true,
-				CloudConfigJSON:    `{"server_url":"https://cloud.example.test"}`,
-				ProjectEnrolled:    false,
+				Captured:        true,
+				ProjectEnrolled: false,
 			},
 		}); err != nil {
 			t.Fatalf("seed upgrade state: %v", err)
@@ -2698,8 +2750,8 @@ func TestRollbackCloudUpgradeSafetyBoundary(t *testing.T) {
 			Stage:       UpgradeStageBootstrapVerified,
 			RepairClass: UpgradeRepairClassReady,
 			Snapshot: CloudUpgradeSnapshot{
-				CloudConfigPresent: true,
-				ProjectEnrolled:    true,
+				Captured:        true,
+				ProjectEnrolled: true,
 			},
 		}); err != nil {
 			t.Fatalf("seed verified state: %v", err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2800,8 +2800,8 @@ func TestRollbackCloudUpgradeSafetyBoundary(t *testing.T) {
 			t.Fatalf("seed uncaptured checkpoint: %v", err)
 		}
 
-		if _, err := s.RollbackCloudUpgrade("rb-uncaptured"); err == nil {
-			t.Fatal("expected rollback with an uncaptured snapshot to fail")
+		if _, err := s.RollbackCloudUpgrade("rb-uncaptured"); err == nil || !strings.Contains(err.Error(), "rollback requires a captured pre-bootstrap snapshot") {
+			t.Fatalf("expected snapshot-specific rollback failure, got %v", err)
 		}
 		enrolled, err := s.IsProjectEnrolled("rb-uncaptured")
 		if err != nil {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -248,6 +248,33 @@ func BootstrapProject(s *store.Store, transport Transport, opts UpgradeBootstrap
 	if state != nil {
 		currentStage = state.Stage
 	}
+	if state != nil &&
+		(currentStage == store.UpgradeStageBootstrapEnrolled ||
+			currentStage == store.UpgradeStageBootstrapPushed ||
+			currentStage == store.UpgradeStageBootstrapVerified) &&
+		!state.Snapshot.Captured {
+		return nil, fmt.Errorf("bootstrap checkpoint requires a captured pre-bootstrap snapshot")
+	}
+	if state == nil || !state.Snapshot.Captured {
+		enrolled, err := s.IsProjectEnrolled(project)
+		if err != nil {
+			return nil, fmt.Errorf("load project enrollment before bootstrap snapshot: %w", err)
+		}
+		next := store.CloudUpgradeState{
+			Project:     project,
+			Stage:       store.UpgradeStagePlanned,
+			RepairClass: store.UpgradeRepairClassNone,
+		}
+		if state != nil {
+			next = *state
+		}
+		next.Snapshot = store.CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: enrolled}
+		if err := s.SaveCloudUpgradeState(next); err != nil {
+			return nil, fmt.Errorf("persist pre-bootstrap rollback snapshot: %w", err)
+		}
+		state = &next
+		currentStage = state.Stage
+	}
 	if currentStage == store.UpgradeStageBootstrapVerified {
 		return &UpgradeBootstrapResult{Project: project, Stage: currentStage, Resumed: true, NoOp: true}, nil
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -227,52 +227,17 @@ func NewCloudWithTransport(s *store.Store, transport Transport, project string) 
 }
 
 func BootstrapProject(s *store.Store, transport Transport, opts UpgradeBootstrapOptions) (*UpgradeBootstrapResult, error) {
-	if s == nil {
-		return nil, fmt.Errorf("cloud upgrade bootstrap requires store")
-	}
-	project, _ := store.NormalizeProject(opts.Project)
-	project = strings.TrimSpace(project)
-	if project == "" {
-		return nil, fmt.Errorf("cloud upgrade bootstrap requires project")
+	project, state, err := CaptureUpgradeSnapshotBeforeBootstrap(s, opts.Project)
+	if err != nil {
+		return nil, err
 	}
 	createdBy := strings.TrimSpace(opts.CreatedBy)
 	if createdBy == "" {
 		createdBy = "upgrade-bootstrap"
 	}
 
-	state, err := s.GetCloudUpgradeState(project)
-	if err != nil {
-		return nil, fmt.Errorf("read cloud upgrade checkpoint: %w", err)
-	}
 	currentStage := store.UpgradeStagePlanned
 	if state != nil {
-		currentStage = state.Stage
-	}
-	if state != nil &&
-		(currentStage == store.UpgradeStageBootstrapEnrolled ||
-			currentStage == store.UpgradeStageBootstrapPushed ||
-			currentStage == store.UpgradeStageBootstrapVerified) &&
-		!state.Snapshot.Captured {
-		return nil, fmt.Errorf("bootstrap checkpoint requires a captured pre-bootstrap snapshot")
-	}
-	if state == nil || !state.Snapshot.Captured {
-		enrolled, err := s.IsProjectEnrolled(project)
-		if err != nil {
-			return nil, fmt.Errorf("load project enrollment before bootstrap snapshot: %w", err)
-		}
-		next := store.CloudUpgradeState{
-			Project:     project,
-			Stage:       store.UpgradeStagePlanned,
-			RepairClass: store.UpgradeRepairClassNone,
-		}
-		if state != nil {
-			next = *state
-		}
-		next.Snapshot = store.CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: enrolled}
-		if err := s.SaveCloudUpgradeState(next); err != nil {
-			return nil, fmt.Errorf("persist pre-bootstrap rollback snapshot: %w", err)
-		}
-		state = &next
 		currentStage = state.Stage
 	}
 	if currentStage == store.UpgradeStageBootstrapVerified {
@@ -342,6 +307,56 @@ func BootstrapProject(s *store.Store, transport Transport, opts UpgradeBootstrap
 		Resumed: resumed,
 		NoOp:    false,
 	}, nil
+}
+
+// CaptureUpgradeSnapshotBeforeBootstrap persists the enrollment state needed to
+// roll back a bootstrap attempt and rejects unsafe post-effect checkpoints.
+func CaptureUpgradeSnapshotBeforeBootstrap(s *store.Store, project string) (string, *store.CloudUpgradeState, error) {
+	if s == nil {
+		return "", nil, fmt.Errorf("cloud upgrade bootstrap requires store")
+	}
+	project, _ = store.NormalizeProject(project)
+	project = strings.TrimSpace(project)
+	if project == "" {
+		return "", nil, fmt.Errorf("cloud upgrade bootstrap requires project")
+	}
+
+	state, err := s.GetCloudUpgradeState(project)
+	if err != nil {
+		return "", nil, fmt.Errorf("read cloud upgrade checkpoint: %w", err)
+	}
+	currentStage := store.UpgradeStagePlanned
+	if state != nil {
+		currentStage = state.Stage
+	}
+	if state != nil &&
+		(currentStage == store.UpgradeStageBootstrapEnrolled ||
+			currentStage == store.UpgradeStageBootstrapPushed ||
+			currentStage == store.UpgradeStageBootstrapVerified) &&
+		!state.Snapshot.Captured {
+		return "", nil, fmt.Errorf("bootstrap checkpoint requires a captured pre-bootstrap snapshot")
+	}
+	if state != nil && state.Snapshot.Captured {
+		return project, state, nil
+	}
+
+	enrolled, err := s.IsProjectEnrolled(project)
+	if err != nil {
+		return "", nil, fmt.Errorf("load project enrollment before bootstrap snapshot: %w", err)
+	}
+	next := store.CloudUpgradeState{
+		Project:     project,
+		Stage:       store.UpgradeStagePlanned,
+		RepairClass: store.UpgradeRepairClassNone,
+	}
+	if state != nil {
+		next = *state
+	}
+	next.Snapshot = store.CloudUpgradeSnapshot{Captured: true, ProjectEnrolled: enrolled}
+	if err := s.SaveCloudUpgradeState(next); err != nil {
+		return "", nil, fmt.Errorf("persist pre-bootstrap rollback snapshot: %w", err)
+	}
+	return project, &next, nil
 }
 
 func upgradeStageOrder(stage string) int {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -949,6 +949,10 @@ func TestUpgradeBootstrapCheckpointResume(t *testing.T) {
 		Project:     "proj-a",
 		Stage:       store.UpgradeStageBootstrapEnrolled,
 		RepairClass: store.UpgradeRepairClassRepairable,
+		Snapshot: store.CloudUpgradeSnapshot{
+			Captured:        true,
+			ProjectEnrolled: false,
+		},
 	}); err != nil {
 		t.Fatalf("seed checkpoint stage: %v", err)
 	}
@@ -976,6 +980,21 @@ func TestUpgradeBootstrapCheckpointResume(t *testing.T) {
 	if transport.writeChunkCalls != writeCallsBefore {
 		t.Fatalf("expected no additional push writes on rerun, before=%d after=%d", writeCallsBefore, transport.writeChunkCalls)
 	}
+
+	state, err := s.GetCloudUpgradeState("proj-a")
+	if err != nil {
+		t.Fatalf("load checkpoint state: %v", err)
+	}
+	if state == nil || !state.Snapshot.Captured || state.Snapshot.ProjectEnrolled {
+		t.Fatalf("expected checkpoints to preserve the pre-bootstrap snapshot, got %+v", state)
+	}
+	var snapshotJSON string
+	if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, "proj-a").Scan(&snapshotJSON); err != nil {
+		t.Fatalf("read persisted checkpoint snapshot: %v", err)
+	}
+	if strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
+		t.Fatalf("checkpoint persisted credential material: %s", snapshotJSON)
+	}
 }
 
 func TestRollbackProjectInvokesAutosyncHooksAndHonorsBoundary(t *testing.T) {
@@ -985,8 +1004,8 @@ func TestRollbackProjectInvokesAutosyncHooksAndHonorsBoundary(t *testing.T) {
 		Stage:       store.UpgradeStageBootstrapPushed,
 		RepairClass: store.UpgradeRepairClassRepairable,
 		Snapshot: store.CloudUpgradeSnapshot{
-			CloudConfigPresent: true,
-			ProjectEnrolled:    false,
+			Captured:        true,
+			ProjectEnrolled: false,
 		},
 	}); err != nil {
 		t.Fatalf("seed rollback state: %v", err)

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -997,6 +997,38 @@ func TestUpgradeBootstrapCheckpointResume(t *testing.T) {
 	}
 }
 
+func TestBootstrapProjectRejectsUncapturedPostSideEffectCheckpoints(t *testing.T) {
+	for _, stage := range []string{
+		store.UpgradeStageBootstrapEnrolled,
+		store.UpgradeStageBootstrapPushed,
+		store.UpgradeStageBootstrapVerified,
+	} {
+		t.Run(stage, func(t *testing.T) {
+			s := newTestStore(t)
+			if err := s.SaveCloudUpgradeState(store.CloudUpgradeState{
+				Project:     "proj-a",
+				Stage:       stage,
+				RepairClass: store.UpgradeRepairClassRepairable,
+			}); err != nil {
+				t.Fatalf("seed uncaptured checkpoint: %v", err)
+			}
+
+			transport := newFakeCloudTransport()
+			_, err := BootstrapProject(s, transport, UpgradeBootstrapOptions{Project: "proj-a"})
+			if err == nil || !strings.Contains(err.Error(), "requires a captured pre-bootstrap snapshot") {
+				t.Fatalf("expected uncaptured checkpoint failure, got %v", err)
+			}
+			if transport.writeChunkCalls != 0 {
+				t.Fatalf("uncaptured checkpoint must not push, writes=%d", transport.writeChunkCalls)
+			}
+			enrolled, err := s.IsProjectEnrolled("proj-a")
+			if err != nil || enrolled {
+				t.Fatalf("uncaptured checkpoint must not change enrollment: enrolled=%t err=%v", enrolled, err)
+			}
+		})
+	}
+}
+
 func TestRollbackProjectInvokesAutosyncHooksAndHonorsBoundary(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.SaveCloudUpgradeState(store.CloudUpgradeState{
@@ -1075,6 +1107,20 @@ func TestBootstrapProjectValidationAndCreatedByDefault(t *testing.T) {
 		if transport.lastCreatedBy != "upgrade-bootstrap" {
 			t.Fatalf("expected default createdBy upgrade-bootstrap, got %q", transport.lastCreatedBy)
 		}
+		state, err := s.GetCloudUpgradeState("proj-a")
+		if err != nil {
+			t.Fatalf("load direct bootstrap state: %v", err)
+		}
+		if state == nil || !state.Snapshot.Captured || state.Snapshot.ProjectEnrolled {
+			t.Fatalf("expected direct bootstrap to preserve the pre-enrollment snapshot, got %+v", state)
+		}
+		var snapshotJSON string
+		if err := s.DB().QueryRow(`SELECT snapshot_json FROM cloud_upgrade_state WHERE project = ?`, "proj-a").Scan(&snapshotJSON); err != nil {
+			t.Fatalf("read persisted direct bootstrap snapshot: %v", err)
+		}
+		if strings.Contains(snapshotJSON, `"token"`) || strings.Contains(snapshotJSON, "cloud_config") {
+			t.Fatalf("direct bootstrap persisted credential material: %s", snapshotJSON)
+		}
 	})
 }
 
@@ -1086,6 +1132,7 @@ func TestRollbackProjectHandlesHookFailures(t *testing.T) {
 			Stage:       store.UpgradeStageBootstrapPushed,
 			RepairClass: store.UpgradeRepairClassRepairable,
 			Snapshot: store.CloudUpgradeSnapshot{
+				Captured:        true,
 				ProjectEnrolled: false,
 			},
 		}); err != nil {
@@ -1109,6 +1156,7 @@ func TestRollbackProjectHandlesHookFailures(t *testing.T) {
 			Stage:       store.UpgradeStageBootstrapPushed,
 			RepairClass: store.UpgradeRepairClassRepairable,
 			Snapshot: store.CloudUpgradeSnapshot{
+				Captured:        true,
 				ProjectEnrolled: false,
 			},
 		}); err != nil {
@@ -1136,6 +1184,7 @@ func TestRollbackProjectHandlesHookFailures(t *testing.T) {
 			Stage:       store.UpgradeStageBootstrapPushed,
 			RepairClass: store.UpgradeRepairClassRepairable,
 			Snapshot: store.CloudUpgradeSnapshot{
+				Captured:        true,
 				ProjectEnrolled: false,
 			},
 		}); err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #740

---

## 🏷️ PR Type

- [x] type:bug — Bug fix
- [ ] type:feature — New feature
- [ ] type:docs — Documentation only
- [ ] type:refactor — Code refactoring
- [ ] type:chore — Maintenance, dependencies, tooling
- [ ] type:breaking-change — Breaking change

---

## 📝 Summary

- Stop bootstrap from persisting raw cloud.json or authentication tokens in cloud_upgrade_state.
- Preserve only safe capture and enrollment metadata across checkpoints and rollback.
- Redact legacy credential-bearing or malformed snapshot rows when the store opens.

## 📂 Changes

| File | Change |
|------|--------|
| cmd/engram/cloud.go | Capture safe upgrade metadata and leave cloud.json untouched during rollback. |
| internal/store/store.go | Redact legacy snapshots safely and preserve captured metadata during checkpoint upserts. |
| cmd/engram/main_extra_test.go | Prove bootstrap and rollback do not persist credentials. |
| internal/store/store_test.go | Cover legacy, uncaptured, and malformed snapshot migration. |
| internal/sync/sync_test.go | Prove checkpoint writes retain safe snapshot metadata. |

## 🧪 Test Plan

- [x] Focused bootstrap, rollback, migration, and checkpoint tests pass.
- [x] go vet ./cmd/engram ./internal/store ./internal/sync
- [x] git diff --check
- [ ] Broad local package runs retain documented Windows-only path and SQLite cleanup failures; Linux CI is authoritative.
- [ ] E2E suite runs in CI.

---

## ✅ Contributor Checklist

- [x] Linked approved issue #740.
- [x] Exactly one type label will be applied: type:bug.
- [x] Relevant focused tests pass locally.
- [x] No documentation change is required for this internal credential-hardening fix.
- [x] Commit follows conventional commits format.
- [x] No Co-Authored-By trailers are present.

---

## 💬 Notes for Reviewers

The issue attributed snapshot creation to doctor, but the confirmed producer was the bootstrap preflight. This PR addresses the confirmed SQLite credential exposure without changing general cloud credential storage. Historical SQLite/WAL page erasure is outside scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Cloud upgrade snapshots no longer store cloud credentials or local cloud configuration data.
  * Existing snapshots are safely redacted during migration.

* **Bug Fixes**
  * Rollbacks now preserve the current cloud configuration while restoring project state.
  * Upgrade snapshots more reliably track capture and enrollment status.
  * Upgrades reject incomplete checkpoints before making further changes.
  * Invalid or incomplete snapshots can no longer trigger unintended rollback actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->