### PR TITLE
fix(cloud): preserve insecure project allowlist

### DIFF
--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -88,7 +88,6 @@ var newCloudRuntime = func(cfg cloud.Config) (cloudServerRuntime, error) {
 		_ = cs.Close()
 		return nil, err
 	}
-	projectAuth := auth.NewProjectScopeAuthorizer(allowedProjects)
 	token := strings.TrimSpace(os.Getenv("ENGRAM_CLOUD_TOKEN"))
 	cs.SetDashboardAllowedProjects(allowedProjects)
 	insecureNoAuth := token == "" && envBool("ENGRAM_CLOUD_INSECURE_NO_AUTH")
@@ -102,18 +101,27 @@ var newCloudRuntime = func(cfg cloud.Config) (cloudServerRuntime, error) {
 			cs,
 			authenticator,
 			cfg.Port,
-			cloudserver.WithHost(cfg.BindHost),
-			cloudserver.WithProjectAuthorizer(projectAuth),
-			cloudserver.WithPrincipalProjectAuthorizer(cloudPrincipalProjectAuthorizer{store: cs}),
-			cloudserver.WithAdminIdentityStore(cs),
-			cloudserver.WithManagedTokenHasher(managedHasher),
-			cloudserver.WithPrincipalStateStore(cs),
-			cloudserver.WithDashboardAdminToken(cfg.AdminToken),
-			cloudserver.WithMaxPushBodyBytes(cfg.MaxPushBodyBytes),
-			cloudserver.WithSyncStatusProvider(cloudDashboardStatusProvider{store: cs, projects: allowedProjects}),
+			cloudRuntimeServerOptions(cfg, cs, allowedProjects, authenticator, managedHasher, cs)...,
 		),
 		store: cs,
 	}, nil
+}
+
+func cloudRuntimeServerOptions(cfg cloud.Config, cs *cloudstore.CloudStore, allowedProjects []string, authenticator cloudserver.Authenticator, managedHasher *auth.ManagedTokenHasher, grantStore cloudProjectGrantStore) []cloudserver.Option {
+	options := []cloudserver.Option{
+		cloudserver.WithHost(cfg.BindHost),
+		cloudserver.WithProjectAuthorizer(auth.NewProjectScopeAuthorizer(allowedProjects)),
+		cloudserver.WithAdminIdentityStore(cs),
+		cloudserver.WithManagedTokenHasher(managedHasher),
+		cloudserver.WithPrincipalStateStore(cs),
+		cloudserver.WithDashboardAdminToken(cfg.AdminToken),
+		cloudserver.WithMaxPushBodyBytes(cfg.MaxPushBodyBytes),
+		cloudserver.WithSyncStatusProvider(cloudDashboardStatusProvider{store: cs, projects: allowedProjects}),
+	}
+	if authenticator != nil {
+		options = append(options, cloudserver.WithPrincipalProjectAuthorizer(cloudPrincipalProjectAuthorizer{store: grantStore}))
+	}
+	return options
 }
 
 // buildRuntimeAuthenticator constructs the cloudserver.Authenticator and

--- a/cmd/engram/cloud_runtime_options_test.go
+++ b/cmd/engram/cloud_runtime_options_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Gentleman-Programming/engram/internal/cloud"
+	cloudauth "github.com/Gentleman-Programming/engram/internal/cloud/auth"
+	"github.com/Gentleman-Programming/engram/internal/cloud/cloudserver"
+	"github.com/Gentleman-Programming/engram/internal/cloud/cloudstore"
+	engramsync "github.com/Gentleman-Programming/engram/internal/sync"
+)
+
+type runtimeOptionTestStore struct{}
+
+func (runtimeOptionTestStore) ReadManifest(context.Context, string) (*engramsync.Manifest, error) {
+	return &engramsync.Manifest{}, nil
+}
+
+func (runtimeOptionTestStore) WriteChunk(context.Context, string, string, string, string, []byte) error {
+	return nil
+}
+
+func (runtimeOptionTestStore) ReadChunk(context.Context, string, string) ([]byte, error) {
+	return nil, nil
+}
+
+func (runtimeOptionTestStore) KnownSessionIDs(context.Context, string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
+type runtimeOptionResolvingAuthenticator struct {
+	principal cloudauth.Principal
+}
+
+func (runtimeOptionResolvingAuthenticator) Authorize(*http.Request) error { return nil }
+
+func (a runtimeOptionResolvingAuthenticator) ResolveBearerToken(_ context.Context, token string) (cloudauth.Principal, error) {
+	if token != "managed-token" {
+		return cloudauth.Principal{}, cloudauth.ErrUnknownToken
+	}
+	return a.principal, nil
+}
+
+type runtimeOptionDenyingGrantStore struct{}
+
+func (runtimeOptionDenyingGrantStore) ListProjectGrants(context.Context, string) ([]cloudstore.ProjectGrant, error) {
+	return nil, nil
+}
+
+func TestCloudRuntimeServerOptionsInsecureModeEnforcesProjectAllowlist(t *testing.T) {
+	server := cloudserver.New(
+		runtimeOptionTestStore{},
+		nil,
+		0,
+		cloudRuntimeServerOptions(cloud.Config{AllowedProjects: []string{"alpha"}}, nil, []string{"alpha"}, nil, nil, nil)...,
+	)
+
+	cases := []struct {
+		name       string
+		project    string
+		wantStatus int
+	}{
+		{name: "allowed project succeeds without authentication", project: "alpha", wantStatus: http.StatusOK},
+		{name: "disallowed project remains forbidden without authentication", project: "beta", wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/sync/pull?project="+tc.project, nil))
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d body=%q", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestCloudRuntimeServerOptionsSecureModeFailsClosedWithoutPrincipal(t *testing.T) {
+	authenticator, managedHasher, err := buildRuntimeAuthenticator(
+		cloud.Config{JWTSecret: "test-jwt-secret-at-least-32-bytes-long"},
+		nil,
+		[]string{"alpha"},
+		"sync-token",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("buildRuntimeAuthenticator: %v", err)
+	}
+	server := cloudserver.New(
+		runtimeOptionTestStore{},
+		authenticator,
+		0,
+		cloudRuntimeServerOptions(cloud.Config{AllowedProjects: []string{"alpha"}}, nil, []string{"alpha"}, authenticator, managedHasher, nil)...,
+	)
+
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/sync/pull?project=alpha", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected secure mode without a principal to fail closed with 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCloudRuntimeServerOptionsSecureModeAppliesPrincipalProjectGrants(t *testing.T) {
+	authenticator := runtimeOptionResolvingAuthenticator{principal: cloudauth.Principal{
+		ID:      "managed-principal",
+		Kind:    cloudauth.PrincipalKindHuman,
+		Role:    cloudauth.RoleMember,
+		Source:  cloudauth.PrincipalSourceManagedToken,
+		Enabled: true,
+	}}
+	server := cloudserver.New(
+		runtimeOptionTestStore{},
+		authenticator,
+		0,
+		cloudRuntimeServerOptions(
+			cloud.Config{AllowedProjects: []string{"alpha"}},
+			nil,
+			[]string{"alpha"},
+			authenticator,
+			nil,
+			runtimeOptionDenyingGrantStore{},
+		)...,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=alpha", nil)
+	req.Header.Set("Authorization", "Bearer managed-token")
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected authenticated managed principal without an alpha grant to be forbidden, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #596

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Keep the project allowlist active when cloud runs without bearer authentication.
- Install principal project-grant authorization only when runtime authentication is active.
- Add behavior-level coverage for insecure and secure authorization boundaries.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/cloud.go` | Compose principal-project authorization conditionally while retaining project allowlist enforcement. |
| `cmd/engram/cloud_runtime_options_test.go` | Cover insecure allowed/denied projects and secure principal/grant enforcement. |

## 🧪 Test Plan

- [x] `go test ./cmd/engram -run "TestCloudRuntimeServerOptions|TestBuildRuntimeAuthenticator" -count=1`
- [x] `go test ./internal/cloud/cloudserver -run "TestPrincipalProjectAuthorizerFailsClosedWithoutResolvedPrincipal|TestHandlerDashboardAdminTokenIsDisabledWhenAuthIsBypassed|TestAdminHandlersRequireManagedAdminAndLeaveNoStateForMembers" -count=1`
- [x] `go test ./internal/cloud/cloudserver -run "TestLegacyPrincipalKeepsAllowlistWhenPrincipalProjectAuthorizerConfigured" -count=1`
- [x] Native RDD approved the exact committed tree.
- [ ] Full `go test ./cmd/engram` did not complete locally; it exceeded 300 seconds without output. CI remains authoritative for the full suite.
- [ ] E2E suite was not run locally; this change is covered at the cloud HTTP handler boundary.

---

## 🤖 Automated Checks

These run automatically and all must pass before merge.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #596`).
- [ ] A maintainer still needs to add exactly one `type:*` label; the contributor token cannot label the upstream PR.
- [ ] I ran the full unit test suite locally.
- [ ] I ran the E2E suite locally.
- [x] Existing docs already describe the intended insecure-mode behavior; no docs change is required.
- [x] Commits follow conventional commits format.
- [x] No `Co-Authored-By` trailers in commits.

---

## 💬 Notes for Reviewers

RDD reviewed candidate tree `d8be828be9a301e31fa6e311481783c0a816f3f8` with the reliability lens and returned approved before commit. Commit `e236b4839f65c7b19043618623cefe08f4fe26f3` preserves that exact tree.

The PR author lacks permission to add labels on the upstream repository. Please add `type:bug`; the initial automated label check failed for that reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud runtime access controls for projects.
  * In insecure mode, project access is now restricted to the configured allowlist.
  * In secure mode, requests are denied when no authenticated principal is available.
  * Authenticated principals’ project grants are now consistently enforced.
  * Added coverage for secure and insecure access-control scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->