### PR TITLE
fix(cli): make project cleanup safe

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1956,6 +1956,47 @@ func findNormalizationEquivalentProjects(name string, existing []string) []proje
 	return matches
 }
 
+// mergedRecordCount reports how many records a merge actually moved. The store
+// validates every source against the canonical name and fail-closes on the ones
+// it cannot prove normalization-equivalent, so a merge can succeed while moving
+// nothing at all. Callers must report that outcome honestly instead of
+// announcing a completed merge.
+func mergedRecordCount(result *store.MergeResult) int64 {
+	if result == nil {
+		return 0
+	}
+	return result.ObservationsUpdated + result.SessionsUpdated + result.PromptsUpdated
+}
+
+// reportUnmergedSources names the selected sources the store left untouched, so
+// a partially applied merge never reads as a complete one.
+func reportUnmergedSources(sources []string, result *store.MergeResult) {
+	merged := make(map[string]bool, len(result.SourcesMerged))
+	for _, name := range result.SourcesMerged {
+		merged[name] = true
+	}
+
+	// SourcesMerged holds the trimmed spelling the store actually rewrote, while
+	// sources holds the raw spellings the operator selected. Only a source that
+	// is literally the canonical name was a no-op by request.
+	var skipped []string
+	seen := make(map[string]bool, len(sources))
+	for _, source := range sources {
+		if strings.TrimSpace(source) == "" || source == result.Canonical {
+			continue
+		}
+		if merged[strings.TrimSpace(source)] || seen[source] {
+			continue
+		}
+		seen[source] = true
+		skipped = append(skipped, source)
+	}
+	if len(skipped) == 0 {
+		return
+	}
+	fmt.Printf("  Not merged (no records moved): %s\n", strings.Join(skipped, ", "))
+}
+
 func cmdProjectsConsolidate(cfg store.Config) {
 	doAll := false
 	dryRun := false
@@ -2067,10 +2108,17 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			fatal(err)
 		}
 
-		fmt.Printf("Done! Merged into %q:\n", result.Canonical)
+		if mergedRecordCount(result) == 0 {
+			fmt.Printf("Nothing merged into %q: the store moved no records for the %d selected project(s).\n",
+				result.Canonical, len(sources))
+			return
+		}
+
+		fmt.Printf("Done! Merged %d project(s) into %q:\n", len(result.SourcesMerged), result.Canonical)
 		fmt.Printf("  Observations: %d\n", result.ObservationsUpdated)
 		fmt.Printf("  Sessions:     %d\n", result.SessionsUpdated)
 		fmt.Printf("  Prompts:      %d\n", result.PromptsUpdated)
+		reportUnmergedSources(sources, result)
 		return
 	}
 
@@ -2188,8 +2236,14 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			fmt.Println()
 			continue
 		}
-		fmt.Printf("  Merged: %d obs, %d sessions, %d prompts\n",
-			result.ObservationsUpdated, result.SessionsUpdated, result.PromptsUpdated)
+		if mergedRecordCount(result) == 0 {
+			fmt.Printf("  Nothing merged into %q: the store moved no records for the %d selected project(s).\n",
+				mergeCanonical, len(sources))
+		} else {
+			fmt.Printf("  Merged: %d obs, %d sessions, %d prompts\n",
+				result.ObservationsUpdated, result.SessionsUpdated, result.PromptsUpdated)
+			reportUnmergedSources(sources, result)
+		}
 
 		if renameTarget != "" && renameTarget != mergeCanonical {
 			migrateResult, err := s.MigrateProject(mergeCanonical, renameTarget)

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -95,7 +95,8 @@ var (
 	storeDeleteProject     = func(s *store.Store, name string, hard bool) (*store.DeleteProjectResult, error) {
 		return s.DeleteProject(name, hard)
 	}
-	storeTimeline = func(s *store.Store, observationID int64, before, after int) (*store.TimelineResult, error) {
+	storePruneProject = func(s *store.Store, name string) (*store.PruneResult, error) { return s.PruneProject(name) }
+	storeTimeline     = func(s *store.Store, observationID int64, before, after int) (*store.TimelineResult, error) {
 		return s.Timeline(observationID, before, after)
 	}
 	storeFormatContext = func(s *store.Store, project, scope string) (string, error) { return s.FormatContext(project, scope) }
@@ -1850,7 +1851,7 @@ func cmdProjects(cfg store.Config) {
 		fmt.Fprintf(os.Stderr, "unknown projects subcommand: %s\n", subCmd)
 		fmt.Fprintln(os.Stderr, "usage: engram projects list")
 		fmt.Fprintln(os.Stderr, "       engram projects consolidate [--all] [--dry-run]")
-		fmt.Fprintln(os.Stderr, "       engram projects prune [--dry-run]")
+		fmt.Fprintln(os.Stderr, "       engram projects prune [--dry-run] [--paths-only]")
 		exitFunc(1)
 	}
 }
@@ -1897,81 +1898,41 @@ type projectGroup struct {
 	Canonical string // suggested canonical (most observations)
 }
 
-// groupSimilarProjects groups projects by name similarity and shared directories.
-// Uses a simple union-find approach.
+// groupSimilarProjects forms deterministic groups from direct name matches.
 func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
-	n := len(projects)
-	if n == 0 {
+	if len(projects) == 0 {
 		return nil
 	}
 
-	// parent[i] holds the root of i's component
-	parent := make([]int, n)
-	for i := range parent {
-		parent[i] = i
-	}
-
-	var find func(int) int
-	find = func(x int) int {
-		if parent[x] != x {
-			parent[x] = find(parent[x])
-		}
-		return parent[x]
-	}
-	union := func(x, y int) {
-		rx, ry := find(x), find(y)
-		if rx != ry {
-			parent[rx] = ry
-		}
-	}
-
-	// Build name-only slice and index map for FindSimilar
-	names := make([]string, n)
-	nameToIndex := make(map[string]int, n)
+	projects = append([]store.ProjectStats(nil), projects...)
+	sort.Slice(projects, func(i, j int) bool { return projects[i].Name < projects[j].Name })
+	names := make([]string, len(projects))
 	for i, p := range projects {
 		names[i] = p.Name
-		nameToIndex[p.Name] = i
 	}
 
-	// Group by name similarity
-	for i := 0; i < n; i++ {
-		similar := project.FindSimilar(projects[i].Name, names, 3)
-		for _, sm := range similar {
-			if j, ok := nameToIndex[sm.Name]; ok {
-				union(i, j)
-			}
-		}
-	}
-
-	// Group by shared directory
-	dirToProjects := make(map[string][]int)
-	for i, p := range projects {
-		for _, dir := range p.Directories {
-			if dir != "" {
-				dirToProjects[dir] = append(dirToProjects[dir], i)
-			}
-		}
-	}
-	for _, idxs := range dirToProjects {
-		for k := 1; k < len(idxs); k++ {
-			union(idxs[0], idxs[k])
-		}
-	}
-
-	// Collect components
-	components := make(map[int][]int)
-	for i := 0; i < n; i++ {
-		root := find(i)
-		components[root] = append(components[root], i)
-	}
-
-	// Build groups — skip singletons (no duplicates)
+	assigned := make([]bool, len(projects))
 	var groups []projectGroup
-	for _, idxs := range components {
-		if len(idxs) < 2 {
+	for i := range projects {
+		if assigned[i] {
 			continue
 		}
-		// Suggest the one with most observations as canonical
+		matches := make(map[string]bool)
+		for _, match := range project.FindSimilar(projects[i].Name, names, 3) {
+			matches[match.Name] = true
+		}
+		idxs := []int{i}
+		for j := i + 1; j < len(projects); j++ {
+			if !assigned[j] && matches[projects[j].Name] {
+				idxs = append(idxs, j)
+			}
+		}
+		if len(idxs) == 1 {
+			continue
+		}
+		for _, idx := range idxs {
+			assigned[idx] = true
+		}
 		bestIdx := idxs[0]
 		for _, idx := range idxs[1:] {
 			if projects[idx].ObservationCount > projects[bestIdx].ObservationCount {
@@ -2038,43 +1999,14 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			fmt.Printf("Note: %q has no existing memories. Merging will move memories into this new project name.\n", canonical)
 		}
 
-		// Find candidates by name similarity
+		// Find candidates by name similarity.
 		similar := project.FindSimilar(canonical, allNames, 3)
 
-		// Also find candidates by shared directory (catches renames like sdd-agent-team → agent-teams-lite)
+		// Load observation counts for the candidate display.
 		allStats, _ := s.ListProjectsWithStats()
 		statsMap := make(map[string]store.ProjectStats)
-		var cwdDirs []string // directories for the canonical project
 		for _, ps := range allStats {
 			statsMap[ps.Name] = ps
-			if ps.Name == canonical {
-				cwdDirs = ps.Directories
-			}
-		}
-		// If canonical has no stats yet, use cwd as its directory
-		if len(cwdDirs) == 0 {
-			cwdDirs = []string{cwd}
-		}
-		// Find projects sharing a directory with the canonical
-		similarNames := make(map[string]bool)
-		for _, sm := range similar {
-			similarNames[sm.Name] = true
-		}
-		for _, ps := range allStats {
-			if ps.Name == canonical || similarNames[ps.Name] {
-				continue
-			}
-			for _, d := range ps.Directories {
-				for _, cd := range cwdDirs {
-					if d == cd {
-						similar = append(similar, project.ProjectMatch{
-							Name:      ps.Name,
-							MatchType: "shared directory",
-						})
-						similarNames[ps.Name] = true
-					}
-				}
-			}
 		}
 
 		if len(similar) == 0 {
@@ -2143,7 +2075,7 @@ func cmdProjectsConsolidate(cfg store.Config) {
 		return
 	}
 
-	// --all mode: group all projects by similarity + shared directories
+	// --all mode: group all projects by direct name similarity.
 	projects, err := s.ListProjectsWithStats()
 	if err != nil {
 		fatal(err)
@@ -2257,9 +2189,13 @@ func cmdProjectsConsolidate(cfg store.Config) {
 
 func cmdProjectsPrune(cfg store.Config) {
 	dryRun := false
+	pathsOnly := false
 	for i := 3; i < len(os.Args); i++ {
-		if os.Args[i] == "--dry-run" {
+		switch os.Args[i] {
+		case "--dry-run":
 			dryRun = true
+		case "--paths-only":
+			pathsOnly = true
 		}
 	}
 
@@ -2274,15 +2210,21 @@ func cmdProjectsPrune(cfg store.Config) {
 		fatal(err)
 	}
 
-	// Find projects with 0 observations
+	// Find projects with 0 observations.
 	var candidates []store.ProjectStats
 	for _, ps := range allStats {
-		if ps.ObservationCount == 0 {
-			candidates = append(candidates, ps)
+		if ps.ObservationCount != 0 || (pathsOnly && !isPathLikeProjectName(ps.Name)) {
+			continue
 		}
+		candidates = append(candidates, ps)
 	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Name < candidates[j].Name })
 
 	if len(candidates) == 0 {
+		if pathsOnly {
+			fmt.Println("No path-named projects to prune.")
+			return
+		}
 		fmt.Println("No empty projects to prune.")
 		return
 	}
@@ -2329,17 +2271,23 @@ func cmdProjectsPrune(cfg store.Config) {
 
 	totalSessions := int64(0)
 	totalPrompts := int64(0)
+	successful := 0
 	for _, ps := range selected {
-		result, err := s.PruneProject(ps.Name)
+		result, err := storePruneProject(s, ps.Name)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error pruning %q: %v\n", ps.Name, err)
 			continue
 		}
+		successful++
 		totalSessions += result.SessionsDeleted
 		totalPrompts += result.PromptsDeleted
 	}
 
-	fmt.Printf("\nPruned %d project(s): %d sessions, %d prompts removed.\n", len(selected), totalSessions, totalPrompts)
+	fmt.Printf("\nPruned %d project(s): %d sessions, %d prompts removed.\n", successful, totalSessions, totalPrompts)
+}
+
+func isPathLikeProjectName(name string) bool {
+	return strings.ContainsAny(name, `/\`)
 }
 
 // cmdSetup classifies os.Args[2:] with a two-pass, order-independent

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2636,6 +2636,10 @@ Commands:
                      Merge similar project names into one canonical name
                        --all      Scan ALL projects for similar name groups
                        --dry-run  Preview what would be merged (no changes)
+  projects prune [--dry-run] [--paths-only]
+                     Remove projects with no observations
+                       --dry-run     Preview projects without removing data
+                       --paths-only  Limit pruning to project names containing / or \
   setup [agent]      Install/setup agent integration (opencode, pi, claude-code,
                      gemini-cli, codex, antigravity-cli, windsurf, qwen, kiro,
                      cursor, vscode-copilot, kilocode)

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1022,7 +1022,7 @@ func TestCmdProjectsConsolidateSingleProject(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected no stderr, got: %q", stderr)
 	}
-	if !strings.Contains(stdout, "Merged into") {
+	if !strings.Contains(stdout, `Merged 1 project(s) into "engram"`) {
 		t.Fatalf("expected merge result, got: %q", stdout)
 	}
 
@@ -1285,6 +1285,279 @@ func TestGroupSimilarProjectsUsesNormalizationEquivalenceAndNormalizedCanonical(
 	}
 	if groups[0].Canonical != "engram" {
 		t.Fatalf("canonical = %q, want normalized group key %q", groups[0].Canonical, "engram")
+	}
+}
+
+// projectRecordCounts reports how many observations, sessions and prompts are
+// stored under an exact project spelling, so tests can compare the counts the
+// CLI printed against the records that actually moved.
+func projectRecordCounts(t *testing.T, cfg store.Config, project string) (observations, sessions, prompts int) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer db.Close()
+
+	queries := []struct {
+		query string
+		dest  *int
+	}{
+		{`SELECT COUNT(*) FROM observations WHERE project = ? AND deleted_at IS NULL`, &observations},
+		{`SELECT COUNT(*) FROM sessions WHERE project = ?`, &sessions},
+		{`SELECT COUNT(*) FROM user_prompts WHERE project = ?`, &prompts},
+	}
+	for _, q := range queries {
+		if err := db.QueryRow(q.query, project).Scan(q.dest); err != nil {
+			t.Fatalf("count %q rows: %v", project, err)
+		}
+	}
+	return observations, sessions, prompts
+}
+
+func TestCmdProjectsConsolidateCaseOnlyVariantReportsMovedRecords(t *testing.T) {
+	cfg := testConfig(t)
+
+	// A case-only legacy spelling must actually move its records, and the
+	// printed counts must match what moved.
+	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	mustSeedPrompt(t, cfg, "s-legacy", "legacy-source")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
+
+	old := detectProject
+	detectProject = func(string) string { return "engram" }
+	t.Cleanup(func() { detectProject = old })
+
+	oldScan := scanInputLine
+	t.Cleanup(func() { scanInputLine = oldScan })
+	scanInputLine = func(a ...any) (int, error) {
+		if ptr, ok := a[0].(*string); ok {
+			*ptr = "all"
+		}
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "projects", "consolidate")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+
+	for _, want := range []string{
+		`Done! Merged 1 project(s) into "engram"`,
+		"Observations: 1",
+		"Sessions:     1",
+		"Prompts:      1",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected %q in merge report, got: %q", want, stdout)
+		}
+	}
+
+	// The reported counts must match the records that actually moved.
+	if obs, sessions, prompts := projectRecordCounts(t, cfg, "ENGRAM"); obs+sessions+prompts != 0 {
+		t.Fatalf("legacy spelling still holds records: obs=%d sessions=%d prompts=%d", obs, sessions, prompts)
+	}
+	obs, sessions, prompts := projectRecordCounts(t, cfg, "engram")
+	if obs != 2 || sessions != 2 || prompts != 1 {
+		t.Fatalf("canonical records = obs:%d sessions:%d prompts:%d, want 2/2/1", obs, sessions, prompts)
+	}
+}
+
+func TestCmdProjectsConsolidateReportsNothingMergedWhenNoRecordsMove(t *testing.T) {
+	cfg := testConfig(t)
+
+	// " engram " normalizes to the canonical name, so it is offered as a
+	// candidate, but the store fail-closes on it because its trimmed spelling
+	// is the canonical name itself. The CLI must not announce completion.
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", " engram ")
+
+	old := detectProject
+	detectProject = func(string) string { return "engram" }
+	t.Cleanup(func() { detectProject = old })
+
+	oldScan := scanInputLine
+	t.Cleanup(func() { scanInputLine = oldScan })
+	scanInputLine = func(a ...any) (int, error) {
+		if ptr, ok := a[0].(*string); ok {
+			*ptr = "all"
+		}
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "projects", "consolidate")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if strings.Contains(stdout, "Done!") {
+		t.Fatalf("completion reported without moving records: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Nothing merged") {
+		t.Fatalf("expected an honest no-op report, got: %q", stdout)
+	}
+
+	// The records must still be reachable under their original spelling.
+	if obs, sessions, _ := projectRecordCounts(t, cfg, " engram "); obs != 1 || sessions != 1 {
+		t.Fatalf("legacy records lost: obs=%d sessions=%d", obs, sessions)
+	}
+}
+
+func TestCmdProjectsConsolidateAllCaseOnlyVariantReportsMovedRecords(t *testing.T) {
+	cfg := testConfig(t)
+
+	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	mustSeedPrompt(t, cfg, "s-legacy", "legacy-source")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
+
+	oldScan := scanInputLine
+	t.Cleanup(func() { scanInputLine = oldScan })
+	scanInputLine = func(a ...any) (int, error) {
+		if ptr, ok := a[0].(*string); ok {
+			*ptr = "all"
+		}
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "projects", "consolidate", "--all")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, "Merged: 1 obs, 1 sessions, 1 prompts") {
+		t.Fatalf("expected counts matching the moved records, got: %q", stdout)
+	}
+	if obs, sessions, prompts := projectRecordCounts(t, cfg, "ENGRAM"); obs+sessions+prompts != 0 {
+		t.Fatalf("legacy spelling still holds records: obs=%d sessions=%d prompts=%d", obs, sessions, prompts)
+	}
+	obs, sessions, prompts := projectRecordCounts(t, cfg, "engram")
+	if obs != 2 || sessions != 2 || prompts != 1 {
+		t.Fatalf("canonical records = obs:%d sessions:%d prompts:%d, want 2/2/1", obs, sessions, prompts)
+	}
+}
+
+func TestCmdProjectsConsolidateAllReportsNothingMergedWhenNoRecordsMove(t *testing.T) {
+	cfg := testConfig(t)
+
+	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", " engram ")
+
+	oldScan := scanInputLine
+	t.Cleanup(func() { scanInputLine = oldScan })
+	scanInputLine = func(a ...any) (int, error) {
+		if ptr, ok := a[0].(*string); ok {
+			*ptr = "all"
+		}
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "projects", "consolidate", "--all")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if strings.Contains(stdout, "Merged:") {
+		t.Fatalf("merge reported without moving records: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Nothing merged") {
+		t.Fatalf("expected an honest no-op report, got: %q", stdout)
+	}
+	if obs, sessions, _ := projectRecordCounts(t, cfg, " engram "); obs != 1 || sessions != 1 {
+		t.Fatalf("legacy records lost: obs=%d sessions=%d", obs, sessions)
+	}
+}
+
+func TestCmdProjectsConsolidateAllNamesSourcesTheStoreLeftUntouched(t *testing.T) {
+	cfg := testConfig(t)
+
+	// "ENGRAM" moves; " engram " is fail-closed by the store because its
+	// trimmed spelling is the canonical name. A partial merge must say so.
+	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
+	mustSeedObservation(t, cfg, "s-upper", "upper-source", "note", "upper note", "content", "project")
+	mustSeedObservation(t, cfg, "s-padded", "padded-source", "note", "padded note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "upper-source", "ENGRAM")
+	rewriteLegacyProjectName(t, cfg, "padded-source", " engram ")
+
+	oldScan := scanInputLine
+	t.Cleanup(func() { scanInputLine = oldScan })
+	scanInputLine = func(a ...any) (int, error) {
+		if ptr, ok := a[0].(*string); ok {
+			*ptr = "all"
+		}
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "projects", "consolidate", "--all")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, "Merged: 1 obs, 1 sessions, 0 prompts") {
+		t.Fatalf("expected counts for the single moved source, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Not merged (no records moved):  engram ") {
+		t.Fatalf("expected the untouched source to be named, got: %q", stdout)
+	}
+	if obs, sessions, _ := projectRecordCounts(t, cfg, " engram "); obs != 1 || sessions != 1 {
+		t.Fatalf("untouched source lost records: obs=%d sessions=%d", obs, sessions)
+	}
+}
+
+func TestCmdProjectsConsolidateLeavesFuzzyMatchesUnmerged(t *testing.T) {
+	// Substring and Levenshtein neighbours are not normalization-equivalent, so
+	// neither cleanup route may merge them or touch their records.
+	tests := []struct {
+		name      string
+		canonical string
+		candidate string
+	}{
+		{name: "substring", canonical: "engram", candidate: "engram-memory"},
+		{name: "levenshtein", canonical: "engram", candidate: "engramm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, args := range [][]string{
+				{"engram", "projects", "consolidate"},
+				{"engram", "projects", "consolidate", "--all"},
+			} {
+				cfg := testConfig(t)
+				mustSeedObservation(t, cfg, "s-canonical", tt.canonical, "note", "canonical", "content", "project")
+				mustSeedObservation(t, cfg, "s-candidate", tt.candidate, "note", "candidate", "content", "project")
+
+				old := detectProject
+				detectProject = func(string) string { return tt.canonical }
+				t.Cleanup(func() { detectProject = old })
+
+				oldScan := scanInputLine
+				t.Cleanup(func() { scanInputLine = oldScan })
+				scanInputLine = func(a ...any) (int, error) {
+					if ptr, ok := a[0].(*string); ok {
+						*ptr = "all"
+					}
+					return 1, nil
+				}
+
+				withArgs(t, args...)
+				stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+				if stderr != "" {
+					t.Fatalf("%v: expected no stderr, got: %q", args, stderr)
+				}
+				if !strings.Contains(stdout, "No similar") {
+					t.Fatalf("%v: fuzzy candidate offered for merge: %q", args, stdout)
+				}
+				for _, project := range []string{tt.canonical, tt.candidate} {
+					if obs, sessions, _ := projectRecordCounts(t, cfg, project); obs != 1 || sessions != 1 {
+						t.Fatalf("%v: %q records changed: obs=%d sessions=%d", args, project, obs, sessions)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1005,6 +1005,141 @@ func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	}
 }
 
+func TestGroupSimilarProjectsIgnoresSharedDirectoriesAndTransitiveMatches(t *testing.T) {
+	for _, projects := range [][]store.ProjectStats{
+		{{Name: "kubernetes", Directories: []string{"/shared"}}, {Name: "photoshop", Directories: []string{"/shared"}}},
+		{{Name: "kubernetes", Directories: []string{"/shared"}}, {Name: "photoshop", Directories: []string{"/shared"}}, {Name: "wireguard", Directories: []string{"/shared"}}},
+		{{Name: "kubernetes", Directories: []string{"/one"}}, {Name: "photoshop", Directories: []string{"/one", "/two"}}, {Name: "wireguard", Directories: []string{"/two"}}},
+	} {
+		if groups := groupSimilarProjects(projects); len(groups) != 0 {
+			t.Fatalf("directory-only projects grouped: %+v", groups)
+		}
+	}
+
+	projects := []store.ProjectStats{
+		{Name: "alpha", ObservationCount: 3, Directories: []string{"/shared"}},
+		{Name: "alpha-old", ObservationCount: 2, Directories: []string{"/shared"}},
+		{Name: "beta", ObservationCount: 1, Directories: []string{"/shared"}},
+		{Name: "beta-old", ObservationCount: 1, Directories: []string{"/shared"}},
+		{Name: "gamma", ObservationCount: 1, Directories: []string{"/shared"}},
+	}
+
+	groups := groupSimilarProjects(projects)
+	if len(groups) != 2 {
+		t.Fatalf("groups = %+v, want two direct-name groups", groups)
+	}
+	if got := groups[0].Names; strings.Join(got, ",") != "alpha,alpha-old" {
+		t.Fatalf("first group = %v, want [alpha alpha-old]", got)
+	}
+	if got := groups[1].Names; strings.Join(got, ",") != "beta,beta-old" {
+		t.Fatalf("second group = %v, want [beta beta-old]", got)
+	}
+
+	chain := []store.ProjectStats{
+		{Name: "abcdefghij", ObservationCount: 3},
+		{Name: "abcXXXghij", ObservationCount: 2},
+		{Name: "abcXXXYYYj", ObservationCount: 1},
+	}
+	groups = groupSimilarProjects(chain)
+	if len(groups) != 1 || strings.Join(groups[0].Names, ",") != "abcXXXYYYj,abcXXXghij" {
+		t.Fatalf("transitive-only member must not be grouped: %+v", groups)
+	}
+}
+
+func TestCmdProjectsConsolidateSingleProjectIgnoresSharedDirectory(t *testing.T) {
+	cfg := testConfig(t)
+	mustSeedObservation(t, cfg, "s-canonical", "canonical", "note", "canonical", "content", "project")
+	mustSeedObservation(t, cfg, "s-unrelated", "unrelated", "note", "unrelated", "content", "project")
+
+	old := detectProject
+	detectProject = func(string) string { return "canonical" }
+	t.Cleanup(func() { detectProject = old })
+
+	withArgs(t, "engram", "projects", "consolidate", "--dry-run")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, "No similar") || strings.Contains(stdout, "unrelated") {
+		t.Fatalf("shared directory must not create a candidate: %q", stdout)
+	}
+}
+
+func TestCmdProjectsPrunePathsOnlyDryRun(t *testing.T) {
+	cfg := testConfig(t)
+	pathProject := `c:\workspace\orphan`
+	mustSeedSession(t, cfg, "s-path", pathProject)
+	mustSeedSession(t, cfg, "s-ordinary", "ordinary-empty")
+	mustSeedObservation(t, cfg, "s-active", "active-project", "note", "active", "content", "project")
+
+	withArgs(t, "engram", "projects", "prune", "--paths-only", "--dry-run")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsPrune(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, pathProject) || strings.Contains(stdout, "ordinary-empty") || strings.Contains(stdout, "active-project") {
+		t.Fatalf("paths-only candidates = %q", stdout)
+	}
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+	stats, err := s.ListProjectsWithStats()
+	if err != nil {
+		t.Fatalf("ListProjectsWithStats: %v", err)
+	}
+	if len(stats) != 3 {
+		t.Fatalf("dry-run mutated projects: %+v", stats)
+	}
+}
+
+func TestCmdProjectsPruneWithoutPathsOnlyKeepsOrdinaryBehavior(t *testing.T) {
+	cfg := testConfig(t)
+	mustSeedSession(t, cfg, "s-path", `c:\workspace\orphan`)
+	mustSeedSession(t, cfg, "s-ordinary", "ordinary-empty")
+
+	withArgs(t, "engram", "projects", "prune", "--dry-run")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsPrune(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, `c:\workspace\orphan`) || !strings.Contains(stdout, "ordinary-empty") {
+		t.Fatalf("ordinary prune candidates = %q", stdout)
+	}
+}
+
+func TestCmdProjectsPruneReportsOnlySuccessfulProjects(t *testing.T) {
+	cfg := testConfig(t)
+	mustSeedSession(t, cfg, "s-success", "success-empty")
+	mustSeedSession(t, cfg, "s-failure", "failure-empty")
+
+	oldPrune := storePruneProject
+	storePruneProject = func(s *store.Store, project string) (*store.PruneResult, error) {
+		if project == "failure-empty" {
+			return nil, errors.New("forced failure")
+		}
+		return oldPrune(s, project)
+	}
+	t.Cleanup(func() { storePruneProject = oldPrune })
+	oldScan := scanInputLine
+	scanInputLine = func(a ...any) (int, error) {
+		*a[0].(*string) = "all"
+		return 1, nil
+	}
+	t.Cleanup(func() { scanInputLine = oldScan })
+
+	withArgs(t, "engram", "projects", "prune")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsPrune(cfg) })
+	if !strings.Contains(stderr, `Error pruning "failure-empty": forced failure`) {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, "Pruned 1 project(s): 1 sessions, 0 prompts removed.") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
 func TestCmdProjectsAllNoGroups(t *testing.T) {
 	cfg := testConfig(t)
 

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1095,6 +1095,71 @@ func TestCmdProjectsPrunePathsOnlyDryRun(t *testing.T) {
 	}
 }
 
+func TestCmdProjectsPrunePathsOnly(t *testing.T) {
+	cfg := testConfig(t)
+	forwardSlashProject := "/tmp/orphan"
+	backslashProject := `c:\workspace\orphan`
+	mustSeedPrompt(t, cfg, "s-forward-slash", forwardSlashProject)
+	mustSeedPrompt(t, cfg, "s-backslash", backslashProject)
+	mustSeedSession(t, cfg, "s-ordinary", "ordinary-empty")
+	mustSeedObservation(t, cfg, "s-active", "active-project", "note", "active", "content", "project")
+
+	oldScan := scanInputLine
+	scanInputLine = func(a ...any) (int, error) {
+		*a[0].(*string) = "all"
+		return 1, nil
+	}
+	t.Cleanup(func() { scanInputLine = oldScan })
+
+	withArgs(t, "engram", "projects", "prune", "--paths-only")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsPrune(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	for _, project := range []string{forwardSlashProject, backslashProject} {
+		if !strings.Contains(stdout, project) {
+			t.Fatalf("paths-only output missing %q: %q", project, stdout)
+		}
+	}
+	if strings.Contains(stdout, "ordinary-empty") || strings.Contains(stdout, "active-project") {
+		t.Fatalf("paths-only output included a retained project: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Pruned 2 project(s): 2 sessions, 2 prompts removed.") {
+		t.Fatalf("prune result = %q", stdout)
+	}
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+	for _, sessionID := range []string{"s-forward-slash", "s-backslash"} {
+		if _, err := s.GetSession(sessionID); err == nil {
+			t.Fatalf("pruned session %q still exists", sessionID)
+		}
+	}
+	stats, err := s.ListProjectsWithStats()
+	if err != nil {
+		t.Fatalf("ListProjectsWithStats: %v", err)
+	}
+	remaining := make(map[string]store.ProjectStats, len(stats))
+	for _, ps := range stats {
+		remaining[ps.Name] = ps
+	}
+	if _, ok := remaining[forwardSlashProject]; ok {
+		t.Fatalf("pruned project %q still has data: %+v", forwardSlashProject, remaining[forwardSlashProject])
+	}
+	if _, ok := remaining[backslashProject]; ok {
+		t.Fatalf("pruned project %q still has data: %+v", backslashProject, remaining[backslashProject])
+	}
+	if ordinary, ok := remaining["ordinary-empty"]; !ok || ordinary.SessionCount != 1 {
+		t.Fatalf("ordinary empty project = %+v, want one retained session", ordinary)
+	}
+	if active, ok := remaining["active-project"]; !ok || active.ObservationCount != 1 || active.SessionCount != 1 {
+		t.Fatalf("active project = %+v, want one retained observation and session", active)
+	}
+}
+
 func TestCmdProjectsPruneWithoutPathsOnlyKeepsOrdinaryBehavior(t *testing.T) {
 	cfg := testConfig(t)
 	mustSeedSession(t, cfg, "s-path", `c:\workspace\orphan`)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5060,9 +5060,9 @@ type PruneResult struct {
 	PromptsDeleted  int64  `json:"prompts_deleted"`
 }
 
-// PruneProject removes all sessions and prompts for a project that has zero
-// (non-deleted) observations. Returns an error if the project still has
-// observations — the caller must verify first.
+// PruneProject removes prompts and sessions without observations for a project
+// that has zero active observations. Soft-deleted observations and their
+// sessions are retained.
 func (s *Store) PruneProject(project string) (*PruneResult, error) {
 	if project == "" {
 		return nil, fmt.Errorf("project name must not be empty")
@@ -5086,7 +5086,9 @@ func (s *Store) PruneProject(project string) (*PruneResult, error) {
 		}
 		result.PromptsDeleted, _ = res.RowsAffected()
 
-		res, err = s.execHook(tx, `DELETE FROM sessions WHERE project = ?`, project)
+		res, err = s.execHook(tx, `DELETE FROM sessions
+			WHERE project = ?
+			  AND NOT EXISTS (SELECT 1 FROM observations WHERE observations.session_id = sessions.id)`, project)
 		if err != nil {
 			return fmt.Errorf("prune sessions: %w", err)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7369,6 +7369,75 @@ func TestCountObservationsForProject(t *testing.T) {
 	}
 }
 
+func TestPruneProjectPreservesSoftDeletedObservationSession(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("referenced", "empty-project", "/work"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	observationID, err := s.AddObservation(AddObservationParams{SessionID: "referenced", Type: "note", Title: "deleted", Content: "deleted content", Project: "empty-project", Scope: "project"})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	if err := s.DeleteObservation(observationID, false); err != nil {
+		t.Fatalf("DeleteObservation: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "referenced", Content: "remove me", Project: "empty-project"}); err != nil {
+		t.Fatalf("AddPrompt: %v", err)
+	}
+
+	result, err := s.PruneProject("empty-project")
+	if err != nil {
+		t.Fatalf("PruneProject: %v", err)
+	}
+	if result.PromptsDeleted != 1 || result.SessionsDeleted != 0 {
+		t.Fatalf("PruneResult = %+v, want one prompt and no sessions", result)
+	}
+	var sessions, observations, prompts int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sessions WHERE id = 'referenced'`).Scan(&sessions); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM observations WHERE id = ? AND deleted_at IS NOT NULL`, observationID).Scan(&observations); err != nil {
+		t.Fatalf("count observations: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM user_prompts WHERE project = 'empty-project'`).Scan(&prompts); err != nil {
+		t.Fatalf("count prompts: %v", err)
+	}
+	if sessions != 1 || observations != 1 || prompts != 0 {
+		t.Fatalf("rows after prune: sessions=%d observations=%d prompts=%d", sessions, observations, prompts)
+	}
+}
+
+func TestPruneProjectDeletesOnlyUnreferencedSessions(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("referenced", "empty-project", "/work"); err != nil {
+		t.Fatalf("CreateSession referenced: %v", err)
+	}
+	if err := s.CreateSession("unreferenced", "empty-project", "/work"); err != nil {
+		t.Fatalf("CreateSession unreferenced: %v", err)
+	}
+	id, err := s.AddObservation(AddObservationParams{SessionID: "referenced", Type: "note", Title: "deleted", Content: "deleted content", Project: "empty-project", Scope: "project"})
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	if err := s.DeleteObservation(id, false); err != nil {
+		t.Fatalf("DeleteObservation: %v", err)
+	}
+
+	result, err := s.PruneProject("empty-project")
+	if err != nil {
+		t.Fatalf("PruneProject: %v", err)
+	}
+	if result.SessionsDeleted != 1 || result.PromptsDeleted != 0 {
+		t.Fatalf("PruneResult = %+v, want one session and no prompts", result)
+	}
+	var referenced, unreferenced int
+	_ = s.DB().QueryRow(`SELECT COUNT(*) FROM sessions WHERE id = 'referenced'`).Scan(&referenced)
+	_ = s.DB().QueryRow(`SELECT COUNT(*) FROM sessions WHERE id = 'unreferenced'`).Scan(&unreferenced)
+	if referenced != 1 || unreferenced != 0 {
+		t.Fatalf("sessions after prune: referenced=%d unreferenced=%d", referenced, unreferenced)
+	}
+}
+
 // ─── DeleteSession tests ─────────────────────────────────────────────────────
 
 func TestRecentObservationsOrderByCreatedAtBeforeID(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #283

---

## 🏷️ PR Type

- [x] type:bug — Bug fix
- [ ] type:feature — New feature
- [ ] type:docs — Documentation only
- [ ] type:refactor — Code refactoring
- [ ] type:chore — Maintenance, dependencies, tooling
- [ ] type:breaking-change — Breaking change

---

## 📝 Summary

- Replace directory-based project consolidation with deterministic direct name matching in both CLI modes.
- Add path-only cleanup with FK-safe pruning for sessions referenced by soft-deleted observations.
- Report only successful prune operations; this maintainer solution supersedes the incomplete approaches in #445 and #647.

## 📂 Changes

| File | Change |
|------|--------|
| cmd/engram/main.go | Safe consolidation, paths-only pruning, and accurate result reporting |
| cmd/engram/main_test.go | CLI regression coverage for consolidation and pruning |
| internal/store/store.go | Preserve sessions referenced by active or soft-deleted observations |
| internal/store/store_test.go | FK-safe prune and mixed-session coverage |

## 🧪 Test Plan

- [x] Focused CLI regressions: go test ./cmd/engram -run targeted-tests -count=1
- [x] Focused store regressions: go test ./internal/store -run targeted-tests -count=1
- [x] E2E server tests: go test -tags e2e ./internal/server/...
- [ ] Full unit suite: go test ./... exceeded the 10-minute local Windows budget; CI remains authoritative

---

## 🤖 Automated Checks

All repository checks must pass before merge.

---

## ✅ Contributor Checklist

- [x] Linked approved issue #283
- [x] Added exactly one type:* label
- [x] Ran unit tests locally; focused regressions passed and full-suite timeout is disclosed above
- [x] Ran E2E tests locally
- [x] CLI usage output was updated with the behavior change
- [x] Commit follows conventional commits
- [x] No Co-Authored-By trailers

---

## 💬 Notes for Reviewers

Native four-lens RDD approved the exact frozen candidate. The review produced only non-blocking advisory findings and consumed its authority. No contributor branches were modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--paths-only` option to target path-based project names during pruning.
  * Pruning now reports successful removals and individual errors.
  * Consolidation reports moved records and identifies projects with no merged records.
* **Bug Fixes**
  * Consolidation now groups projects only when their names are directly similar.
  * Pruning preserves sessions linked to soft-deleted observations and removes only unreferenced sessions.
* **Documentation**
  * Updated command usage text to describe the new pruning option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->