### PR TITLE
fix(store): defer enrolled repair until sync

### DIFF
--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -1102,6 +1104,64 @@ func TestCmdMCPDetectsProjectFromGit(t *testing.T) {
 
 	if capturedCfg.DefaultProject != "" {
 		t.Fatalf("DefaultProject = %q; want empty without flag/env", capturedCfg.DefaultProject)
+	}
+}
+
+func TestCmdMCPServesBeforeDeferredEnrolledProjectRepair(t *testing.T) {
+	cfg := testConfig(t)
+	seed, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	if err := seed.CreateSession("legacy-session", "legacy-project", t.TempDir()); err != nil {
+		_ = seed.Close()
+		t.Fatalf("seed session: %v", err)
+	}
+	if err := seed.EnrollProject("legacy-project"); err != nil {
+		_ = seed.Close()
+		t.Fatalf("enroll project: %v", err)
+	}
+	if _, err := seed.DB().Exec(`DELETE FROM sync_mutations WHERE project = ?`, "legacy-project"); err != nil {
+		_ = seed.Close()
+		t.Fatalf("remove journal entries: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+
+	oldStoreNew := storeNew
+	oldNewMCPServerWithConfig := newMCPServerWithConfig
+	oldServeMCP := serveMCP
+	t.Cleanup(func() {
+		storeNew = oldStoreNew
+		newMCPServerWithConfig = oldNewMCPServerWithConfig
+		serveMCP = oldServeMCP
+	})
+	storeNew = store.New
+
+	var mcpStore *store.Store
+	newMCPServerWithConfig = func(s *store.Store, mcpCfg mcp.MCPConfig, allowlist map[string]bool) *mcpserver.MCPServer {
+		mcpStore = s
+		return oldNewMCPServerWithConfig(s, mcpCfg, allowlist)
+	}
+	serveMCP = func(_ *mcpserver.MCPServer, _ ...mcpserver.StdioOption) error {
+		if mcpStore == nil {
+			return errors.New("MCP server did not receive a store")
+		}
+		var mutations int
+		if err := mcpStore.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE project = ?`, "legacy-project").Scan(&mutations); err != nil {
+			return fmt.Errorf("count journal entries at MCP readiness: %w", err)
+		}
+		if mutations != 0 {
+			return fmt.Errorf("MCP readiness ran deferred repair: got %d mutations", mutations)
+		}
+		return nil
+	}
+
+	withArgs(t, "engram", "mcp")
+	_, stderr := captureOutput(t, func() { cmdMCP(cfg) })
+	if stderr != "" {
+		t.Fatalf("MCP startup stderr = %q", stderr)
 	}
 }
 

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -93,6 +93,10 @@ type LocalStore interface {
 	CountDeferredAndDead() (deferred, dead int, err error)
 }
 
+type enrolledProjectRepairEnsurer interface {
+	EnsureEnrolledProjectSyncMutations(ctx context.Context) error
+}
+
 type nonEnrolledPendingError struct {
 	counts []store.PendingSyncMutationProjectCount
 }
@@ -488,6 +492,11 @@ func (m *Manager) push(ctx context.Context) error {
 	}
 
 	m.setPhase(PhasePushing)
+	if repairer, ok := m.store.(enrolledProjectRepairEnsurer); ok {
+		if err := repairer.EnsureEnrolledProjectSyncMutations(ctx); err != nil {
+			return fmt.Errorf("repair enrolled sync journal: %w", err)
+		}
+	}
 
 	pending, err := m.store.ListPendingSyncMutations(m.cfg.TargetKey, m.cfg.PushBatchSize)
 	if err != nil {

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -589,6 +589,38 @@ func TestManagerPushPersistsProjectIsolationAcrossStoreRestart(t *testing.T) {
 	}
 }
 
+func TestManagerPushRepairsEnrolledJournalBeforeListingMutations(t *testing.T) {
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatalf("store default config: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	local, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer local.Close() //nolint:errcheck
+
+	if err := local.CreateSession("legacy-session", "legacy-project", "/tmp/legacy-project"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := local.EnrollProject("legacy-project"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if _, err := local.DB().Exec(`DELETE FROM sync_mutations WHERE project = ?`, "legacy-project"); err != nil {
+		t.Fatalf("remove journal entries to simulate legacy store: %v", err)
+	}
+
+	transport := newFakeTransport()
+	transport.pushResult = &PushMutationsResult{AcceptedSeqs: []int64{1}}
+	if err := New(local, transport, DefaultConfig()).push(context.Background()); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if len(transport.pushed) != 1 || len(transport.pushed[0]) != 1 || transport.pushed[0][0].Entity != store.SyncEntitySession {
+		t.Fatalf("pushed mutations = %+v, want repaired session mutation", transport.pushed)
+	}
+}
+
 // ─── Phase + lifecycle tests (REQ-204) ───────────────────────────────────────
 
 func TestManagerPhaseTransitions(t *testing.T) {

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -144,6 +144,15 @@ func (s *fakeLocalStore) ReplayDeferred() (store.ReplayDeferredResult, error) {
 
 func (s *fakeLocalStore) CountDeferredAndDead() (int, int, error) { return 0, 0, nil }
 
+type fakeLocalStoreWithRepairError struct {
+	*fakeLocalStore
+	repairErr error
+}
+
+func (s *fakeLocalStoreWithRepairError) EnsureEnrolledProjectSyncMutations(context.Context) error {
+	return s.repairErr
+}
+
 // ─── Fake Transport ───────────────────────────────────────────────────────────
 
 type fakeCloudTransport struct {
@@ -618,6 +627,23 @@ func TestManagerPushRepairsEnrolledJournalBeforeListingMutations(t *testing.T) {
 	}
 	if len(transport.pushed) != 1 || len(transport.pushed[0]) != 1 || transport.pushed[0][0].Entity != store.SyncEntitySession {
 		t.Fatalf("pushed mutations = %+v, want repaired session mutation", transport.pushed)
+	}
+}
+
+func TestManagerPushReturnsRepairErrorBeforeTransport(t *testing.T) {
+	local := &fakeLocalStoreWithRepairError{
+		fakeLocalStore: newFakeLocalStore(),
+		repairErr:      errors.New("repair failed"),
+	}
+	local.mutations = []store.SyncMutation{{Seq: 1, Project: "project"}}
+	transport := newFakeTransport()
+
+	err := New(local, transport, DefaultConfig()).push(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "repair enrolled sync journal") {
+		t.Fatalf("push error = %v, want repair enrolled sync journal", err)
+	}
+	if calls := atomic.LoadInt32(&transport.pushCalls); calls != 0 {
+		t.Fatalf("transport push calls = %d, want 0", calls)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5139,6 +5139,9 @@ func (s *Store) EnsureEnrolledProjectSyncMutations(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	s.repairMu.Lock()
 	if s.repairDone {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,6 +6,7 @@
 package store
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
@@ -19,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Gentleman-Programming/engram/internal/timeutil"
@@ -492,6 +494,16 @@ type Store struct {
 	db    *sql.DB
 	cfg   Config
 	hooks storeHooks
+
+	repairMu        sync.Mutex
+	repairDone      bool
+	repairInFlight  *enrolledProjectRepair
+	repairOperation func() error // test seam; production uses repairEnrolledProjectSyncMutations.
+}
+
+type enrolledProjectRepair struct {
+	done chan struct{}
+	err  error
 }
 
 type execer interface {
@@ -644,15 +656,12 @@ func New(cfg Config) (*Store, error) {
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("engram: migration: %w", err)
 	}
-	if err := s.repairEnrolledProjectSyncMutations(); err != nil {
-		return nil, fmt.Errorf("engram: repair enrolled sync journal: %w", err)
-	}
 
 	return s, nil
 }
 
-// newWithoutRepair is the same as New but skips repairEnrolledProjectSyncMutations.
-// It exists solely to support tests that need to seed data and call repair manually.
+// newWithoutRepair is retained as a test helper alias for New. Enrolled-project
+// repair is deferred until the first synchronization operation in both cases.
 func newWithoutRepair(cfg Config) (*Store, error) {
 	if !filepath.IsAbs(cfg.DataDir) {
 		return nil, fmt.Errorf("engram: data directory must be an absolute path, got %q — set ENGRAM_DATA_DIR or ensure your home directory is resolvable", cfg.DataDir)
@@ -5120,6 +5129,52 @@ func (s *Store) projectNeedsBackfill(project string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// EnsureEnrolledProjectSyncMutations repairs legacy enrolled-project journal
+// entries before a sync operation reads them. A successful repair is memoized
+// for this Store's lifetime; failures are returned to callers and retried by a
+// later synchronization attempt.
+func (s *Store) EnsureEnrolledProjectSyncMutations(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	s.repairMu.Lock()
+	if s.repairDone {
+		s.repairMu.Unlock()
+		return nil
+	}
+	if inFlight := s.repairInFlight; inFlight != nil {
+		s.repairMu.Unlock()
+		select {
+		case <-inFlight.done:
+			return inFlight.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	inFlight := &enrolledProjectRepair{done: make(chan struct{})}
+	s.repairInFlight = inFlight
+	s.repairMu.Unlock()
+
+	var err error
+	if s.repairOperation != nil {
+		err = s.repairOperation()
+	} else {
+		err = s.repairEnrolledProjectSyncMutations()
+	}
+
+	s.repairMu.Lock()
+	inFlight.err = err
+	if err == nil {
+		s.repairDone = true
+	}
+	s.repairInFlight = nil
+	close(inFlight.done)
+	s.repairMu.Unlock()
+	return err
 }
 
 func (s *Store) repairEnrolledProjectSyncMutations() error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7729,6 +7729,25 @@ func TestEnsureEnrolledProjectSyncMutationsRetriesAfterFailure(t *testing.T) {
 	}
 }
 
+func TestEnsureEnrolledProjectSyncMutationsCanceledLeaderSkipsRepair(t *testing.T) {
+	s := newTestStore(t)
+
+	calls := 0
+	s.repairOperation = func() error {
+		calls++
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := s.EnsureEnrolledProjectSyncMutations(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled leader error = %v, want context.Canceled", err)
+	}
+	if calls != 0 {
+		t.Fatalf("repair calls = %d, want 0", calls)
+	}
+}
+
 func TestEnsureEnrolledProjectSyncMutationsSharesConcurrentFirstRepair(t *testing.T) {
 	s := newTestStore(t)
 
@@ -7766,6 +7785,25 @@ func TestEnsureEnrolledProjectSyncMutationsSharesConcurrentFirstRepair(t *testin
 	}
 	if calls != 1 {
 		t.Fatalf("repair calls = %d, want exactly one", calls)
+	}
+}
+
+func TestEnsureEnrolledProjectSyncMutationsWaiterReceivesSuccessfulInFlightResult(t *testing.T) {
+	s := newTestStore(t)
+	inFlight := &enrolledProjectRepair{done: make(chan struct{})}
+
+	s.repairMu.Lock()
+	s.repairInFlight = inFlight
+	s.repairMu.Unlock()
+
+	result := make(chan error, 1)
+	go func() { result <- s.EnsureEnrolledProjectSyncMutations(context.Background()) }()
+
+	s.repairMu.Lock()
+	close(inFlight.done)
+	s.repairMu.Unlock()
+	if err := <-result; err != nil {
+		t.Fatalf("successful waiter error = %v, want nil", err)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -5499,7 +5500,7 @@ func TestEnrollProjectBackfillsPromptDeleteTombstonesWithDerivedProject(t *testi
 	}
 }
 
-func TestNewRepairsSoftDeletedObservationDeleteMutationsForEnrolledProjects(t *testing.T) {
+func TestEnsureRepairsSoftDeletedObservationDeleteMutationsForEnrolledProjects(t *testing.T) {
 	dataDir := t.TempDir()
 	dbPath := filepath.Join(dataDir, "engram.db")
 
@@ -5598,6 +5599,9 @@ func TestNewRepairsSoftDeletedObservationDeleteMutationsForEnrolledProjects(t *t
 		t.Fatalf("new store: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
+	if err := s.EnsureEnrolledProjectSyncMutations(context.Background()); err != nil {
+		t.Fatalf("ensure enrolled sync journal: %v", err)
+	}
 
 	var op string
 	if err := s.db.QueryRow(
@@ -5612,7 +5616,7 @@ func TestNewRepairsSoftDeletedObservationDeleteMutationsForEnrolledProjects(t *t
 	}
 }
 
-func TestNewRepairsAlreadyEnrolledProjectsMissingHistoricalSyncMutations(t *testing.T) {
+func TestStoreNewDefersRepairUntilSynchronization(t *testing.T) {
 	dataDir := t.TempDir()
 	dbPath := filepath.Join(dataDir, "engram.db")
 
@@ -5713,6 +5717,20 @@ func TestNewRepairsAlreadyEnrolledProjectsMissingHistoricalSyncMutations(t *test
 		t.Fatalf("new store after enrolled legacy state: %v", err)
 	}
 
+	var beforeRepair int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_mutations`).Scan(&beforeRepair); err != nil {
+		_ = s.Close()
+		t.Fatalf("count mutations before deferred repair: %v", err)
+	}
+	if beforeRepair != 0 {
+		_ = s.Close()
+		t.Fatalf("Store.New repaired journal before synchronization: got %d mutations", beforeRepair)
+	}
+	if err := s.EnsureEnrolledProjectSyncMutations(context.Background()); err != nil {
+		_ = s.Close()
+		t.Fatalf("ensure enrolled sync journal: %v", err)
+	}
+
 	mutations, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
 	if err != nil {
 		_ = s.Close()
@@ -5730,7 +5748,7 @@ func TestNewRepairsAlreadyEnrolledProjectsMissingHistoricalSyncMutations(t *test
 	}
 	if state.LastEnqueuedSeq != 3 {
 		_ = s.Close()
-		t.Fatalf("expected last_enqueued_seq 3 after automatic repair, got %d", state.LastEnqueuedSeq)
+		t.Fatalf("expected last_enqueued_seq 3 after deferred repair, got %d", state.LastEnqueuedSeq)
 	}
 
 	if err := s.Close(); err != nil {
@@ -7683,6 +7701,97 @@ func newTestStoreRaw(t *testing.T) *Store {
 		_ = s.Close()
 	})
 	return s
+}
+
+func TestEnsureEnrolledProjectSyncMutationsRetriesAfterFailure(t *testing.T) {
+	s := newTestStore(t)
+
+	calls := 0
+	s.repairOperation = func() error {
+		calls++
+		if calls == 1 {
+			return errors.New("repair failed")
+		}
+		return nil
+	}
+
+	if err := s.EnsureEnrolledProjectSyncMutations(context.Background()); err == nil || !strings.Contains(err.Error(), "repair failed") {
+		t.Fatalf("first ensure error = %v, want repair failure", err)
+	}
+	if err := s.EnsureEnrolledProjectSyncMutations(context.Background()); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if err := s.EnsureEnrolledProjectSyncMutations(context.Background()); err != nil {
+		t.Fatalf("memoized ensure: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("repair calls = %d, want 2 (failed attempt plus successful retry)", calls)
+	}
+}
+
+func TestEnsureEnrolledProjectSyncMutationsSharesConcurrentFirstRepair(t *testing.T) {
+	s := newTestStore(t)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	calls := 0
+	s.repairOperation = func() error {
+		calls++
+		close(started)
+		<-release
+		return nil
+	}
+
+	const callers = 8
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- s.EnsureEnrolledProjectSyncMutations(context.Background())
+		}()
+	}
+	close(start)
+	<-started
+	close(release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent ensure: %v", err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("repair calls = %d, want exactly one", calls)
+	}
+}
+
+func TestEnsureEnrolledProjectSyncMutationsWaiterCanCancel(t *testing.T) {
+	s := newTestStore(t)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	s.repairOperation = func() error {
+		close(started)
+		<-release
+		return nil
+	}
+	leaderDone := make(chan error, 1)
+	go func() { leaderDone <- s.EnsureEnrolledProjectSyncMutations(context.Background()) }()
+	<-started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.EnsureEnrolledProjectSyncMutations(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled waiter error = %v, want context.Canceled", err)
+	}
+	close(release)
+	if err := <-leaderDone; err != nil {
+		t.Fatalf("leader ensure: %v", err)
+	}
 }
 
 // countSyncMutations returns the total number of rows in sync_mutations for a project.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -21,6 +21,7 @@ package sync
 
 import (
 	"compress/gzip"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -1376,6 +1377,10 @@ func (sy *Syncer) filterByPendingMutations(data *store.ExportData, project strin
 }
 
 func (sy *Syncer) listPendingMutationsForExport() ([]store.SyncMutation, error) {
+	if err := sy.store.EnsureEnrolledProjectSyncMutations(context.Background()); err != nil {
+		return nil, fmt.Errorf("repair enrolled sync journal: %w", err)
+	}
+
 	const pageSize = 5000
 	afterSeq := int64(0)
 	mutations := make([]store.SyncMutation, 0, pageSize)

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1877,6 +1877,29 @@ func TestCloudSyncEnrolledExportImportAndIdempotentPull(t *testing.T) {
 	}
 }
 
+func TestCloudExportRepairsEnrolledJournalBeforeListingMutations(t *testing.T) {
+	s := newTestStore(t)
+	seedStoreForSync(t, s)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if _, err := s.DB().Exec(`DELETE FROM sync_mutations WHERE project = ?`, "proj-a"); err != nil {
+		t.Fatalf("remove journal entries to simulate legacy store: %v", err)
+	}
+
+	transport := newFakeCloudTransport()
+	result, err := NewCloudWithTransport(s, transport, "proj-a").Export("alice", "proj-a")
+	if err != nil {
+		t.Fatalf("cloud export: %v", err)
+	}
+	if result.IsEmpty || result.MutationsExported != 3 {
+		t.Fatalf("export result = %+v, want three repaired mutations", result)
+	}
+	if transport.writeChunkCalls != 1 {
+		t.Fatalf("write chunk calls = %d, want 1", transport.writeChunkCalls)
+	}
+}
+
 func TestCloudExportUsesMutationJournalForUpdatesAndDeletes(t *testing.T) {
 	s := newTestStore(t)
 	transport := newFakeCloudTransport()


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #665

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Remove enrolled-project journal repair from synchronous `Store.New` so MCP can reach `ServeStdio` without waiting for project-wide scans.
- Repair lazily at cloud export and autosync push boundaries before reading pending mutations.
- Coordinate concurrent first repairs with retryable errors, memoized success, and cancelable waiters.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Defer repair and add single-flight `EnsureEnrolledProjectSyncMutations`. |
| `internal/sync/sync.go` | Ensure repair before cloud export reads the journal. |
| `internal/cloud/autosync/manager.go` | Ensure repair before autosync lists pending mutations. |
| `cmd/engram/main_test.go` | Prove MCP reaches the serve boundary before deferred repair. |
| Store, sync, and autosync tests | Cover ordering, retry, concurrency, cancellation, and idempotency. |

## 🧪 Test Plan

- [x] Focused Store repair tests pass.
- [x] Focused cloud export and autosync ordering tests pass.
- [x] Focused MCP readiness regression passes.
- [x] Full `internal/cloud/autosync` suite passes.
- [x] `git diff --check` passes.
- [ ] Full local `go test ./...` — Windows-only SQLite/FileTransport failures outside this diff remain; CI will provide the authoritative clean-environment result.
- [ ] E2E suite — not run locally; this change does not modify server routes and CI will run repository-required checks.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #665`).
- [x] I added exactly **one** `type:*` label to this PR.
- [ ] I ran the complete unit suite locally; focused affected suites passed, with unrelated Windows failures documented above.
- [ ] I ran the complete E2E suite locally; CI remains authoritative.
- [x] Docs are not required because the external sync and MCP contracts remain unchanged.
- [x] Commits follow conventional commits format.
- [x] No `Co-Authored-By` trailers in commits.

---

## 💬 Notes for Reviewers

Native four-lens RDD approved the exact 7-file candidate before commit. `go test -race` was unavailable because this Windows environment has `CGO_ENABLED=0`; focused concurrency tests pass. RDD informational follow-ups did not open a correction or block this candidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization for previously enrolled projects with missing journal entries.
  * Repairs now occur before cloud uploads and exports, preventing missed changes.
  * Startup is no longer blocked by deferred repair work, improving MCP readiness.
  * Repair failures can be retried, and concurrent synchronization requests are coordinated safely.
  * Canceled synchronization requests no longer leave repair operations stuck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->