### PR TITLE
fix(sync): isolate invalid relation imports

### DIFF
--- a/cmd/engram/autosync_e2e_test.go
+++ b/cmd/engram/autosync_e2e_test.go
@@ -343,11 +343,13 @@ func (s *autosyncFakeStore) MarkSyncBlocked(_, _, _ string) error { return nil }
 func (s *autosyncFakeStore) MarkSyncHealthy(_ string) error { return nil }
 
 // Phase E: deferred replay stubs — no-ops for the E2E fake store.
-func (s *autosyncFakeStore) ReplayDeferred() (store.ReplayDeferredResult, error) {
+func (s *autosyncFakeStore) ReplayDeferredForScope(_, _ string) (store.ReplayDeferredResult, error) {
 	return store.ReplayDeferredResult{}, nil
 }
 
-func (s *autosyncFakeStore) CountDeferredAndDead() (int, int, error) { return 0, 0, nil }
+func (s *autosyncFakeStore) CountDeferredAndDeadForScope(_, _ string) (int, int, error) {
+	return 0, 0, nil
+}
 
 // httpPushMutations is a helper to push mutations directly to a test server.
 func httpPushMutations(t *testing.T, serverURL, token string, entries []map[string]any) *http.Response {

--- a/cmd/engram/autosync_e2e_test.go
+++ b/cmd/engram/autosync_e2e_test.go
@@ -342,6 +342,10 @@ func (s *autosyncFakeStore) MarkSyncBlocked(_, _, _ string) error { return nil }
 
 func (s *autosyncFakeStore) MarkSyncHealthy(_ string) error { return nil }
 
+func (s *autosyncFakeStore) ListDeferredProjectsForTarget(_ string) ([]string, error) {
+	return nil, nil
+}
+
 // Phase E: deferred replay stubs — no-ops for the E2E fake store.
 func (s *autosyncFakeStore) ReplayDeferredForScope(_, _ string) (store.ReplayDeferredResult, error) {
 	return store.ReplayDeferredResult{}, nil

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1574,6 +1574,7 @@ func cmdSync(cfg store.Config) {
 			if result.ChunksSkipped > 0 {
 				fmt.Printf("  (%d chunks already imported)\n", result.ChunksSkipped)
 			}
+			printImportRelationCounts(result)
 			return
 		}
 
@@ -1588,6 +1589,7 @@ func cmdSync(cfg store.Config) {
 		if result.ChunksSkipped > 0 {
 			fmt.Printf("  Skipped:      %d (already imported)\n", result.ChunksSkipped)
 		}
+		printImportRelationCounts(result)
 		return
 	}
 
@@ -1635,6 +1637,12 @@ func cmdSync(cfg store.Config) {
 	fmt.Println()
 	fmt.Println("Add to git:")
 	fmt.Printf("  git add .engram/ && git commit -m \"sync engram memories\"\n")
+}
+
+func printImportRelationCounts(result *engramsync.ImportResult) {
+	fmt.Printf("  Relations replayed: %d\n", result.RelationsReplayed)
+	fmt.Printf("  Relations deferred: %d\n", result.RelationsDeferred)
+	fmt.Printf("  Relations dead:     %d\n", result.RelationsDead)
 }
 
 func printSyncUsage() {

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -232,6 +232,7 @@ func (a *mutationTransportAdapter) PullMutations(sinceSeq int64, limit int) (*au
 	for i, m := range resp.Mutations {
 		mutations[i] = autosync.PulledMutation{
 			Seq:        m.Seq,
+			Project:    m.Project,
 			Entity:     m.Entity,
 			EntityKey:  m.EntityKey,
 			Op:         m.Op,
@@ -1521,7 +1522,7 @@ func cmdSync(cfg store.Config) {
 		markCloudHealthy()
 	}
 
-	sy = engramsync.NewLocal(s, syncDir)
+	sy = engramsync.NewLocalWithProject(s, syncDir, project)
 	if cloudEnabled {
 		cc, err := preflightCloudSync(s, cfg, project, !doStatus)
 		if err != nil {

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -3858,6 +3858,30 @@ func TestCmdSyncImportEmptyAndMixedChunks(t *testing.T) {
 	})
 }
 
+func TestCmdSyncImportPrintsRelationCounts(t *testing.T) {
+	stubExitWithPanic(t)
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+	cfg := testConfig(t)
+
+	originalSyncImport := syncImport
+	t.Cleanup(func() { syncImport = originalSyncImport })
+	syncImport = func(*engramsync.Syncer) (*engramsync.ImportResult, error) {
+		return &engramsync.ImportResult{RelationsReplayed: 2, RelationsDeferred: 3, RelationsDead: 4}, nil
+	}
+
+	withArgs(t, "engram", "sync", "--import")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("sync import failed: panic=%v stderr=%q", recovered, stderr)
+	}
+	for _, want := range []string{"No new chunks to import", "Relations replayed: 2", "Relations deferred: 3", "Relations dead:     4"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, stdout)
+		}
+	}
+}
+
 func TestCommandErrorSeamsAndUncoveredBranches(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -60,6 +60,7 @@ type PushMutationsResult struct {
 
 type PulledMutation struct {
 	Seq        int64           `json:"seq"`
+	Project    string          `json:"project"`
 	Entity     string          `json:"entity"`
 	EntityKey  string          `json:"entity_key"`
 	Op         string          `json:"op"`
@@ -88,9 +89,8 @@ type LocalStore interface {
 	MarkSyncFailure(targetKey, message string, backoffUntil time.Time) error
 	MarkSyncBlocked(targetKey, reasonCode, message string) error
 	MarkSyncHealthy(targetKey string) error
-	// Phase E: deferred relation retry.
-	ReplayDeferred() (store.ReplayDeferredResult, error)
-	CountDeferredAndDead() (deferred, dead int, err error)
+	ReplayDeferredForScope(targetKey, project string) (store.ReplayDeferredResult, error)
+	CountDeferredAndDeadForScope(targetKey, project string) (deferred, dead int, err error)
 }
 
 type nonEnrolledPendingError struct {
@@ -237,7 +237,7 @@ func (m *Manager) Status() Status {
 	m.mu.RUnlock()
 
 	// Phase E: populate deferred/dead counts from store (live query, best-effort).
-	if deferred, dead, err := m.store.CountDeferredAndDead(); err == nil {
+	if deferred, dead, err := m.store.CountDeferredAndDeadForScope(m.cfg.TargetKey, ""); err == nil {
 		st.DeferredCount = deferred
 		st.DeadCount = dead
 	}
@@ -566,17 +566,6 @@ func (m *Manager) pull(ctx context.Context) error {
 
 	m.setPhase(PhasePulling)
 
-	// Phase E: replay deferred relation rows before fetching new mutations.
-	// This gives previously-deferred rows a chance to apply now that their
-	// referenced observations may have arrived.
-	if res, err := m.store.ReplayDeferred(); err != nil {
-		log.Printf("[autosync] replayDeferred error: %v", err)
-		// Non-fatal: log and continue — deferred replay failures must not halt pulls.
-	} else if res.Retried > 0 {
-		log.Printf("[autosync] replayDeferred: retried=%d succeeded=%d failed=%d dead=%d",
-			res.Retried, res.Succeeded, res.Failed, res.Dead)
-	}
-
 	state, err := m.store.GetSyncState(m.cfg.TargetKey)
 	if err != nil {
 		return fmt.Errorf("get sync state: %w", err)
@@ -584,6 +573,8 @@ func (m *Manager) pull(ctx context.Context) error {
 
 	sinceSeq := state.LastPulledSeq
 
+	touchedProjects := make(map[string]struct{})
+	projectOrder := make([]string, 0)
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -598,6 +589,7 @@ func (m *Manager) pull(ctx context.Context) error {
 			localMut := store.SyncMutation{
 				Seq:        rm.Seq,
 				TargetKey:  m.cfg.TargetKey,
+				Project:    rm.Project,
 				Entity:     rm.Entity,
 				EntityKey:  rm.EntityKey,
 				Op:         rm.Op,
@@ -612,6 +604,13 @@ func (m *Manager) pull(ctx context.Context) error {
 			if err := m.store.ApplyPulledMutation(m.cfg.TargetKey, localMut); err != nil {
 				return fmt.Errorf("apply pulled mutation seq=%d: %w", rm.Seq, err)
 			}
+			project := strings.TrimSpace(rm.Project)
+			if project != "" {
+				if _, seen := touchedProjects[project]; !seen {
+					touchedProjects[project] = struct{}{}
+					projectOrder = append(projectOrder, project)
+				}
+			}
 			if rm.Seq > sinceSeq {
 				sinceSeq = rm.Seq
 			}
@@ -619,6 +618,15 @@ func (m *Manager) pull(ctx context.Context) error {
 
 		if !resp.HasMore {
 			break
+		}
+	}
+
+	for _, project := range projectOrder {
+		if res, err := m.store.ReplayDeferredForScope(m.cfg.TargetKey, project); err != nil {
+			log.Printf("[autosync] replayDeferred project=%q error: %v", project, err)
+		} else if res.Retried > 0 {
+			log.Printf("[autosync] replayDeferred project=%q retried=%d succeeded=%d failed=%d dead=%d",
+				project, res.Retried, res.Succeeded, res.Failed, res.Dead)
 		}
 	}
 

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"math/rand"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -89,6 +90,7 @@ type LocalStore interface {
 	MarkSyncFailure(targetKey, message string, backoffUntil time.Time) error
 	MarkSyncBlocked(targetKey, reasonCode, message string) error
 	MarkSyncHealthy(targetKey string) error
+	ListDeferredProjectsForTarget(targetKey string) ([]string, error)
 	ReplayDeferredForScope(targetKey, project string) (store.ReplayDeferredResult, error)
 	CountDeferredAndDeadForScope(targetKey, project string) (deferred, dead int, err error)
 }
@@ -620,6 +622,24 @@ func (m *Manager) pull(ctx context.Context) error {
 			break
 		}
 	}
+
+	pendingProjects, err := m.store.ListDeferredProjectsForTarget(m.cfg.TargetKey)
+	if err != nil {
+		log.Printf("[autosync] list deferred projects target=%q error: %v", m.cfg.TargetKey, err)
+	} else {
+		for _, project := range pendingProjects {
+			project = strings.TrimSpace(project)
+			if project == "" {
+				continue
+			}
+			if _, seen := touchedProjects[project]; seen {
+				continue
+			}
+			touchedProjects[project] = struct{}{}
+			projectOrder = append(projectOrder, project)
+		}
+	}
+	sort.Strings(projectOrder)
 
 	for _, project := range projectOrder {
 		if res, err := m.store.ReplayDeferredForScope(m.cfg.TargetKey, project); err != nil {

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -138,11 +138,13 @@ func (s *fakeLocalStore) MarkSyncHealthy(_ string) error {
 
 // Phase E: deferred replay stubs — base fakeLocalStore always returns zero counts
 // and no error. Tests that need real replay behavior use fakeLocalStoreWithDeferred.
-func (s *fakeLocalStore) ReplayDeferred() (store.ReplayDeferredResult, error) {
+func (s *fakeLocalStore) ReplayDeferredForScope(_, _ string) (store.ReplayDeferredResult, error) {
 	return store.ReplayDeferredResult{}, nil
 }
 
-func (s *fakeLocalStore) CountDeferredAndDead() (int, int, error) { return 0, 0, nil }
+func (s *fakeLocalStore) CountDeferredAndDeadForScope(_, _ string) (int, int, error) {
+	return 0, 0, nil
+}
 
 // ─── Fake Transport ───────────────────────────────────────────────────────────
 
@@ -1424,6 +1426,7 @@ func TestReplayDeferred_RetriesAndApplies(t *testing.T) {
 	ls.mu.Lock()
 	ls.deferredRows = []DeferredRow{{
 		SyncID:      "rel-1",
+		Project:     "proj-a",
 		Entity:      "relation",
 		Payload:     `{"sync_id":"rel-1"}`,
 		RetryCount:  0,
@@ -1432,6 +1435,7 @@ func TestReplayDeferred_RetriesAndApplies(t *testing.T) {
 	ls.mu.Unlock()
 
 	// ReplayDeferred must be called by pull; simulate it resolving successfully.
+	tr.pullResult = &PullMutationsResponse{Mutations: []PulledMutation{{Seq: 1, Project: "proj-a", Entity: "observation", Op: "upsert"}}}
 	mgr := New(ls, tr, cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
@@ -1463,6 +1467,7 @@ func TestReplayDeferred_DeadAfterFiveRetries(t *testing.T) {
 	ls.mu.Lock()
 	ls.deferredRows = []DeferredRow{{
 		SyncID:      "rel-dead",
+		Project:     "proj-a",
 		Entity:      "relation",
 		Payload:     `{"sync_id":"rel-dead"}`,
 		RetryCount:  4,
@@ -1471,6 +1476,7 @@ func TestReplayDeferred_DeadAfterFiveRetries(t *testing.T) {
 	// Always return FK-missing for this deferred row.
 	ls.replayErr = store.ErrRelationFKMissing
 	ls.mu.Unlock()
+	tr.pullResult = &PullMutationsResponse{Mutations: []PulledMutation{{Seq: 1, Project: "proj-a", Entity: "observation", Op: "upsert"}}}
 
 	mgr := New(ls, tr, cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -1510,12 +1516,14 @@ func TestReplayDeferred_DeadRowNotRetried(t *testing.T) {
 	ls.mu.Lock()
 	ls.deferredRows = []DeferredRow{{
 		SyncID:      "rel-already-dead",
+		Project:     "proj-a",
 		Entity:      "relation",
 		Payload:     `{"sync_id":"rel-already-dead"}`,
 		RetryCount:  5,
 		ApplyStatus: "dead",
 	}}
 	ls.mu.Unlock()
+	tr.pullResult = &PullMutationsResponse{Mutations: []PulledMutation{{Seq: 1, Project: "proj-a", Entity: "observation", Op: "upsert"}}}
 
 	mgr := New(ls, tr, cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -1530,7 +1538,7 @@ func TestReplayDeferred_DeadRowNotRetried(t *testing.T) {
 		if called {
 			// Dead row must never have been applied.
 			ls.mu.Lock()
-			appliedCount := len(ls.appliedMuts)
+			appliedCount := ls.deferredApplied
 			ls.mu.Unlock()
 			if appliedCount != 0 {
 				t.Fatalf("dead row should never be applied; got %d applied mutations", appliedCount)
@@ -1599,6 +1607,7 @@ func TestPull_LegacyEntityNonFKError_StillHalts(t *testing.T) {
 // DeferredRow is a minimal representation of a sync_apply_deferred row used in tests.
 type DeferredRow struct {
 	SyncID      string
+	Project     string
 	Entity      string
 	Payload     string
 	RetryCount  int
@@ -1610,18 +1619,24 @@ type fakeLocalStoreWithDeferred struct {
 	fakeLocalStore
 	deferredRows         []DeferredRow
 	replayDeferredCalled bool
+	replayProjects       []string
+	deferredApplied      int
 	markDeadCalled       bool
 	replayErr            error
 }
 
-func (s *fakeLocalStoreWithDeferred) ReplayDeferred() (store.ReplayDeferredResult, error) {
+func (s *fakeLocalStoreWithDeferred) ReplayDeferredForScope(_ string, project string) (store.ReplayDeferredResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.replayDeferredCalled = true
+	s.replayProjects = append(s.replayProjects, project)
 
 	var res store.ReplayDeferredResult
 	for i := range s.deferredRows {
 		row := &s.deferredRows[i]
+		if row.Project != project {
+			continue
+		}
 		if row.ApplyStatus == "dead" {
 			continue // Dead rows must not be retried.
 		}
@@ -1637,16 +1652,20 @@ func (s *fakeLocalStoreWithDeferred) ReplayDeferred() (store.ReplayDeferredResul
 			}
 		} else {
 			row.ApplyStatus = "applied"
+			s.deferredApplied++
 			res.Succeeded++
 		}
 	}
 	return res, nil
 }
 
-func (s *fakeLocalStoreWithDeferred) CountDeferredAndDead() (deferred, dead int, err error) {
+func (s *fakeLocalStoreWithDeferred) CountDeferredAndDeadForScope(_, project string) (deferred, dead int, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, row := range s.deferredRows {
+		if project != "" && row.Project != project {
+			continue
+		}
 		switch row.ApplyStatus {
 		case "deferred":
 			deferred++
@@ -1655,6 +1674,30 @@ func (s *fakeLocalStoreWithDeferred) CountDeferredAndDead() (deferred, dead int,
 		}
 	}
 	return deferred, dead, nil
+}
+
+func TestPullReplaysOnlyProjectsImportedThisCycle(t *testing.T) {
+	ls := &fakeLocalStoreWithDeferred{fakeLocalStore: *newFakeLocalStore()}
+	ls.deferredRows = []DeferredRow{
+		{SyncID: "rel-project-a", Project: "project-a", RetryCount: 4, ApplyStatus: "deferred"},
+		{SyncID: "rel-project-b", Project: "project-b", RetryCount: 0, ApplyStatus: "deferred"},
+	}
+	tr := newFakeTransport()
+	tr.pullResult = &PullMutationsResponse{Mutations: []PulledMutation{{
+		Seq: 1, Project: "project-b", Entity: "observation", Op: "upsert",
+	}}}
+
+	if err := New(ls, tr, DefaultConfig()).pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if got := ls.replayProjects; len(got) != 1 || got[0] != "project-b" {
+		t.Fatalf("replay projects = %v, want [project-b]", got)
+	}
+	if row := ls.deferredRows[0]; row.RetryCount != 4 || row.ApplyStatus != "deferred" {
+		t.Fatalf("project-a deferred row changed by project-b pull: %+v", row)
+	}
 }
 
 // ─── Helper types ─────────────────────────────────────────────────────────────

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -1684,8 +1684,8 @@ func (s *fakeLocalStoreWithDeferred) ReplayDeferredForScope(targetKey, project s
 		if row.TargetKey != targetKey || row.Project != project {
 			continue
 		}
-		if row.ApplyStatus == "dead" {
-			continue // Dead rows must not be retried.
+		if row.ApplyStatus != "deferred" {
+			continue
 		}
 		res.Retried++
 		if s.replayErr != nil {
@@ -1737,16 +1737,30 @@ func TestPullDoesNotReplayOtherTargetDeferredScopes(t *testing.T) {
 	if err := New(ls, tr, DefaultConfig()).pull(context.Background()); err != nil {
 		t.Fatalf("pull: %v", err)
 	}
+	func() {
+		ls.mu.Lock()
+		defer ls.mu.Unlock()
+		if got := ls.replayProjects; len(got) != 1 || got[0] != "project-b" {
+			t.Fatalf("replay projects = %v, want [project-b]", got)
+		}
+		if row := ls.deferredRows[0]; row.RetryCount != 4 || row.ApplyStatus != "deferred" {
+			t.Fatalf("project-a deferred row changed by project-b pull: %+v", row)
+		}
+		if row := ls.deferredRows[1]; row.ApplyStatus != "applied" {
+			t.Fatalf("project-b deferred row was not applied: %+v", row)
+		}
+		if ls.deferredApplied != 1 {
+			t.Fatalf("applied deferred rows = %d, want 1", ls.deferredApplied)
+		}
+	}()
+
+	if err := New(ls, tr, DefaultConfig()).pull(context.Background()); err != nil {
+		t.Fatalf("second pull: %v", err)
+	}
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
-	if got := ls.replayProjects; len(got) != 1 || got[0] != "project-b" {
-		t.Fatalf("replay projects = %v, want [project-b]", got)
-	}
-	if row := ls.deferredRows[0]; row.RetryCount != 4 || row.ApplyStatus != "deferred" {
-		t.Fatalf("project-a deferred row changed by project-b pull: %+v", row)
-	}
-	if row := ls.deferredRows[1]; row.ApplyStatus != "applied" {
-		t.Fatalf("project-b deferred row was not applied: %+v", row)
+	if ls.deferredApplied != 1 {
+		t.Fatalf("second pull reapplied deferred rows: got %d, want 1", ls.deferredApplied)
 	}
 }
 

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,10 @@ type fakeLocalStore struct {
 	ackErr            error
 	healthyCalls      int
 	nonEnrolledCounts []store.PendingSyncMutationProjectCount
+	deferredProjects  []string
+	listDeferredErr   error
+	listedTargets     []string
+	replayedScopes    []string
 }
 
 func newFakeLocalStore() *fakeLocalStore {
@@ -136,9 +141,22 @@ func (s *fakeLocalStore) MarkSyncHealthy(_ string) error {
 	return nil
 }
 
+func (s *fakeLocalStore) ListDeferredProjectsForTarget(targetKey string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listedTargets = append(s.listedTargets, targetKey)
+	if s.listDeferredErr != nil {
+		return nil, s.listDeferredErr
+	}
+	return append([]string(nil), s.deferredProjects...), nil
+}
+
 // Phase E: deferred replay stubs — base fakeLocalStore always returns zero counts
 // and no error. Tests that need real replay behavior use fakeLocalStoreWithDeferred.
-func (s *fakeLocalStore) ReplayDeferredForScope(_, _ string) (store.ReplayDeferredResult, error) {
+func (s *fakeLocalStore) ReplayDeferredForScope(_ string, project string) (store.ReplayDeferredResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.replayedScopes = append(s.replayedScopes, project)
 	return store.ReplayDeferredResult{}, nil
 }
 
@@ -1426,6 +1444,7 @@ func TestReplayDeferred_RetriesAndApplies(t *testing.T) {
 	ls.mu.Lock()
 	ls.deferredRows = []DeferredRow{{
 		SyncID:      "rel-1",
+		TargetKey:   "cloud",
 		Project:     "proj-a",
 		Entity:      "relation",
 		Payload:     `{"sync_id":"rel-1"}`,
@@ -1467,6 +1486,7 @@ func TestReplayDeferred_DeadAfterFiveRetries(t *testing.T) {
 	ls.mu.Lock()
 	ls.deferredRows = []DeferredRow{{
 		SyncID:      "rel-dead",
+		TargetKey:   "cloud",
 		Project:     "proj-a",
 		Entity:      "relation",
 		Payload:     `{"sync_id":"rel-dead"}`,
@@ -1516,6 +1536,7 @@ func TestReplayDeferred_DeadRowNotRetried(t *testing.T) {
 	ls.mu.Lock()
 	ls.deferredRows = []DeferredRow{{
 		SyncID:      "rel-already-dead",
+		TargetKey:   "cloud",
 		Project:     "proj-a",
 		Entity:      "relation",
 		Payload:     `{"sync_id":"rel-already-dead"}`,
@@ -1607,6 +1628,7 @@ func TestPull_LegacyEntityNonFKError_StillHalts(t *testing.T) {
 // DeferredRow is a minimal representation of a sync_apply_deferred row used in tests.
 type DeferredRow struct {
 	SyncID      string
+	TargetKey   string
 	Project     string
 	Entity      string
 	Payload     string
@@ -1623,18 +1645,43 @@ type fakeLocalStoreWithDeferred struct {
 	deferredApplied      int
 	markDeadCalled       bool
 	replayErr            error
+	replayCallErr        error
 }
 
-func (s *fakeLocalStoreWithDeferred) ReplayDeferredForScope(_ string, project string) (store.ReplayDeferredResult, error) {
+func (s *fakeLocalStoreWithDeferred) ListDeferredProjectsForTarget(targetKey string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listedTargets = append(s.listedTargets, targetKey)
+	if s.listDeferredErr != nil {
+		return nil, s.listDeferredErr
+	}
+	projects := make(map[string]struct{})
+	for _, row := range s.deferredRows {
+		if row.TargetKey == targetKey && row.Project != "" && row.ApplyStatus == "deferred" {
+			projects[row.Project] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(projects))
+	for project := range projects {
+		result = append(result, project)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func (s *fakeLocalStoreWithDeferred) ReplayDeferredForScope(targetKey, project string) (store.ReplayDeferredResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.replayDeferredCalled = true
 	s.replayProjects = append(s.replayProjects, project)
+	if s.replayCallErr != nil {
+		return store.ReplayDeferredResult{}, s.replayCallErr
+	}
 
 	var res store.ReplayDeferredResult
 	for i := range s.deferredRows {
 		row := &s.deferredRows[i]
-		if row.Project != project {
+		if row.TargetKey != targetKey || row.Project != project {
 			continue
 		}
 		if row.ApplyStatus == "dead" {
@@ -1676,11 +1723,11 @@ func (s *fakeLocalStoreWithDeferred) CountDeferredAndDeadForScope(_, project str
 	return deferred, dead, nil
 }
 
-func TestPullReplaysOnlyProjectsImportedThisCycle(t *testing.T) {
+func TestPullDoesNotReplayOtherTargetDeferredScopes(t *testing.T) {
 	ls := &fakeLocalStoreWithDeferred{fakeLocalStore: *newFakeLocalStore()}
 	ls.deferredRows = []DeferredRow{
-		{SyncID: "rel-project-a", Project: "project-a", RetryCount: 4, ApplyStatus: "deferred"},
-		{SyncID: "rel-project-b", Project: "project-b", RetryCount: 0, ApplyStatus: "deferred"},
+		{SyncID: "rel-project-a", TargetKey: "cloud:project-a", Project: "project-a", RetryCount: 4, ApplyStatus: "deferred"},
+		{SyncID: "rel-project-b", TargetKey: "cloud", Project: "project-b", RetryCount: 0, ApplyStatus: "deferred"},
 	}
 	tr := newFakeTransport()
 	tr.pullResult = &PullMutationsResponse{Mutations: []PulledMutation{{
@@ -1697,6 +1744,98 @@ func TestPullReplaysOnlyProjectsImportedThisCycle(t *testing.T) {
 	}
 	if row := ls.deferredRows[0]; row.RetryCount != 4 || row.ApplyStatus != "deferred" {
 		t.Fatalf("project-a deferred row changed by project-b pull: %+v", row)
+	}
+	if row := ls.deferredRows[1]; row.ApplyStatus != "applied" {
+		t.Fatalf("project-b deferred row was not applied: %+v", row)
+	}
+}
+
+func TestPullReplaysPersistedDeferredScopeWithoutMutations(t *testing.T) {
+	ls := &fakeLocalStoreWithDeferred{fakeLocalStore: *newFakeLocalStore()}
+	ls.deferredRows = []DeferredRow{
+		{SyncID: "rel-project-b", TargetKey: "cloud:project-b", Project: "project-b", ApplyStatus: "deferred"},
+		{SyncID: "rel-project-a", TargetKey: "cloud:project-a", Project: "project-a", RetryCount: 4, ApplyStatus: "deferred"},
+	}
+	tr := newFakeTransport()
+	tr.pullResult = &PullMutationsResponse{}
+	cfg := DefaultConfig()
+	cfg.TargetKey = "cloud:project-b"
+
+	if err := New(ls, tr, cfg).pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if got := ls.replayProjects; len(got) != 1 || got[0] != "project-b" {
+		t.Fatalf("replay projects = %v, want [project-b]", got)
+	}
+	if row := ls.deferredRows[0]; row.ApplyStatus != "applied" {
+		t.Fatalf("pending project-b row was not applied: %+v", row)
+	}
+	if row := ls.deferredRows[1]; row.RetryCount != 4 || row.ApplyStatus != "deferred" {
+		t.Fatalf("other target/project row changed: %+v", row)
+	}
+}
+
+func TestPullMergesTouchedAndPendingDeferredScopes(t *testing.T) {
+	ls := &fakeLocalStoreWithDeferred{fakeLocalStore: *newFakeLocalStore()}
+	ls.deferredRows = []DeferredRow{
+		{SyncID: "rel-project-a", TargetKey: "cloud", Project: "project-a", ApplyStatus: "deferred"},
+		{SyncID: "rel-project-b", TargetKey: "cloud", Project: "project-b", ApplyStatus: "deferred"},
+	}
+	tr := newFakeTransport()
+	tr.pullResult = &PullMutationsResponse{Mutations: []PulledMutation{{
+		Seq: 1, Project: "project-b", Entity: "observation", Op: "upsert",
+	}}}
+
+	if err := New(ls, tr, DefaultConfig()).pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if got, want := fmt.Sprint(ls.replayProjects), "[project-a project-b]"; got != want {
+		t.Fatalf("replay projects = %s, want %s", got, want)
+	}
+	if ls.deferredApplied != 2 {
+		t.Fatalf("applied deferred rows = %d, want 2", ls.deferredApplied)
+	}
+}
+
+func TestPullDeferredScopeEnumerationFailureDoesNotInventScopes(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.listDeferredErr = errors.New("list deferred projects")
+	tr := newFakeTransport()
+	tr.pullResult = &PullMutationsResponse{}
+
+	if err := New(ls, tr, DefaultConfig()).pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if got := ls.replayedScopes; len(got) != 0 {
+		t.Fatalf("replayed scopes = %v, want none", got)
+	}
+}
+
+func TestPullDeferredScopeReplayErrorIsNonFatal(t *testing.T) {
+	ls := &fakeLocalStoreWithDeferred{fakeLocalStore: *newFakeLocalStore()}
+	ls.deferredRows = []DeferredRow{{
+		SyncID: "rel-project-b", TargetKey: "cloud", Project: "project-b", ApplyStatus: "deferred",
+	}}
+	ls.replayCallErr = errors.New("replay deferred")
+	tr := newFakeTransport()
+	tr.pullResult = &PullMutationsResponse{}
+
+	if err := New(ls, tr, DefaultConfig()).pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if got := ls.replayProjects; len(got) != 1 || got[0] != "project-b" {
+		t.Fatalf("replay projects = %v, want [project-b]", got)
+	}
+	if row := ls.deferredRows[0]; row.ApplyStatus != "deferred" {
+		t.Fatalf("replay error changed deferred row: %+v", row)
 	}
 }
 

--- a/internal/cloud/remote/transport.go
+++ b/internal/cloud/remote/transport.go
@@ -268,6 +268,7 @@ type PushMutationsResult struct {
 
 type PulledMutation struct {
 	Seq        int64           `json:"seq"`
+	Project    string          `json:"project"`
 	Entity     string          `json:"entity"`
 	EntityKey  string          `json:"entity_key"`
 	Op         string          `json:"op"`

--- a/internal/cloud/remote/transport_mutations_test.go
+++ b/internal/cloud/remote/transport_mutations_test.go
@@ -93,7 +93,7 @@ func TestMutationTransportPullSinceSeq(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"mutations":[{"seq":6,"entity":"obs","entity_key":"k6","op":"upsert","payload":{}}],"has_more":false,"latest_seq":10}`))
+		_, _ = w.Write([]byte(`{"mutations":[{"seq":6,"project":"project-a","entity":"obs","entity_key":"k6","op":"upsert","payload":{}}],"has_more":false,"latest_seq":10}`))
 	}))
 	defer srv.Close()
 
@@ -110,6 +110,9 @@ func TestMutationTransportPullSinceSeq(t *testing.T) {
 	}
 	if resp.LatestSeq != 10 {
 		t.Fatalf("expected latest_seq=10, got %d", resp.LatestSeq)
+	}
+	if resp.Mutations[0].Project != "project-a" {
+		t.Fatalf("expected mutation project project-a, got %q", resp.Mutations[0].Project)
 	}
 }
 

--- a/internal/store/relation_sync_integration_test.go
+++ b/internal/store/relation_sync_integration_test.go
@@ -149,6 +149,8 @@ func TestRelationSync_PushPull_CrossMachine(t *testing.T) {
 // deferred. Then observations arrive. replayDeferred() succeeds.
 func TestRelationSync_FKMissDeferRetrySuccess(t *testing.T) {
 	s := newTestStore(t)
+	actor := "test-actor"
+	kind := "test"
 	if err := s.CreateSession("ses-g2-a", "proj-g2", "/tmp/g2-a"); err != nil {
 		t.Fatalf("G.2: CreateSession: %v", err)
 	}
@@ -166,6 +168,8 @@ func TestRelationSync_FKMissDeferRetrySuccess(t *testing.T) {
 		TargetID:       missingTargetSyncID,
 		Relation:       RelationSupersedes,
 		JudgmentStatus: JudgmentStatusJudged,
+		MarkedByActor:  &actor,
+		MarkedByKind:   &kind,
 		Project:        "proj-g2",
 		CreatedAt:      "2026-04-26T12:00:00Z",
 		UpdatedAt:      "2026-04-26T12:00:00Z",
@@ -212,6 +216,8 @@ func TestRelationSync_FKMissDeferRetrySuccess(t *testing.T) {
 		TargetID:       arrivedTargetSyncID,
 		Relation:       RelationSupersedes,
 		JudgmentStatus: JudgmentStatusJudged,
+		MarkedByActor:  &actor,
+		MarkedByKind:   &kind,
 		Project:        "proj-g2",
 		CreatedAt:      "2026-04-26T12:00:00Z",
 		UpdatedAt:      "2026-04-26T12:00:00Z",
@@ -249,6 +255,8 @@ func TestRelationSync_FKMissDeferRetrySuccess(t *testing.T) {
 // After 5 retries, apply_status='dead' and the row is no longer attempted.
 func TestRelationSync_RetryCapDead(t *testing.T) {
 	s := newTestStore(t)
+	actor := "test-actor"
+	kind := "test"
 	if err := s.CreateSession("ses-g3", "proj-g3", "/tmp/g3"); err != nil {
 		t.Fatalf("G.3: CreateSession: %v", err)
 	}
@@ -262,6 +270,8 @@ func TestRelationSync_RetryCapDead(t *testing.T) {
 		TargetID:       missingTarget,
 		Relation:       RelationCompatible,
 		JudgmentStatus: JudgmentStatusJudged,
+		MarkedByActor:  &actor,
+		MarkedByKind:   &kind,
 		Project:        "proj-g3",
 		CreatedAt:      "2026-04-26T12:00:00Z",
 		UpdatedAt:      "2026-04-26T12:00:00Z",

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -26,13 +26,13 @@ var ErrSemanticPromptBuilderRequired = errors.New("semantic scan requires a non-
 // Valid relation type values. Type compatibility is NOT enforced in Phase 1;
 // the agent does that judgment.
 const (
-	RelationPending      = "pending"
-	RelationRelated      = "related"
-	RelationCompatible   = "compatible"
-	RelationScoped       = "scoped"
+	RelationPending       = "pending"
+	RelationRelated       = "related"
+	RelationCompatible    = "compatible"
+	RelationScoped        = "scoped"
 	RelationConflictsWith = "conflicts_with"
-	RelationSupersedes   = "supersedes"
-	RelationNotConflict  = "not_conflict"
+	RelationSupersedes    = "supersedes"
+	RelationNotConflict   = "not_conflict"
 )
 
 // Valid judgment_status values.
@@ -118,17 +118,20 @@ type RelationListItem struct {
 
 // RelationStats holds aggregate counts of relations for a project.
 type RelationStats struct {
-	Project         string         `json:"project"`
-	ByRelation      map[string]int `json:"by_relation"`
+	Project          string         `json:"project"`
+	ByRelation       map[string]int `json:"by_relation"`
 	ByJudgmentStatus map[string]int `json:"by_judgment_status"`
-	DeferredCount   int            `json:"deferred"`
-	DeadCount       int            `json:"dead"`
+	DeferredCount    int            `json:"deferred"`
+	DeadCount        int            `json:"dead"`
 }
 
 // DeferredRow represents a row in sync_apply_deferred with the payload decoded.
 type DeferredRow struct {
 	SyncID          string         `json:"sync_id"`
 	Entity          string         `json:"entity"`
+	TargetKey       string         `json:"target_key"`
+	Project         string         `json:"project"`
+	ScopeClass      string         `json:"scope_class"`
 	Payload         map[string]any `json:"payload,omitempty"`
 	PayloadRaw      string         `json:"payload_raw"`
 	PayloadValid    bool           `json:"payload_valid"`
@@ -141,13 +144,13 @@ type DeferredRow struct {
 
 // ScanResult holds the output of a ScanProject call.
 type ScanResult struct {
-	Project            string `json:"project"`
-	Inspected          int    `json:"inspected"`
-	CandidatesFound    int    `json:"candidates_found"`
-	AlreadyRelated     int    `json:"already_related"`
-	RelationsInserted  int    `json:"inserted"`
-	Capped             bool   `json:"capped"`
-	DryRun             bool   `json:"dry_run"`
+	Project           string `json:"project"`
+	Inspected         int    `json:"inspected"`
+	CandidatesFound   int    `json:"candidates_found"`
+	AlreadyRelated    int    `json:"already_related"`
+	RelationsInserted int    `json:"inserted"`
+	Capped            bool   `json:"capped"`
+	DryRun            bool   `json:"dry_run"`
 
 	// Semantic counters — populated only when ScanOptions.Semantic is true.
 	// Zero-value is safe for existing JSON consumers.
@@ -244,31 +247,31 @@ type Candidate struct {
 
 // Relation represents a row in memory_relations.
 type Relation struct {
-	ID                    int64    `json:"id"`
-	SyncID                string   `json:"sync_id"`
-	SourceID              string   `json:"source_id"`
-	TargetID              string   `json:"target_id"`
-	Relation              string   `json:"relation"`
-	Reason                *string  `json:"reason,omitempty"`
-	Evidence              *string  `json:"evidence,omitempty"`
-	Confidence            *float64 `json:"confidence,omitempty"`
-	JudgmentStatus        string   `json:"judgment_status"`
-	MarkedByActor         *string  `json:"marked_by_actor,omitempty"`
-	MarkedByKind          *string  `json:"marked_by_kind,omitempty"`
-	MarkedByModel         *string  `json:"marked_by_model,omitempty"`
-	SessionID             *string  `json:"session_id,omitempty"`
-	CreatedAt             string   `json:"created_at"`
-	UpdatedAt             string   `json:"updated_at"`
+	ID             int64    `json:"id"`
+	SyncID         string   `json:"sync_id"`
+	SourceID       string   `json:"source_id"`
+	TargetID       string   `json:"target_id"`
+	Relation       string   `json:"relation"`
+	Reason         *string  `json:"reason,omitempty"`
+	Evidence       *string  `json:"evidence,omitempty"`
+	Confidence     *float64 `json:"confidence,omitempty"`
+	JudgmentStatus string   `json:"judgment_status"`
+	MarkedByActor  *string  `json:"marked_by_actor,omitempty"`
+	MarkedByKind   *string  `json:"marked_by_kind,omitempty"`
+	MarkedByModel  *string  `json:"marked_by_model,omitempty"`
+	SessionID      *string  `json:"session_id,omitempty"`
+	CreatedAt      string   `json:"created_at"`
+	UpdatedAt      string   `json:"updated_at"`
 
 	// Annotation fields — populated by GetRelationsForObservations via LEFT JOIN.
 	// Excluded from JSON output (used only for in-process annotation building).
 	// REQ-005, REQ-012 | Design §7, §8.
-	SourceIntID     int64  `json:"-"` // integer primary key of source observation
-	SourceTitle     string `json:"-"` // title of source observation; empty if missing/deleted
-	SourceMissing   bool   `json:"-"` // true if source is soft-deleted or not found
-	TargetIntID     int64  `json:"-"` // integer primary key of target observation
-	TargetTitle     string `json:"-"` // title of target observation; empty if missing/deleted
-	TargetMissing   bool   `json:"-"` // true if target is soft-deleted or not found
+	SourceIntID   int64  `json:"-"` // integer primary key of source observation
+	SourceTitle   string `json:"-"` // title of source observation; empty if missing/deleted
+	SourceMissing bool   `json:"-"` // true if source is soft-deleted or not found
+	TargetIntID   int64  `json:"-"` // integer primary key of target observation
+	TargetTitle   string `json:"-"` // title of target observation; empty if missing/deleted
+	TargetMissing bool   `json:"-"` // true if target is soft-deleted or not found
 }
 
 // ObservationRelations groups relations for a single observation, split by role.
@@ -282,7 +285,7 @@ type ObservationRelations struct {
 // SaveRelationParams holds the inputs for SaveRelation.
 type SaveRelationParams struct {
 	// SyncID is the unique identifier for this relation row (format: rel-<16hex>).
-	SyncID   string
+	SyncID string
 	// SourceID is the TEXT sync_id of the source observation.
 	SourceID string
 	// TargetID is the TEXT sync_id of the target observation.
@@ -292,23 +295,23 @@ type SaveRelationParams struct {
 // JudgeRelationParams holds the inputs for JudgeRelation.
 type JudgeRelationParams struct {
 	// JudgmentID is the sync_id of the relation row to update (required).
-	JudgmentID    string
+	JudgmentID string
 	// Relation is the verdict verb (required); must be one of validRelationVerbs.
-	Relation      string
+	Relation string
 	// Reason is an optional free-text explanation.
-	Reason        *string
+	Reason *string
 	// Evidence is optional free-form JSON or text evidence.
-	Evidence      *string
+	Evidence *string
 	// Confidence is optional 0..1 confidence score.
-	Confidence    *float64
+	Confidence *float64
 	// MarkedByActor is the actor identifier (e.g. "agent:claude-sonnet-4-6" or "user").
 	MarkedByActor string
 	// MarkedByKind is the actor kind ("agent", "human", "system").
-	MarkedByKind  string
+	MarkedByKind string
 	// MarkedByModel is the model ID (may be empty for human actors).
 	MarkedByModel string
 	// SessionID is the session in which the judgment was made (optional).
-	SessionID     string
+	SessionID string
 }
 
 // ─── FindCandidates ───────────────────────────────────────────────────────────
@@ -1209,7 +1212,7 @@ func (s *Store) GetRelationStats(project string) (RelationStats, error) {
 		return stats, fmt.Errorf("GetRelationStats: rows error: %w", err)
 	}
 
-	deferred, dead, err := s.CountDeferredAndDead()
+	deferred, dead, err := s.CountDeferredAndDeadForScope("", project)
 	if err != nil {
 		return stats, fmt.Errorf("GetRelationStats: count deferred/dead: %w", err)
 	}

--- a/internal/store/relations_test.go
+++ b/internal/store/relations_test.go
@@ -383,12 +383,12 @@ func TestJudgeRelation_HappyPath(t *testing.T) {
 
 	confidence := 0.9
 	judged, err := s.JudgeRelation(JudgeRelationParams{
-		JudgmentID:     relSyncID,
-		Relation:       "not_conflict",
-		Confidence:     &confidence,
-		MarkedByActor:  "agent:claude-sonnet-4-6",
-		MarkedByKind:   "agent",
-		MarkedByModel:  "claude-sonnet-4-6",
+		JudgmentID:    relSyncID,
+		Relation:      "not_conflict",
+		Confidence:    &confidence,
+		MarkedByActor: "agent:claude-sonnet-4-6",
+		MarkedByKind:  "agent",
+		MarkedByModel: "claude-sonnet-4-6",
 	})
 	if err != nil {
 		t.Fatalf("JudgeRelation: %v", err)
@@ -595,14 +595,14 @@ func TestProvenance_FullRowPersisted(t *testing.T) {
 	evidence := `{"basis":"title overlap"}`
 	reason := "titles are nearly identical"
 	judged, err := s.JudgeRelation(JudgeRelationParams{
-		JudgmentID:     relSyncID,
-		Relation:       "compatible",
-		Confidence:     &confidence,
-		Evidence:       &evidence,
-		Reason:         &reason,
-		MarkedByActor:  "agent:claude-sonnet-4-6",
-		MarkedByKind:   "agent",
-		MarkedByModel:  "claude-sonnet-4-6",
+		JudgmentID:    relSyncID,
+		Relation:      "compatible",
+		Confidence:    &confidence,
+		Evidence:      &evidence,
+		Reason:        &reason,
+		MarkedByActor: "agent:claude-sonnet-4-6",
+		MarkedByKind:  "agent",
+		MarkedByModel: "claude-sonnet-4-6",
 	})
 	if err != nil {
 		t.Fatalf("JudgeRelation: %v", err)
@@ -1380,6 +1380,34 @@ func TestGetRelationStats_EmptyProject(t *testing.T) {
 	}
 	if stats.DeferredCount != 0 || stats.DeadCount != 0 {
 		t.Errorf("expected DeferredCount=0 DeadCount=0; got %d %d", stats.DeferredCount, stats.DeadCount)
+	}
+}
+
+func TestGetRelationStats_ScopesDeferredCountsByProject(t *testing.T) {
+	s := newTestStore(t)
+	for _, row := range []struct {
+		syncID  string
+		project string
+		status  string
+	}{
+		{syncID: "deferred-alpha", project: "alpha", status: "deferred"},
+		{syncID: "dead-beta", project: "beta", status: "dead"},
+	} {
+		if _, err := s.db.Exec(`
+			INSERT INTO sync_apply_deferred
+				(sync_id, entity, payload, target_key, project, scope_class, apply_status, first_seen_at)
+			VALUES (?, 'relation', '{}', 'cloud', ?, 'scoped', ?, datetime('now'))
+		`, row.syncID, row.project, row.status); err != nil {
+			t.Fatalf("seed %s deferred row: %v", row.project, err)
+		}
+	}
+
+	stats, err := s.GetRelationStats("alpha")
+	if err != nil {
+		t.Fatalf("GetRelationStats alpha: %v", err)
+	}
+	if stats.DeferredCount != 1 || stats.DeadCount != 0 {
+		t.Fatalf("alpha deferred stats = deferred=%d dead=%d, want 1/0", stats.DeferredCount, stats.DeadCount)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1075,6 +1075,9 @@ func (s *Store) migrate() error {
 			sync_id           TEXT    PRIMARY KEY,
 			entity            TEXT    NOT NULL,
 			payload           TEXT    NOT NULL,
+			target_key        TEXT    NOT NULL DEFAULT '',
+			project           TEXT    NOT NULL DEFAULT '',
+			scope_class       TEXT    NOT NULL DEFAULT 'legacy_unscoped',
 			apply_status      TEXT    NOT NULL DEFAULT 'deferred',
 			retry_count       INTEGER NOT NULL DEFAULT 0,
 			last_error        TEXT,
@@ -1083,6 +1086,25 @@ func (s *Store) migrate() error {
 		);
 		CREATE INDEX IF NOT EXISTS idx_sad_status_seen
 			ON sync_apply_deferred(apply_status, first_seen_at);
+	`); err != nil {
+		return err
+	}
+	deferredColumns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "target_key", definition: "TEXT NOT NULL DEFAULT ''"},
+		{name: "project", definition: "TEXT NOT NULL DEFAULT ''"},
+		{name: "scope_class", definition: "TEXT NOT NULL DEFAULT 'legacy_unscoped'"},
+	}
+	for _, c := range deferredColumns {
+		if err := s.addColumnIfNotExists("sync_apply_deferred", c.name, c.definition); err != nil {
+			return err
+		}
+	}
+	if _, err := s.execHook(s.db, `
+		CREATE INDEX IF NOT EXISTS idx_sad_scope_status_seen
+			ON sync_apply_deferred(target_key, project, apply_status, first_seen_at);
 	`); err != nil {
 		return err
 	}
@@ -4230,7 +4252,7 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 
 		applyErr := s.applyPulledMutationTx(tx, mutation)
 		if applyErr != nil {
-			if handled, err := s.recordRelationApplyFailureTx(tx, mutation, applyErr); err != nil {
+			if handled, err := s.recordRelationApplyFailureTx(tx, targetKey, mutation, applyErr); err != nil {
 				return err
 			} else if !handled {
 				return applyErr
@@ -4250,7 +4272,7 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 // recordRelationApplyFailureTx records relation failures that are safe to
 // acknowledge while preserving the existing fail-fast behavior for other
 // entities and errors.
-func (s *Store) recordRelationApplyFailureTx(tx *sql.Tx, mutation SyncMutation, applyErr error) (bool, error) {
+func (s *Store) recordRelationApplyFailureTx(tx *sql.Tx, targetKey string, mutation SyncMutation, applyErr error) (bool, error) {
 	if mutation.Entity != SyncEntityRelation {
 		return false, nil
 	}
@@ -4265,18 +4287,34 @@ func (s *Store) recordRelationApplyFailureTx(tx *sql.Tx, mutation SyncMutation, 
 		return false, nil
 	}
 
+	project := strings.TrimSpace(mutation.Project)
+	if project == "" {
+		var payload syncRelationPayload
+		if err := json.Unmarshal([]byte(mutation.Payload), &payload); err == nil {
+			project = strings.TrimSpace(payload.Project)
+		}
+	}
+	project, _ = NormalizeProject(project)
+	scopeClass := "target_scoped"
+	if project != "" {
+		scopeClass = "scoped"
+	}
+
 	if _, err := s.execHook(tx, `
 		INSERT INTO sync_apply_deferred
-			(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
-		VALUES (?, ?, ?, ?, 0, datetime('now'))
+			(sync_id, entity, payload, target_key, project, scope_class, apply_status, retry_count, first_seen_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 0, datetime('now'))
 		ON CONFLICT(sync_id) DO UPDATE SET
 			payload           = excluded.payload,
+			target_key        = excluded.target_key,
+			project           = excluded.project,
+			scope_class       = excluded.scope_class,
 			apply_status      = CASE
 				WHEN excluded.apply_status = 'dead' THEN 'dead'
 				ELSE sync_apply_deferred.apply_status
 			END,
 			last_attempted_at = datetime('now')
-	`, mutation.EntityKey, mutation.Entity, mutation.Payload, status); err != nil {
+	`, mutation.EntityKey, mutation.Entity, mutation.Payload, targetKey, project, scopeClass, status); err != nil {
 		return false, fmt.Errorf("write relation apply failure: %w", err)
 	}
 
@@ -4320,7 +4358,7 @@ func (s *Store) ApplyPulledChunk(targetKey, chunkID string, mutations []SyncMuta
 			mutation.TargetKey = targetKey
 			mutation.Source = SyncSourceRemote
 			if applyErr := s.applyPulledMutationTx(tx, mutation); applyErr != nil {
-				if handled, err := s.recordRelationApplyFailureTx(tx, mutation, applyErr); err != nil {
+				if handled, err := s.recordRelationApplyFailureTx(tx, targetKey, mutation, applyErr); err != nil {
 					return fmt.Errorf("apply chunk mutation %d: %w", i, err)
 				} else if !handled {
 					return fmt.Errorf("apply chunk mutation %d: %w", i, applyErr)
@@ -6881,7 +6919,18 @@ type ReplayDeferredResult struct {
 	Dead      int
 }
 
-// ReplayDeferred retries all rows in sync_apply_deferred with apply_status='deferred'
+// ReplayDeferred retries every deferred row, including legacy-unscoped rows. It is
+// reserved for deliberate administrative operations such as conflict recovery.
+func (s *Store) ReplayDeferred() (ReplayDeferredResult, error) {
+	return s.ReplayDeferredForScope("", "")
+}
+
+// ReplayDeferredForScope retries deferred rows for one sync target and optional
+// project. An empty project includes all safely target-scoped rows for that target;
+// an empty target is reserved for ReplayDeferred's administrative global replay.
+// Legacy-unscoped rows are excluded whenever a target or project scope is supplied.
+//
+// It retries rows with apply_status='deferred'
 // (up to 50 per call, ordered by first_seen_at). For each row:
 //   - Calls applyPulledMutationTx inside a transaction.
 //   - On success: the apply itself deletes the deferred row (applyRelationUpsertTx
@@ -6895,17 +6944,29 @@ type ReplayDeferredResult struct {
 // in place.
 //
 // Returns counts (retried, succeeded, failed, dead) for caller logging.
-func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
+func (s *Store) ReplayDeferredForScope(targetKey, project string) (result ReplayDeferredResult, err error) {
 	const limit = 50
 	const deadThreshold = 5
+	targetKey = strings.TrimSpace(targetKey)
+	project, _ = NormalizeProject(strings.TrimSpace(project))
 
-	rows, err := s.db.Query(`
+	query := `
 		SELECT sync_id, entity, payload, retry_count
 		FROM sync_apply_deferred
-		WHERE apply_status = 'deferred'
-		ORDER BY first_seen_at
-		LIMIT ?
-	`, limit)
+		WHERE apply_status = 'deferred'`
+	args := []any{}
+	if targetKey != "" {
+		query += ` AND target_key = ? AND scope_class != 'legacy_unscoped'`
+		args = append(args, normalizeSyncTargetKey(targetKey))
+	}
+	if project != "" {
+		query += ` AND project = ? AND scope_class = 'scoped'`
+		args = append(args, project)
+	}
+	query += ` ORDER BY first_seen_at LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return result, fmt.Errorf("ReplayDeferred: list deferred: %w", err)
 	}
@@ -6939,6 +7000,8 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 			Op:        SyncOpUpsert,
 			Payload:   row.payload,
 			Source:    SyncSourceRemote,
+			TargetKey: targetKey,
+			Project:   project,
 		}
 
 		applyErr := s.withTx(func(tx *sql.Tx) error {
@@ -6979,16 +7042,33 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 	return result, nil
 }
 
-// CountDeferredAndDead returns the count of rows in sync_apply_deferred grouped
-// by apply_status. Only 'deferred' and 'dead' statuses are counted; 'applied'
-// rows (if any) are not included.
+// CountDeferredAndDead returns global administrative totals, including legacy
+// unscoped rows that normal scoped imports intentionally leave untouched.
 func (s *Store) CountDeferredAndDead() (deferred, dead int, err error) {
-	rows, err := s.db.Query(`
+	return s.CountDeferredAndDeadForScope("", "")
+}
+
+// CountDeferredAndDeadForScope returns queue totals for an optional target and
+// project. Scoped totals exclude legacy-unscoped rows; empty filters return the
+// global administrative totals.
+func (s *Store) CountDeferredAndDeadForScope(targetKey, project string) (deferred, dead int, err error) {
+	targetKey = strings.TrimSpace(targetKey)
+	project, _ = NormalizeProject(strings.TrimSpace(project))
+	query := `
 		SELECT apply_status, count(*)
 		FROM sync_apply_deferred
-		WHERE apply_status IN ('deferred', 'dead')
-		GROUP BY apply_status
-	`)
+		WHERE apply_status IN ('deferred', 'dead')`
+	args := []any{}
+	if targetKey != "" {
+		query += ` AND target_key = ? AND scope_class != 'legacy_unscoped'`
+		args = append(args, normalizeSyncTargetKey(targetKey))
+	}
+	if project != "" {
+		query += ` AND project = ? AND scope_class = 'scoped'`
+		args = append(args, project)
+	}
+	query += ` GROUP BY apply_status`
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return 0, 0, fmt.Errorf("CountDeferredAndDead: query: %w", err)
 	}
@@ -7020,7 +7100,7 @@ func (s *Store) CountDeferredAndDead() (deferred, dead int, err error) {
 // JSON, PayloadValid is false and PayloadRaw is preserved.
 func (s *Store) ListDeferred(opts ListDeferredOptions) ([]DeferredRow, error) {
 	query := `
-		SELECT sync_id, entity, payload, apply_status, retry_count,
+		SELECT sync_id, entity, payload, target_key, project, scope_class, apply_status, retry_count,
 		       last_error, last_attempted_at, first_seen_at
 		FROM sync_apply_deferred
 		WHERE 1=1`
@@ -7067,7 +7147,7 @@ func (s *Store) ListDeferred(opts ListDeferredOptions) ([]DeferredRow, error) {
 // Returns an error wrapping "not found" when no row exists (matches FindCandidates style).
 func (s *Store) GetDeferred(syncID string) (DeferredRow, error) {
 	row := s.db.QueryRow(`
-		SELECT sync_id, entity, payload, apply_status, retry_count,
+		SELECT sync_id, entity, payload, target_key, project, scope_class, apply_status, retry_count,
 		       last_error, last_attempted_at, first_seen_at
 		FROM sync_apply_deferred
 		WHERE sync_id = ?
@@ -7093,7 +7173,7 @@ func scanDeferredRow(row scannable) (DeferredRow, error) {
 	var r DeferredRow
 	var rawPayload string
 	if err := row.Scan(
-		&r.SyncID, &r.Entity, &rawPayload, &r.ApplyStatus, &r.RetryCount,
+		&r.SyncID, &r.Entity, &rawPayload, &r.TargetKey, &r.Project, &r.ScopeClass, &r.ApplyStatus, &r.RetryCount,
 		&r.LastError, &r.LastAttemptedAt, &r.FirstSeenAt,
 	); err != nil {
 		return r, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5679,16 +5679,63 @@ func (s *Store) applyPulledMutationTx(tx *sql.Tx, mutation SyncMutation) error {
 //  4. On successful apply, DELETE any pre-existing deferred row for this sync_id
 //     so it is not retried unnecessarily.
 func (s *Store) applyRelationUpsertTx(tx *sql.Tx, mutation SyncMutation) error {
+	if mutation.Op != SyncOpUpsert {
+		return fmt.Errorf("%w: unsupported relation operation %q", ErrApplyDead, mutation.Op)
+	}
+
 	// Step 1: decode payload.
 	var p syncRelationPayload
 	if err := decodeSyncPayload([]byte(mutation.Payload), &p); err != nil {
 		return fmt.Errorf("%w: decode relation payload: %v", ErrApplyDead, err)
 	}
 
-	// Step 1b: required field validation — missing source_id or target_id is not
-	// a retryable FK miss; it is a permanent payload defect (ErrApplyDead).
-	if strings.TrimSpace(p.SourceID) == "" || strings.TrimSpace(p.TargetID) == "" {
-		return fmt.Errorf("%w: relation payload missing required source_id or target_id", ErrApplyDead)
+	p.SyncID = strings.TrimSpace(p.SyncID)
+	p.SourceID = strings.TrimSpace(p.SourceID)
+	p.TargetID = strings.TrimSpace(p.TargetID)
+	p.Relation = strings.TrimSpace(p.Relation)
+	p.JudgmentStatus = strings.TrimSpace(p.JudgmentStatus)
+	p.Project = strings.TrimSpace(p.Project)
+	if p.MarkedByActor != nil {
+		actor := strings.TrimSpace(*p.MarkedByActor)
+		p.MarkedByActor = &actor
+	}
+	if p.MarkedByKind != nil {
+		kind := strings.TrimSpace(*p.MarkedByKind)
+		p.MarkedByKind = &kind
+	}
+
+	// Step 1b: validate the relation wire contract before classifying an FK miss.
+	// A malformed relation is terminal evidence, never a retryable dependency.
+	missing := make([]string, 0, 8)
+	if p.SyncID == "" {
+		missing = append(missing, "sync_id")
+	}
+	if p.SourceID == "" {
+		missing = append(missing, "source_id")
+	}
+	if p.TargetID == "" {
+		missing = append(missing, "target_id")
+	}
+	if p.Relation == "" {
+		missing = append(missing, "relation")
+	}
+	if p.JudgmentStatus == "" {
+		missing = append(missing, "judgment_status")
+	}
+	if p.MarkedByActor == nil || *p.MarkedByActor == "" {
+		missing = append(missing, "marked_by_actor")
+	}
+	if p.MarkedByKind == nil || *p.MarkedByKind == "" {
+		missing = append(missing, "marked_by_kind")
+	}
+	if p.Project == "" {
+		missing = append(missing, "project")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: relation payload missing required fields: %s", ErrApplyDead, strings.Join(missing, ", "))
+	}
+	if entityKey := strings.TrimSpace(mutation.EntityKey); entityKey == "" || entityKey != p.SyncID {
+		return fmt.Errorf("%w: relation entity_key %q does not match payload sync_id %q", ErrApplyDead, mutation.EntityKey, p.SyncID)
 	}
 
 	// Step 2: FK precondition — both observations must exist locally (by sync_id).
@@ -6887,10 +6934,11 @@ func (s *Store) ReplayDeferred() (result ReplayDeferredResult, err error) {
 	for _, row := range pending {
 		result.Retried++
 		mut := SyncMutation{
-			Entity:  row.entity,
-			Op:      SyncOpUpsert,
-			Payload: row.payload,
-			Source:  SyncSourceRemote,
+			Entity:    row.entity,
+			EntityKey: row.syncID,
+			Op:        SyncOpUpsert,
+			Payload:   row.payload,
+			Source:    SyncSourceRemote,
 		}
 
 		applyErr := s.withTx(func(tx *sql.Tx) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6925,6 +6925,35 @@ func (s *Store) ReplayDeferred() (ReplayDeferredResult, error) {
 	return s.ReplayDeferredForScope("", "")
 }
 
+func (s *Store) ListDeferredProjectsForTarget(targetKey string) ([]string, error) {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT project
+		FROM sync_apply_deferred
+		WHERE target_key = ?
+		  AND scope_class = 'scoped'
+		  AND apply_status = 'deferred'
+		  AND project != ''
+		ORDER BY project
+	`, normalizeSyncTargetKey(targetKey))
+	if err != nil {
+		return nil, fmt.Errorf("ListDeferredProjectsForTarget: query: %w", err)
+	}
+	defer rows.Close()
+
+	projects := make([]string, 0)
+	for rows.Next() {
+		var project string
+		if err := rows.Scan(&project); err != nil {
+			return nil, fmt.Errorf("ListDeferredProjectsForTarget: scan: %w", err)
+		}
+		projects = append(projects, project)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ListDeferredProjectsForTarget: rows: %w", err)
+	}
+	return projects, nil
+}
+
 // ReplayDeferredForScope retries deferred rows for one sync target and optional
 // project. An empty project includes all safely target-scoped rows for that target;
 // an empty target is reserved for ReplayDeferred's administrative global replay.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4230,41 +4230,9 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 
 		applyErr := s.applyPulledMutationTx(tx, mutation)
 		if applyErr != nil {
-			// Phase E: per-entity skip+log policy (design §9).
-			// For relation FK misses, write to sync_apply_deferred and ACK the seq
-			// so the cursor can advance. All other errors propagate and halt the pull.
-			if mutation.Entity == SyncEntityRelation && errors.Is(applyErr, ErrRelationFKMissing) {
-				log.Printf("[store] ApplyPulledMutation: relation FK miss seq=%d entity_key=%s — deferring",
-					mutation.Seq, mutation.EntityKey)
-				if _, deferErr := s.execHook(tx, `
-					INSERT INTO sync_apply_deferred
-						(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
-					VALUES (?, ?, ?, 'deferred', 0, datetime('now'))
-					ON CONFLICT(sync_id) DO UPDATE SET
-						payload            = excluded.payload,
-						last_attempted_at  = datetime('now')
-				`, mutation.EntityKey, mutation.Entity, mutation.Payload); deferErr != nil {
-					return fmt.Errorf("ApplyPulledMutation: write deferred row: %w", deferErr)
-				}
-				// Fall through to advance the cursor (ACK the seq).
-			} else if mutation.Entity == SyncEntityRelation && errors.Is(applyErr, ErrApplyDead) {
-				// Payload is permanently undecodable — write directly as dead and ACK.
-				// There is no point retrying; a malformed payload will never become valid.
-				log.Printf("[store] ApplyPulledMutation: relation payload dead seq=%d entity_key=%s err=%v — marking dead",
-					mutation.Seq, mutation.EntityKey, applyErr)
-				if _, deferErr := s.execHook(tx, `
-					INSERT INTO sync_apply_deferred
-						(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
-					VALUES (?, ?, ?, 'dead', 0, datetime('now'))
-					ON CONFLICT(sync_id) DO UPDATE SET
-						payload           = excluded.payload,
-						apply_status      = 'dead',
-						last_attempted_at = datetime('now')
-				`, mutation.EntityKey, mutation.Entity, mutation.Payload); deferErr != nil {
-					return fmt.Errorf("ApplyPulledMutation: write dead row: %w", deferErr)
-				}
-				// Fall through to advance the cursor (ACK the seq).
-			} else {
+			if handled, err := s.recordRelationApplyFailureTx(tx, mutation, applyErr); err != nil {
+				return err
+			} else if !handled {
 				return applyErr
 			}
 		}
@@ -4277,6 +4245,43 @@ func (s *Store) ApplyPulledMutation(targetKey string, mutation SyncMutation) err
 		)
 		return err
 	})
+}
+
+// recordRelationApplyFailureTx records relation failures that are safe to
+// acknowledge while preserving the existing fail-fast behavior for other
+// entities and errors.
+func (s *Store) recordRelationApplyFailureTx(tx *sql.Tx, mutation SyncMutation, applyErr error) (bool, error) {
+	if mutation.Entity != SyncEntityRelation {
+		return false, nil
+	}
+
+	status := ""
+	switch {
+	case errors.Is(applyErr, ErrRelationFKMissing):
+		status = "deferred"
+	case errors.Is(applyErr, ErrApplyDead):
+		status = "dead"
+	default:
+		return false, nil
+	}
+
+	if _, err := s.execHook(tx, `
+		INSERT INTO sync_apply_deferred
+			(sync_id, entity, payload, apply_status, retry_count, first_seen_at)
+		VALUES (?, ?, ?, ?, 0, datetime('now'))
+		ON CONFLICT(sync_id) DO UPDATE SET
+			payload           = excluded.payload,
+			apply_status      = CASE
+				WHEN excluded.apply_status = 'dead' THEN 'dead'
+				ELSE sync_apply_deferred.apply_status
+			END,
+			last_attempted_at = datetime('now')
+	`, mutation.EntityKey, mutation.Entity, mutation.Payload, status); err != nil {
+		return false, fmt.Errorf("write relation apply failure: %w", err)
+	}
+
+	log.Printf("[store] relation apply seq=%d entity_key=%s err=%v - marking %s", mutation.Seq, mutation.EntityKey, applyErr, status)
+	return true, nil
 }
 
 // ApplyPulledChunk atomically applies all mutations contained in a pulled chunk
@@ -4314,8 +4319,12 @@ func (s *Store) ApplyPulledChunk(targetKey, chunkID string, mutations []SyncMuta
 			mutation.Seq = seq
 			mutation.TargetKey = targetKey
 			mutation.Source = SyncSourceRemote
-			if err := s.applyPulledMutationTx(tx, mutation); err != nil {
-				return fmt.Errorf("apply chunk mutation %d: %w", i, err)
+			if applyErr := s.applyPulledMutationTx(tx, mutation); applyErr != nil {
+				if handled, err := s.recordRelationApplyFailureTx(tx, mutation, applyErr); err != nil {
+					return fmt.Errorf("apply chunk mutation %d: %w", i, err)
+				} else if !handled {
+					return fmt.Errorf("apply chunk mutation %d: %w", i, applyErr)
+				}
 			}
 		}
 
@@ -5690,7 +5699,11 @@ func (s *Store) applyRelationUpsertTx(tx *sql.Tx, mutation SyncMutation) error {
 	).Scan(&obsCount); err != nil {
 		return fmt.Errorf("applyRelationUpsertTx: check observations: %w", err)
 	}
-	if obsCount < 2 {
+	requiredObservations := 2
+	if p.SourceID == p.TargetID {
+		requiredObservations = 1
+	}
+	if obsCount < requiredObservations {
 		return ErrRelationFKMissing
 	}
 

--- a/internal/store/store_migration_test.go
+++ b/internal/store/store_migration_test.go
@@ -821,3 +821,54 @@ func TestMigrate_AddsIdxMemrelStatusCreated(t *testing.T) {
 		t.Errorf("pending relations count = %d, want 2 (seeded rows with judgment_status='pending')", pendingCount)
 	}
 }
+
+func TestMigrate_LegacyDeferredRowsRemainAdministrativeOnly(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "engram.db")
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy database: %v", err)
+	}
+	if _, err := raw.Exec(legacyDDLPostMemoryConflictAudit); err != nil {
+		raw.Close()
+		t.Fatalf("apply legacy DDL: %v", err)
+	}
+	if _, err := raw.Exec(`
+		INSERT INTO sync_apply_deferred (sync_id, entity, payload, retry_count, apply_status)
+		VALUES ('legacy-deferred', 'relation', '{}', 4, 'deferred')
+	`); err != nil {
+		raw.Close()
+		t.Fatalf("seed legacy deferred row: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close legacy database: %v", err)
+	}
+
+	cfg := mustDefaultConfig(t)
+	cfg.DataDir = dir
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("migrate legacy database: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	assertDeferredScope(t, s, "legacy-deferred", "", "", "legacy_unscoped")
+	result, err := s.ReplayDeferredForScope("cloud:project-b", "project-b")
+	if err != nil {
+		t.Fatalf("scoped replay: %v", err)
+	}
+	if result.Retried != 0 {
+		t.Fatalf("scoped replay retried legacy row: %+v", result)
+	}
+	status, retries := getDeferredRow(t, s, "legacy-deferred")
+	if status != "deferred" || retries != 4 {
+		t.Fatalf("legacy row changed by scoped replay: status=%q retries=%d", status, retries)
+	}
+	deferred, dead, err := s.CountDeferredAndDead()
+	if err != nil || deferred != 1 || dead != 0 {
+		t.Fatalf("global administrative visibility = deferred=%d dead=%d err=%v", deferred, dead, err)
+	}
+	if err := s.migrate(); err != nil {
+		t.Fatalf("second migration must be idempotent: %v", err)
+	}
+}

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -140,13 +140,13 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	missingID := newSyncID("rel-missing")
 	mutations := []SyncMutation{
 		buildRelationMutation(t, syncRelationPayload{
-			SyncID: validID, SourceID: syncA, TargetID: syncB,
-			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
+			SyncID: missingID, SourceID: syncA, TargetID: missingTarget,
+			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged,
 			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
 		}),
 		buildRelationMutation(t, syncRelationPayload{
-			SyncID: missingID, SourceID: syncA, TargetID: missingTarget,
-			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged,
+			SyncID: validID, SourceID: syncA, TargetID: syncB,
+			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
 			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
 		}),
 	}

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -160,6 +160,10 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	if got := countDeferredRows(t, s, missingID); got != 1 {
 		t.Fatalf("expected missing relation to defer, got %d rows", got)
 	}
+	status, _ := getDeferredRow(t, s, missingID)
+	if status != "deferred" {
+		t.Fatalf("apply_status: want deferred, got %q", status)
+	}
 	var lastPulled int64
 	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
 		t.Fatalf("read last_pulled_seq: %v", err)

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -164,6 +164,9 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	if status != "deferred" {
 		t.Fatalf("apply_status: want deferred, got %q", status)
 	}
+	if got := countRelationRows(t, s, missingID); got != 0 {
+		t.Fatalf("expected missing relation to remain unapplied, got %d rows", got)
+	}
 	var lastPulled int64
 	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
 		t.Fatalf("read last_pulled_seq: %v", err)

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -173,6 +173,7 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	if status != "deferred" {
 		t.Fatalf("apply_status: want deferred, got %q", status)
 	}
+	assertDeferredScope(t, s, missingID, DefaultSyncTargetKey, "proj-apply", "scoped")
 	if got := countRelationRows(t, s, missingID); got != 0 {
 		t.Fatalf("expected missing relation to remain unapplied, got %d rows", got)
 	}
@@ -217,6 +218,7 @@ func TestApplyPulledMutation_DefersMissingRelationAndAdvancesCursor(t *testing.T
 	if status != "deferred" {
 		t.Fatalf("apply_status: want deferred, got %q", status)
 	}
+	assertDeferredScope(t, s, relSyncID, DefaultSyncTargetKey, "proj-apply", "scoped")
 	if got := countRelationRows(t, s, relSyncID); got != 0 {
 		t.Fatalf("expected missing relation to remain unapplied, got %d rows", got)
 	}
@@ -440,6 +442,32 @@ func getDeferredRow(t *testing.T, s *Store, syncID string) (applyStatus string, 
 	return applyStatus, retryCount
 }
 
+func assertDeferredScope(t *testing.T, s *Store, syncID, targetKey, project, scopeClass string) {
+	t.Helper()
+	var gotTargetKey, gotProject, gotScopeClass string
+	if err := s.db.QueryRow(`
+		SELECT target_key, project, scope_class
+		FROM sync_apply_deferred
+		WHERE sync_id = ?
+	`, syncID).Scan(&gotTargetKey, &gotProject, &gotScopeClass); err != nil {
+		t.Fatalf("read deferred scope for %q: %v", syncID, err)
+	}
+	if gotTargetKey != targetKey || gotProject != project || gotScopeClass != scopeClass {
+		t.Fatalf("deferred scope: got target=%q project=%q class=%q, want target=%q project=%q class=%q", gotTargetKey, gotProject, gotScopeClass, targetKey, project, scopeClass)
+	}
+}
+
+func insertScopedDeferredRow(t *testing.T, s *Store, syncID, payload, targetKey, project string, retryCount int) {
+	t.Helper()
+	if _, err := s.db.Exec(`
+		INSERT INTO sync_apply_deferred
+			(sync_id, entity, payload, target_key, project, scope_class, retry_count, apply_status, first_seen_at)
+		VALUES (?, 'relation', ?, ?, ?, 'scoped', ?, 'deferred', datetime('now'))
+	`, syncID, payload, targetKey, project, retryCount); err != nil {
+		t.Fatalf("insertScopedDeferredRow %q: %v", syncID, err)
+	}
+}
+
 // TestReplayDeferred_RetrySucceeds: A deferred row; after the missing obs arrives
 // and ReplayDeferred runs, the row is applied and removed.
 func TestReplayDeferred_RetrySucceeds(t *testing.T) {
@@ -634,6 +662,62 @@ func TestCountDeferredAndDead(t *testing.T) {
 	}
 	if dead != 1 {
 		t.Errorf("dead: want 1, got %d", dead)
+	}
+}
+
+func TestReplayDeferredForScope_IsolatesTargetAndProject(t *testing.T) {
+	s, syncA, _ := setupSyncApplyStore(t)
+	actor := "test-actor"
+	kind := "test"
+	missingPayload := func(syncID, project string) string {
+		payload, err := json.Marshal(syncRelationPayload{
+			SyncID: syncID, SourceID: syncA, TargetID: "obs-missing-" + syncID,
+			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged,
+			MarkedByActor: &actor, MarkedByKind: &kind, Project: project,
+		})
+		if err != nil {
+			t.Fatalf("marshal deferred payload: %v", err)
+		}
+		return string(payload)
+	}
+
+	cloudA := "rel-cloud-a"
+	cloudB := "rel-cloud-b"
+	localA := "rel-local-a"
+	insertScopedDeferredRow(t, s, cloudA, missingPayload(cloudA, "project-a"), "cloud", "project-a", 4)
+	insertScopedDeferredRow(t, s, cloudB, missingPayload(cloudB, "project-b"), "cloud", "project-b", 4)
+	insertScopedDeferredRow(t, s, localA, missingPayload(localA, "project-a"), LocalChunkTargetKey, "project-a", 4)
+
+	result, err := s.ReplayDeferredForScope("cloud", "project-b")
+	if err != nil {
+		t.Fatalf("ReplayDeferredForScope cloud project-b: %v", err)
+	}
+	if result.Retried != 1 || result.Dead != 1 {
+		t.Fatalf("cloud project-b replay = %+v, want one dead retry", result)
+	}
+	statusA, retriesA := getDeferredRow(t, s, cloudA)
+	if statusA != "deferred" || retriesA != 4 {
+		t.Fatalf("cloud project-a row changed by project-b replay: status=%q retries=%d", statusA, retriesA)
+	}
+	statusLocal, retriesLocal := getDeferredRow(t, s, localA)
+	if statusLocal != "deferred" || retriesLocal != 4 {
+		t.Fatalf("local row changed by cloud replay: status=%q retries=%d", statusLocal, retriesLocal)
+	}
+	deferred, dead, err := s.CountDeferredAndDeadForScope("cloud", "project-b")
+	if err != nil || deferred != 0 || dead != 1 {
+		t.Fatalf("cloud project-b counts = deferred=%d dead=%d err=%v", deferred, dead, err)
+	}
+
+	result, err = s.ReplayDeferredForScope(LocalChunkTargetKey, "project-a")
+	if err != nil {
+		t.Fatalf("ReplayDeferredForScope local project-a: %v", err)
+	}
+	if result.Retried != 1 || result.Dead != 1 {
+		t.Fatalf("local project-a replay = %+v, want one dead retry", result)
+	}
+	statusA, retriesA = getDeferredRow(t, s, cloudA)
+	if statusA != "deferred" || retriesA != 4 {
+		t.Fatalf("cloud row changed by local replay: status=%q retries=%d", statusA, retriesA)
 	}
 }
 

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -109,6 +109,108 @@ func TestApplyPulledRelation_InsertsWhenObsExist(t *testing.T) {
 	}
 }
 
+func TestApplyPulledRelation_AllowsSelfReference(t *testing.T) {
+	s, syncA, _ := setupSyncApplyStore(t)
+
+	relSyncID := newSyncID("rel-self")
+	m := buildRelationMutation(t, syncRelationPayload{
+		SyncID:         relSyncID,
+		SourceID:       syncA,
+		TargetID:       syncA,
+		Relation:       RelationCompatible,
+		JudgmentStatus: JudgmentStatusJudged,
+		Project:        "proj-apply",
+		CreatedAt:      "2026-04-26T10:00:00Z",
+		UpdatedAt:      "2026-04-26T10:00:00Z",
+	})
+
+	if err := applyRelationMutation(t, s, m); err != nil {
+		t.Fatalf("applyPulledMutationTx: %v", err)
+	}
+	if got := countRelationRows(t, s, relSyncID); got != 1 {
+		t.Fatalf("expected 1 self-referential relation, got %d", got)
+	}
+}
+
+func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
+	s, syncA, syncB := setupSyncApplyStore(t)
+	missingTarget := "obs-ghost-" + newSyncID("x")
+
+	validID := newSyncID("rel-valid")
+	missingID := newSyncID("rel-missing")
+	mutations := []SyncMutation{
+		buildRelationMutation(t, syncRelationPayload{
+			SyncID: validID, SourceID: syncA, TargetID: syncB,
+			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
+			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
+		}),
+		buildRelationMutation(t, syncRelationPayload{
+			SyncID: missingID, SourceID: syncA, TargetID: missingTarget,
+			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged,
+			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
+		}),
+	}
+
+	if err := s.ApplyPulledChunk(DefaultSyncTargetKey, "chunk-local-relations", mutations); err != nil {
+		t.Fatalf("ApplyPulledChunk: %v", err)
+	}
+	if got := countRelationRows(t, s, validID); got != 1 {
+		t.Fatalf("expected valid relation to apply, got %d rows", got)
+	}
+	if got := countDeferredRows(t, s, missingID); got != 1 {
+		t.Fatalf("expected missing relation to defer, got %d rows", got)
+	}
+	var lastPulled int64
+	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
+		t.Fatalf("read last_pulled_seq: %v", err)
+	}
+	if lastPulled != int64(len(mutations)) {
+		t.Fatalf("last_pulled_seq: want %d, got %d", len(mutations), lastPulled)
+	}
+	chunks, err := s.GetSyncedChunksForTarget(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("read synced chunks: %v", err)
+	}
+	if !chunks["chunk-local-relations"] {
+		t.Fatal("expected chunk with deferred relation to be marked as synced")
+	}
+}
+
+func TestApplyPulledChunk_MarksMalformedRelationDeadAndContinues(t *testing.T) {
+	s, syncA, syncB := setupSyncApplyStore(t)
+	validID := newSyncID("rel-valid")
+	deadID := newSyncID("rel-dead")
+	mutations := []SyncMutation{
+		{Entity: SyncEntityRelation, EntityKey: deadID, Op: SyncOpUpsert, Payload: "not json"},
+		buildRelationMutation(t, syncRelationPayload{
+			SyncID: validID, SourceID: syncA, TargetID: syncB,
+			Relation: RelationCompatible, JudgmentStatus: JudgmentStatusJudged,
+			Project: "proj-apply", CreatedAt: "2026-04-26T10:00:00Z", UpdatedAt: "2026-04-26T10:00:00Z",
+		}),
+	}
+
+	if err := s.ApplyPulledChunk(DefaultSyncTargetKey, "chunk-dead-relation", mutations); err != nil {
+		t.Fatalf("ApplyPulledChunk: %v", err)
+	}
+	if got := countRelationRows(t, s, validID); got != 1 {
+		t.Fatalf("expected valid relation to apply, got %d rows", got)
+	}
+	var status string
+	if err := s.db.QueryRow(`SELECT apply_status FROM sync_apply_deferred WHERE sync_id = ?`, deadID).Scan(&status); err != nil {
+		t.Fatalf("read dead relation status: %v", err)
+	}
+	if status != "dead" {
+		t.Fatalf("apply_status: want dead, got %q", status)
+	}
+	var lastPulled int64
+	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
+		t.Fatalf("read last_pulled_seq: %v", err)
+	}
+	if lastPulled != int64(len(mutations)) {
+		t.Fatalf("last_pulled_seq: want %d, got %d", len(mutations), lastPulled)
+	}
+}
+
 // C.3b — ApplyPulledRelation_DefersOnFKMiss: target observation absent →
 // row written to sync_apply_deferred; no halt; seq is ACK-able.
 func TestApplyPulledRelation_DefersOnFKMiss(t *testing.T) {

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -183,6 +183,43 @@ func TestApplyPulledChunk_DefersMissingRelationAndContinues(t *testing.T) {
 	}
 }
 
+func TestApplyPulledMutation_DefersMissingRelationAndAdvancesCursor(t *testing.T) {
+	s, syncA, _ := setupSyncApplyStore(t)
+	relSyncID := newSyncID("rel-missing")
+	m := buildRelationMutation(t, syncRelationPayload{
+		SyncID:         relSyncID,
+		SourceID:       syncA,
+		TargetID:       "obs-ghost-" + newSyncID("x"),
+		Relation:       RelationRelated,
+		JudgmentStatus: JudgmentStatusJudged,
+		Project:        "proj-apply",
+		CreatedAt:      "2026-04-26T10:00:00Z",
+		UpdatedAt:      "2026-04-26T10:00:00Z",
+	})
+	m.Seq = 1
+
+	if err := s.ApplyPulledMutation(DefaultSyncTargetKey, m); err != nil {
+		t.Fatalf("ApplyPulledMutation: %v", err)
+	}
+	if got := countDeferredRows(t, s, relSyncID); got != 1 {
+		t.Fatalf("expected missing relation to defer, got %d rows", got)
+	}
+	status, _ := getDeferredRow(t, s, relSyncID)
+	if status != "deferred" {
+		t.Fatalf("apply_status: want deferred, got %q", status)
+	}
+	if got := countRelationRows(t, s, relSyncID); got != 0 {
+		t.Fatalf("expected missing relation to remain unapplied, got %d rows", got)
+	}
+	var lastPulled int64
+	if err := s.db.QueryRow(`SELECT last_pulled_seq FROM sync_state WHERE target_key = ?`, DefaultSyncTargetKey).Scan(&lastPulled); err != nil {
+		t.Fatalf("read last_pulled_seq: %v", err)
+	}
+	if lastPulled != m.Seq {
+		t.Fatalf("last_pulled_seq: want %d, got %d", m.Seq, lastPulled)
+	}
+}
+
 func TestApplyPulledChunk_MarksMalformedRelationDeadAndContinues(t *testing.T) {
 	s, syncA, syncB := setupSyncApplyStore(t)
 	validID := newSyncID("rel-valid")

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -721,6 +721,40 @@ func TestReplayDeferredForScope_IsolatesTargetAndProject(t *testing.T) {
 	}
 }
 
+func TestListDeferredProjectsForTargetScopesAndOrders(t *testing.T) {
+	s, syncA, _ := setupSyncApplyStore(t)
+	payload := func(syncID, project string) string {
+		encoded, err := json.Marshal(syncRelationPayload{
+			SyncID: syncID, SourceID: syncA, TargetID: "obs-missing-" + syncID,
+			Relation: RelationRelated, JudgmentStatus: JudgmentStatusJudged, Project: project,
+		})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return string(encoded)
+	}
+	insertScopedDeferredRow(t, s, "rel-project-b-1", payload("rel-project-b-1", "project-b"), "cloud", "project-b", 0)
+	insertScopedDeferredRow(t, s, "rel-project-a", payload("rel-project-a", "project-a"), "cloud", "project-a", 0)
+	insertScopedDeferredRow(t, s, "rel-project-b-2", payload("rel-project-b-2", "project-b"), "cloud", "project-b", 1)
+	insertScopedDeferredRow(t, s, "rel-other-target", payload("rel-other-target", "project-c"), "cloud:project-c", "project-c", 0)
+	if _, err := s.db.Exec(`
+		INSERT INTO sync_apply_deferred
+			(sync_id, entity, payload, target_key, project, scope_class, apply_status, first_seen_at)
+		VALUES ('rel-dead', 'relation', '{}', 'cloud', 'project-dead', 'scoped', 'dead', datetime('now'))
+	`); err != nil {
+		t.Fatalf("insert dead scoped deferred: %v", err)
+	}
+	insertDeferredRow(t, s, "rel-legacy", SyncEntityRelation, "{}", 0, "deferred")
+
+	projects, err := s.ListDeferredProjectsForTarget("CLOUD")
+	if err != nil {
+		t.Fatalf("ListDeferredProjectsForTarget: %v", err)
+	}
+	if got, want := fmt.Sprint(projects), "[project-a project-b]"; got != want {
+		t.Fatalf("projects = %s, want %s", got, want)
+	}
+}
+
 // TestApplyPulledMutation_DeferredOnFKMiss: ApplyPulledMutation for relation FK miss
 // writes to sync_apply_deferred and returns nil (cursor can advance).
 func TestApplyPulledMutation_DeferredOnFKMiss(t *testing.T) {

--- a/internal/store/sync_apply_test.go
+++ b/internal/store/sync_apply_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -13,6 +14,14 @@ import (
 // syncRelationPayload.
 func buildRelationMutation(t *testing.T, p syncRelationPayload) SyncMutation {
 	t.Helper()
+	if p.MarkedByActor == nil {
+		actor := "test-actor"
+		p.MarkedByActor = &actor
+	}
+	if p.MarkedByKind == nil {
+		kind := "test"
+		p.MarkedByKind = &kind
+	}
 	raw, err := json.Marshal(p)
 	if err != nil {
 		t.Fatalf("buildRelationMutation: marshal: %v", err)
@@ -255,6 +264,58 @@ func TestApplyPulledChunk_MarksMalformedRelationDeadAndContinues(t *testing.T) {
 	}
 }
 
+func TestApplyPulledChunk_MarksInvalidRelationContractsDead(t *testing.T) {
+	s, syncA, syncB := setupSyncApplyStore(t)
+	validPayload, err := json.Marshal(syncRelationPayload{
+		SyncID:         "rel-invalid-contract",
+		SourceID:       syncA,
+		TargetID:       syncB,
+		Relation:       RelationRelated,
+		JudgmentStatus: JudgmentStatusJudged,
+		Project:        "proj-apply",
+		CreatedAt:      "2026-08-25T00:00:00Z",
+		UpdatedAt:      "2026-08-25T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal relation payload: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		mutation SyncMutation
+	}{
+		{
+			name: "unsupported operation",
+			mutation: SyncMutation{
+				Entity: SyncEntityRelation, EntityKey: "rel-invalid-contract", Op: SyncOpDelete, Payload: string(validPayload),
+			},
+		},
+		{
+			name: "missing required provenance fields",
+			mutation: SyncMutation{
+				Entity:    SyncEntityRelation,
+				EntityKey: "rel-missing-provenance",
+				Op:        SyncOpUpsert,
+				Payload:   fmt.Sprintf(`{"sync_id":"rel-missing-provenance","source_id":%q,"target_id":%q,"relation":"related","judgment_status":"judged","project":"proj-apply"}`, syncA, syncB),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := s.ApplyPulledChunk(DefaultSyncTargetKey, "chunk-"+tt.mutation.EntityKey, []SyncMutation{tt.mutation}); err != nil {
+				t.Fatalf("ApplyPulledChunk: %v", err)
+			}
+			status, _ := getDeferredRow(t, s, tt.mutation.EntityKey)
+			if status != "dead" {
+				t.Fatalf("apply_status: want dead, got %q", status)
+			}
+			if got := countRelationRows(t, s, tt.mutation.EntityKey); got != 0 {
+				t.Fatalf("expected invalid relation to remain unapplied, got %d rows", got)
+			}
+		})
+	}
+}
+
 // C.3b — ApplyPulledRelation_DefersOnFKMiss: target observation absent →
 // row written to sync_apply_deferred; no halt; seq is ACK-able.
 func TestApplyPulledRelation_DefersOnFKMiss(t *testing.T) {
@@ -383,6 +444,8 @@ func getDeferredRow(t *testing.T, s *Store, syncID string) (applyStatus string, 
 // and ReplayDeferred runs, the row is applied and removed.
 func TestReplayDeferred_RetrySucceeds(t *testing.T) {
 	s, syncA, _ := setupSyncApplyStore(t)
+	actor := "test-actor"
+	kind := "test"
 
 	// Missing target obs.
 	missingTarget := "obs-missing-" + newSyncID("x")
@@ -394,6 +457,8 @@ func TestReplayDeferred_RetrySucceeds(t *testing.T) {
 		TargetID:       missingTarget,
 		Relation:       RelationRelated,
 		JudgmentStatus: JudgmentStatusJudged,
+		MarkedByActor:  &actor,
+		MarkedByKind:   &kind,
 		Project:        "proj-apply",
 		CreatedAt:      "2026-04-26T10:00:00Z",
 		UpdatedAt:      "2026-04-26T10:00:00Z",
@@ -426,6 +491,8 @@ func TestReplayDeferred_RetrySucceeds(t *testing.T) {
 		TargetID:       missingTargetSync,
 		Relation:       RelationRelated,
 		JudgmentStatus: JudgmentStatusJudged,
+		MarkedByActor:  &actor,
+		MarkedByKind:   &kind,
 		Project:        "proj-apply",
 		CreatedAt:      "2026-04-26T10:00:00Z",
 		UpdatedAt:      "2026-04-26T10:00:00Z",
@@ -462,6 +529,8 @@ func TestReplayDeferred_RetrySucceeds(t *testing.T) {
 // TestReplayDeferred_DeadAtFiveRetries: retry_count=4; FK still missing → row becomes dead.
 func TestReplayDeferred_DeadAtFiveRetries(t *testing.T) {
 	s, syncA, _ := setupSyncApplyStore(t)
+	actor := "test-actor"
+	kind := "test"
 
 	missingTarget := "obs-ghost-" + newSyncID("x")
 	relSyncID := newSyncID("rel-dead")
@@ -471,6 +540,8 @@ func TestReplayDeferred_DeadAtFiveRetries(t *testing.T) {
 		TargetID:       missingTarget,
 		Relation:       RelationRelated,
 		JudgmentStatus: JudgmentStatusJudged,
+		MarkedByActor:  &actor,
+		MarkedByKind:   &kind,
 		Project:        "proj-apply",
 		CreatedAt:      "2026-04-26T10:00:00Z",
 		UpdatedAt:      "2026-04-26T10:00:00Z",

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -208,6 +208,15 @@ func NewLocal(s *store.Store, syncDir string) *Syncer {
 	return New(s, syncDir)
 }
 
+// NewLocalWithProject creates a filesystem Syncer whose deferred replay is
+// limited to the supplied project. An empty project preserves all-project mode.
+func NewLocalWithProject(s *store.Store, syncDir, project string) *Syncer {
+	sy := New(s, syncDir)
+	project, _ = store.NormalizeProject(project)
+	sy.project = strings.TrimSpace(project)
+	return sy
+}
+
 // NewWithTransport creates a Syncer with a custom Transport implementation.
 // This is used for remote (cloud) sync where chunks travel over HTTP.
 func NewWithTransport(s *store.Store, transport Transport) *Syncer {
@@ -542,12 +551,13 @@ func (sy *Syncer) Import() (*ImportResult, error) {
 // finalizeImport drives the bounded deferred-relation lifecycle after every
 // successful import, including imports with no new chunks.
 func (sy *Syncer) finalizeImport(result *ImportResult) (*ImportResult, error) {
-	replay, err := sy.store.ReplayDeferred()
+	targetKey := sy.chunkTrackingTargetKey("")
+	replay, err := sy.store.ReplayDeferredForScope(targetKey, sy.project)
 	if err != nil {
 		return nil, fmt.Errorf("replay deferred relations: %w", err)
 	}
 	result.RelationsReplayed = replay.Succeeded
-	result.RelationsDeferred, result.RelationsDead, err = sy.store.CountDeferredAndDead()
+	result.RelationsDeferred, result.RelationsDead, err = sy.store.CountDeferredAndDeadForScope(targetKey, sy.project)
 	if err != nil {
 		return nil, fmt.Errorf("count deferred relations: %w", err)
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -113,6 +113,9 @@ type ImportResult struct {
 	SessionsImported     int `json:"sessions_imported"`
 	ObservationsImported int `json:"observations_imported"`
 	PromptsImported      int `json:"prompts_imported"`
+	RelationsReplayed    int `json:"relations_replayed"`
+	RelationsDeferred    int `json:"relations_deferred"`
+	RelationsDead        int `json:"relations_dead"`
 }
 
 // ─── Syncer ──────────────────────────────────────────────────────────────────
@@ -514,7 +517,7 @@ func (sy *Syncer) Import() (*ImportResult, error) {
 	}
 
 	if len(manifest.Chunks) == 0 {
-		return &ImportResult{}, nil
+		return sy.finalizeImport(&ImportResult{})
 	}
 
 	// Get chunks we've already imported
@@ -524,10 +527,31 @@ func (sy *Syncer) Import() (*ImportResult, error) {
 	}
 
 	entries := manifest.Chunks
+	var result *ImportResult
 	if sy.cloudMode {
-		return sy.importEntriesDependencySafe(entries, knownChunks, importModeCloud)
+		result, err = sy.importEntriesDependencySafe(entries, knownChunks, importModeCloud)
+	} else {
+		result, err = sy.importEntriesDependencySafe(entries, knownChunks, importModeLocal)
 	}
-	return sy.importEntriesDependencySafe(entries, knownChunks, importModeLocal)
+	if err != nil {
+		return nil, err
+	}
+	return sy.finalizeImport(result)
+}
+
+// finalizeImport drives the bounded deferred-relation lifecycle after every
+// successful import, including imports with no new chunks.
+func (sy *Syncer) finalizeImport(result *ImportResult) (*ImportResult, error) {
+	replay, err := sy.store.ReplayDeferred()
+	if err != nil {
+		return nil, fmt.Errorf("replay deferred relations: %w", err)
+	}
+	result.RelationsReplayed = replay.Succeeded
+	result.RelationsDeferred, result.RelationsDead, err = sy.store.CountDeferredAndDead()
+	if err != nil {
+		return nil, fmt.Errorf("count deferred relations: %w", err)
+	}
+	return result, nil
 }
 
 type importMode string

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2710,6 +2710,47 @@ func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
 	}
 }
 
+func TestCloudImportEmptyProjectDoesNotReplayAnotherProjectDeferredRelation(t *testing.T) {
+	dst := newTestStore(t)
+	for _, project := range []string{"project-a", "project-b"} {
+		if err := dst.EnrollProject(project); err != nil {
+			t.Fatalf("enroll %s: %v", project, err)
+		}
+	}
+
+	if err := dst.ApplyPulledMutation(cloudTargetKey("project-a"), store.SyncMutation{
+		Seq:       1,
+		Entity:    store.SyncEntityRelation,
+		EntityKey: "rel-project-a-deferred",
+		Op:        store.SyncOpUpsert,
+		Payload:   `{"sync_id":"rel-project-a-deferred","source_id":"obs-project-a-source","target_id":"obs-project-a-missing","relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"project-a"}`,
+	}); err != nil {
+		t.Fatalf("seed project-a deferred relation: %v", err)
+	}
+
+	transport := newFakeCloudTransport()
+	transport.manifest = &Manifest{Version: 1}
+	result, err := NewCloudWithTransport(dst, transport, "project-b").Import()
+	if err != nil {
+		t.Fatalf("empty project-b import: %v", err)
+	}
+	if result.RelationsReplayed != 0 || result.RelationsDeferred != 0 || result.RelationsDead != 0 {
+		t.Fatalf("unexpected project-b import result: %+v", result)
+	}
+
+	rows, err := dst.ListDeferred(store.ListDeferredOptions{Status: "deferred"})
+	if err != nil {
+		t.Fatalf("list deferred rows: %v", err)
+	}
+	if len(rows) != 1 || rows[0].TargetKey != cloudTargetKey("project-a") || rows[0].Project != "project-a" || rows[0].RetryCount != 0 {
+		t.Fatalf("project-a deferred row changed by empty project-b import: %+v", rows)
+	}
+	deferred, dead, err := dst.CountDeferredAndDeadForScope(cloudTargetKey("project-b"), "project-b")
+	if err != nil || deferred != 0 || dead != 0 {
+		t.Fatalf("project-b scoped counts = deferred=%d dead=%d err=%v", deferred, dead, err)
+	}
+}
+
 func TestCloudImportMixedChunkAppliesDirectArrayDependenciesBeforeMutations(t *testing.T) {
 	dst := newTestStore(t)
 	if err := dst.EnrollProject("proj-a"); err != nil {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2476,7 +2476,7 @@ func TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk(t *testi
 	}
 }
 
-func TestCloudImportRollsBackRelationFirstChunkWhenEndpointIsMissing(t *testing.T) {
+func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
 	dst := newTestStore(t)
 	if err := dst.EnrollProject("proj-a"); err != nil {
 		t.Fatalf("enroll destination project: %v", err)
@@ -2514,22 +2514,35 @@ func TestCloudImportRollsBackRelationFirstChunkWhenEndpointIsMissing(t *testing.
 	if _, err := dst.GetObservationBySyncID("obs-missing-target"); err == nil {
 		t.Fatal("missing relation target must be absent from the destination before import")
 	}
-	if _, err := NewCloudWithTransport(dst, transport, "proj-a").Import(); !errors.Is(err, store.ErrRelationFKMissing) {
-		t.Fatalf("expected import to fail for the missing relation endpoint, got %v", err)
+	result, err := NewCloudWithTransport(dst, transport, "proj-a").Import()
+	if err != nil {
+		t.Fatalf("import should defer the missing relation endpoint, got %v", err)
 	}
-
-	if _, err := dst.GetObservationBySyncID("obs-rollback-source"); err == nil {
-		t.Fatal("expected source observation upsert to roll back after failed relation import")
+	if result.ChunksImported != 1 || result.SessionsImported != 1 || result.ObservationsImported != 1 {
+		t.Fatalf("unexpected import result: %+v", result)
 	}
-	if _, err := dst.GetSession("sess-relation-rollback"); err == nil {
-		t.Fatal("expected session upsert to roll back after failed relation import")
+	if _, err := dst.GetObservationBySyncID("obs-rollback-source"); err != nil {
+		t.Fatalf("expected source observation to import: %v", err)
 	}
-	synced, err := dst.GetSyncedChunks()
+	if _, err := dst.GetSession("sess-relation-rollback"); err != nil {
+		t.Fatalf("expected session to import: %v", err)
+	}
+	if _, err := dst.GetRelation("rel-missing-endpoint"); err == nil {
+		t.Fatal("expected unresolved relation to remain unapplied")
+	}
+	deferred, dead, err := dst.CountDeferredAndDead()
+	if err != nil {
+		t.Fatalf("count deferred relation: %v", err)
+	}
+	if deferred != 1 || dead != 0 {
+		t.Fatalf("expected one deferred relation and no dead relations, got deferred=%d dead=%d", deferred, dead)
+	}
+	synced, err := dst.GetSyncedChunksForTarget(cloudTargetKey("proj-a"))
 	if err != nil {
 		t.Fatalf("get synced chunks: %v", err)
 	}
-	if synced[chunkID] {
-		t.Fatalf("failed chunk %q must not be marked synced", chunkID)
+	if !synced[chunkID] {
+		t.Fatalf("expected chunk %q with a deferred relation to be marked synced", chunkID)
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1602,6 +1602,170 @@ func TestLocalImportDependencySafeAcrossChunksRegardlessManifestOrder(t *testing
 	}
 }
 
+func TestLocalImportHandlesRelationEndpointFailuresWithoutStalling(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		mutations     []store.SyncMutation
+		assertApplied func(t *testing.T, s *store.Store)
+		deferred      int
+	}{
+		{
+			name: "self-referential relation applies when its observation exists",
+			mutations: []store.SyncMutation{
+				{Entity: store.SyncEntityRelation, EntityKey: "rel-self", Op: store.SyncOpUpsert, Payload: `{"sync_id":"rel-self","source_id":"obs-self","target_id":"obs-self","relation":"compatible","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a","created_at":"2026-08-25T00:00:00Z","updated_at":"2026-08-25T00:00:00Z"}`},
+				{Entity: store.SyncEntityObservation, EntityKey: "obs-self", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-self","session_id":"sess-relations","type":"decision","title":"self","content":"self relation endpoint","project":"proj-a","scope":"project"}`},
+				{Entity: store.SyncEntitySession, EntityKey: "sess-relations", Op: store.SyncOpUpsert, Payload: `{"id":"sess-relations","project":"proj-a","directory":"/tmp/proj-a"}`},
+			},
+			assertApplied: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				relation, err := s.GetRelation("rel-self")
+				if err != nil {
+					t.Fatalf("expected self-referential relation to import: %v", err)
+				}
+				if relation.SourceID != "obs-self" || relation.TargetID != "obs-self" {
+					t.Fatalf("unexpected self-referential relation: %+v", relation)
+				}
+			},
+		},
+		{
+			name: "missing endpoint relation defers while the chunk imports",
+			mutations: []store.SyncMutation{
+				{Entity: store.SyncEntityRelation, EntityKey: "rel-orphan", Op: store.SyncOpUpsert, Payload: `{"sync_id":"rel-orphan","source_id":"obs-present","target_id":"obs-never-exported","relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a","created_at":"2026-08-25T00:00:00Z","updated_at":"2026-08-25T00:00:00Z"}`},
+				{Entity: store.SyncEntityObservation, EntityKey: "obs-present", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-present","session_id":"sess-relations","type":"decision","title":"present","content":"available relation endpoint","project":"proj-a","scope":"project"}`},
+				{Entity: store.SyncEntitySession, EntityKey: "sess-relations", Op: store.SyncOpUpsert, Payload: `{"id":"sess-relations","project":"proj-a","directory":"/tmp/proj-a"}`},
+			},
+			assertApplied: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				if _, err := s.GetObservationBySyncID("obs-present"); err != nil {
+					t.Fatalf("expected available relation endpoint to import: %v", err)
+				}
+				if _, err := s.GetRelation("rel-orphan"); err == nil {
+					t.Fatal("expected unresolved relation to remain unapplied")
+				}
+			},
+			deferred: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestStore(t)
+			syncDir := t.TempDir()
+			chunkID := "chunk-relation-" + strings.ReplaceAll(tt.name, " ", "-")
+			writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-25T00:00:00Z"}}})
+			writeLocalChunkFile(t, syncDir, chunkID, ChunkData{Mutations: tt.mutations})
+
+			result, err := New(s, syncDir).Import()
+			if err != nil {
+				t.Fatalf("local import should not stall on relation endpoint failures: %v", err)
+			}
+			if result.ChunksImported != 1 {
+				t.Fatalf("expected one imported chunk, got %+v", result)
+			}
+			tt.assertApplied(t, s)
+
+			deferred, dead, err := s.CountDeferredAndDead()
+			if err != nil {
+				t.Fatalf("count deferred and dead relations: %v", err)
+			}
+			if deferred != tt.deferred || dead != 0 {
+				t.Fatalf("unexpected deferred state: deferred=%d dead=%d", deferred, dead)
+			}
+			synced, err := s.GetSyncedChunks()
+			if err != nil {
+				t.Fatalf("get synced chunks: %v", err)
+			}
+			if !synced[chunkID] {
+				t.Fatalf("expected chunk %q to be marked synced", chunkID)
+			}
+		})
+	}
+}
+
+func TestLocalImportReplaysDeferredRelationAfterReverseOrderedChunks(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{
+		{ID: "chunk-relation-first", CreatedAt: "2026-08-25T00:00:00Z"},
+		{ID: "chunk-endpoints-second", CreatedAt: "2026-08-25T00:01:00Z"},
+	}})
+	writeLocalChunkFile(t, syncDir, "chunk-relation-first", ChunkData{Mutations: []store.SyncMutation{{
+		Entity: store.SyncEntityRelation, EntityKey: "rel-cross-chunk", Op: store.SyncOpUpsert,
+		Payload: `{"sync_id":"rel-cross-chunk","source_id":"obs-cross-source","target_id":"obs-cross-target","relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`,
+	}}})
+	writeLocalChunkFile(t, syncDir, "chunk-endpoints-second", ChunkData{Mutations: []store.SyncMutation{
+		{Entity: store.SyncEntitySession, EntityKey: "sess-cross-chunk", Op: store.SyncOpUpsert, Payload: `{"id":"sess-cross-chunk","project":"proj-a","directory":"/tmp/proj-a"}`},
+		{Entity: store.SyncEntityObservation, EntityKey: "obs-cross-source", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-cross-source","session_id":"sess-cross-chunk","type":"decision","title":"source","content":"source endpoint","project":"proj-a","scope":"project"}`},
+		{Entity: store.SyncEntityObservation, EntityKey: "obs-cross-target", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-cross-target","session_id":"sess-cross-chunk","type":"decision","title":"target","content":"target endpoint","project":"proj-a","scope":"project"}`},
+	}})
+
+	result, err := New(s, syncDir).Import()
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if result.ChunksImported != 2 || result.RelationsReplayed != 1 || result.RelationsDeferred != 0 || result.RelationsDead != 0 {
+		t.Fatalf("unexpected import result: %+v", result)
+	}
+	if _, err := s.GetRelation("rel-cross-chunk"); err != nil {
+		t.Fatalf("expected deferred relation to replay after endpoint chunk: %v", err)
+	}
+}
+
+func TestLocalImportReplaysDeferredRelationWithoutNewChunks(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: "chunk-missing-target", CreatedAt: "2026-08-25T00:00:00Z"}}})
+	writeLocalChunkFile(t, syncDir, "chunk-missing-target", ChunkData{Mutations: []store.SyncMutation{
+		{Entity: store.SyncEntitySession, EntityKey: "sess-no-new-chunks", Op: store.SyncOpUpsert, Payload: `{"id":"sess-no-new-chunks","project":"proj-a","directory":"/tmp/proj-a"}`},
+		{Entity: store.SyncEntityObservation, EntityKey: "obs-present", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-present","session_id":"sess-no-new-chunks","type":"decision","title":"present","content":"available endpoint","project":"proj-a","scope":"project"}`},
+		{Entity: store.SyncEntityRelation, EntityKey: "rel-no-new-chunks", Op: store.SyncOpUpsert, Payload: `{"sync_id":"rel-no-new-chunks","source_id":"obs-present","target_id":"obs-arrives-without-chunk","relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`},
+	}})
+
+	if _, err := New(s, syncDir).Import(); err != nil {
+		t.Fatalf("initial Import: %v", err)
+	}
+	if err := s.ApplyPulledMutation(store.LocalChunkTargetKey, store.SyncMutation{
+		Seq: 4, Entity: store.SyncEntityObservation, EntityKey: "obs-arrives-without-chunk", Op: store.SyncOpUpsert,
+		Payload: `{"sync_id":"obs-arrives-without-chunk","session_id":"sess-no-new-chunks","type":"decision","title":"arrived","content":"arrived outside chunks","project":"proj-a","scope":"project"}`,
+	}); err != nil {
+		t.Fatalf("apply arriving endpoint: %v", err)
+	}
+
+	result, err := New(s, syncDir).Import()
+	if err != nil {
+		t.Fatalf("Import without new chunks: %v", err)
+	}
+	if result.ChunksImported != 0 || result.ChunksSkipped != 1 || result.RelationsReplayed != 1 || result.RelationsDeferred != 0 || result.RelationsDead != 0 {
+		t.Fatalf("unexpected no-new-chunks import result: %+v", result)
+	}
+	if _, err := s.GetRelation("rel-no-new-chunks"); err != nil {
+		t.Fatalf("expected deferred relation to replay without new chunks: %v", err)
+	}
+}
+
+func TestLocalImportMarksMismatchedRelationIdentityDead(t *testing.T) {
+	s := newTestStore(t)
+	syncDir := t.TempDir()
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: "chunk-mismatched-relation", CreatedAt: "2026-08-25T00:00:00Z"}}})
+	writeLocalChunkFile(t, syncDir, "chunk-mismatched-relation", ChunkData{Mutations: []store.SyncMutation{{
+		Entity: store.SyncEntityRelation, EntityKey: "rel-entity-key", Op: store.SyncOpUpsert,
+		Payload: `{"sync_id":"rel-payload-id","source_id":"obs-missing-a","target_id":"obs-missing-b","relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`,
+	}}})
+
+	result, err := New(s, syncDir).Import()
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if result.RelationsReplayed != 0 || result.RelationsDeferred != 0 || result.RelationsDead != 1 {
+		t.Fatalf("unexpected identity mismatch result: %+v", result)
+	}
+	deferred, dead, err := s.CountDeferredAndDead()
+	if err != nil {
+		t.Fatalf("count deferred and dead: %v", err)
+	}
+	if deferred != 0 || dead != 1 {
+		t.Fatalf("identity mismatch must be terminal, got deferred=%d dead=%d", deferred, dead)
+	}
+}
+
 func TestLocalImportOrdersExplicitMutationsAndDirectArraysSafely(t *testing.T) {
 	s := newTestStore(t)
 	syncDir := t.TempDir()
@@ -2428,7 +2592,7 @@ func TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk(t *testi
 			Entity:    store.SyncEntityRelation,
 			EntityKey: "rel-before-observations",
 			Op:        store.SyncOpUpsert,
-			Payload:   `{"sync_id":"rel-before-observations","source_id":"obs-relation-source","target_id":"obs-relation-target","relation":"compatible","judgment_status":"judged","project":"proj-a","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"}`,
+			Payload:   `{"sync_id":"rel-before-observations","source_id":"obs-relation-source","target_id":"obs-relation-target","relation":"compatible","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"}`,
 		},
 		{
 			Entity:    store.SyncEntityObservation,
@@ -2490,7 +2654,7 @@ func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
 			Entity:    store.SyncEntityRelation,
 			EntityKey: "rel-missing-endpoint",
 			Op:        store.SyncOpUpsert,
-			Payload:   `{"sync_id":"rel-missing-endpoint","source_id":"obs-rollback-source","target_id":"obs-missing-target","relation":"compatible","judgment_status":"judged","project":"proj-a","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"}`,
+			Payload:   `{"sync_id":"rel-missing-endpoint","source_id":"obs-rollback-source","target_id":"obs-missing-target","relation":"compatible","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"}`,
 		},
 		{
 			Entity:    store.SyncEntityObservation,


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #649

Carries forward and rebases the approved implementation from #715. The four contributor commits retain @pzentenoe's original authorship; this replacement branch was necessary because the current account cannot update the contributor fork branch.

---

## 🏷️ PR Type

- [x] type:bug — Bug fix
- [ ] type:feature — New feature
- [ ] type:docs — Documentation only
- [ ] type:refactor — Code refactoring
- [ ] type:chore — Maintenance, dependencies, tooling
- [ ] type:breaking-change — Breaking change

---

## 📝 Summary

- Allow valid self-referential relations when their single distinct endpoint exists.
- Defer missing-endpoint relations and retain malformed relation payloads as dead audit evidence without stalling the rest of a chunk.
- Preserve current relation ordering and atomic rollback for non-relation failures.

## 📂 Changes

| File | Change |
|------|--------|
| internal/store/store.go | Share relation-failure recording across mutation and chunk paths; support self-relations. |
| internal/store/sync_apply_test.go | Cover self-relations, deferred orphans, dead payloads, continuation, cursor advancement, and chunk registration. |
| internal/sync/sync_test.go | Align cloud-import expectations with retained deferred relation history. |

## 🧪 Test Plan

- [x] Focused internal/store relation apply and deferred replay tests.
- [x] Focused internal/sync relation ordering and missing-endpoint tests.
- [x] go vet ./internal/store ./internal/sync
- [x] git diff --check
- [ ] Full-package Windows runs retain documented SQLite temp-handle and path-semantics baseline failures; Linux CI is authoritative.

---

## ✅ Contributor Checklist

- [x] Linked approved issue #649.
- [x] Exactly one type label will be applied: type:bug.
- [x] Retained audit history decision is preserved; no tombstones or destructive pruning were introduced.
- [x] Original contributor authorship is preserved.
- [x] Commit messages follow conventional commits.
- [x] No Co-Authored-By trailers are present.

---

## 💬 Notes for Reviewers

This branch is based on current main, including the merged relation-ordering work from #772. Export-side completeness remains separate in #701. The reviewed final tree is 3f50911e52c184a1abac8e72fa9feba615f591b0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync imports now report replayed, deferred, and permanently failed relation counts.
  * Deferred relation processing is scoped to the relevant target and project.

* **Bug Fixes**
  * Imports continue when relations reference missing endpoints; those relations are deferred for later processing.
  * Deferred relations replay when their endpoints become available.
  * Malformed or invalid relations are marked as failed without blocking valid changes.
  * Self-referential relations apply successfully.
  * Sync progress is preserved during recoverable relation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->