### PR TITLE
fix(sync): prevent orphaned relation exports

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -416,7 +416,7 @@ func (sy *Syncer) Export(createdBy string, project string) (*SyncResult, error) 
 			return nil, fmt.Errorf("scan exported relations: %w", err)
 		}
 		chunk.Mutations = filterRelationMutationsForExport(relationMutations, exportedRelations, lastChunkTime)
-		if err := filterRelationMutationsForEndpointAvailability(chunk, data, exportedObservations); err != nil {
+		if err := filterRelationMutationsForEndpointAvailability(chunk, data, exportedObservations, strings.TrimSpace(project) != ""); err != nil {
 			return nil, fmt.Errorf("filter relation endpoints: %w", err)
 		}
 	}
@@ -1170,8 +1170,8 @@ func filterExportDataToProjectScope(data *store.ExportData) *store.ExportData {
 // when both endpoints are available in the current or a prior manifest chunk.
 // It never re-exports stale observations as relation closure because a receiver
 // could overwrite newer local content. Relations involving endpoints outside
-// the current project export are skipped with a visible warning.
-func filterRelationMutationsForEndpointAvailability(chunk *ChunkData, data *store.ExportData, exportedObservations map[string]struct{}) error {
+// a named project export are skipped with a visible warning.
+func filterRelationMutationsForEndpointAvailability(chunk *ChunkData, data *store.ExportData, exportedObservations map[string]struct{}, requireProjectScope bool) error {
 	observationsBySyncID := make(map[string]store.Observation, len(data.Observations))
 	for _, observation := range data.Observations {
 		observationsBySyncID[observation.SyncID] = observation
@@ -1209,7 +1209,7 @@ func filterRelationMutationsForEndpointAvailability(chunk *ChunkData, data *stor
 				skip = true
 				break
 			}
-			if observation.Scope != "project" {
+			if requireProjectScope && observation.Scope != "project" {
 				log.Printf("[sync] warning: skipping relation %s because endpoint %s has %q scope", mutation.EntityKey, endpointID, observation.Scope)
 				skip = true
 				break

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -386,6 +387,9 @@ func (sy *Syncer) Export(createdBy string, project string) (*SyncResult, error) 
 	if err != nil {
 		return nil, fmt.Errorf("export data: %w", err)
 	}
+	if !sy.cloudMode && strings.TrimSpace(project) != "" {
+		data = filterExportDataToProjectScope(data)
+	}
 	chunk := &ChunkData{}
 	mutationSeqs := []int64{}
 	if sy.cloudMode {
@@ -407,11 +411,14 @@ func (sy *Syncer) Export(createdBy string, project string) (*SyncResult, error) 
 
 		// Relations are filtered by chunk presence, not timestamp; see the
 		// rationale on filterRelationMutationsForExport and issue #353.
-		exportedRelations, err := sy.exportedRelationKeys(manifest)
+		exportedRelations, exportedObservations, err := sy.exportedChunkKeys(manifest)
 		if err != nil {
 			return nil, fmt.Errorf("scan exported relations: %w", err)
 		}
 		chunk.Mutations = filterRelationMutationsForExport(relationMutations, exportedRelations, lastChunkTime)
+		if err := filterRelationMutationsForEndpointAvailability(chunk, data, exportedObservations); err != nil {
+			return nil, fmt.Errorf("filter relation endpoints: %w", err)
+		}
 	}
 
 	// Nothing new to export
@@ -1145,19 +1152,98 @@ func (sy *Syncer) filterNewData(data *store.ExportData, lastChunkTime string) *C
 	return chunk
 }
 
-// exportedRelationKeys returns the set of relation EntityKeys already present
+// filterExportDataToProjectScope excludes personal observations from a local
+// project export. Scope is a privacy boundary even when an observation has the
+// same project as the requested chunk.
+func filterExportDataToProjectScope(data *store.ExportData) *store.ExportData {
+	filtered := *data
+	filtered.Observations = make([]store.Observation, 0, len(data.Observations))
+	for _, observation := range data.Observations {
+		if observation.Scope == "project" {
+			filtered.Observations = append(filtered.Observations, observation)
+		}
+	}
+	return &filtered
+}
+
+// filterRelationMutationsForEndpointAvailability retains relation upserts only
+// when both endpoints are available in the current or a prior manifest chunk.
+// It never re-exports stale observations as relation closure because a receiver
+// could overwrite newer local content. Relations involving endpoints outside
+// the current project export are skipped with a visible warning.
+func filterRelationMutationsForEndpointAvailability(chunk *ChunkData, data *store.ExportData, exportedObservations map[string]struct{}) error {
+	observationsBySyncID := make(map[string]store.Observation, len(data.Observations))
+	for _, observation := range data.Observations {
+		observationsBySyncID[observation.SyncID] = observation
+	}
+
+	includedObservations := make(map[string]struct{}, len(chunk.Observations)+len(exportedObservations))
+	for syncID := range exportedObservations {
+		includedObservations[syncID] = struct{}{}
+	}
+	for _, observation := range chunk.Observations {
+		includedObservations[observation.SyncID] = struct{}{}
+	}
+
+	retainedMutations := make([]store.SyncMutation, 0, len(chunk.Mutations))
+	for _, mutation := range chunk.Mutations {
+		if mutation.Entity != store.SyncEntityRelation || mutation.Op != store.SyncOpUpsert {
+			retainedMutations = append(retainedMutations, mutation)
+			continue
+		}
+		var payload struct {
+			SourceID string `json:"source_id"`
+			TargetID string `json:"target_id"`
+		}
+		if err := decodeSyncPayloadForProject([]byte(mutation.Payload), &payload); err != nil {
+			return fmt.Errorf("decode relation %s: %w", mutation.EntityKey, err)
+		}
+		skip := false
+		for _, endpointID := range []string{strings.TrimSpace(payload.SourceID), strings.TrimSpace(payload.TargetID)} {
+			if endpointID == "" {
+				return fmt.Errorf("relation %s has an empty endpoint", mutation.EntityKey)
+			}
+			observation, ok := observationsBySyncID[endpointID]
+			if !ok {
+				log.Printf("[sync] warning: skipping relation %s because endpoint %s is outside the project export", mutation.EntityKey, endpointID)
+				skip = true
+				break
+			}
+			if observation.Scope != "project" {
+				log.Printf("[sync] warning: skipping relation %s because endpoint %s has %q scope", mutation.EntityKey, endpointID, observation.Scope)
+				skip = true
+				break
+			}
+			if _, included := includedObservations[endpointID]; !included {
+				log.Printf("[sync] warning: skipping relation %s because endpoint %s was excluded by incremental export", mutation.EntityKey, endpointID)
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+
+		retainedMutations = append(retainedMutations, mutation)
+	}
+	chunk.Mutations = retainedMutations
+
+	return nil
+}
+
+// exportedChunkKeys returns the relation and observation keys already present
 // in the chunks recorded by the manifest. The manifest itself does not track
-// relations, so the chunk contents are the source of truth for "has this
-// relation ever been exported".
+// those keys, so chunk contents are the source of truth for their availability.
 //
 // Cost: this reads every chunk listed in the manifest on each export. A
 // relation may live in any chunk, so the scan cannot stop early. For very long
 // sync histories this is O(total chunks); tracking relation keys in the
 // manifest would remove the rescan if it ever becomes a bottleneck.
-func (sy *Syncer) exportedRelationKeys(m *Manifest) (map[string]struct{}, error) {
-	keys := make(map[string]struct{})
+func (sy *Syncer) exportedChunkKeys(m *Manifest) (map[string]struct{}, map[string]struct{}, error) {
+	relationKeys := make(map[string]struct{})
+	observationKeys := make(map[string]struct{})
 	if m == nil {
-		return keys, nil
+		return relationKeys, observationKeys, nil
 	}
 	for _, entry := range m.Chunks {
 		// Read through the transport (not the local filesystem directly) so the
@@ -1173,19 +1259,22 @@ func (sy *Syncer) exportedRelationKeys(m *Manifest) (map[string]struct{}, error)
 				// but cannot be read is a real fault and fails loudly below.
 				continue
 			}
-			return nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
+			return nil, nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
 		}
 		var chunk ChunkData
 		if err := json.Unmarshal(raw, &chunk); err != nil {
-			return nil, fmt.Errorf("unmarshal chunk %s: %w", entry.ID, err)
+			return nil, nil, fmt.Errorf("unmarshal chunk %s: %w", entry.ID, err)
+		}
+		for _, observation := range chunk.Observations {
+			observationKeys[observation.SyncID] = struct{}{}
 		}
 		for _, mutation := range chunk.Mutations {
 			if mutation.Entity == store.SyncEntityRelation {
-				keys[mutation.EntityKey] = struct{}{}
+				relationKeys[mutation.EntityKey] = struct{}{}
 			}
 		}
 	}
-	return keys, nil
+	return relationKeys, observationKeys, nil
 }
 
 // filterRelationMutationsForExport returns the relation mutations that still

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -639,7 +639,7 @@ func TestFilterRelationMutationsForEndpointAvailability(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			chunk := &ChunkData{Mutations: []store.SyncMutation{mutation}}
-			if err := filterRelationMutationsForEndpointAvailability(chunk, &store.ExportData{Observations: tc.observations}, tc.exported); err != nil {
+			if err := filterRelationMutationsForEndpointAvailability(chunk, &store.ExportData{Observations: tc.observations}, tc.exported, true); err != nil {
 				t.Fatalf("filter relation endpoints: %v", err)
 			}
 			if got := len(chunk.Mutations); (got == 1) != tc.wantRetained {
@@ -750,6 +750,87 @@ func TestLocalChunkExportSkipsRelationWithPersonalEndpoint(t *testing.T) {
 			t.Fatalf("personal endpoint must not be added for relation closure: %+v", observation)
 		}
 	}
+}
+
+func TestLocalChunkExportIncludesRelationWithPersonalEndpointInFullExport(t *testing.T) {
+	s := newTestStore(t)
+	const sessionID = "sess-full-personal-relation-endpoint"
+	if err := s.CreateSession(sessionID, "proj-a", "/tmp/proj-a"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	sourceID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "project endpoint",
+		Content:   "project endpoint content",
+		Project:   "proj-a",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add project endpoint: %v", err)
+	}
+	personalID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "personal endpoint",
+		Content:   "personal endpoint content",
+		Project:   "proj-a",
+		Scope:     "personal",
+	})
+	if err != nil {
+		t.Fatalf("add personal endpoint: %v", err)
+	}
+	source, err := s.GetObservation(sourceID)
+	if err != nil {
+		t.Fatalf("get project endpoint: %v", err)
+	}
+	personal, err := s.GetObservation(personalID)
+	if err != nil {
+		t.Fatalf("get personal endpoint: %v", err)
+	}
+
+	const relationID = "rel-full-personal-endpoint"
+	if _, err := s.SaveRelation(store.SaveRelationParams{SyncID: relationID, SourceID: source.SyncID, TargetID: personal.SyncID}); err != nil {
+		t.Fatalf("save relation: %v", err)
+	}
+	confidence := 0.9
+	if _, err := s.JudgeRelation(store.JudgeRelationParams{
+		JudgmentID:    relationID,
+		Relation:      store.RelationCompatible,
+		Confidence:    &confidence,
+		MarkedByActor: "test",
+		MarkedByKind:  "system",
+	}); err != nil {
+		t.Fatalf("judge relation: %v", err)
+	}
+
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+	result, err := New(s, syncDir).Export("alice", "")
+	if err != nil {
+		t.Fatalf("full export: %v", err)
+	}
+	chunkJSON, err := readGzip(filepath.Join(syncDir, "chunks", result.ChunkID+".jsonl.gz"))
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	var chunk ChunkData
+	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+		t.Fatalf("unmarshal chunk: %v", err)
+	}
+
+	observations := map[string]bool{}
+	for _, observation := range chunk.Observations {
+		observations[observation.SyncID] = true
+	}
+	if !observations[source.SyncID] || !observations[personal.SyncID] {
+		t.Fatalf("expected both relation endpoints in full export, got %+v", chunk.Observations)
+	}
+	for _, mutation := range chunk.Mutations {
+		if mutation.Entity == store.SyncEntityRelation && mutation.EntityKey == relationID {
+			return
+		}
+	}
+	t.Fatalf("relation with personal endpoint was not exported: %+v", chunk.Mutations)
 }
 
 func TestLocalChunkExportRejectsMalformedRelationEndpointPayload(t *testing.T) {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -506,6 +506,270 @@ func TestLocalChunkExportIncludesRelationsForObservationsInheritingSessionProjec
 	}
 }
 
+func TestLocalChunkExportIncludesRelationWithPriorChunkEndpoints(t *testing.T) {
+	s := newTestStore(t)
+	const (
+		project   = "proj-a"
+		sessionID = "sess-relation-closure"
+	)
+	if err := s.CreateSession(sessionID, project, "/tmp/proj-a"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	sourceID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "project endpoint",
+		Content:   "project endpoint content",
+		Project:   project,
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add project endpoint: %v", err)
+	}
+	targetID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "second project endpoint",
+		Content:   "second project endpoint content",
+		Project:   project,
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add second project endpoint: %v", err)
+	}
+	source, err := s.GetObservation(sourceID)
+	if err != nil {
+		t.Fatalf("get project endpoint: %v", err)
+	}
+	target, err := s.GetObservation(targetID)
+	if err != nil {
+		t.Fatalf("get second project endpoint: %v", err)
+	}
+
+	const oldTime = "2025-01-01 00:00:00"
+	if _, err := s.DB().Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, oldTime, sessionID); err != nil {
+		t.Fatalf("backdate session: %v", err)
+	}
+	if _, err := s.DB().Exec(`UPDATE observations SET created_at = ?, updated_at = ? WHERE sync_id IN (?, ?)`, oldTime, oldTime, source.SyncID, target.SyncID); err != nil {
+		t.Fatalf("backdate endpoints: %v", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "new project observation",
+		Content:   "new project observation content",
+		Project:   project,
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add new project observation: %v", err)
+	}
+
+	const relationID = "rel-watermark-closure"
+	if _, err := s.SaveRelation(store.SaveRelationParams{SyncID: relationID, SourceID: source.SyncID, TargetID: target.SyncID}); err != nil {
+		t.Fatalf("save relation: %v", err)
+	}
+	confidence := 0.9
+	if _, err := s.JudgeRelation(store.JudgeRelationParams{
+		JudgmentID:    relationID,
+		Relation:      store.RelationCompatible,
+		Confidence:    &confidence,
+		MarkedByActor: "test",
+		MarkedByKind:  "system",
+	}); err != nil {
+		t.Fatalf("judge relation: %v", err)
+	}
+
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+	writeLocalChunkFile(t, syncDir, "previous-chunk", ChunkData{Observations: []store.Observation{
+		{SyncID: source.SyncID},
+		{SyncID: target.SyncID},
+	}})
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{
+		ID: "previous-chunk", CreatedAt: "2025-06-01T00:00:00Z",
+	}}})
+
+	result, err := New(s, syncDir).Export("alice", project)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	chunkJSON, err := readGzip(filepath.Join(syncDir, "chunks", result.ChunkID+".jsonl.gz"))
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	var chunk ChunkData
+	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+		t.Fatalf("unmarshal chunk: %v", err)
+	}
+	foundRelation := false
+	for _, mutation := range chunk.Mutations {
+		if mutation.Entity == store.SyncEntityRelation && mutation.EntityKey == relationID {
+			foundRelation = true
+		}
+	}
+	if !foundRelation {
+		t.Fatalf("relation with prior-chunk endpoints was not exported: %+v", chunk.Mutations)
+	}
+	for _, observation := range chunk.Observations {
+		if observation.SyncID == source.SyncID || observation.SyncID == target.SyncID {
+			t.Fatalf("prior-chunk endpoint must not be re-exported for relation closure: %+v", observation)
+		}
+	}
+}
+
+func TestFilterRelationMutationsForEndpointAvailability(t *testing.T) {
+	mutation := store.SyncMutation{
+		Entity:    store.SyncEntityRelation,
+		EntityKey: "rel-endpoint-availability",
+		Op:        store.SyncOpUpsert,
+		Payload:   `{"source_id":"source","target_id":"target"}`,
+	}
+	projectEndpoints := []store.Observation{{SyncID: "source", Scope: "project"}, {SyncID: "target", Scope: "project"}}
+	bothEndpoints := map[string]struct{}{"source": {}, "target": {}}
+
+	for _, tc := range []struct {
+		name         string
+		observations []store.Observation
+		exported     map[string]struct{}
+		wantRetained bool
+	}{
+		{name: "prior project endpoints", observations: projectEndpoints, exported: bothEndpoints, wantRetained: true},
+		{name: "personal endpoint", observations: []store.Observation{{SyncID: "source", Scope: "project"}, {SyncID: "target", Scope: "personal"}}, exported: bothEndpoints},
+		{name: "out of project endpoint", observations: []store.Observation{{SyncID: "source", Scope: "project"}}, exported: bothEndpoints},
+		{name: "never delivered endpoint", observations: projectEndpoints, exported: map[string]struct{}{"source": {}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			chunk := &ChunkData{Mutations: []store.SyncMutation{mutation}}
+			if err := filterRelationMutationsForEndpointAvailability(chunk, &store.ExportData{Observations: tc.observations}, tc.exported); err != nil {
+				t.Fatalf("filter relation endpoints: %v", err)
+			}
+			if got := len(chunk.Mutations); (got == 1) != tc.wantRetained {
+				t.Fatalf("retained %d relation mutations, want retained=%t", got, tc.wantRetained)
+			}
+		})
+	}
+}
+
+func TestLocalChunkExportSkipsRelationWithPersonalEndpoint(t *testing.T) {
+	s := newTestStore(t)
+	const (
+		project   = "proj-a"
+		sessionID = "sess-personal-relation-endpoint"
+	)
+	if err := s.CreateSession(sessionID, project, "/tmp/proj-a"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	sourceID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "project endpoint",
+		Content:   "project endpoint content",
+		Project:   project,
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add project endpoint: %v", err)
+	}
+	personalID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "personal endpoint",
+		Content:   "personal endpoint content",
+		Project:   project,
+		Scope:     "personal",
+	})
+	if err != nil {
+		t.Fatalf("add personal endpoint: %v", err)
+	}
+	source, err := s.GetObservation(sourceID)
+	if err != nil {
+		t.Fatalf("get project endpoint: %v", err)
+	}
+	personal, err := s.GetObservation(personalID)
+	if err != nil {
+		t.Fatalf("get personal endpoint: %v", err)
+	}
+
+	const oldTime = "2025-01-01 00:00:00"
+	if _, err := s.DB().Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, oldTime, sessionID); err != nil {
+		t.Fatalf("backdate session: %v", err)
+	}
+	if _, err := s.DB().Exec(`UPDATE observations SET created_at = ?, updated_at = ? WHERE sync_id = ?`, oldTime, oldTime, source.SyncID); err != nil {
+		t.Fatalf("backdate project endpoint: %v", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "new project observation",
+		Content:   "new project observation content",
+		Project:   project,
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add new project observation: %v", err)
+	}
+
+	const relationID = "rel-personal-endpoint"
+	if _, err := s.SaveRelation(store.SaveRelationParams{SyncID: relationID, SourceID: personal.SyncID, TargetID: source.SyncID}); err != nil {
+		t.Fatalf("save relation: %v", err)
+	}
+	confidence := 0.9
+	if _, err := s.JudgeRelation(store.JudgeRelationParams{
+		JudgmentID:    relationID,
+		Relation:      store.RelationCompatible,
+		Confidence:    &confidence,
+		MarkedByActor: "test",
+		MarkedByKind:  "system",
+	}); err != nil {
+		t.Fatalf("judge relation: %v", err)
+	}
+
+	syncDir := filepath.Join(t.TempDir(), ".engram")
+	writeLocalChunkFile(t, syncDir, "previous-chunk", ChunkData{})
+	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{
+		ID: "previous-chunk", CreatedAt: "2025-06-01T00:00:00Z",
+	}}})
+
+	result, err := New(s, syncDir).Export("alice", project)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	chunkJSON, err := readGzip(filepath.Join(syncDir, "chunks", result.ChunkID+".jsonl.gz"))
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	var chunk ChunkData
+	if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+		t.Fatalf("unmarshal chunk: %v", err)
+	}
+	for _, mutation := range chunk.Mutations {
+		if mutation.Entity == store.SyncEntityRelation && mutation.EntityKey == relationID {
+			t.Fatalf("personal endpoint relation must not be exported: %+v", mutation)
+		}
+	}
+	for _, observation := range chunk.Observations {
+		if observation.SyncID == personal.SyncID {
+			t.Fatalf("personal endpoint must not be added for relation closure: %+v", observation)
+		}
+	}
+}
+
+func TestLocalChunkExportRejectsMalformedRelationEndpointPayload(t *testing.T) {
+	originalExportRelations := storeExportRelations
+	t.Cleanup(func() { storeExportRelations = originalExportRelations })
+	storeExportRelations = func(_ *store.Store, _ string) ([]store.SyncMutation, error) {
+		return []store.SyncMutation{{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: "rel-malformed",
+			Op:        store.SyncOpUpsert,
+			Payload:   "{",
+		}}, nil
+	}
+
+	_, err := New(newTestStore(t), filepath.Join(t.TempDir(), ".engram")).Export("alice", "proj-a")
+	if err == nil || !strings.Contains(err.Error(), "filter relation endpoints: decode relation rel-malformed") {
+		t.Fatalf("expected malformed relation payload error, got %v", err)
+	}
+}
+
 func TestLocalChunkImportRestoresRelationsAfterObservations(t *testing.T) {
 	src := newTestStore(t)
 	sourceSyncID, targetSyncID := seedRelationForProject(t, src, "proj-a", "sess-rel-import", "rel-import")
@@ -636,7 +900,7 @@ func TestIncrementalRelationExport(t *testing.T) {
 	pastChunkID := "pastchunk00"
 	writeLocalChunkFile(t, syncDir, pastChunkID, ChunkData{
 		// rel-inc-1 is genuinely present in this prior chunk, so
-		// exportedRelationKeys treats it as already exported and skips it.
+		// Exported relation keys treat it as already exported and skip it.
 		Mutations: []store.SyncMutation{{
 			Entity:    store.SyncEntityRelation,
 			EntityKey: "rel-inc-1",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #701

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Keep personal observations out of project-scoped local sync chunks.
- Export relation mutations only when both project endpoints are available in the current or prior chunks.
- Cover prior-chunk, personal-scope, unavailable-endpoint, and malformed-payload behavior.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/sync/sync.go` | Track exported observation identities and gate relation export on safe endpoint availability. |
| `internal/sync/sync_test.go` | Add behavior-focused regression coverage for relation endpoint availability. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` (timed out after 120 seconds without a failure result; CI will run the complete suite)
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Focused verification:

- `go test -count=1 ./internal/sync -run Relation`
- `git diff --check`
- Native Gentle AI 4R review approved after one bounded correction and targeted validation.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (timed out locally; delegated to CI)
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (not required: this change enforces an internal sync safety invariant)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The relation gate accepts endpoints present in earlier manifest chunks without re-exporting stale observation bodies. Relations involving personal, out-of-project, or never-delivered endpoints remain excluded with visible warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project exports by excluding personal-scope observations.
  - Preserved valid relations whose endpoints were exported in earlier chunks, without duplicating observations.
  - Excluded relations with unavailable, non-project, or omitted endpoints.
  - Preserved personal endpoints in full exports.
  - Added clearer errors for malformed relation data and missing endpoints.

- **Tests**
  - Expanded coverage for incremental exports, relation filtering, endpoint availability, full exports, and malformed payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->