### PR TITLE
fix(cloud): recover stranded bootstrap admin token

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -549,6 +549,7 @@ Inspect or replay the `sync_apply_deferred` queue.
 - `engram cloud upgrade rollback --project <project>` — restore pre-upgrade local snapshot before `bootstrap_verified`; blocked afterwards
 - `engram cloud repair materialize-mutations --project <project> (--dry-run|--apply)` — explicit server-side Postgres repair that backfills existing `cloud_mutations` into compatible `cloud_chunks` without deleting remote data
 - `engram cloud bootstrap admin --username <name> [--email <email>] [--grant-project <project>]... [--issue-token [name]]` — create the first managed admin (see [Managed users, tokens, and CLI bootstrap](#managed-users-tokens-and-cli-bootstrap))
+- `engram cloud bootstrap recover-token [--name <name>]` — recover the one stranded managed admin token state described below
 
 Cloud auth token is provided at runtime via `ENGRAM_CLOUD_TOKEN` (not by a dedicated CLI subcommand).
 Cloud server startup fails closed when the token is missing unless `ENGRAM_CLOUD_INSECURE_NO_AUTH=1` is explicitly set for local insecure development.
@@ -601,6 +602,14 @@ engram cloud bootstrap admin --username alice \
 - Running the command again once a managed admin already exists is rejected (no silent duplicate first-admin creation); the attempt is still recorded as a denied `bootstrap.cli` audit event.
 - Every bootstrap attempt (accepted or denied) writes a `bootstrap.cli` audit event to `cloud_auth_audit_log`, with the same non-secret metadata rules (no raw tokens, hashes, or bearer headers) as every other cloud auth audit event.
 - Grant/role/duplicate-admin validation reuses the exact same `cloudstore` methods and last-admin guard used by the dashboard's own first-admin bootstrap flow — there is no parallel/looser bootstrap path.
+
+If a historical failed bootstrap left exactly one enabled managed human admin, retained its grants, and created no principal token anywhere in the deployment, run the explicit recovery command:
+
+```bash
+engram cloud bootstrap recover-token --name replacement
+```
+
+It requires `ENGRAM_CLOUD_TOKEN_PEPPER`, preserves existing grants, and prints the recovered raw token exactly once only after the token and its `bootstrap.cli` recovery audit event commit together. It refuses all other states, including multiple enabled managed human admins or any existing principal token; it does not create users, grants, or partial tokens.
 
 **Runtime authentication:** `engram cloud serve` resolves managed tokens first, then falls back to the legacy env-token credentials (`ENGRAM_CLOUD_TOKEN` for sync, `ENGRAM_CLOUD_ADMIN` for dashboard bootstrap/admin), on every `/sync/*`, `/admin/*`, and dashboard-login request:
 

--- a/cmd/engram/cloud_bootstrap.go
+++ b/cmd/engram/cloud_bootstrap.go
@@ -44,6 +44,7 @@ const (
 type cloudBootstrapStore interface {
 	CreateFirstAdminHumanUser(ctx context.Context, params cloudstore.CreateHumanUserParams) (cloudstore.HumanUser, error)
 	CreatePrincipalTokenWithAudit(ctx context.Context, params cloudstore.CreatePrincipalTokenParams, audit cloudstore.AuthAuditEvent) (cloudstore.PrincipalToken, error)
+	RecoverStrandedAdminTokenWithAudit(ctx context.Context, params cloudstore.RecoverStrandedAdminTokenParams, audit cloudstore.AuthAuditEvent) (cloudstore.PrincipalToken, error)
 	CreateProjectGrant(ctx context.Context, params cloudstore.CreateProjectGrantParams) (cloudstore.ProjectGrant, error)
 	InsertAuthAuditEvent(ctx context.Context, event cloudstore.AuthAuditEvent) error
 	Close() error
@@ -64,6 +65,10 @@ type cloudBootstrapAdminArgs struct {
 	issueTokenName string
 }
 
+type cloudBootstrapRecoverTokenArgs struct {
+	name string
+}
+
 func cmdCloudBootstrap() {
 	if len(os.Args) < 4 {
 		printCloudBootstrapUsage()
@@ -74,6 +79,8 @@ func cmdCloudBootstrap() {
 	switch strings.TrimSpace(os.Args[3]) {
 	case "admin":
 		cmdCloudBootstrapAdmin()
+	case "recover-token":
+		cmdCloudBootstrapRecoverToken()
 	case "--help", "-h", "help":
 		printCloudBootstrapUsage()
 	default:
@@ -85,6 +92,7 @@ func cmdCloudBootstrap() {
 
 func printCloudBootstrapUsage() {
 	fmt.Println("usage: engram cloud bootstrap admin --username <name> [--email <email>] [--grant-project <project>]... [--issue-token [name]]")
+	fmt.Println("       engram cloud bootstrap recover-token [--name <name>]")
 	fmt.Println("creates the first managed admin for a self-hosted cloud deployment")
 }
 
@@ -254,6 +262,76 @@ func cmdCloudBootstrapAdmin() {
 	}
 }
 
+// cmdCloudBootstrapRecoverToken repairs only the partial bootstrap state where
+// the sole enabled managed human admin has no token anywhere in the deployment.
+// Eligibility and token-plus-audit atomicity are enforced by cloudstore; this
+// command only generates and hashes the one-time credential before that call.
+func cmdCloudBootstrapRecoverToken() {
+	args, err := parseCloudBootstrapRecoverTokenArgs(os.Args[4:])
+	if err != nil {
+		printCloudBootstrapUsage()
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		exitFunc(1)
+		return
+	}
+
+	runtimeCfg := cloud.ConfigFromEnv()
+	pepper := strings.TrimSpace(runtimeCfg.TokenPepper)
+	if pepper == "" {
+		fmt.Fprintln(os.Stderr, "error: recover-token requires ENGRAM_CLOUD_TOKEN_PEPPER to be configured (a dedicated cloud token pepper, distinct from ENGRAM_JWT_SECRET)")
+		exitFunc(1)
+		return
+	}
+	hasher, err := cloudauth.NewManagedTokenHasher([]byte(pepper))
+	if err != nil {
+		fatal(fmt.Errorf("cloud bootstrap recover-token: %w", err))
+		return
+	}
+
+	cs, err := newCloudBootstrapStore(runtimeCfg)
+	if err != nil {
+		fatal(fmt.Errorf("cloud bootstrap recover-token: connect cloud store: %w", err))
+		return
+	}
+	defer cs.Close()
+
+	managedToken, err := cloudauth.GenerateManagedToken("live")
+	if err != nil {
+		fatal(fmt.Errorf("cloud bootstrap recover-token: generate token: %w", err))
+		return
+	}
+	tokenHash, err := hasher.Hash(managedToken.Raw)
+	if err != nil {
+		fatal(fmt.Errorf("cloud bootstrap recover-token: hash token: %w", err))
+		return
+	}
+	name := strings.TrimSpace(args.name)
+	if name == "" {
+		name = "cli-bootstrap-recovery"
+	}
+	_, err = cs.RecoverStrandedAdminTokenWithAudit(context.Background(), cloudstore.RecoverStrandedAdminTokenParams{
+		TokenPrefix: managedToken.Prefix,
+		TokenHash:   tokenHash,
+		Name:        name,
+	}, cloudstore.AuthAuditEvent{
+		ActorSource: string(cloudauth.PrincipalSourceBootstrapCLI),
+		Action:      cloudBootstrapAuditAction,
+		Outcome:     cloudBootstrapAuditOutcomeSuccess,
+		ReasonCode:  "stranded_admin_token_recovered",
+		Metadata: map[string]any{
+			"recovered":    true,
+			"token_prefix": managedToken.Prefix,
+		},
+	})
+	if err != nil {
+		fatal(fmt.Errorf("cloud bootstrap recover-token: %w", err))
+		return
+	}
+
+	fmt.Println("Managed admin token recovered — SHOWN ONCE, copy and store it now, it cannot be retrieved again:")
+	fmt.Println(managedToken.Raw)
+}
+
 func cloudBootstrapCompletionMetadata(username string, issuedToken bool, grants []cloudstore.ProjectGrant) map[string]any {
 	metadata := map[string]any{
 		"created_admin": true,
@@ -331,6 +409,26 @@ func parseCloudBootstrapAdminArgs(args []string) (cloudBootstrapAdminArgs, error
 	}
 	if strings.TrimSpace(out.username) == "" {
 		return out, fmt.Errorf("--username is required")
+	}
+	return out, nil
+}
+
+func parseCloudBootstrapRecoverTokenArgs(args []string) (cloudBootstrapRecoverTokenArgs, error) {
+	var out cloudBootstrapRecoverTokenArgs
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--name":
+			if i+1 >= len(args) {
+				return out, fmt.Errorf("--name requires a value")
+			}
+			i++
+			out.name = strings.TrimSpace(args[i])
+			if out.name == "" {
+				return out, fmt.Errorf("--name requires a non-empty value")
+			}
+		default:
+			return out, fmt.Errorf("unknown flag: %s", args[i])
+		}
 	}
 	return out, nil
 }

--- a/cmd/engram/cloud_bootstrap.go
+++ b/cmd/engram/cloud_bootstrap.go
@@ -93,7 +93,8 @@ func cmdCloudBootstrap() {
 func printCloudBootstrapUsage() {
 	fmt.Println("usage: engram cloud bootstrap admin --username <name> [--email <email>] [--grant-project <project>]... [--issue-token [name]]")
 	fmt.Println("       engram cloud bootstrap recover-token [--name <name>]")
-	fmt.Println("creates the first managed admin for a self-hosted cloud deployment")
+	fmt.Println("admin creates the first managed admin for a self-hosted cloud deployment")
+	fmt.Println("recover-token issues one token for the eligible stranded managed admin")
 }
 
 func cmdCloudBootstrapAdmin() {
@@ -418,7 +419,7 @@ func parseCloudBootstrapRecoverTokenArgs(args []string) (cloudBootstrapRecoverTo
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--name":
-			if i+1 >= len(args) {
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
 				return out, fmt.Errorf("--name requires a value")
 			}
 			i++

--- a/cmd/engram/cloud_bootstrap_test.go
+++ b/cmd/engram/cloud_bootstrap_test.go
@@ -809,6 +809,41 @@ func TestCloudBootstrapRecoverTokenRequiresTokenPepperBeforeOpeningStore(t *test
 	}
 }
 
+func TestCloudBootstrapHelpDescribesAdminAndRecoverySeparately(t *testing.T) {
+	withArgs(t, "engram", "cloud", "bootstrap", "--help")
+	stdout, _, recovered := captureOutputAndRecover(t, cmdCloudBootstrap)
+	if recovered != nil {
+		t.Fatalf("expected help to return normally, got %v", recovered)
+	}
+	if !strings.Contains(stdout, "admin creates the first managed admin") || !strings.Contains(stdout, "recover-token issues one token for the eligible stranded managed admin") {
+		t.Fatalf("expected separate accurate bootstrap help descriptions, got %q", stdout)
+	}
+}
+
+func TestParseCloudBootstrapRecoverTokenArgsRejectsMissingNameValue(t *testing.T) {
+	for _, args := range [][]string{{"--name"}, {"--name", "--unknown"}} {
+		if _, err := parseCloudBootstrapRecoverTokenArgs(args); err == nil || err.Error() != "--name requires a value" {
+			t.Fatalf("parseCloudBootstrapRecoverTokenArgs(%v) = %v, want --name requires a value", args, err)
+		}
+	}
+}
+
+func TestCloudBootstrapRecoverTokenRejectsFlagAsNameBeforeOpeningStore(t *testing.T) {
+	stubExitWithPanic(t)
+	store := &fakeCloudBootstrapStore{}
+	calls := stubNewCloudBootstrapStore(t, store)
+
+	withArgs(t, "engram", "cloud", "bootstrap", "recover-token", "--name", "--unknown")
+	_, stderr, recovered := captureOutputAndRecover(t, cmdCloudBootstrap)
+	code, ok := recovered.(exitCode)
+	if !ok || int(code) != 1 {
+		t.Fatalf("expected exit code 1 for a flag-like --name value, got %v", recovered)
+	}
+	if !strings.Contains(stderr, "--name requires a value") || *calls != 0 || store.recoverTokenCalls != 0 {
+		t.Fatalf("flag-like --name value must fail before opening the store, stderr=%q calls=%d recoveryCalls=%d", stderr, *calls, store.recoverTokenCalls)
+	}
+}
+
 // TestCloudBootstrapUnknownSubcommandIsRejected proves `engram cloud
 // bootstrap <x>` for x != admin is rejected instead of silently no-op.
 func TestCloudBootstrapUnknownSubcommandIsRejected(t *testing.T) {

--- a/cmd/engram/cloud_bootstrap_test.go
+++ b/cmd/engram/cloud_bootstrap_test.go
@@ -21,11 +21,12 @@ type fakeCloudBootstrapStore struct {
 	hasAdmin    bool
 	hasAdminErr error
 
-	createUserErr  error
-	createGrantErr error
-	createTokenErr error
-	auditErr       error
-	auditErrOnCall int
+	createUserErr   error
+	createGrantErr  error
+	createTokenErr  error
+	recoverTokenErr error
+	auditErr        error
+	auditErrOnCall  int
 
 	users       []cloudstore.HumanUser
 	grants      []cloudstore.ProjectGrant
@@ -35,6 +36,7 @@ type fakeCloudBootstrapStore struct {
 	createUserCalls       int
 	createGrantCalls      int
 	createTokenCalls      int
+	recoverTokenCalls     int
 	createFirstAdminCalls int
 	auditCalls            int
 	closeCalls            int
@@ -126,6 +128,26 @@ func (s *fakeCloudBootstrapStore) CreatePrincipalTokenWithAudit(_ context.Contex
 	if err := s.insertAuthAuditEvent(audit); err != nil {
 		return cloudstore.PrincipalToken{}, err
 	}
+	s.tokens = append(s.tokens, token)
+	return token, nil
+}
+
+func (s *fakeCloudBootstrapStore) RecoverStrandedAdminTokenWithAudit(_ context.Context, params cloudstore.RecoverStrandedAdminTokenParams, audit cloudstore.AuthAuditEvent) (cloudstore.PrincipalToken, error) {
+	s.recoverTokenCalls++
+	if s.recoverTokenErr != nil {
+		return cloudstore.PrincipalToken{}, s.recoverTokenErr
+	}
+	audit.TargetPrincipalID = "p-stranded-admin"
+	if err := s.insertAuthAuditEvent(audit); err != nil {
+		return cloudstore.PrincipalToken{}, err
+	}
+	token := fakePrincipalToken(cloudstore.CreatePrincipalTokenParams{
+		PrincipalID:          audit.TargetPrincipalID,
+		TokenPrefix:          params.TokenPrefix,
+		TokenHash:            params.TokenHash,
+		Name:                 params.Name,
+		CreatedByPrincipalID: audit.TargetPrincipalID,
+	})
 	s.tokens = append(s.tokens, token)
 	return token, nil
 }
@@ -694,6 +716,96 @@ func TestCloudBootstrapAdminRejectsUnknownFlag(t *testing.T) {
 	}
 	if *calls != 0 {
 		t.Fatalf("expected cloud store to never be constructed for invalid input, got %d calls", *calls)
+	}
+}
+
+func TestCloudBootstrapRecoverTokenIssuesOneTokenAndAuditsRecovery(t *testing.T) {
+	stubExitWithPanic(t)
+	t.Setenv("ENGRAM_CLOUD_TOKEN_PEPPER", "dedicated-cloud-token-pepper-for-tests")
+	store := &fakeCloudBootstrapStore{}
+	stubNewCloudBootstrapStore(t, store)
+
+	withArgs(t, "engram", "cloud", "bootstrap", "recover-token", "--name", "replacement")
+	stdout, _, recovered := captureOutputAndRecover(t, cmdCloudBootstrap)
+	if recovered != nil {
+		t.Fatalf("expected stranded-admin recovery to succeed, got %v; stdout=%q", recovered, stdout)
+	}
+	if store.recoverTokenCalls != 1 || len(store.tokens) != 1 {
+		t.Fatalf("expected one recovery token attempt and one token, calls=%d tokens=%+v", store.recoverTokenCalls, store.tokens)
+	}
+	if store.tokens[0].Name != "replacement" {
+		t.Fatalf("expected requested recovery token name, got %+v", store.tokens[0])
+	}
+	if strings.Count(stdout, "egc_live_") != 1 {
+		t.Fatalf("expected the raw recovery token exactly once, got stdout=%q", stdout)
+	}
+	if len(store.auditEvents) != 1 {
+		t.Fatalf("expected one recovery audit event, got %+v", store.auditEvents)
+	}
+	event := store.auditEvents[0]
+	if event.TargetPrincipalID != "p-stranded-admin" || event.ReasonCode != "stranded_admin_token_recovered" || event.Metadata["recovered"] != true {
+		t.Fatalf("unexpected recovery audit event: %+v", event)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	rawToken := strings.TrimSpace(lines[len(lines)-1])
+	for _, value := range event.Metadata {
+		if value == rawToken {
+			t.Fatalf("recovery audit metadata leaked the raw token: %+v", event.Metadata)
+		}
+	}
+}
+
+func TestCloudBootstrapRecoverTokenDoesNotPersistOrDiscloseWhenAuditFails(t *testing.T) {
+	stubExitWithPanic(t)
+	t.Setenv("ENGRAM_CLOUD_TOKEN_PEPPER", "dedicated-cloud-token-pepper-for-tests")
+	store := &fakeCloudBootstrapStore{auditErrOnCall: 1}
+	stubNewCloudBootstrapStore(t, store)
+
+	withArgs(t, "engram", "cloud", "bootstrap", "recover-token")
+	stdout, _, recovered := captureOutputAndRecover(t, cmdCloudBootstrap)
+	code, ok := recovered.(exitCode)
+	if !ok || int(code) != 1 {
+		t.Fatalf("expected exit code 1 when recovery audit fails, got %v", recovered)
+	}
+	if strings.Contains(stdout, "egc_live_") || len(store.tokens) != 0 || len(store.auditEvents) != 0 {
+		t.Fatalf("failed recovery audit must not disclose or persist a token, stdout=%q tokens=%+v audits=%+v", stdout, store.tokens, store.auditEvents)
+	}
+}
+
+func TestCloudBootstrapRecoverTokenRejectsIneligibleStateWithoutDisclosure(t *testing.T) {
+	stubExitWithPanic(t)
+	t.Setenv("ENGRAM_CLOUD_TOKEN_PEPPER", "dedicated-cloud-token-pepper-for-tests")
+	store := &fakeCloudBootstrapStore{recoverTokenErr: fmt.Errorf("%w: requires zero principal tokens, found 1", cloudstore.ErrStrandedAdminRecoveryIneligible)}
+	stubNewCloudBootstrapStore(t, store)
+
+	withArgs(t, "engram", "cloud", "bootstrap", "recover-token")
+	stdout, stderr, recovered := captureOutputAndRecover(t, cmdCloudBootstrap)
+	code, ok := recovered.(exitCode)
+	if !ok || int(code) != 1 {
+		t.Fatalf("expected exit code 1 for ineligible recovery, got %v", recovered)
+	}
+	if !strings.Contains(stderr, "requires zero principal tokens") {
+		t.Fatalf("expected actionable ineligibility error, got stderr=%q", stderr)
+	}
+	if strings.Contains(stdout, "egc_live_") || len(store.tokens) != 0 || len(store.auditEvents) != 0 {
+		t.Fatalf("ineligible recovery must not disclose or mutate, stdout=%q tokens=%+v audits=%+v", stdout, store.tokens, store.auditEvents)
+	}
+}
+
+func TestCloudBootstrapRecoverTokenRequiresTokenPepperBeforeOpeningStore(t *testing.T) {
+	stubExitWithPanic(t)
+	t.Setenv("ENGRAM_CLOUD_TOKEN_PEPPER", "")
+	store := &fakeCloudBootstrapStore{}
+	calls := stubNewCloudBootstrapStore(t, store)
+
+	withArgs(t, "engram", "cloud", "bootstrap", "recover-token")
+	_, stderr, recovered := captureOutputAndRecover(t, cmdCloudBootstrap)
+	code, ok := recovered.(exitCode)
+	if !ok || int(code) != 1 {
+		t.Fatalf("expected exit code 1 without a token pepper, got %v", recovered)
+	}
+	if !strings.Contains(stderr, "ENGRAM_CLOUD_TOKEN_PEPPER") || *calls != 0 || store.recoverTokenCalls != 0 {
+		t.Fatalf("missing pepper must fail before opening the store, stderr=%q calls=%d recoveryCalls=%d", stderr, *calls, store.recoverTokenCalls)
 	}
 }
 

--- a/docs/engram-cloud/troubleshooting.md
+++ b/docs/engram-cloud/troubleshooting.md
@@ -299,12 +299,14 @@ Do not manually edit SQLite without a backup.
 
 ---
 
-## `engram cloud bootstrap admin` errors
+## `engram cloud bootstrap` errors
 
 | Message | Cause | Next step |
 |---|---|---|
 | `a managed admin already exists; refusing to create a duplicate first admin via CLI bootstrap` | A managed admin was already bootstrapped (via CLI or dashboard). | This is expected safety behavior, not a bug. Use the existing managed admin, or a documented recovery path, instead of re-running first-admin bootstrap. |
 | `--issue-token requires ENGRAM_CLOUD_TOKEN_PEPPER to be configured` | `--issue-token` was passed without `ENGRAM_CLOUD_TOKEN_PEPPER` set. | Set `ENGRAM_CLOUD_TOKEN_PEPPER` to a dedicated secret (distinct from `ENGRAM_JWT_SECRET`) and re-run. No admin/user was created by the failed attempt. |
+| `stranded admin token recovery is not eligible` | `recover-token` found anything other than exactly one enabled managed human admin and zero principal tokens. | Use `engram cloud bootstrap recover-token` only for the documented partial-bootstrap state; it intentionally refuses a normal, ambiguous, or already recovered deployment. |
+| `recover-token requires ENGRAM_CLOUD_TOKEN_PEPPER to be configured` | The recovery command cannot hash a managed token safely. | Set the dedicated pepper, then retry. No token was created. |
 | `connect cloud store` | `ENGRAM_DATABASE_URL` is missing/unreachable, same as any other `engram cloud` database command. | Verify `ENGRAM_DATABASE_URL` and that Postgres is reachable, same as `engram cloud serve`. |
 
 Rollback / legacy migration path: `engram cloud bootstrap admin` only adds new `cloud_principals`/`cloud_human_users`/`cloud_principal_tokens`/`cloud_project_grants` rows — it never disables `ENGRAM_CLOUD_TOKEN` or `ENGRAM_CLOUD_ADMIN`. If you want to stop using managed admins/tokens, simply keep using the legacy env credentials (or unset `ENGRAM_CLOUD_TOKEN_PEPPER` to disable managed-token authentication entirely); no migration or rollback command is required to fall back. See [DOCS.md — Managed users, tokens, and CLI bootstrap](../../DOCS.md#managed-users-tokens-and-cli-bootstrap) for how `engram cloud serve` resolves managed tokens first, then legacy env-token credentials.

--- a/internal/cloud/cloudstore/identity.go
+++ b/internal/cloud/cloudstore/identity.go
@@ -22,15 +22,16 @@ const (
 )
 
 var (
-	ErrInvalidPrincipalKind   = errors.New("cloudstore: invalid principal kind")
-	ErrInvalidPrincipalRole   = errors.New("cloudstore: invalid principal role")
-	ErrLastActiveAdmin        = errors.New("cloudstore: cannot remove last active admin")
-	ErrSensitiveAuditMetadata = errors.New("cloudstore: sensitive auth audit metadata is not allowed")
-	ErrAuthAuditInsertFailed  = errors.New("cloudstore: auth audit insert failed")
-	ErrAdminAlreadyExists     = errors.New("cloudstore: a managed admin already exists")
-	ErrPrincipalNotFound      = errors.New("cloudstore: principal not found")
-	ErrPrincipalDisabled      = errors.New("cloudstore: principal is disabled")
-	ErrPrincipalTokenNotFound = errors.New("cloudstore: principal token not found")
+	ErrInvalidPrincipalKind            = errors.New("cloudstore: invalid principal kind")
+	ErrInvalidPrincipalRole            = errors.New("cloudstore: invalid principal role")
+	ErrLastActiveAdmin                 = errors.New("cloudstore: cannot remove last active admin")
+	ErrSensitiveAuditMetadata          = errors.New("cloudstore: sensitive auth audit metadata is not allowed")
+	ErrAuthAuditInsertFailed           = errors.New("cloudstore: auth audit insert failed")
+	ErrAdminAlreadyExists              = errors.New("cloudstore: a managed admin already exists")
+	ErrStrandedAdminRecoveryIneligible = errors.New("cloudstore: stranded admin token recovery is not eligible")
+	ErrPrincipalNotFound               = errors.New("cloudstore: principal not found")
+	ErrPrincipalDisabled               = errors.New("cloudstore: principal is disabled")
+	ErrPrincipalTokenNotFound          = errors.New("cloudstore: principal token not found")
 )
 
 type Principal struct {
@@ -92,6 +93,14 @@ type CreatePrincipalTokenParams struct {
 	TokenHash            string
 	Name                 string
 	CreatedByPrincipalID string
+}
+
+// RecoverStrandedAdminTokenParams contains the non-secret token data needed to
+// recover the single admin left without a token by a failed bootstrap.
+type RecoverStrandedAdminTokenParams struct {
+	TokenPrefix string
+	TokenHash   string
+	Name        string
 }
 
 type ProjectGrant struct {
@@ -300,7 +309,9 @@ func (cs *CloudStore) CreateFirstAdminHumanUser(ctx context.Context, params Crea
 
 	// Same advisory lock key as guardLastActiveAdminTx: first-admin creation
 	// serializes with concurrent admin-removal/demotion guard transactions
-	// as well as with concurrent first-admin bootstrap attempts.
+	// as well as with concurrent first-admin bootstrap attempts. There is no
+	// existing target principal to lock before this creation check, so it never
+	// waits on a principal row while holding the advisory lock.
 	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext('engram_cloud_active_admin_guard'))`); err != nil {
 		return HumanUser{}, fmt.Errorf("cloudstore: lock active admin guard: %w", err)
 	}
@@ -405,22 +416,32 @@ func (cs *CloudStore) CreatePrincipalToken(ctx context.Context, params CreatePri
 	if err != nil {
 		return PrincipalToken{}, err
 	}
-	const q = `
-		WITH target_principal AS (
-			SELECT id
-			FROM cloud_principals
-			WHERE id = $1 AND enabled = TRUE
-			FOR UPDATE
-		)
-		INSERT INTO cloud_principal_tokens (principal_id, token_prefix, token_hash, name, created_by_principal_id)
-		SELECT p.id, $2, $3, $4, $5
-		FROM target_principal p
-		RETURNING id::text, principal_id::text, token_prefix, '' AS token_hash, name, COALESCE(created_by_principal_id::text, ''), created_at, last_used_at, revoked_at, COALESCE(revoked_by_principal_id::text, ''), COALESCE(revocation_reason, '')`
-	token, err := scanPrincipalToken(cs.db.QueryRowContext(ctx, q, values.principalID, values.tokenPrefix, values.tokenHash, values.name, values.createdByPrincipalID))
-	if errors.Is(err, sql.ErrNoRows) {
-		return PrincipalToken{}, principalTokenTargetError(ctx, cs.db, values.principalID)
+	tx, err := cs.db.BeginTx(ctx, nil)
+	if err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: begin principal token tx: %w", err)
 	}
-	return token, err
+	defer func() { _ = tx.Rollback() }()
+	if err := lockPrincipalTokenTargetTx(ctx, tx, values.principalID); err != nil {
+		return PrincipalToken{}, err
+	}
+	// Lock the token target before the shared advisory guard. This matches the
+	// existing last-active-admin transitions, which also lock their target row
+	// before acquiring the guard, and prevents inverse-order deadlocks.
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext('engram_cloud_active_admin_guard'))`); err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: lock active admin guard: %w", err)
+	}
+	const q = `
+		INSERT INTO cloud_principal_tokens (principal_id, token_prefix, token_hash, name, created_by_principal_id)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id::text, principal_id::text, token_prefix, '' AS token_hash, name, COALESCE(created_by_principal_id::text, ''), created_at, last_used_at, revoked_at, COALESCE(revoked_by_principal_id::text, ''), COALESCE(revocation_reason, '')`
+	token, err := scanPrincipalToken(tx.QueryRowContext(ctx, q, values.principalID, values.tokenPrefix, values.tokenHash, values.name, values.createdByPrincipalID))
+	if err != nil {
+		return PrincipalToken{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: commit principal token tx: %w", err)
+	}
+	return token, nil
 }
 
 func (cs *CloudStore) CreatePrincipalTokenWithAudit(ctx context.Context, params CreatePrincipalTokenParams, audit AuthAuditEvent) (PrincipalToken, error) {
@@ -436,22 +457,21 @@ func (cs *CloudStore) CreatePrincipalTokenWithAudit(ctx context.Context, params 
 		return PrincipalToken{}, fmt.Errorf("cloudstore: begin principal token audit tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := lockPrincipalTokenTargetTx(ctx, tx, values.principalID); err != nil {
+		return PrincipalToken{}, err
+	}
+	// Keep normal token issuance in the same eligibility serialization as the
+	// stranded-admin recovery, after taking the target-row lock to preserve the
+	// lock order used by last-active-admin transitions.
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext('engram_cloud_active_admin_guard'))`); err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: lock active admin guard: %w", err)
+	}
 
 	const q = `
-		WITH target_principal AS (
-			SELECT id
-			FROM cloud_principals
-			WHERE id = $1 AND enabled = TRUE
-			FOR UPDATE
-		)
 		INSERT INTO cloud_principal_tokens (principal_id, token_prefix, token_hash, name, created_by_principal_id)
-		SELECT p.id, $2, $3, $4, $5
-		FROM target_principal p
+		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id::text, principal_id::text, token_prefix, '' AS token_hash, name, COALESCE(created_by_principal_id::text, ''), created_at, last_used_at, revoked_at, COALESCE(revoked_by_principal_id::text, ''), COALESCE(revocation_reason, '')`
 	token, err := scanPrincipalToken(tx.QueryRowContext(ctx, q, values.principalID, values.tokenPrefix, values.tokenHash, values.name, values.createdByPrincipalID))
-	if errors.Is(err, sql.ErrNoRows) {
-		return PrincipalToken{}, principalTokenTargetError(ctx, tx, values.principalID)
-	}
 	if err != nil {
 		return PrincipalToken{}, err
 	}
@@ -462,6 +482,119 @@ func (cs *CloudStore) CreatePrincipalTokenWithAudit(ctx context.Context, params 
 		return PrincipalToken{}, fmt.Errorf("cloudstore: commit principal token audit tx: %w", err)
 	}
 	return token, nil
+}
+
+// RecoverStrandedAdminTokenWithAudit atomically issues a token to the sole
+// enabled managed human admin only when no principal token exists anywhere in
+// the deployment. It is intentionally narrower than normal token issuance:
+// it repairs only the partial state left by the historical bootstrap audit
+// failure, preserves all grants, and cannot be repeated after a token exists.
+func (cs *CloudStore) RecoverStrandedAdminTokenWithAudit(ctx context.Context, params RecoverStrandedAdminTokenParams, audit AuthAuditEvent) (PrincipalToken, error) {
+	if cs == nil || cs.db == nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: not initialized")
+	}
+	tokenPrefix := strings.TrimSpace(params.TokenPrefix)
+	if tokenPrefix == "" {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: token prefix is required")
+	}
+	tokenHash := strings.TrimSpace(params.TokenHash)
+	if tokenHash == "" {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: token hash is required")
+	}
+
+	tx, err := cs.db.BeginTx(ctx, nil)
+	if err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: begin stranded admin token recovery tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Lock active human-admin rows first, matching normal issuance's row-then-
+	// advisory-lock order. Re-read them after the guard is held so a concurrent
+	// transition cannot make the recovery eligibility stale while waiting.
+	if _, err := lockedEnabledHumanAdminIDsTx(ctx, tx); err != nil {
+		return PrincipalToken{}, err
+	}
+	// Use the same transaction-scoped lock as first-admin creation and the
+	// last-active-admin guard so recovery eligibility and token issuance cannot
+	// race with those safety-critical admin transitions.
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext('engram_cloud_active_admin_guard'))`); err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: lock active admin guard: %w", err)
+	}
+
+	adminIDs, err := lockedEnabledHumanAdminIDsTx(ctx, tx)
+	if err != nil {
+		return PrincipalToken{}, err
+	}
+	if len(adminIDs) != 1 {
+		return PrincipalToken{}, fmt.Errorf("%w: requires exactly one enabled managed human admin, found %d", ErrStrandedAdminRecoveryIneligible, len(adminIDs))
+	}
+
+	var tokenCount int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM cloud_principal_tokens`).Scan(&tokenCount); err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: count stranded admin recovery tokens: %w", err)
+	}
+	if tokenCount != 0 {
+		return PrincipalToken{}, fmt.Errorf("%w: requires zero principal tokens, found %d", ErrStrandedAdminRecoveryIneligible, tokenCount)
+	}
+
+	principalID := adminIDs[0]
+	const q = `
+		INSERT INTO cloud_principal_tokens (principal_id, token_prefix, token_hash, name, created_by_principal_id)
+		VALUES ($1, $2, $3, $4, $1)
+		RETURNING id::text, principal_id::text, token_prefix, '' AS token_hash, name, COALESCE(created_by_principal_id::text, ''), created_at, last_used_at, revoked_at, COALESCE(revoked_by_principal_id::text, ''), COALESCE(revocation_reason, '')`
+	token, err := scanPrincipalToken(tx.QueryRowContext(ctx, q, principalID, tokenPrefix, tokenHash, strings.TrimSpace(params.Name)))
+	if err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: create stranded admin recovery token: %w", err)
+	}
+
+	// The store owns the target identity so a caller cannot create an audit
+	// event that claims recovery for a different principal.
+	audit.TargetPrincipalID = principalID
+	if err := insertAuthAuditEvent(ctx, tx, audit); err != nil {
+		return PrincipalToken{}, fmt.Errorf("%w: %w", ErrAuthAuditInsertFailed, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return PrincipalToken{}, fmt.Errorf("cloudstore: commit stranded admin token recovery tx: %w", err)
+	}
+	return token, nil
+}
+
+func lockPrincipalTokenTargetTx(ctx context.Context, tx *sql.Tx, principalID string) error {
+	var lockedPrincipalID string
+	err := tx.QueryRowContext(ctx, `SELECT id::text FROM cloud_principals WHERE id = $1 AND enabled = TRUE FOR UPDATE`, principalID).Scan(&lockedPrincipalID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return principalTokenTargetError(ctx, tx, principalID)
+	}
+	if err != nil {
+		return fmt.Errorf("cloudstore: lock token principal: %w", err)
+	}
+	return nil
+}
+
+func lockedEnabledHumanAdminIDsTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT p.id::text
+		FROM cloud_principals p
+		JOIN cloud_human_users h ON h.principal_id = p.id
+		WHERE p.kind = $1 AND p.role = $2 AND p.enabled = TRUE
+		ORDER BY p.id
+		FOR UPDATE OF p`, PrincipalKindHuman, PrincipalRoleAdmin)
+	if err != nil {
+		return nil, fmt.Errorf("cloudstore: find stranded admin recovery target: %w", err)
+	}
+	defer rows.Close()
+	adminIDs := make([]string, 0, 2)
+	for rows.Next() {
+		var principalID string
+		if err := rows.Scan(&principalID); err != nil {
+			return nil, fmt.Errorf("cloudstore: scan stranded admin recovery target: %w", err)
+		}
+		adminIDs = append(adminIDs, principalID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cloudstore: iterate stranded admin recovery targets: %w", err)
+	}
+	return adminIDs, nil
 }
 
 type createPrincipalTokenValues struct {
@@ -878,9 +1011,6 @@ func normalizeCloudProjectGrant(project string) string {
 }
 
 func guardLastActiveAdminTx(ctx context.Context, tx *sql.Tx, principalID string, nextRole string, nextEnabled bool) error {
-	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext('engram_cloud_active_admin_guard'))`); err != nil {
-		return fmt.Errorf("cloudstore: lock active admin guard: %w", err)
-	}
 	var currentRole string
 	var currentEnabled bool
 	err := tx.QueryRowContext(ctx, `SELECT role, enabled FROM cloud_principals WHERE id = $1 FOR UPDATE`, principalID).Scan(&currentRole, &currentEnabled)
@@ -889,6 +1019,12 @@ func guardLastActiveAdminTx(ctx context.Context, tx *sql.Tx, principalID string,
 	}
 	if err != nil {
 		return fmt.Errorf("cloudstore: read admin guard candidate: %w", err)
+	}
+	// All principal-targeted users of engram_cloud_active_admin_guard lock their
+	// principal rows first, then acquire the advisory lock. This avoids an
+	// advisory-to-row inversion with token issuance and recovery.
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext('engram_cloud_active_admin_guard'))`); err != nil {
+		return fmt.Errorf("cloudstore: lock active admin guard: %w", err)
 	}
 	if currentRole != PrincipalRoleAdmin || !currentEnabled {
 		return nil

--- a/internal/cloud/cloudstore/identity_storage_test.go
+++ b/internal/cloud/cloudstore/identity_storage_test.go
@@ -271,6 +271,289 @@ func TestCreatePrincipalTokenWithAuditRollsBackTokenWhenAuditValidationFails(t *
 	}
 }
 
+func TestRecoverStrandedAdminTokenWithAuditPreservesGrants(t *testing.T) {
+	ctx := context.Background()
+	cs := openIsolatedCloudStore(t)
+
+	admin, err := cs.CreateFirstAdminHumanUser(ctx, CreateHumanUserParams{Username: "stranded-admin", DisplayName: "Stranded Admin"})
+	if err != nil {
+		t.Fatalf("CreateFirstAdminHumanUser: %v", err)
+	}
+	if _, err := cs.CreateProjectGrant(ctx, CreateProjectGrantParams{PrincipalID: admin.PrincipalID, Project: "recovery-project", GrantedByPrincipalID: admin.PrincipalID}); err != nil {
+		t.Fatalf("CreateProjectGrant: %v", err)
+	}
+
+	token, err := cs.RecoverStrandedAdminTokenWithAudit(ctx, RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_recovery", TokenHash: "hmac-sha256:v1:recovery", Name: "recovered"}, AuthAuditEvent{
+		ActorSource: "bootstrap_cli",
+		Action:      "bootstrap.cli",
+		Outcome:     "success",
+		ReasonCode:  "stranded_admin_token_recovered",
+		Metadata:    map[string]any{"recovered": true, "token_prefix": "egc_live_recovery"},
+	})
+	if err != nil {
+		t.Fatalf("RecoverStrandedAdminTokenWithAudit: %v", err)
+	}
+	if token.PrincipalID != admin.PrincipalID || token.CreatedByPrincipalID != admin.PrincipalID {
+		t.Fatalf("recovery token must belong to and be attributed to the stranded admin, got %+v", token)
+	}
+	grants, err := cs.ListProjectGrants(ctx, admin.PrincipalID)
+	if err != nil {
+		t.Fatalf("ListProjectGrants: %v", err)
+	}
+	assertProjects(t, grants, []string{"recovery-project"})
+	events, err := cs.ListAuthAuditEvents(ctx, AuthAuditQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAuthAuditEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].TargetPrincipalID != admin.PrincipalID || events[0].ReasonCode != "stranded_admin_token_recovered" || events[0].Metadata["recovered"] != true {
+		t.Fatalf("expected one recovery audit attributed to the recovered admin, got %+v", events)
+	}
+}
+
+func TestRecoverStrandedAdminTokenWithAuditRejectsUnsafeOrRepeatedState(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, cs *CloudStore, admin HumanUser)
+	}{
+		{
+			name: "multiple enabled human admins",
+			setup: func(t *testing.T, cs *CloudStore, _ HumanUser) {
+				t.Helper()
+				if _, err := cs.CreateHumanUser(context.Background(), CreateHumanUserParams{Username: "second-admin", DisplayName: "Second Admin", Role: PrincipalRoleAdmin}); err != nil {
+					t.Fatalf("CreateHumanUser second admin: %v", err)
+				}
+			},
+		},
+		{
+			name: "existing token anywhere",
+			setup: func(t *testing.T, cs *CloudStore, admin HumanUser) {
+				t.Helper()
+				if _, err := cs.CreatePrincipalToken(context.Background(), CreatePrincipalTokenParams{PrincipalID: admin.PrincipalID, TokenPrefix: "egc_live_existing", TokenHash: "hmac-sha256:v1:existing", Name: "existing", CreatedByPrincipalID: admin.PrincipalID}); err != nil {
+					t.Fatalf("CreatePrincipalToken setup: %v", err)
+				}
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cs := openIsolatedCloudStore(t)
+			admin, err := cs.CreateFirstAdminHumanUser(ctx, CreateHumanUserParams{Username: "recovery-target", DisplayName: "Recovery Target"})
+			if err != nil {
+				t.Fatalf("CreateFirstAdminHumanUser: %v", err)
+			}
+			tt.setup(t, cs, admin)
+
+			_, err = cs.RecoverStrandedAdminTokenWithAudit(ctx, RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_rejected", TokenHash: "hmac-sha256:v1:rejected"}, AuthAuditEvent{ActorSource: "bootstrap_cli", Action: "bootstrap.cli", Outcome: "success", Metadata: map[string]any{"recovered": true}})
+			if !errors.Is(err, ErrStrandedAdminRecoveryIneligible) {
+				t.Fatalf("expected ineligible recovery error, got %v", err)
+			}
+			events, err := cs.ListAuthAuditEvents(ctx, AuthAuditQuery{Limit: 10})
+			if err != nil {
+				t.Fatalf("ListAuthAuditEvents: %v", err)
+			}
+			if len(events) != 0 {
+				t.Fatalf("ineligible recovery must not write an audit event, got %+v", events)
+			}
+		})
+	}
+}
+
+func TestRecoverStrandedAdminTokenWithAuditRollsBackTokenWhenAuditFails(t *testing.T) {
+	ctx := context.Background()
+	cs := openIsolatedCloudStore(t)
+	admin, err := cs.CreateFirstAdminHumanUser(ctx, CreateHumanUserParams{Username: "audit-recovery", DisplayName: "Audit Recovery"})
+	if err != nil {
+		t.Fatalf("CreateFirstAdminHumanUser: %v", err)
+	}
+	if _, err := cs.CreateProjectGrant(ctx, CreateProjectGrantParams{PrincipalID: admin.PrincipalID, Project: "preserved-project", GrantedByPrincipalID: admin.PrincipalID}); err != nil {
+		t.Fatalf("CreateProjectGrant: %v", err)
+	}
+
+	_, err = cs.RecoverStrandedAdminTokenWithAudit(ctx, RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_audit", TokenHash: "hmac-sha256:v1:audit"}, AuthAuditEvent{ActorSource: "bootstrap_cli", Action: "bootstrap.cli", Outcome: "success", Metadata: map[string]any{"raw_token": "must-not-persist"}})
+	if !errors.Is(err, ErrSensitiveAuditMetadata) {
+		t.Fatalf("expected sensitive audit metadata error, got %v", err)
+	}
+	tokens, err := cs.ListPrincipalTokens(ctx, admin.PrincipalID)
+	if err != nil {
+		t.Fatalf("ListPrincipalTokens: %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("failed recovery audit must roll back token creation, got %+v", tokens)
+	}
+	grants, err := cs.ListProjectGrants(ctx, admin.PrincipalID)
+	if err != nil {
+		t.Fatalf("ListProjectGrants: %v", err)
+	}
+	assertProjects(t, grants, []string{"preserved-project"})
+}
+
+func TestPrincipalTokenIssuanceSerializesWithStrandedRecoveryEligibility(t *testing.T) {
+	cases := []struct {
+		name  string
+		issue func(context.Context, *CloudStore, HumanUser) error
+	}{
+		{
+			name: "without audit",
+			issue: func(ctx context.Context, cs *CloudStore, admin HumanUser) error {
+				_, err := cs.CreatePrincipalToken(ctx, CreatePrincipalTokenParams{PrincipalID: admin.PrincipalID, TokenPrefix: "egc_live_normal", TokenHash: "hmac-sha256:v1:normal", Name: "normal", CreatedByPrincipalID: admin.PrincipalID})
+				return err
+			},
+		},
+		{
+			name: "with audit",
+			issue: func(ctx context.Context, cs *CloudStore, admin HumanUser) error {
+				_, err := cs.CreatePrincipalTokenWithAudit(ctx, CreatePrincipalTokenParams{PrincipalID: admin.PrincipalID, TokenPrefix: "egc_live_audited", TokenHash: "hmac-sha256:v1:audited", Name: "audited", CreatedByPrincipalID: admin.PrincipalID}, AuthAuditEvent{ActorPrincipalID: admin.PrincipalID, ActorSource: "managed", TargetPrincipalID: admin.PrincipalID, Action: "token.create", Outcome: "success", Metadata: map[string]any{"token_prefix": "egc_live_audited"}})
+				return err
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cs := openIsolatedCloudStore(t)
+			admin, err := cs.CreateFirstAdminHumanUser(ctx, CreateHumanUserParams{Username: "serialized-recovery", DisplayName: "Serialized Recovery"})
+			if err != nil {
+				t.Fatalf("CreateFirstAdminHumanUser: %v", err)
+			}
+
+			blocker, err := cs.db.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatalf("begin advisory-lock blocker: %v", err)
+			}
+			defer func() { _ = blocker.Rollback() }()
+			if _, err := blocker.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext('engram_cloud_active_admin_guard'))`); err != nil {
+				t.Fatalf("acquire advisory-lock blocker: %v", err)
+			}
+
+			issueErrs := make(chan error, 1)
+			go func() { issueErrs <- tt.issue(ctx, cs, admin) }()
+			waitForActiveAdminGuardWaiter(t, cs.db)
+
+			if err := blocker.Commit(); err != nil {
+				t.Fatalf("release advisory-lock blocker: %v", err)
+			}
+			if err := <-issueErrs; err != nil {
+				t.Fatalf("normal token issuance after lock release: %v", err)
+			}
+
+			_, err = cs.RecoverStrandedAdminTokenWithAudit(ctx, RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_recovery-race", TokenHash: "hmac-sha256:v1:recovery-race"}, AuthAuditEvent{ActorSource: "bootstrap_cli", Action: "bootstrap.cli", Outcome: "success", Metadata: map[string]any{"recovered": true}})
+			if !errors.Is(err, ErrStrandedAdminRecoveryIneligible) {
+				t.Fatalf("recovery must see the serialized normal issuance and refuse, got %v", err)
+			}
+		})
+	}
+}
+
+func TestTokenIssuanceAndLastAdminGuardLockTargetBeforeAdvisoryGuard(t *testing.T) {
+	cases := []struct {
+		name  string
+		issue func(context.Context, *CloudStore, HumanUser) error
+	}{
+		{
+			name: "without audit",
+			issue: func(ctx context.Context, cs *CloudStore, admin HumanUser) error {
+				_, err := cs.CreatePrincipalToken(ctx, CreatePrincipalTokenParams{PrincipalID: admin.PrincipalID, TokenPrefix: "egc_live_lock-order", TokenHash: "hmac-sha256:v1:lock-order", Name: "lock-order", CreatedByPrincipalID: admin.PrincipalID})
+				return err
+			},
+		},
+		{
+			name: "with audit",
+			issue: func(ctx context.Context, cs *CloudStore, admin HumanUser) error {
+				_, err := cs.CreatePrincipalTokenWithAudit(ctx, CreatePrincipalTokenParams{PrincipalID: admin.PrincipalID, TokenPrefix: "egc_live_lock-order-audit", TokenHash: "hmac-sha256:v1:lock-order-audit", Name: "lock-order-audit", CreatedByPrincipalID: admin.PrincipalID}, AuthAuditEvent{ActorPrincipalID: admin.PrincipalID, ActorSource: "managed", TargetPrincipalID: admin.PrincipalID, Action: "token.create", Outcome: "success", Metadata: map[string]any{"token_prefix": "egc_live_lock-order-audit"}})
+				return err
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cs := openIsolatedCloudStore(t)
+			admin, err := cs.CreateFirstAdminHumanUser(ctx, CreateHumanUserParams{Username: "lock-order-admin", DisplayName: "Lock Order Admin"})
+			if err != nil {
+				t.Fatalf("CreateFirstAdminHumanUser: %v", err)
+			}
+
+			blocker, err := cs.db.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatalf("begin principal-row blocker: %v", err)
+			}
+			defer func() { _ = blocker.Rollback() }()
+			var lockedPrincipalID string
+			if err := blocker.QueryRowContext(ctx, `SELECT id::text FROM cloud_principals WHERE id = $1 FOR UPDATE`, admin.PrincipalID).Scan(&lockedPrincipalID); err != nil {
+				t.Fatalf("acquire principal-row blocker: %v", err)
+			}
+
+			operationCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+			errs := make(chan error, 2)
+			go func() { errs <- tt.issue(operationCtx, cs, admin) }()
+			go func() {
+				errs <- cs.UpdatePrincipal(operationCtx, admin.PrincipalID, UpdatePrincipalParams{Role: PrincipalRoleAdmin, Enabled: true})
+			}()
+			waitForDatabaseLockWaiters(t, cs.db, 2)
+			assertNoActiveAdminGuardHeld(t, cs.db)
+
+			if err := blocker.Commit(); err != nil {
+				t.Fatalf("release principal-row blocker: %v", err)
+			}
+			for range 2 {
+				select {
+				case err := <-errs:
+					if err != nil {
+						t.Fatalf("concurrent operation must complete without a lock-order error: %v", err)
+					}
+				case <-time.After(3 * time.Second):
+					t.Fatal("concurrent token issuance and admin update did not complete after the principal-row blocker released")
+				}
+			}
+		})
+	}
+}
+
+func waitForActiveAdminGuardWaiter(t *testing.T, db *sql.DB) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiters int
+		if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND granted = FALSE`).Scan(&waiters); err != nil {
+			t.Fatalf("count active-admin guard waiters: %v", err)
+		}
+		if waiters > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("normal token issuance did not wait for engram_cloud_active_admin_guard")
+}
+
+func waitForDatabaseLockWaiters(t *testing.T, db *sql.DB, wantAtLeast int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiters int
+		if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pg_stat_activity WHERE datname = current_database() AND wait_event_type = 'Lock'`).Scan(&waiters); err != nil {
+			t.Fatalf("count database lock waiters: %v", err)
+		}
+		if waiters >= wantAtLeast {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected at least %d database lock waiters", wantAtLeast)
+}
+
+func assertNoActiveAdminGuardHeld(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var held int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND granted = TRUE`).Scan(&held); err != nil {
+		t.Fatalf("count held advisory locks: %v", err)
+	}
+	if held != 0 {
+		t.Fatalf("token issuance and last-admin guard must wait on the principal row before acquiring the advisory guard, found %d held advisory locks", held)
+	}
+}
+
 // TestFindPrincipalTokenByHashResolvesActiveTokenAndRejectsUnknownOrRevoked
 // is the RED-first proof for the runtime managed-token wiring slice: before
 // FindPrincipalTokenByHash existed, this test failed to compile (undefined

--- a/internal/cloud/cloudstore/identity_storage_test.go
+++ b/internal/cloud/cloudstore/identity_storage_test.go
@@ -416,6 +416,49 @@ func TestRecoverStrandedAdminTokenWithAuditRejectsUnsafeOrRepeatedState(t *testi
 	}
 }
 
+func TestRecoverStrandedAdminTokenWithAuditRejectsTokenOwnedByNonAdmin(t *testing.T) {
+	ctx := context.Background()
+	cs := openIsolatedCloudStore(t)
+	admin, err := cs.CreateFirstAdminHumanUser(ctx, CreateHumanUserParams{Username: "recovery-target", DisplayName: "Recovery Target"})
+	if err != nil {
+		t.Fatalf("CreateFirstAdminHumanUser: %v", err)
+	}
+	other, err := cs.CreatePrincipal(ctx, CreatePrincipalParams{Kind: PrincipalKindServiceAccount, DisplayName: "Recovery Member", Role: PrincipalRoleMember})
+	if err != nil {
+		t.Fatalf("CreatePrincipal non-admin token owner: %v", err)
+	}
+	existing, err := cs.CreatePrincipalToken(ctx, CreatePrincipalTokenParams{PrincipalID: other.ID, TokenPrefix: "egc_live_other", TokenHash: "hmac-sha256:v1:other", Name: "other", CreatedByPrincipalID: admin.PrincipalID})
+	if err != nil {
+		t.Fatalf("CreatePrincipalToken non-admin token owner: %v", err)
+	}
+
+	_, err = cs.RecoverStrandedAdminTokenWithAudit(ctx, RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_rejected", TokenHash: "hmac-sha256:v1:rejected"}, AuthAuditEvent{ActorSource: "bootstrap_cli", Action: "bootstrap.cli", Outcome: "success", Metadata: map[string]any{"recovered": true}})
+	if !errors.Is(err, ErrStrandedAdminRecoveryIneligible) {
+		t.Fatalf("expected ErrStrandedAdminRecoveryIneligible, got %v", err)
+	}
+	targetTokens, err := cs.ListPrincipalTokens(ctx, admin.PrincipalID)
+	if err != nil {
+		t.Fatalf("ListPrincipalTokens recovery target: %v", err)
+	}
+	if len(targetTokens) != 0 {
+		t.Fatalf("ineligible recovery must not create a target token, got %+v", targetTokens)
+	}
+	otherTokens, err := cs.ListPrincipalTokens(ctx, other.ID)
+	if err != nil {
+		t.Fatalf("ListPrincipalTokens non-admin token owner: %v", err)
+	}
+	if len(otherTokens) != 1 || otherTokens[0].ID != existing.ID || otherTokens[0].PrincipalID != other.ID || otherTokens[0].TokenPrefix != existing.TokenPrefix || otherTokens[0].Name != existing.Name || otherTokens[0].CreatedByPrincipalID != admin.PrincipalID || otherTokens[0].RevokedAt != nil {
+		t.Fatalf("ineligible recovery must preserve the non-admin token, got %+v want %+v", otherTokens, existing)
+	}
+	events, err := cs.ListAuthAuditEvents(ctx, AuthAuditQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAuthAuditEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("ineligible recovery must not write an audit event, got %+v", events)
+	}
+}
+
 func TestRecoverStrandedAdminTokenWithAuditRollsBackTokenWhenAuditFails(t *testing.T) {
 	ctx := context.Background()
 	cs := openIsolatedCloudStore(t)

--- a/internal/cloud/cloudstore/identity_storage_test.go
+++ b/internal/cloud/cloudstore/identity_storage_test.go
@@ -312,8 +312,11 @@ func TestRecoverStrandedAdminTokenWithAuditPreservesGrants(t *testing.T) {
 
 func TestRecoverStrandedAdminTokenWithAuditRejectsUnsafeOrRepeatedState(t *testing.T) {
 	cases := []struct {
-		name  string
-		setup func(t *testing.T, cs *CloudStore, admin HumanUser)
+		name           string
+		setup          func(t *testing.T, cs *CloudStore, admin HumanUser)
+		params         RecoverStrandedAdminTokenParams
+		wantErr        string
+		wantTokenCount int
 	}{
 		{
 			name: "multiple enabled human admins",
@@ -323,6 +326,20 @@ func TestRecoverStrandedAdminTokenWithAuditRejectsUnsafeOrRepeatedState(t *testi
 					t.Fatalf("CreateHumanUser second admin: %v", err)
 				}
 			},
+			wantErr: ErrStrandedAdminRecoveryIneligible.Error(),
+		},
+		{
+			name: "zero enabled human admins",
+			setup: func(t *testing.T, cs *CloudStore, admin HumanUser) {
+				t.Helper()
+				if _, err := cs.CreatePrincipal(context.Background(), CreatePrincipalParams{Kind: PrincipalKindServiceAccount, DisplayName: "Recovery Backup", Role: PrincipalRoleAdmin}); err != nil {
+					t.Fatalf("CreatePrincipal backup admin: %v", err)
+				}
+				if err := cs.SetHumanUserEnabled(context.Background(), admin.PrincipalID, false); err != nil {
+					t.Fatalf("SetHumanUserEnabled stranded admin false: %v", err)
+				}
+			},
+			wantErr: ErrStrandedAdminRecoveryIneligible.Error(),
 		},
 		{
 			name: "existing token anywhere",
@@ -332,6 +349,33 @@ func TestRecoverStrandedAdminTokenWithAuditRejectsUnsafeOrRepeatedState(t *testi
 					t.Fatalf("CreatePrincipalToken setup: %v", err)
 				}
 			},
+			wantErr:        ErrStrandedAdminRecoveryIneligible.Error(),
+			wantTokenCount: 1,
+		},
+		{
+			name: "revoked token row",
+			setup: func(t *testing.T, cs *CloudStore, admin HumanUser) {
+				t.Helper()
+				token, err := cs.CreatePrincipalToken(context.Background(), CreatePrincipalTokenParams{PrincipalID: admin.PrincipalID, TokenPrefix: "egc_live_revoked", TokenHash: "hmac-sha256:v1:revoked", Name: "revoked", CreatedByPrincipalID: admin.PrincipalID})
+				if err != nil {
+					t.Fatalf("CreatePrincipalToken setup: %v", err)
+				}
+				if err := cs.RevokePrincipalToken(context.Background(), token.ID, admin.PrincipalID, "setup"); err != nil {
+					t.Fatalf("RevokePrincipalToken setup: %v", err)
+				}
+			},
+			wantErr:        ErrStrandedAdminRecoveryIneligible.Error(),
+			wantTokenCount: 1,
+		},
+		{
+			name:    "empty token prefix",
+			params:  RecoverStrandedAdminTokenParams{TokenHash: "hmac-sha256:v1:rejected"},
+			wantErr: "cloudstore: token prefix is required",
+		},
+		{
+			name:    "empty token hash",
+			params:  RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_rejected"},
+			wantErr: "cloudstore: token hash is required",
 		},
 	}
 	for _, tt := range cases {
@@ -342,11 +386,24 @@ func TestRecoverStrandedAdminTokenWithAuditRejectsUnsafeOrRepeatedState(t *testi
 			if err != nil {
 				t.Fatalf("CreateFirstAdminHumanUser: %v", err)
 			}
-			tt.setup(t, cs, admin)
+			if tt.setup != nil {
+				tt.setup(t, cs, admin)
+			}
 
-			_, err = cs.RecoverStrandedAdminTokenWithAudit(ctx, RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_rejected", TokenHash: "hmac-sha256:v1:rejected"}, AuthAuditEvent{ActorSource: "bootstrap_cli", Action: "bootstrap.cli", Outcome: "success", Metadata: map[string]any{"recovered": true}})
-			if !errors.Is(err, ErrStrandedAdminRecoveryIneligible) {
-				t.Fatalf("expected ineligible recovery error, got %v", err)
+			params := tt.params
+			if params.TokenPrefix == "" && params.TokenHash == "" {
+				params = RecoverStrandedAdminTokenParams{TokenPrefix: "egc_live_rejected", TokenHash: "hmac-sha256:v1:rejected"}
+			}
+			_, err = cs.RecoverStrandedAdminTokenWithAudit(ctx, params, AuthAuditEvent{ActorSource: "bootstrap_cli", Action: "bootstrap.cli", Outcome: "success", Metadata: map[string]any{"recovered": true}})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected recovery rejection containing %q, got %v", tt.wantErr, err)
+			}
+			tokens, err := cs.ListPrincipalTokens(ctx, admin.PrincipalID)
+			if err != nil {
+				t.Fatalf("ListPrincipalTokens after rejected recovery: %v", err)
+			}
+			if len(tokens) != tt.wantTokenCount {
+				t.Fatalf("rejected recovery must not change token rows, got %+v want %d tokens", tokens, tt.wantTokenCount)
 			}
 			events, err := cs.ListAuthAuditEvents(ctx, AuthAuditQuery{Limit: 10})
 			if err != nil {
@@ -484,7 +541,7 @@ func TestTokenIssuanceAndLastAdminGuardLockTargetBeforeAdvisoryGuard(t *testing.
 				t.Fatalf("acquire principal-row blocker: %v", err)
 			}
 
-			operationCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			operationCtx, cancel := context.WithTimeout(ctx, lockOrderOperationTimeout)
 			defer cancel()
 			errs := make(chan error, 2)
 			go func() { errs <- tt.issue(operationCtx, cs, admin) }()
@@ -503,7 +560,7 @@ func TestTokenIssuanceAndLastAdminGuardLockTargetBeforeAdvisoryGuard(t *testing.
 					if err != nil {
 						t.Fatalf("concurrent operation must complete without a lock-order error: %v", err)
 					}
-				case <-time.After(3 * time.Second):
+				case <-time.After(lockOrderOperationTimeout):
 					t.Fatal("concurrent token issuance and admin update did not complete after the principal-row blocker released")
 				}
 			}
@@ -511,12 +568,22 @@ func TestTokenIssuanceAndLastAdminGuardLockTargetBeforeAdvisoryGuard(t *testing.
 	}
 }
 
+const (
+	lockOrderOperationTimeout = 5 * time.Second
+	activeAdminGuardLockWhere = `
+		locktype = 'advisory'
+		AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+		AND classid::bigint = ((hashtext('engram_cloud_active_admin_guard')::bigint >> 32) & 4294967295)
+		AND objid::bigint = (hashtext('engram_cloud_active_admin_guard')::bigint & 4294967295)
+		AND objsubid = 1`
+)
+
 func waitForActiveAdminGuardWaiter(t *testing.T, db *sql.DB) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		var waiters int
-		if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND granted = FALSE`).Scan(&waiters); err != nil {
+		if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pg_locks WHERE `+activeAdminGuardLockWhere+` AND granted = FALSE`).Scan(&waiters); err != nil {
 			t.Fatalf("count active-admin guard waiters: %v", err)
 		}
 		if waiters > 0 {
@@ -546,12 +613,26 @@ func waitForDatabaseLockWaiters(t *testing.T, db *sql.DB, wantAtLeast int) {
 func assertNoActiveAdminGuardHeld(t *testing.T, db *sql.DB) {
 	t.Helper()
 	var held int
-	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND granted = TRUE`).Scan(&held); err != nil {
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM pg_locks WHERE `+activeAdminGuardLockWhere+` AND granted = TRUE`).Scan(&held); err != nil {
 		t.Fatalf("count held advisory locks: %v", err)
 	}
 	if held != 0 {
 		t.Fatalf("token issuance and last-admin guard must wait on the principal row before acquiring the advisory guard, found %d held advisory locks", held)
 	}
+}
+
+func TestActiveAdminGuardLockQueriesIgnoreUnrelatedAdvisoryLocks(t *testing.T) {
+	ctx := context.Background()
+	cs := openIsolatedCloudStore(t)
+	tx, err := cs.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin unrelated advisory-lock tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(42::bigint)`); err != nil {
+		t.Fatalf("acquire unrelated advisory lock: %v", err)
+	}
+	assertNoActiveAdminGuardHeld(t, cs.db)
 }
 
 // TestFindPrincipalTokenByHashResolvesActiveTokenAndRejectsUnknownOrRevoked


### PR DESCRIPTION
## 🔗 Linked Issue

Refs #747 (root cause fixed by #663; this PR adds the recovery path)

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add `engram cloud bootstrap recover-token` for installations left with one enabled managed admin and no tokens.
- Serialize recovery, normal token issuance, and last-admin protection through a consistent row-lock → advisory-lock order.
- Preserve grants and create the replacement token plus redacted audit evidence atomically.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/cloud_bootstrap.go` | Add the bounded recovery CLI and one-time token output. |
| `internal/cloud/cloudstore/identity.go` | Add recovery eligibility/transaction logic and unify token/admin lock ordering. |
| `cmd/engram/cloud_bootstrap_test.go` | Cover CLI success and rejected states. |
| `internal/cloud/cloudstore/identity_storage_test.go` | Cover atomicity, eligibility, grant preservation, serialization, and lock ordering with isolated Postgres schemas. |
| `DOCS.md` | Document the recovery command. |
| `docs/engram-cloud/troubleshooting.md` | Add stranded-admin recovery guidance. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality
- [x] Focused CLI tests pass: `go test -p 1 -vet=off ./cmd/engram -run TestCloudBootstrapRecoverToken -count=1 -v`
- [x] Focused pure cloudstore tests pass: `go test -p 1 -vet=off ./internal/cloud/cloudstore -run TestCloudstoreIdentityPureHelpers -count=1 -v`
- [x] Focused Postgres tests compile and skip cleanly when `CLOUDSTORE_TEST_DSN` is unavailable.

Local real-Postgres execution was unavailable because `CLOUDSTORE_TEST_DSN`, Docker, and `psql` are not present. CI or a maintainer environment must run the isolated-schema Postgres cases before merge.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** Label | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

- PR #663 independently fixes future bootstrap completion audits by allowing boolean `issued_token` metadata. This PR does not duplicate that change; it recovers installations already stranded without a token.
- The maintainer explicitly accepted `size:exception` for this 724-line atomic work unit. Splitting store serialization, recovery behavior, tests, and documentation would leave incomplete or weakly verified boundaries.
- Rollback boundary: revert this commit to remove the recovery command, store operation, lock-order coverage, and related documentation together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recovery-token functionality for eligible stranded managed administrators.
  - Displays the newly generated token once while preserving existing administrator access.
  - Enforces eligibility checks and requires the configured recovery secret.
  - Records token creation and audit details atomically.

- **Documentation**
  - Added command usage, eligibility requirements, refusal conditions, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
