### PR TITLE
fix(opencode): isolate compaction context by session

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -848,7 +848,7 @@ Save structured observations. The tool description teaches agents the format:
 - **observation**: backward-compatible alias for `content` for older/raw MCP clients; prefer `content` for new integrations
 
 Exact duplicate saves are deduplicated in a rolling time window using a normalized content hash + project + scope + type + title.
-When `topic_key` is provided, `mem_save` upserts the latest observation in the same `project + scope + topic_key`, incrementing `revision_count`.
+When `topic_key` is provided, `mem_save` upserts the latest observation in the same `project + scope + topic_key`, incrementing `revision_count` and attributing it to the latest writer session.
 Save responses include lifecycle metadata for the saved observation: computed `state` (`active` or `needs_review`) and `review_after` when the observation type has a review cycle.
 
 ### mem_update

--- a/DOCS.md
+++ b/DOCS.md
@@ -171,7 +171,8 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 
 ### Context
 
-- `GET /context` — Formatted context. Query: `?project=X&scope=project|personal|global`
+- `GET /context` — Manual formatted context scoped by project and optional scope. Query: `?project=X&scope=project|personal|global`
+- `GET /context/compaction` — Runtime compaction context scoped strictly to one persisted session. Query: `?session_id=X`. The server derives the session project; this endpoint does not accept project or scope selection.
 
 ### Passive Capture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,7 @@ When you are not sure which key to use, call `mem_suggest_topic_key` before `mem
    → creates new observation (revision_count=1)
 
 3. (later session) mem_save(..., topic_key="architecture/auth-model")
-   → updates existing observation (revision_count=2)
+   → updates the existing observation (revision_count=2) and attributes it to the latest writer session
 ```
 
 `mem_suggest_topic_key` families:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -46,7 +46,7 @@ The plugin:
 - **Auto-imports** git-synced memories from `.engram/manifest.json` if present in the project
 - **Creates sessions** on-demand via `ensureSession()` (resilient to restarts/reconnects)
 - **Injects the Memory Protocol** into the agent's system prompt via `chat.system.transform` — strict rules for when to save, when to search, and a mandatory session close protocol. The protocol is concatenated into the existing system message (not pushed as a separate one), ensuring compatibility with models that only accept a single system block (Qwen, Mistral/Ministral via llama.cpp, etc.)
-- **Injects previous session context** into the compaction prompt
+- **Injects session-only runtime context** into the compaction prompt; manual `mem_context` and `GET /context` remain project/scope-scoped
 - **Instructs the compressor** to tell the new agent to persist the compacted summary via `mem_session_summary`
 - **Strips `<private>` tags** before sending data
 - **Enables** `opencode-subagent-statusline` in `tui.json` or `tui.jsonc` during `engram setup opencode`, adding a live sub-agent monitor to OpenCode's sidebar/home footer. To disable it later, remove `"opencode-subagent-statusline"` from the `"plugin"` array in your TUI config and restart OpenCode.

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1230,6 +1230,43 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 	}
 }
 
+func TestMemContextRemainsProjectScopedAcrossSessions(t *testing.T) {
+	s := newMCPTestStore(t)
+	for _, sessionID := range []string{"manual-a", "manual-b"} {
+		if err := s.CreateSession(sessionID, "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create %s: %v", sessionID, err)
+		}
+		if _, err := s.AddObservation(store.AddObservationParams{
+			SessionID: sessionID,
+			Type:      "decision",
+			Title:     sessionID,
+			Content:   "content-" + sessionID,
+			Project:   "engram",
+			Scope:     "project",
+		}); err != nil {
+			t.Fatalf("add %s observation: %v", sessionID, err)
+		}
+	}
+
+	h := handleContext(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"project": "engram",
+		"scope":   "project",
+	}}})
+	if err != nil {
+		t.Fatalf("mem_context handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected mem_context error: %s", callResultText(t, res))
+	}
+	context := callResultText(t, res)
+	for _, value := range []string{"manual-a", "manual-b"} {
+		if !strings.Contains(context, value) {
+			t.Fatalf("manual mem_context must remain project-scoped and include %q:\n%s", value, context)
+		}
+	}
+}
+
 func TestMCPHandlersErrorBranches(t *testing.T) {
 	s := newMCPTestStore(t)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -216,6 +216,7 @@ func (s *Server) routes() {
 
 	// Context
 	s.mux.HandleFunc("GET /context", s.handleContext)
+	s.mux.HandleFunc("GET /context/compaction", s.handleCompactionContext)
 
 	// Export / Import — sensitive: full data read and bulk mutation.
 	s.mux.HandleFunc("GET /export", requireAuth(s.handleExport))
@@ -793,6 +794,26 @@ func (s *Server) handleContext(w http.ResponseWriter, r *http.Request) {
 
 	context, err := s.store.FormatContext(project, scope)
 	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]string{"context": context})
+}
+
+func (s *Server) handleCompactionContext(w http.ResponseWriter, r *http.Request) {
+	sessionID := strings.TrimSpace(r.URL.Query().Get("session_id"))
+	if sessionID == "" {
+		jsonError(w, http.StatusBadRequest, "session_id is required")
+		return
+	}
+
+	context, err := s.store.FormatCompactionContext(sessionID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			jsonError(w, http.StatusNotFound, "session not found")
+			return
+		}
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/server_e2e_test.go
+++ b/internal/server/server_e2e_test.go
@@ -570,6 +570,99 @@ func TestValidationAndImportExportErrorsE2E(t *testing.T) {
 	recentPromptsResp.Body.Close()
 }
 
+func TestCompactionContextE2EIsSessionScoped(t *testing.T) {
+	s, ts := newE2EServer(t)
+	client := ts.Client()
+
+	for _, sessionID := range []string{"runtime-a", "runtime-b"} {
+		resp := postJSON(t, client, ts.URL+"/sessions", map[string]any{"id": sessionID, "project": "engram"})
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %s: got %d", sessionID, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+	for _, item := range []struct {
+		sessionID string
+		title     string
+		content   string
+		pinned    bool
+	}{
+		{"runtime-a", "pinned-a", "pinned-content-a", true},
+		{"runtime-a", "recent-a", "recent-content-a", false},
+		{"runtime-b", "pinned-b", "pinned-content-b", true},
+		{"runtime-b", "recent-b", "recent-content-b", false},
+	} {
+		resp := postJSON(t, client, ts.URL+"/observations", map[string]any{"session_id": item.sessionID, "type": "decision", "title": item.title, "content": item.content, "project": "engram"})
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %s: got %d", item.title, resp.StatusCode)
+		}
+		id := int64(decodeJSON[map[string]any](t, resp)["id"].(float64))
+		if item.pinned {
+			if err := s.PinObservation(id); err != nil {
+				t.Fatalf("pin %s: %v", item.title, err)
+			}
+		}
+	}
+
+	for _, item := range []struct{ sessionID, content string }{{"runtime-a", "prompt-a"}, {"runtime-b", "prompt-b"}} {
+		resp := postJSON(t, client, ts.URL+"/prompts", map[string]any{"session_id": item.sessionID, "content": item.content, "project": "engram"})
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %s: got %d", item.content, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+
+	response, err := client.Get(ts.URL + "/context/compaction?session_id=runtime-a&project=foreign")
+	if err != nil {
+		t.Fatalf("get compaction context: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("compaction context status = %d, want 200", response.StatusCode)
+	}
+	context := decodeJSON[map[string]string](t, response)["context"]
+	for _, value := range []string{"runtime-a", "prompt-a", "recent-a"} {
+		if !strings.Contains(context, value) {
+			t.Errorf("context missing %q:\n%s", value, context)
+		}
+	}
+	for _, value := range []string{"runtime-b", "prompt-b", "recent-b"} {
+		if strings.Contains(context, value) {
+			t.Errorf("context leaked %q:\n%s", value, context)
+		}
+	}
+
+	missing, err := client.Get(ts.URL + "/context/compaction")
+	if err != nil {
+		t.Fatalf("get missing compaction session: %v", err)
+	}
+	if missing.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing session status = %d, want 400", missing.StatusCode)
+	}
+	missing.Body.Close()
+
+	unknown, err := client.Get(ts.URL + "/context/compaction?session_id=unknown")
+	if err != nil {
+		t.Fatalf("get unknown compaction session: %v", err)
+	}
+	if unknown.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown session status = %d, want 404", unknown.StatusCode)
+	}
+	unknown.Body.Close()
+
+	manual, err := client.Get(ts.URL + "/context?project=engram")
+	if err != nil {
+		t.Fatalf("get manual context: %v", err)
+	}
+	if manual.StatusCode != http.StatusOK {
+		t.Fatalf("manual context status = %d, want 200", manual.StatusCode)
+	}
+	manualContext := decodeJSON[map[string]string](t, manual)["context"]
+	if !strings.Contains(manualContext, "prompt-a") || !strings.Contains(manualContext, "prompt-b") ||
+		!strings.Contains(manualContext, "recent-a") || !strings.Contains(manualContext, "recent-b") {
+		t.Fatalf("manual project context must remain project-scoped:\n%s", manualContext)
+	}
+}
+
 func TestPromptAndObservationMutationHandlersE2E(t *testing.T) {
 	_, ts := newE2EServer(t)
 	client := ts.Client()

--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -122,7 +122,7 @@ This is NOT optional. If you skip this, the next session starts blind.
 
 If you see a message about compaction or context reset, or if you see "FIRST ACTION REQUIRED" in your context:
 1. IMMEDIATELY call \`mem_session_summary\` with the compacted summary content — this persists what was done before compaction
-2. Then call \`mem_context\` to recover any additional context from previous sessions
+2. The session-only compaction context has already been injected. Do not automatically call \`mem_context\`, which is project-scoped; use it only when explicitly requested.
 3. Only THEN continue working
 
 Do not skip step 1. Without it, everything done before compaction is lost from memory.

--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -678,17 +678,21 @@ export const Engram: Plugin = async (ctx) => {
     // 3. Tell the compressor to remind the new agent to save memories
 
     "experimental.session.compacting": async (input, output) => {
+      let sessionId = ""
       if (input.sessionID) {
-        const sessionId = await resolveAuthoritativeSessionID(input.sessionID)
-        if (sessionId) await ensureSession(sessionId)
+        sessionId = await resolveAuthoritativeSessionID(input.sessionID)
       }
 
-      // Inject context from previous sessions
-      const data = await engramFetch(
-        `/context?project=${encodeURIComponent(project)}`
-      )
-      if (data?.context) {
-        output.context.push(data.context)
+      // Runtime compaction context must never cross session boundaries. If the
+      // authoritative session cannot be resolved or registered, skip this
+      // injection rather than falling back to project-wide manual context.
+      if (sessionId && await ensureSession(sessionId)) {
+        const data = await engramFetch(
+          `/context/compaction?session_id=${encodeURIComponent(sessionId)}`
+        )
+        if (data?.context) {
+          output.context.push(data.context)
+        }
       }
 
       // Tell the compressor to instruct the new agent to persist the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2290,7 +2290,8 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 			if err == nil {
 				if _, err := s.execHook(tx,
 					`UPDATE observations
-					 SET type = ?,
+					 SET session_id = ?,
+					     type = ?,
 					     title = ?,
 					     content = ?,
 					     tool_name = ?,
@@ -2300,6 +2301,7 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 					     last_seen_at = datetime('now'),
 					     updated_at = datetime('now')
 					 WHERE id = ?`,
+					p.SessionID,
 					p.Type,
 					title,
 					content,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2504,6 +2504,24 @@ func (s *Store) recentUnpinnedObservations(project, scope string, limit int) ([]
 	return s.queryObservations(query, args...)
 }
 
+func (s *Store) compactionObservations(sessionID, project string, pinned bool, limit int) ([]Observation, error) {
+	pinnedValue := 0
+	if pinned {
+		pinnedValue = 1
+	}
+	query := `
+		SELECT ` + observationSelectColumns + `
+		FROM observations o
+		WHERE o.deleted_at IS NULL AND o.session_id = ? AND LOWER(o.project) = ? AND o.pinned = ?
+		ORDER BY datetime(o.created_at) DESC, o.id DESC`
+	args := []any{sessionID, project, pinnedValue}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	return s.queryObservations(query, args...)
+}
+
 // ObservationsNeedingReview returns non-deleted observations whose review_after has passed.
 // An empty project searches all projects, matching existing browse/search conventions.
 func (s *Store) ObservationsNeedingReview(project string, limit int) ([]Observation, error) {
@@ -2682,6 +2700,33 @@ func (s *Store) RecentPrompts(project string, limit int) ([]Prompt, error) {
 	args = append(args, limit)
 
 	rows, err := s.queryItHook(s.db, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []Prompt
+	for rows.Next() {
+		var p Prompt
+		if err := rows.Scan(&p.ID, &p.SyncID, &p.SessionID, &p.Content, &p.Project, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		results = append(results, p)
+	}
+	return results, rows.Err()
+}
+
+func (s *Store) compactionPrompts(sessionID, project string, limit int) ([]Prompt, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	rows, err := s.queryItHook(s.db, `
+		SELECT id, ifnull(sync_id, '') as sync_id, session_id, content, ifnull(project, '') as project, created_at
+		FROM user_prompts
+		WHERE session_id = ? AND LOWER(ifnull(project, '')) = ?
+		ORDER BY created_at DESC
+		LIMIT ?`, sessionID, project, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -3380,6 +3425,67 @@ func (s *Store) FormatContext(project, scope string) (string, error) {
 		for _, obs := range observations {
 			fmt.Fprintf(&b, "- [%s] **%s**: %s\n",
 				obs.Type, obs.Title, truncate(obs.Content, 300))
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String(), nil
+}
+
+// FormatCompactionContext returns runtime context that is strictly limited to
+// one persisted session. The session's project is derived from the store and
+// is never supplied by the caller.
+func (s *Store) FormatCompactionContext(sessionID string) (string, error) {
+	session, err := s.GetSession(sessionID)
+	if err != nil {
+		return "", err
+	}
+
+	project, _ := NormalizeProject(session.Project)
+	var observationCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM observations WHERE session_id = ? AND LOWER(project) = ? AND deleted_at IS NULL`, session.ID, project).Scan(&observationCount); err != nil {
+		return "", err
+	}
+	pinned, err := s.compactionObservations(session.ID, project, true, 0)
+	if err != nil {
+		return "", err
+	}
+	observations, err := s.compactionObservations(session.ID, project, false, s.cfg.MaxContextResults)
+	if err != nil {
+		return "", err
+	}
+	prompts, err := s.compactionPrompts(session.ID, project, 10)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	b.WriteString("## Memory from This Session\n\n")
+	b.WriteString("### Session\n")
+	summary := ""
+	if session.Summary != nil {
+		summary = fmt.Sprintf(": %s", truncate(*session.Summary, 200))
+	}
+	fmt.Fprintf(&b, "- **%s** (%s)%s [%d observations]\n\n", session.ID, timeutil.FormatLocal(session.StartedAt), summary, observationCount)
+
+	if len(prompts) > 0 {
+		b.WriteString("### Recent User Prompts\n")
+		for _, p := range prompts {
+			fmt.Fprintf(&b, "- %s: %s\n", timeutil.FormatLocal(p.CreatedAt), truncate(p.Content, 200))
+		}
+		b.WriteString("\n")
+	}
+	if len(pinned) > 0 {
+		b.WriteString("### Pinned\n")
+		for _, obs := range pinned {
+			fmt.Fprintf(&b, "- [%s] **%s**: %s\n", obs.Type, obs.Title, truncate(obs.Content, 300))
+		}
+		b.WriteString("\n")
+	}
+	if len(observations) > 0 {
+		b.WriteString("### Recent Observations\n")
+		for _, obs := range observations {
+			fmt.Fprintf(&b, "- [%s] **%s**: %s\n", obs.Type, obs.Title, truncate(obs.Content, 300))
 		}
 		b.WriteString("\n")
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -800,6 +800,72 @@ func TestTopicKeyUpsertUpdatesSameTopicWithoutCreatingNewRow(t *testing.T) {
 	}
 }
 
+func TestTopicKeyUpsertMovesObservationToLatestSession(t *testing.T) {
+	s := newTestStore(t)
+
+	for _, sessionID := range []string{"session-a", "session-b"} {
+		if err := s.CreateSession(sessionID, "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create %s: %v", sessionID, err)
+		}
+	}
+
+	firstID, err := s.AddObservation(AddObservationParams{
+		SessionID: "session-a",
+		Type:      "architecture",
+		Title:     "Auth model",
+		Content:   "content-written-by-session-a",
+		Project:   "engram",
+		Scope:     "project",
+		TopicKey:  "architecture/auth-model",
+	})
+	if err != nil {
+		t.Fatalf("add session A observation: %v", err)
+	}
+
+	secondID, err := s.AddObservation(AddObservationParams{
+		SessionID: "session-b",
+		Type:      "architecture",
+		Title:     "Auth model",
+		Content:   "content-written-by-session-b",
+		Project:   "engram",
+		Scope:     "project",
+		TopicKey:  "architecture/auth-model",
+	})
+	if err != nil {
+		t.Fatalf("upsert session B observation: %v", err)
+	}
+	if firstID != secondID {
+		t.Fatalf("expected cross-session topic upsert to reuse id, got %d and %d", firstID, secondID)
+	}
+
+	observation, err := s.GetObservation(firstID)
+	if err != nil {
+		t.Fatalf("get upserted observation: %v", err)
+	}
+	if observation.SessionID != "session-b" {
+		t.Fatalf("expected latest writer session, got %q", observation.SessionID)
+	}
+	if observation.RevisionCount != 2 {
+		t.Fatalf("expected revision_count=2, got %d", observation.RevisionCount)
+	}
+
+	context, err := s.FormatCompactionContext("session-a")
+	if err != nil {
+		t.Fatalf("format session A compaction context: %v", err)
+	}
+	if strings.Contains(context, "content-written-by-session-b") {
+		t.Fatalf("session A compaction context leaked session B content: %s", context)
+	}
+
+	observations, err := s.AllObservations("engram", "project", 10)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("expected one topic observation, got %d", len(observations))
+	}
+}
+
 func TestDifferentTopicsDoNotReplaceEachOther(t *testing.T) {
 	s := newTestStore(t)
 
@@ -4591,7 +4657,7 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 		}
 		origExec := s.hooks.exec
 		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
-			if strings.Contains(query, "SET type = ?") {
+			if strings.Contains(query, "SET session_id = ?") {
 				return nil, errors.New("forced topic update error")
 			}
 			return origExec(db, query, args...)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -654,6 +654,100 @@ func TestPinnedObservationsAndFormatContextPriority(t *testing.T) {
 	}
 }
 
+func TestFormatCompactionContextIsSessionScoped(t *testing.T) {
+	s := newTestStore(t)
+
+	for _, sessionID := range []string{"session-a", "session-b"} {
+		if err := s.CreateSession(sessionID, "engram", "/tmp/engram"); err != nil {
+			t.Fatalf("create %s: %v", sessionID, err)
+		}
+	}
+	if err := s.EndSession("session-a", "summary-a"); err != nil {
+		t.Fatalf("end session A: %v", err)
+	}
+	if err := s.EndSession("session-b", "summary-b"); err != nil {
+		t.Fatalf("end session B: %v", err)
+	}
+
+	addObservation := func(sessionID, title, content string, pinned bool) {
+		t.Helper()
+		id, err := s.AddObservation(AddObservationParams{
+			SessionID: sessionID,
+			Type:      "decision",
+			Title:     title,
+			Content:   content,
+			Project:   "engram",
+			Scope:     "project",
+		})
+		if err != nil {
+			t.Fatalf("add %s observation: %v", sessionID, err)
+		}
+		if pinned {
+			if err := s.PinObservation(id); err != nil {
+				t.Fatalf("pin %s observation: %v", sessionID, err)
+			}
+		}
+	}
+	addObservation("session-a", "pinned-a", "pinned-content-a", true)
+	addObservation("session-a", "recent-a", "recent-content-a", false)
+	addObservation("session-b", "pinned-b", "pinned-content-b", true)
+	addObservation("session-b", "recent-b", "recent-content-b", false)
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "session-a",
+		Type:      "decision",
+		Title:     "foreign-project-observation",
+		Content:   "must-not-appear",
+		Project:   "foreign",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add foreign-project observation: %v", err)
+	}
+
+	for _, prompt := range []struct{ sessionID, content string }{
+		{"session-a", "prompt-a"},
+		{"session-b", "prompt-b"},
+		{"session-a", "foreign-project-prompt"},
+	} {
+		project := "engram"
+		if prompt.content == "foreign-project-prompt" {
+			project = "foreign"
+		}
+		if _, err := s.AddPrompt(AddPromptParams{SessionID: prompt.sessionID, Content: prompt.content, Project: project}); err != nil {
+			t.Fatalf("add %s: %v", prompt.content, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		sessionID string
+		included  []string
+		excluded  []string
+	}{
+		{"session-a", []string{"session-a", "summary-a", "pinned-a", "recent-a", "prompt-a"}, []string{"session-b", "summary-b", "pinned-b", "recent-b", "prompt-b", "foreign-project-observation", "foreign-project-prompt"}},
+		{"session-b", []string{"session-b", "summary-b", "pinned-b", "recent-b", "prompt-b"}, []string{"session-a", "summary-a", "pinned-a", "recent-a", "prompt-a"}},
+	} {
+		t.Run(tc.sessionID, func(t *testing.T) {
+			context, err := s.FormatCompactionContext(tc.sessionID)
+			if err != nil {
+				t.Fatalf("format compaction context: %v", err)
+			}
+			for _, value := range tc.included {
+				if !strings.Contains(context, value) {
+					t.Errorf("context missing %q:\n%s", value, context)
+				}
+			}
+			for _, value := range tc.excluded {
+				if strings.Contains(context, value) {
+					t.Errorf("context leaked %q:\n%s", value, context)
+				}
+			}
+		})
+	}
+
+	if _, err := s.FormatCompactionContext("missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("missing session error = %v, want sql.ErrNoRows", err)
+	}
+}
+
 func TestTopicKeyUpsertUpdatesSameTopicWithoutCreatingNewRow(t *testing.T) {
 	s := newTestStore(t)
 

--- a/plugin/opencode/engram.test.mjs
+++ b/plugin/opencode/engram.test.mjs
@@ -70,6 +70,7 @@ function assertNoRegistration(runtime, message) {
 async function createRuntime(t, {
   sessionGet = async ({ path }) => sdkResult(session(path.id)),
   registrationResponse,
+  contextResponse,
 } = {}) {
   const originalFetch = globalThis.fetch
   const originalBun = globalThis.Bun
@@ -88,12 +89,13 @@ async function createRuntime(t, {
     const path = new URL(url).pathname
     if (path === "/health") return { ok: true, async json() { return { status: "ok" } } }
     const body = init?.body ? JSON.parse(init.body) : undefined
-    requests.push({ path, body })
+    requests.push({ path, url: String(url), body })
     if (path === "/sessions") {
       registeredIDs.push(body.id)
       if (registrationResponse) return registrationResponse(registeredIDs.length)
       return httpResponse()
     }
+    if (path === "/context/compaction" && contextResponse) return contextResponse()
     return httpResponse({})
   }
 
@@ -488,12 +490,19 @@ test("Task passive capture resolves an unobserved child and attributes the root"
 })
 
 test("compaction resolves an unobserved child and registers only its root", async (t) => {
-  const runtime = await createRuntime(t, { sessionGet: sdkLookup(CHILD_SESSIONS) })
+  const runtime = await createRuntime(t, {
+    sessionGet: sdkLookup(CHILD_SESSIONS),
+    contextResponse: () => httpResponse({ context: "root-only context" }),
+  })
   const output = { context: [] }
   await runtime.compact({ sessionID: "leaf" }, output)
 
   assert.deepEqual(runtime.sessionGetIDs, ["leaf", "root"])
   assert.deepEqual(runtime.registeredIDs, ["root"], "compaction must never register the child")
+  const compactionContext = runtime.requests.find(({ path }) => path === "/context/compaction")
+  assert.equal(new URL(compactionContext?.url).searchParams.get("session_id"), "root")
+  assert.equal(runtime.requests.some(({ path }) => path === "/context"), false)
+  assert.ok(output.context.includes("root-only context"))
   assert.match(output.context.at(-1), /FIRST ACTION REQUIRED/)
 })
 
@@ -517,9 +526,22 @@ test("compaction skips invalid or missing sessions and still injects recovery co
       await runtime.compact({ sessionID: "runtime" }, output)
 
       assertNoRegistration(runtime)
+      assert.equal(runtime.requests.some(({ path }) => path === "/context/compaction" || path === "/context"), false)
       assert.match(output.context.at(-1), /FIRST ACTION REQUIRED/)
     })
   }
+})
+
+test("compaction fails closed when the session context endpoint is unavailable", async (t) => {
+  const runtime = await createRuntime(t, {
+    contextResponse: () => httpResponse({ context: "must not inject" }, false),
+  })
+  const output = { context: [] }
+  await runtime.compact({ sessionID: "runtime" }, output)
+
+  assert.equal(runtime.requests.filter(({ path }) => path === "/context/compaction").length, 1)
+  assert.equal(runtime.requests.some(({ path }) => path === "/context"), false)
+  assert.equal(output.context.includes("must not inject"), false)
 })
 
 test("automatic hooks omit writes when ownership changes during registration", async (t) => {

--- a/plugin/opencode/engram.test.mjs
+++ b/plugin/opencode/engram.test.mjs
@@ -506,6 +506,14 @@ test("compaction resolves an unobserved child and registers only its root", asyn
   assert.match(output.context.at(-1), /FIRST ACTION REQUIRED/)
 })
 
+test("post-compaction protocol relies on injected session-only context", () => {
+	const afterCompaction = source.match(/### AFTER COMPACTION[\s\S]*?Do not skip step 1\.[\s\S]*?memory\./)?.[0]
+  assert.ok(afterCompaction, "AFTER COMPACTION protocol must exist")
+  assert.match(afterCompaction, /session-only compaction context has already been injected/)
+  assert.match(afterCompaction, /use it only when explicitly requested/)
+  assert.doesNotMatch(afterCompaction, /\d\.\s+(?:Then )?call `mem_context`/)
+})
+
 test("compaction skips invalid or missing sessions and still injects recovery context", async (t) => {
   for (const scenario of [
     {

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -122,7 +122,7 @@ This is NOT optional. If you skip this, the next session starts blind.
 
 If you see a message about compaction or context reset, or if you see "FIRST ACTION REQUIRED" in your context:
 1. IMMEDIATELY call \`mem_session_summary\` with the compacted summary content — this persists what was done before compaction
-2. Then call \`mem_context\` to recover any additional context from previous sessions
+2. The session-only compaction context has already been injected. Do not automatically call \`mem_context\`, which is project-scoped; use it only when explicitly requested.
 3. Only THEN continue working
 
 Do not skip step 1. Without it, everything done before compaction is lost from memory.

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -678,17 +678,21 @@ export const Engram: Plugin = async (ctx) => {
     // 3. Tell the compressor to remind the new agent to save memories
 
     "experimental.session.compacting": async (input, output) => {
+      let sessionId = ""
       if (input.sessionID) {
-        const sessionId = await resolveAuthoritativeSessionID(input.sessionID)
-        if (sessionId) await ensureSession(sessionId)
+        sessionId = await resolveAuthoritativeSessionID(input.sessionID)
       }
 
-      // Inject context from previous sessions
-      const data = await engramFetch(
-        `/context?project=${encodeURIComponent(project)}`
-      )
-      if (data?.context) {
-        output.context.push(data.context)
+      // Runtime compaction context must never cross session boundaries. If the
+      // authoritative session cannot be resolved or registered, skip this
+      // injection rather than falling back to project-wide manual context.
+      if (sessionId && await ensureSession(sessionId)) {
+        const data = await engramFetch(
+          `/context/compaction?session_id=${encodeURIComponent(sessionId)}`
+        )
+        if (data?.context) {
+          output.context.push(data.context)
+        }
       }
 
       // Tell the compressor to instruct the new agent to persist the


### PR DESCRIPTION
## Linked Issue

Closes #748

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Add a dedicated session-scoped compaction context endpoint.
- Make the OpenCode compaction hook fail closed instead of injecting project-wide context.
- Preserve project/scope semantics for manual `/context` and `mem_context`.
- Move evolving `topic_key` attribution to the latest writer session and remove automatic post-compaction `mem_context`.

## Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Compose session-scoped context and keep evolving topic observations attributed to the latest writer. |
| `internal/server/server.go` | Expose `/context/compaction` with safe 400/404 handling. |
| `plugin/opencode/engram.ts` | Request authoritative session context without project-wide fallback. |
| `internal/setup/plugins/opencode/engram.ts` | Keep the embedded OpenCode plugin byte-aligned. |
| Tests and docs | Add A/B isolation, review regressions, failure-path coverage, and contract documentation. |

## Test Plan

- [x] Focused Store, MCP, server E2E, and embedded-plugin tests pass.
- [x] OpenCode plugin tests pass: 38/38.
- [x] `go test -tags=e2e ./internal/server` passed before candidate freeze.
- [ ] `go test ./...` completed locally - the Windows run timed out after 10 minutes; focused affected-package coverage passed.

---

## Automated Checks

These run automatically and all must pass before merge.

| Check | What it verifies | Status |
|-------|-----------------|--------|
| Check Issue Reference | PR body contains `Closes #N` | Pending |
| Check Issue Has status:approved | Linked issue is approved | Pending |
| Check PR Has type:* Label | Exactly one type label | Pending |
| Unit Tests | `go test ./...` | Pending |
| E2E Tests | Server E2E suite | Pending |

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #748`).
- [x] I added exactly one `type:*` label to this PR.
- [x] I ran unit tests locally; the full Windows command timed out and focused suites passed.
- [x] I ran the affected E2E tests locally.
- [x] Docs updated for the behavior change.
- [x] Commits follow Conventional Commits.
- [x] No `Co-Authored-By` trailers.

---

## Notes for Reviewers

- Maintainer approved `size:exception` for this single 510-line PR, including the review correction.
- Native RDD approved both exact candidate trees before their commits; each committed tree is byte-identical to its reviewed candidate.
- RDD advisories are non-blocking follow-up candidates and did not open a correction.
- Rollback is the ordered revert of correction commit `8a71ed3` followed by implementation commit `4ab288a`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added session-specific compaction context retrieval.
  - Compaction context now includes only information associated with the requested session.
  - Context injection targets the authoritative session after successful registration.

- **Bug Fixes**
  - Preserved project-wide behavior for manual context retrieval.
  - Updated topic revisions to reflect the latest writing session.
  - Prevented context injection when sessions cannot be resolved or registered.
  - Added clear handling for missing and unknown sessions.

- **Documentation**
  - Clarified session-scoped compaction and project-scoped manual context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->