### PR TITLE
fix(store): optimize search and propagate cancellation

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1018,7 +1018,7 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		sessionID := defaultSessionID(project)
 		activity.RecordToolCall(sessionID)
 
-		results, err := s.Search(query, store.SearchOptions{
+		results, err := s.SearchContext(ctx, query, store.SearchOptions{
 			Type:      typ,
 			Project:   searchProject,
 			Scope:     scope,
@@ -1043,8 +1043,10 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 		}
 		relationsMap := map[string]store.ObservationRelations{}
 		if len(syncIDs) > 0 {
-			if rm, relErr := s.GetRelationsForObservations(syncIDs); relErr == nil {
+			if rm, relErr := s.GetRelationsForObservationsContext(ctx, syncIDs); relErr == nil {
 				relationsMap = rm
+			} else if errors.Is(relErr, context.Canceled) || errors.Is(relErr, context.DeadlineExceeded) {
+				return mcp.NewToolResultError(fmt.Sprintf("Search error: %s. Try simpler keywords.", relErr)), nil
 			}
 			// Errors from relation loading are swallowed — search must not fail.
 		}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -984,6 +984,41 @@ func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 	}
 }
 
+func TestHandleSearch_PropagatesCanceledContext(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("s-canceled-search", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "s-canceled-search",
+		Type:      "decision",
+		Title:     "Canceled search must stop",
+		Content:   "Search cancellation is observable at the handler boundary.",
+		Project:   "engram",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(ctx, mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{
+			"query":   "canceled search",
+			"project": "engram",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handle search: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected canceled search to be a tool error, got %s", callResultText(t, result))
+	}
+	if !strings.Contains(callResultText(t, result), context.Canceled.Error()) {
+		t.Fatalf("expected cancellation error, got %s", callResultText(t, result))
+	}
+}
+
 func TestHandleSaveReturnsLifecycleState(t *testing.T) {
 	s := newMCPTestStore(t)
 	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -361,19 +361,7 @@ func (s *Store) FindCandidates(savedID int64, opts CandidateOptions) ([]Candidat
 
 	// FTS5 query: same project, same scope, exclude just-saved row, exclude soft-deleted.
 	// BM25 floor filtering is done in Go after scanning.
-	rows, err := s.db.Query(`
-		SELECT o.id, ifnull(o.sync_id,'') as sync_id, o.title, o.type, o.topic_key,
-		       fts.rank
-		FROM observations_fts fts
-		JOIN observations o ON o.id = fts.rowid
-		WHERE observations_fts MATCH ?
-		  AND o.id != ?
-		  AND o.deleted_at IS NULL
-		  AND ifnull(o.project,'') = ifnull(?,'')
-		  AND o.scope = ?
-		ORDER BY fts.rank
-		LIMIT ?
-	`, ftsQuery, savedID, project, scope, limit*3) // fetch extra rows to allow floor filtering
+	rows, err := s.db.Query(findCandidatesFTSQuery, ftsQuery, savedID, project, scope, limit*3) // fetch extra rows to allow floor filtering
 	if err != nil {
 		return nil, fmt.Errorf("FindCandidates: FTS5 query: %w", err)
 	}
@@ -944,6 +932,15 @@ func (s *Store) getRelationTx(tx *sql.Tx, syncID string) (*Relation, error) {
 // titles via LEFT JOIN, used by the MCP annotation builder (REQ-005, REQ-012).
 // Missing or soft-deleted observations set the corresponding *Missing flag to true.
 func (s *Store) GetRelationsForObservations(syncIDs []string) (map[string]ObservationRelations, error) {
+	return s.GetRelationsForObservationsContext(context.Background(), syncIDs)
+}
+
+// GetRelationsForObservationsContext enriches observations with relations while
+// honoring cancellation from the caller, including while materializing rows.
+func (s *Store) GetRelationsForObservationsContext(ctx context.Context, syncIDs []string) (map[string]ObservationRelations, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(syncIDs) == 0 {
 		return map[string]ObservationRelations{}, nil
 	}
@@ -981,8 +978,11 @@ func (s *Store) GetRelationsForObservations(syncIDs []string) (map[string]Observ
 		  AND r.judgment_status != 'orphaned'
 	`, inClause, inClause)
 
-	rows, err := s.db.Query(query, args...)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, fmt.Errorf("GetRelationsForObservations: query: %w", err)
 	}
 	defer rows.Close()
@@ -990,6 +990,9 @@ func (s *Store) GetRelationsForObservations(syncIDs []string) (map[string]Observ
 	result := make(map[string]ObservationRelations)
 
 	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		var r Relation
 		var sourceID, targetID string
 		// SQLite BOOLEAN → int; use int for missing flags.
@@ -1003,7 +1006,13 @@ func (s *Store) GetRelationsForObservations(syncIDs []string) (map[string]Observ
 			&r.SourceIntID, &r.SourceTitle, &sourceMissingInt,
 			&r.TargetIntID, &r.TargetTitle, &targetMissingInt,
 		); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
 			return nil, fmt.Errorf("GetRelationsForObservations: scan: %w", err)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 		r.SourceID = sourceID
 		r.TargetID = targetID
@@ -1012,6 +1021,9 @@ func (s *Store) GetRelationsForObservations(syncIDs []string) (map[string]Observ
 
 		// Index by source_id.
 		for _, id := range syncIDs {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if r.SourceID == id {
 				entry := result[id]
 				entry.AsSource = append(entry.AsSource, r)
@@ -1025,11 +1037,31 @@ func (s *Store) GetRelationsForObservations(syncIDs []string) (map[string]Observ
 		}
 	}
 	if err := rows.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, fmt.Errorf("GetRelationsForObservations: rows error: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	return result, nil
 }
+
+const findCandidatesFTSQuery = `
+	SELECT o.id, ifnull(o.sync_id,'') as sync_id, o.title, o.type, o.topic_key,
+	       fts.rank
+	FROM observations_fts fts
+	CROSS JOIN observations o ON o.id = fts.rowid
+	WHERE observations_fts MATCH ?
+	  AND o.id != ?
+	  AND o.deleted_at IS NULL
+	  AND ifnull(o.project,'') = ifnull(?,'')
+	  AND o.scope = ?
+	ORDER BY fts.rank
+	LIMIT ?
+`
 
 // sanitizeFTSCandidates builds an OR-based FTS5 query from a title so that
 // FindCandidates returns documents with ANY term overlap (not all terms).

--- a/internal/store/relations_test.go
+++ b/internal/store/relations_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log"
 	"strings"
@@ -19,6 +20,21 @@ func setupRelationsStore(t *testing.T) *Store {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	return s
+}
+
+func TestGetRelationsForObservationsContext_AlreadyCanceled(t *testing.T) {
+	s := setupRelationsStore(t)
+	_, syncID := addTestObs(t, s, "Contextual relation", "decision", "testproject", "project")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	relations, err := s.GetRelationsForObservationsContext(ctx, []string{syncID})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got relations=%v err=%v", relations, err)
+	}
+	if relations != nil {
+		t.Fatalf("expected no relations from canceled enrichment, got %v", relations)
+	}
 }
 
 // addTestObs inserts a single observation and returns its (id, syncID).

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,6 +6,7 @@
 package store
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
@@ -537,11 +538,12 @@ func closeRowsWithError(rows rowScanner, err error) error {
 }
 
 type storeHooks struct {
-	exec    func(db execer, query string, args ...any) (sql.Result, error)
-	query   func(db queryer, query string, args ...any) (*sql.Rows, error)
-	queryIt func(db queryer, query string, args ...any) (rowScanner, error)
-	beginTx func(db *sql.DB) (*sql.Tx, error)
-	commit  func(tx *sql.Tx) error
+	exec           func(db execer, query string, args ...any) (sql.Result, error)
+	query          func(db queryer, query string, args ...any) (*sql.Rows, error)
+	queryIt        func(db queryer, query string, args ...any) (rowScanner, error)
+	queryItContext func(ctx context.Context, db *sql.DB, query string, args ...any) (rowScanner, error)
+	beginTx        func(db *sql.DB) (*sql.Tx, error)
+	commit         func(tx *sql.Tx) error
 }
 
 func defaultStoreHooks() storeHooks {
@@ -554,6 +556,13 @@ func defaultStoreHooks() storeHooks {
 		},
 		queryIt: func(db queryer, query string, args ...any) (rowScanner, error) {
 			rows, err := db.Query(query, args...)
+			if err != nil {
+				return nil, err
+			}
+			return sqlRowScanner{rows: rows}, nil
+		},
+		queryItContext: func(ctx context.Context, db *sql.DB, query string, args ...any) (rowScanner, error) {
+			rows, err := db.QueryContext(ctx, query, args...)
 			if err != nil {
 				return nil, err
 			}
@@ -592,6 +601,17 @@ func (s *Store) queryItHook(db queryer, query string, args ...any) (rowScanner, 
 		return s.hooks.queryIt(db, query, args...)
 	}
 	rows, err := s.queryHook(db, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return sqlRowScanner{rows: rows}, nil
+}
+
+func (s *Store) queryItContextHook(ctx context.Context, query string, args ...any) (rowScanner, error) {
+	if s.hooks.queryItContext != nil {
+		return s.hooks.queryItContext(ctx, s.db, query, args...)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -3121,7 +3141,19 @@ func (s *Store) Timeline(observationID int64, before, after int) (*TimelineResul
 
 // ─── Search (FTS5) ───────────────────────────────────────────────────────────
 
+// Search preserves the original non-context API for callers that do not need
+// cancellation.
 func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error) {
+	return s.SearchContext(context.Background(), query, opts)
+}
+
+// SearchContext searches observations while honoring cancellation from the
+// caller, including while materializing rows.
+func (s *Store) SearchContext(ctx context.Context, query string, opts SearchOptions) ([]SearchResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Validate match_mode early so invalid values always error regardless of query shape.
 	switch opts.MatchMode {
 	case "", "all", "any":
@@ -3166,21 +3198,35 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		tkSQL += " ORDER BY updated_at DESC LIMIT ?"
 		tkArgs = append(tkArgs, limit)
 
-		tkRows, err := s.queryItHook(s.db, tkSQL, tkArgs...)
+		tkRows, err := s.db.QueryContext(ctx, tkSQL, tkArgs...)
 		if err == nil {
 			defer tkRows.Close()
 			for tkRows.Next() {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 				var sr SearchResult
 				if err := tkRows.Scan(
 					&sr.ID, &sr.SyncID, &sr.SessionID, &sr.Type, &sr.Title, &sr.Content,
 					&sr.ToolName, &sr.Project, &sr.Scope, &sr.TopicKey, &sr.RevisionCount, &sr.DuplicateCount,
 					&sr.LastSeenAt, &sr.ReviewAfter, &sr.Pinned, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
 				); err != nil {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return nil, ctxErr
+					}
 					break
+				}
+				if err := ctx.Err(); err != nil {
+					return nil, err
 				}
 				sr.Rank = -1000
 				directResults = append(directResults, sr)
 			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		} else if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
 		}
 	}
 
@@ -3192,36 +3238,12 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		ftsQuery = sanitizeFTS(query)
 	}
 
-	sqlQ := `
-		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
-		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.pinned, o.created_at, o.updated_at, o.deleted_at,
-		       bm25(observations_fts, 5.0, 1.0, 0.0, 0.0, 0.0, 3.0) as rank
-		FROM observations_fts fts
-		JOIN observations o ON o.id = fts.rowid
-		WHERE observations_fts MATCH ? AND o.deleted_at IS NULL
-	`
-	args := []any{ftsQuery}
-
-	if opts.Type != "" {
-		sqlQ += " AND o.type = ?"
-		args = append(args, opts.Type)
-	}
-
-	if opts.Project != "" {
-		sqlQ += " AND LOWER(o.project) = ?"
-		args = append(args, opts.Project)
-	}
-
-	if opts.Scope != "" {
-		sqlQ += " AND o.scope = ?"
-		args = append(args, normalizeScope(opts.Scope))
-	}
-
-	sqlQ += " ORDER BY rank LIMIT ?"
-	args = append(args, limit)
-
-	rows, err := s.queryItHook(s.db, sqlQ, args...)
+	sqlQ, args := buildSearchFTSQuery(ftsQuery, opts, limit)
+	rows, err := s.queryItContextHook(ctx, sqlQ, args...)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, fmt.Errorf("search: %w", err)
 	}
 	defer rows.Close()
@@ -3234,6 +3256,9 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 	var results []SearchResult
 	results = append(results, directResults...)
 	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		var sr SearchResult
 		if err := rows.Scan(
 			&sr.ID, &sr.SyncID, &sr.SessionID, &sr.Type, &sr.Title, &sr.Content,
@@ -3241,6 +3266,12 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 			&sr.LastSeenAt, &sr.ReviewAfter, &sr.Pinned, &sr.CreatedAt, &sr.UpdatedAt, &sr.DeletedAt,
 			&sr.Rank,
 		); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			return nil, err
+		}
+		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
 		if !seen[sr.ID] {
@@ -3248,6 +3279,12 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		}
 	}
 	if err := rows.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
@@ -3255,6 +3292,34 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 		results = results[:limit]
 	}
 	return results, nil
+}
+
+func buildSearchFTSQuery(ftsQuery string, opts SearchOptions, limit int) (string, []any) {
+	sqlQ := `
+		SELECT o.id, ifnull(o.sync_id, '') as sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project,
+		       o.scope, o.topic_key, o.revision_count, o.duplicate_count, o.last_seen_at, o.review_after, o.pinned, o.created_at, o.updated_at, o.deleted_at,
+		       bm25(observations_fts, 5.0, 1.0, 0.0, 0.0, 0.0, 3.0) as rank
+		FROM observations_fts fts
+		CROSS JOIN observations o ON o.id = fts.rowid
+		WHERE observations_fts MATCH ? AND o.deleted_at IS NULL
+	`
+	args := []any{ftsQuery}
+
+	if opts.Type != "" {
+		sqlQ += " AND o.type = ?"
+		args = append(args, opts.Type)
+	}
+	if opts.Project != "" {
+		sqlQ += " AND LOWER(o.project) = ?"
+		args = append(args, opts.Project)
+	}
+	if opts.Scope != "" {
+		sqlQ += " AND o.scope = ?"
+		args = append(args, normalizeScope(opts.Scope))
+	}
+
+	sqlQ += " ORDER BY rank LIMIT ?"
+	return sqlQ, append(args, limit)
 }
 
 // ─── Stats ───────────────────────────────────────────────────────────────────

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4570,6 +4570,7 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 	t.Run("query iterator scan and rows.Err branches", func(t *testing.T) {
 		s := newTestStore(t)
 		origQueryIt := s.hooks.queryIt
+		origQueryItContext := s.hooks.queryItContext
 
 		setScanErr := func(match string) {
 			s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
@@ -4577,6 +4578,12 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 					return &fakeRows{next: []bool{true, false}, scanErr: errors.New("forced scan error")}, nil
 				}
 				return origQueryIt(db, query, args...)
+			}
+			s.hooks.queryItContext = func(ctx context.Context, db *sql.DB, query string, args ...any) (rowScanner, error) {
+				if strings.Contains(query, match) {
+					return &fakeRows{next: []bool{true, false}, scanErr: errors.New("forced scan error")}, nil
+				}
+				return origQueryItContext(ctx, db, query, args...)
 			}
 		}
 
@@ -4586,6 +4593,12 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 					return &fakeRows{next: []bool{false}, err: errors.New("forced rows err")}, nil
 				}
 				return origQueryIt(db, query, args...)
+			}
+			s.hooks.queryItContext = func(ctx context.Context, db *sql.DB, query string, args ...any) (rowScanner, error) {
+				if strings.Contains(query, match) {
+					return &fakeRows{next: []bool{false}, err: errors.New("forced rows err")}, nil
+				}
+				return origQueryItContext(ctx, db, query, args...)
 			}
 		}
 
@@ -9073,6 +9086,34 @@ func TestSearch_WeightedBM25Ranking(t *testing.T) {
 	if results[1].ID != idB {
 		t.Errorf("expected observation B (content match) to rank second; got second: %d (title: %q, rank: %v)",
 			results[1].ID, results[1].Title, results[1].Rank)
+	}
+}
+
+func TestSearchContext_AlreadyCanceled(t *testing.T) {
+	s := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results, err := s.SearchContext(ctx, "unreachable", SearchOptions{Project: "engram", Limit: 10})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got results=%v err=%v", results, err)
+	}
+	if results != nil {
+		t.Fatalf("expected no results from canceled search, got %v", results)
+	}
+}
+
+func TestFTSQueriesUseFTSFirstCrossJoin(t *testing.T) {
+	searchQuery, _ := buildSearchFTSQuery(`"memory"`, SearchOptions{}, 10)
+	for name, query := range map[string]string{
+		"search":          searchQuery,
+		"find candidates": findCandidatesFTSQuery,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(query, "CROSS JOIN observations o ON o.id = fts.rowid") {
+				t.Fatalf("expected FTS-first CROSS JOIN, got query:\n%s", query)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #662

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Force FTS-first plans for search and candidate queries with `CROSS JOIN`.
- Propagate MCP handler cancellation through SQLite search and relation enrichment.
- Add focused regressions for SQL shape and canceled contexts.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Add `SearchContext`, contextual query execution, cancellation checks, and FTS-first search SQL. |
| `internal/store/relations.go` | Use FTS-first candidate SQL and add contextual relation enrichment. |
| `internal/mcp/mcp.go` | Pass handler context through search and relation loading. |
| Store and MCP tests | Cover cancellation propagation and the required FTS join shape. |

## 🧪 Test Plan

- [x] Focused store and MCP regression tests pass.
- [x] Existing ANY/ALL, ranking, filtering, candidate, and annotation tests pass.
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Full unit suite passes locally: `go test ./...` — Windows baseline failures remain in unrelated command/setup/store/sync tests; affected packages and focused candidate tests pass.
- [x] Gentle AI RDD four-lens review approved the exact committed tree.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue is approved | ⏳ |
| **Check PR Has type:* Label** | Exactly one type label | ⏳ |
| **Unit Tests** | `go test ./...` | ⏳ |
| **E2E Tests** | Server E2E suite | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #662`)
- [x] I added exactly one `type:*` label to this PR
- [ ] I ran a fully green local `go test ./...` (see Windows baseline failures above)
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated if required (not required; internal behavior and existing API remain compatible)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

RDD approved candidate tree `8cd1e81d1c4fed69af4475e24f5e56a9300a56d9` under lineage `review-9b98dc0a60fd8a89`. Four non-blocking informational findings were recorded; no correction was opened. The full Windows unit run reproduced unrelated baseline failures, while focused candidate tests, MCP, E2E, and diff checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search and relation loading now respond correctly when operations are canceled or reach a deadline.
  * Canceled searches stop promptly without returning incomplete results.
  * Search queries use improved full-text matching behavior.
* **Reliability**
  * Non-cancellation errors during relation loading continue to be handled without interrupting requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->