### PR TITLE
fix(store): prevent semantic dry-run persistence

### DIFF
--- a/internal/store/judge_by_semantic_test.go
+++ b/internal/store/judge_by_semantic_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -252,6 +253,74 @@ func TestJudgeBySemantic_ValidationErrors(t *testing.T) {
 			}
 			if syncID != "" {
 				t.Errorf("expected empty sync_id on validation error; got %q", syncID)
+			}
+		})
+	}
+}
+
+// TestJudgeBySemantic_RejectsNonFiniteConfidence verifies that non-finite
+// confidence values are rejected before relation or sync state can change.
+func TestJudgeBySemantic_RejectsNonFiniteConfidence(t *testing.T) {
+	s := setupRelationsStore(t)
+	_, syncA := addTestObs(t, s, "Some decision", "decision", "testproject", "project")
+	_, syncB := addTestObs(t, s, "Another decision", "decision", "testproject", "project")
+	if err := s.EnrollProject("testproject"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name       string
+		confidence float64
+	}{
+		{name: "NaN", confidence: math.NaN()},
+		{name: "positive infinity", confidence: math.Inf(1)},
+		{name: "negative infinity", confidence: math.Inf(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var relationsBefore, mutationsBefore int
+			if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsBefore); err != nil {
+				t.Fatalf("count relations before judgment: %v", err)
+			}
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+				t.Fatalf("count sync mutations before judgment: %v", err)
+			}
+			syncStateBefore, err := s.GetSyncState(DefaultSyncTargetKey)
+			if err != nil {
+				t.Fatalf("GetSyncState before judgment: %v", err)
+			}
+
+			syncID, err := s.JudgeBySemantic(JudgeBySemanticParams{
+				SourceID:   syncA,
+				TargetID:   syncB,
+				Relation:   RelationCompatible,
+				Confidence: tc.confidence,
+			})
+			if err == nil {
+				t.Fatalf("expected confidence validation error; got sync_id=%q", syncID)
+			}
+			if syncID != "" {
+				t.Errorf("expected empty sync_id; got %q", syncID)
+			}
+
+			var relationsAfter, mutationsAfter int
+			if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsAfter); err != nil {
+				t.Fatalf("count relations after judgment: %v", err)
+			}
+			if relationsAfter != relationsBefore {
+				t.Errorf("relation count = %d, want unchanged %d", relationsAfter, relationsBefore)
+			}
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+				t.Fatalf("count sync mutations after judgment: %v", err)
+			}
+			if mutationsAfter != mutationsBefore {
+				t.Errorf("sync mutation count = %d, want unchanged %d", mutationsAfter, mutationsBefore)
+			}
+			syncStateAfter, err := s.GetSyncState(DefaultSyncTargetKey)
+			if err != nil {
+				t.Fatalf("GetSyncState after judgment: %v", err)
+			}
+			if syncStateAfter.LastEnqueuedSeq != syncStateBefore.LastEnqueuedSeq || syncStateAfter.Lifecycle != syncStateBefore.Lifecycle {
+				t.Errorf("sync state changed: before last_enqueued_seq=%d lifecycle=%q; after last_enqueued_seq=%d lifecycle=%q", syncStateBefore.LastEnqueuedSeq, syncStateBefore.Lifecycle, syncStateAfter.LastEnqueuedSeq, syncStateAfter.Lifecycle)
 			}
 		})
 	}

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -1262,8 +1262,9 @@ func (s *Store) GetRelationStats(project string) (RelationStats, error) {
 // pending relation (after a pre-check to skip already-related pairs).
 //
 // Phase 4 extension: when ScanOptions.Semantic is true, after the FTS5 candidate
-// collection a bounded worker pool calls Runner.Compare on each pair and persists
-// non-"not_conflict" verdicts via JudgeBySemantic. Semantic=false (zero value)
+// collection a bounded worker pool calls Runner.Compare on each pair. Applied
+// scans persist non-"not_conflict" verdicts via JudgeBySemantic, while dry-runs
+// report their semantic results without persistence. Semantic=false (zero value)
 // preserves Phase 3 behaviour exactly.
 //
 // Returns a ScanResult with counts of inspected observations, candidates found,
@@ -1506,6 +1507,20 @@ func (s *Store) ScanProject(opts ScanOptions) (ScanResult, error) {
 					if verdict.Relation == RelationNotConflict {
 						mu.Lock()
 						result.SemanticSkipped++
+						mu.Unlock()
+						return
+					}
+
+					// Dry-runs evaluate and count valid verdicts without persistence.
+					// Invalid verdicts still flow through JudgeBySemantic so existing
+					// semantic error behavior remains unchanged.
+					if !opts.Apply &&
+						pair.sourceSnippet.SyncID != "" &&
+						pair.candidateSnippet.SyncID != "" &&
+						isValidRelationVerb(verdict.Relation) &&
+						verdict.Confidence >= 0 && verdict.Confidence <= 1 {
+						mu.Lock()
+						result.SemanticJudged++
 						mu.Unlock()
 						return
 					}

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -57,6 +58,11 @@ var validRelationVerbs = map[string]bool{
 // isValidRelationVerb returns true if v is an accepted mem_judge relation verb.
 func isValidRelationVerb(v string) bool {
 	return validRelationVerbs[v]
+}
+
+// isValidConfidence returns true when confidence is finite and in [0.0, 1.0].
+func isValidConfidence(confidence float64) bool {
+	return !math.IsNaN(confidence) && !math.IsInf(confidence, 0) && confidence >= 0.0 && confidence <= 1.0
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -746,7 +752,7 @@ func (s *Store) JudgeBySemantic(p JudgeBySemanticParams) (string, error) {
 	if !isValidRelationVerb(p.Relation) {
 		return "", fmt.Errorf("JudgeBySemantic: invalid relation verb %q — must be one of: related, compatible, scoped, conflicts_with, supersedes, not_conflict", p.Relation)
 	}
-	if p.Confidence < 0.0 || p.Confidence > 1.0 {
+	if !isValidConfidence(p.Confidence) {
 		return "", fmt.Errorf("JudgeBySemantic: confidence %v is out of range [0.0, 1.0]", p.Confidence)
 	}
 
@@ -1518,7 +1524,7 @@ func (s *Store) ScanProject(opts ScanOptions) (ScanResult, error) {
 						pair.sourceSnippet.SyncID != "" &&
 						pair.candidateSnippet.SyncID != "" &&
 						isValidRelationVerb(verdict.Relation) &&
-						verdict.Confidence >= 0 && verdict.Confidence <= 1 {
+						isValidConfidence(verdict.Confidence) {
 						mu.Lock()
 						result.SemanticJudged++
 						mu.Unlock()

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -1523,7 +1523,7 @@ func (s *Store) ScanProject(opts ScanOptions) (ScanResult, error) {
 						return
 					}
 
-					if verdict.Relation == RelationNotConflict {
+					if verdict.Relation == RelationNotConflict && isValidConfidence(verdict.Confidence) {
 						mu.Lock()
 						result.SemanticSkipped++
 						mu.Unlock()
@@ -1544,7 +1544,7 @@ func (s *Store) ScanProject(opts ScanOptions) (ScanResult, error) {
 						return
 					}
 
-					// Persist non-not_conflict verdict.
+					// Validate and persist non-skipped verdict.
 					_, judgeErr := s.JudgeBySemantic(JudgeBySemanticParams{
 						SourceID:   pair.sourceSnippet.SyncID,
 						TargetID:   pair.candidateSnippet.SyncID,

--- a/internal/store/scan_semantic_test.go
+++ b/internal/store/scan_semantic_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -153,92 +154,109 @@ func TestScanProject_Semantic_HappyPath(t *testing.T) {
 // TestScanProject_Semantic_DryRunDoesNotPersist verifies that semantic dry-runs
 // evaluate valid verdicts without changing relation or sync state.
 func TestScanProject_Semantic_DryRunDoesNotPersist(t *testing.T) {
-	s := newTestStore(t)
-	_, syncA, _, syncB := seedSimilarPair(t, s, "semantic-dry-run-project")
+	for _, tc := range []struct {
+		name              string
+		confidence        float64
+		wantJudged        bool
+		wantSemanticError bool
+	}{
+		{name: "valid confidence", confidence: 0.9, wantJudged: true},
+		{name: "NaN confidence", confidence: math.NaN(), wantSemanticError: true},
+		{name: "positive infinite confidence", confidence: math.Inf(1), wantSemanticError: true},
+		{name: "negative infinite confidence", confidence: math.Inf(-1), wantSemanticError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			_, syncA, _, syncB := seedSimilarPair(t, s, "semantic-dry-run-project")
 
-	if _, err := s.db.Exec(`
+			if _, err := s.db.Exec(`
 		INSERT INTO memory_relations
 			(sync_id, source_id, target_id, relation, judgment_status, confidence, reason, created_at, updated_at)
 		VALUES (?, ?, ?, 'related', 'pending', 0.2, 'awaiting judgment', datetime('now'), datetime('now'))
-	`, "rel-semantic-dry-run", syncA, syncB); err != nil {
-		t.Fatalf("seed pending relation: %v", err)
-	}
-	if err := s.EnrollProject("semantic-dry-run-project"); err != nil {
-		t.Fatalf("EnrollProject: %v", err)
-	}
+			`, "rel-semantic-dry-run", syncA, syncB); err != nil {
+				t.Fatalf("seed pending relation: %v", err)
+			}
+			if err := s.EnrollProject("semantic-dry-run-project"); err != nil {
+				t.Fatalf("EnrollProject: %v", err)
+			}
 
-	var relationsBefore, mutationsBefore int
-	if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsBefore); err != nil {
-		t.Fatalf("count relations before scan: %v", err)
-	}
-	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
-		t.Fatalf("count sync mutations before scan: %v", err)
-	}
-	syncStateBefore, err := s.GetSyncState(DefaultSyncTargetKey)
-	if err != nil {
-		t.Fatalf("GetSyncState before scan: %v", err)
-	}
+			var relationsBefore, mutationsBefore int
+			if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsBefore); err != nil {
+				t.Fatalf("count relations before scan: %v", err)
+			}
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+				t.Fatalf("count sync mutations before scan: %v", err)
+			}
+			syncStateBefore, err := s.GetSyncState(DefaultSyncTargetKey)
+			if err != nil {
+				t.Fatalf("GetSyncState before scan: %v", err)
+			}
 
-	runner := &verdictRunner{
-		verdict: SemanticVerdict{
-			Relation:   "compatible",
-			Confidence: 0.9,
-			Reasoning:  "both discuss JWT auth",
-			Model:      "haiku",
-		},
-	}
-	result, err := s.ScanProject(ScanOptions{
-		Project:        "semantic-dry-run-project",
-		Apply:          false,
-		Semantic:       true,
-		Concurrency:    1,
-		TimeoutPerCall: 5 * time.Second,
-		MaxSemantic:    10,
-		Runner:         runner,
-		BuildPrompt:    identityPromptBuilder,
-	})
-	if err != nil {
-		t.Fatalf("ScanProject: %v", err)
-	}
-	if result.SemanticJudged == 0 || result.SemanticErrors != 0 {
-		t.Errorf("semantic counters = judged:%d errors:%d, want judged > 0 and errors = 0", result.SemanticJudged, result.SemanticErrors)
-	}
-	if runner.calls == 0 {
-		t.Error("semantic runner was not called during dry-run")
-	}
+			runner := &verdictRunner{
+				verdict: SemanticVerdict{
+					Relation:   "compatible",
+					Confidence: tc.confidence,
+					Reasoning:  "both discuss JWT auth",
+					Model:      "haiku",
+				},
+			}
+			result, err := s.ScanProject(ScanOptions{
+				Project:        "semantic-dry-run-project",
+				Apply:          false,
+				Semantic:       true,
+				Concurrency:    1,
+				TimeoutPerCall: 5 * time.Second,
+				MaxSemantic:    10,
+				Runner:         runner,
+				BuildPrompt:    identityPromptBuilder,
+			})
+			if err != nil {
+				t.Fatalf("ScanProject: %v", err)
+			}
+			if tc.wantJudged && (result.SemanticJudged == 0 || result.SemanticErrors != 0) {
+				t.Errorf("semantic counters = judged:%d errors:%d, want judged > 0 and errors = 0", result.SemanticJudged, result.SemanticErrors)
+			}
+			if tc.wantSemanticError && (result.SemanticJudged != 0 || result.SemanticErrors == 0) {
+				t.Errorf("semantic counters = judged:%d errors:%d, want judged = 0 and errors > 0", result.SemanticJudged, result.SemanticErrors)
+			}
+			if runner.calls == 0 {
+				t.Error("semantic runner was not called during dry-run")
+			}
 
-	var relationsAfter, mutationsAfter int
-	if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsAfter); err != nil {
-		t.Fatalf("count relations after scan: %v", err)
-	}
-	if relationsAfter != relationsBefore {
-		t.Errorf("relation count = %d, want unchanged %d", relationsAfter, relationsBefore)
-	}
+			var relationsAfter, mutationsAfter int
+			if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsAfter); err != nil {
+				t.Fatalf("count relations after scan: %v", err)
+			}
+			if relationsAfter != relationsBefore {
+				t.Errorf("relation count = %d, want unchanged %d", relationsAfter, relationsBefore)
+			}
 
-	var relation, status, reason string
-	var confidence float64
-	if err := s.db.QueryRow(`
+			var relation, status, reason string
+			var confidence float64
+			if err := s.db.QueryRow(`
 		SELECT relation, judgment_status, confidence, reason
 		FROM memory_relations WHERE sync_id = ?
-	`, "rel-semantic-dry-run").Scan(&relation, &status, &confidence, &reason); err != nil {
-		t.Fatalf("load pending relation after scan: %v", err)
-	}
-	if relation != "related" || status != "pending" || confidence != 0.2 || reason != "awaiting judgment" {
-		t.Errorf("pending relation mutated: relation=%q status=%q confidence=%v reason=%q", relation, status, confidence, reason)
-	}
+			`, "rel-semantic-dry-run").Scan(&relation, &status, &confidence, &reason); err != nil {
+				t.Fatalf("load pending relation after scan: %v", err)
+			}
+			if relation != "related" || status != "pending" || confidence != 0.2 || reason != "awaiting judgment" {
+				t.Errorf("pending relation mutated: relation=%q status=%q confidence=%v reason=%q", relation, status, confidence, reason)
+			}
 
-	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
-		t.Fatalf("count sync mutations after scan: %v", err)
-	}
-	if mutationsAfter != mutationsBefore {
-		t.Errorf("sync mutation count = %d, want unchanged %d", mutationsAfter, mutationsBefore)
-	}
-	syncStateAfter, err := s.GetSyncState(DefaultSyncTargetKey)
-	if err != nil {
-		t.Fatalf("GetSyncState after scan: %v", err)
-	}
-	if syncStateAfter.LastEnqueuedSeq != syncStateBefore.LastEnqueuedSeq || syncStateAfter.Lifecycle != syncStateBefore.Lifecycle {
-		t.Errorf("sync state changed: before last_enqueued_seq=%d lifecycle=%q; after last_enqueued_seq=%d lifecycle=%q", syncStateBefore.LastEnqueuedSeq, syncStateBefore.Lifecycle, syncStateAfter.LastEnqueuedSeq, syncStateAfter.Lifecycle)
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+				t.Fatalf("count sync mutations after scan: %v", err)
+			}
+			if mutationsAfter != mutationsBefore {
+				t.Errorf("sync mutation count = %d, want unchanged %d", mutationsAfter, mutationsBefore)
+			}
+			syncStateAfter, err := s.GetSyncState(DefaultSyncTargetKey)
+			if err != nil {
+				t.Fatalf("GetSyncState after scan: %v", err)
+			}
+			if syncStateAfter.LastEnqueuedSeq != syncStateBefore.LastEnqueuedSeq || syncStateAfter.Lifecycle != syncStateBefore.Lifecycle {
+				t.Errorf("sync state changed: before last_enqueued_seq=%d lifecycle=%q; after last_enqueued_seq=%d lifecycle=%q", syncStateBefore.LastEnqueuedSeq, syncStateBefore.Lifecycle, syncStateAfter.LastEnqueuedSeq, syncStateAfter.Lifecycle)
+			}
+		})
 	}
 }
 

--- a/internal/store/scan_semantic_test.go
+++ b/internal/store/scan_semantic_test.go
@@ -307,6 +307,88 @@ func TestScanProject_Semantic_NotConflictSkipped(t *testing.T) {
 	}
 }
 
+// TestScanProject_Semantic_InvalidNotConflictConfidence verifies that invalid
+// not_conflict verdicts are rejected without changing relation or sync state.
+func TestScanProject_Semantic_InvalidNotConflictConfidence(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		apply      bool
+		confidence float64
+	}{
+		{name: "apply/NaN", apply: true, confidence: math.NaN()},
+		{name: "apply/positive infinity", apply: true, confidence: math.Inf(1)},
+		{name: "apply/negative infinity", apply: true, confidence: math.Inf(-1)},
+		{name: "dry-run/NaN", confidence: math.NaN()},
+		{name: "dry-run/positive infinity", confidence: math.Inf(1)},
+		{name: "dry-run/negative infinity", confidence: math.Inf(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			_, _, _, _ = seedSimilarPair(t, s, "invalid-not-conflict-project")
+			if err := s.EnrollProject("invalid-not-conflict-project"); err != nil {
+				t.Fatalf("EnrollProject: %v", err)
+			}
+
+			var relationsBefore, mutationsBefore int
+			if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsBefore); err != nil {
+				t.Fatalf("count relations before scan: %v", err)
+			}
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+				t.Fatalf("count sync mutations before scan: %v", err)
+			}
+			syncStateBefore, err := s.GetSyncState(DefaultSyncTargetKey)
+			if err != nil {
+				t.Fatalf("GetSyncState before scan: %v", err)
+			}
+
+			runner := &verdictRunner{verdict: SemanticVerdict{
+				Relation:   RelationNotConflict,
+				Confidence: tc.confidence,
+			}}
+			result, err := s.ScanProject(ScanOptions{
+				Project:        "invalid-not-conflict-project",
+				Apply:          tc.apply,
+				Semantic:       true,
+				Concurrency:    1,
+				TimeoutPerCall: 5 * time.Second,
+				MaxSemantic:    10,
+				Runner:         runner,
+				BuildPrompt:    identityPromptBuilder,
+			})
+			if err != nil {
+				t.Fatalf("ScanProject: %v", err)
+			}
+			if result.SemanticErrors == 0 || result.SemanticSkipped != 0 || result.SemanticJudged != 0 {
+				t.Errorf("semantic counters = judged:%d skipped:%d errors:%d, want judged:0 skipped:0 errors:>0", result.SemanticJudged, result.SemanticSkipped, result.SemanticErrors)
+			}
+			if runner.calls == 0 {
+				t.Fatal("semantic runner was not called")
+			}
+
+			var relationsAfter, mutationsAfter int
+			if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsAfter); err != nil {
+				t.Fatalf("count relations after scan: %v", err)
+			}
+			if relationsAfter != relationsBefore {
+				t.Errorf("relation count = %d, want unchanged %d", relationsAfter, relationsBefore)
+			}
+			if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+				t.Fatalf("count sync mutations after scan: %v", err)
+			}
+			if mutationsAfter != mutationsBefore {
+				t.Errorf("sync mutation count = %d, want unchanged %d", mutationsAfter, mutationsBefore)
+			}
+			syncStateAfter, err := s.GetSyncState(DefaultSyncTargetKey)
+			if err != nil {
+				t.Fatalf("GetSyncState after scan: %v", err)
+			}
+			if syncStateAfter.LastEnqueuedSeq != syncStateBefore.LastEnqueuedSeq || syncStateAfter.Lifecycle != syncStateBefore.Lifecycle {
+				t.Errorf("sync state changed: before last_enqueued_seq=%d lifecycle=%q; after last_enqueued_seq=%d lifecycle=%q", syncStateBefore.LastEnqueuedSeq, syncStateBefore.Lifecycle, syncStateAfter.LastEnqueuedSeq, syncStateAfter.Lifecycle)
+			}
+		})
+	}
+}
+
 // ─── C.5c — TestScanProject_Semantic_ErrorIsolation ──────────────────────────
 
 // TestScanProject_Semantic_ErrorIsolation verifies that a runner error on one

--- a/internal/store/scan_semantic_test.go
+++ b/internal/store/scan_semantic_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -13,9 +14,14 @@ import (
 // verdictRunner returns a fixed SemanticVerdict for every Compare call.
 type verdictRunner struct {
 	verdict SemanticVerdict
+	mu      sync.Mutex
+	calls   int
 }
 
 func (r *verdictRunner) Compare(_ context.Context, _ string) (SemanticVerdict, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
 	return r.verdict, nil
 }
 
@@ -30,8 +36,8 @@ func (r *errorRunner) Compare(_ context.Context, _ string) (SemanticVerdict, err
 
 // routingRunner routes calls to different runners based on the call index.
 type routingRunner struct {
-	runners  []SemanticRunner
-	callIdx  int
+	runners []SemanticRunner
+	callIdx int
 }
 
 func (r *routingRunner) Compare(ctx context.Context, prompt string) (SemanticVerdict, error) {
@@ -141,6 +147,98 @@ func TestScanProject_Semantic_HappyPath(t *testing.T) {
 	}
 	if count == 0 {
 		t.Error("expected at least 1 relation row with marked_by_actor='engram'; got 0")
+	}
+}
+
+// TestScanProject_Semantic_DryRunDoesNotPersist verifies that semantic dry-runs
+// evaluate valid verdicts without changing relation or sync state.
+func TestScanProject_Semantic_DryRunDoesNotPersist(t *testing.T) {
+	s := newTestStore(t)
+	_, syncA, _, syncB := seedSimilarPair(t, s, "semantic-dry-run-project")
+
+	if _, err := s.db.Exec(`
+		INSERT INTO memory_relations
+			(sync_id, source_id, target_id, relation, judgment_status, confidence, reason, created_at, updated_at)
+		VALUES (?, ?, ?, 'related', 'pending', 0.2, 'awaiting judgment', datetime('now'), datetime('now'))
+	`, "rel-semantic-dry-run", syncA, syncB); err != nil {
+		t.Fatalf("seed pending relation: %v", err)
+	}
+	if err := s.EnrollProject("semantic-dry-run-project"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+
+	var relationsBefore, mutationsBefore int
+	if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsBefore); err != nil {
+		t.Fatalf("count relations before scan: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count sync mutations before scan: %v", err)
+	}
+	syncStateBefore, err := s.GetSyncState(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("GetSyncState before scan: %v", err)
+	}
+
+	runner := &verdictRunner{
+		verdict: SemanticVerdict{
+			Relation:   "compatible",
+			Confidence: 0.9,
+			Reasoning:  "both discuss JWT auth",
+			Model:      "haiku",
+		},
+	}
+	result, err := s.ScanProject(ScanOptions{
+		Project:        "semantic-dry-run-project",
+		Apply:          false,
+		Semantic:       true,
+		Concurrency:    1,
+		TimeoutPerCall: 5 * time.Second,
+		MaxSemantic:    10,
+		Runner:         runner,
+		BuildPrompt:    identityPromptBuilder,
+	})
+	if err != nil {
+		t.Fatalf("ScanProject: %v", err)
+	}
+	if result.SemanticJudged == 0 || result.SemanticErrors != 0 {
+		t.Errorf("semantic counters = judged:%d errors:%d, want judged > 0 and errors = 0", result.SemanticJudged, result.SemanticErrors)
+	}
+	if runner.calls == 0 {
+		t.Error("semantic runner was not called during dry-run")
+	}
+
+	var relationsAfter, mutationsAfter int
+	if err := s.db.QueryRow(`SELECT count(*) FROM memory_relations`).Scan(&relationsAfter); err != nil {
+		t.Fatalf("count relations after scan: %v", err)
+	}
+	if relationsAfter != relationsBefore {
+		t.Errorf("relation count = %d, want unchanged %d", relationsAfter, relationsBefore)
+	}
+
+	var relation, status, reason string
+	var confidence float64
+	if err := s.db.QueryRow(`
+		SELECT relation, judgment_status, confidence, reason
+		FROM memory_relations WHERE sync_id = ?
+	`, "rel-semantic-dry-run").Scan(&relation, &status, &confidence, &reason); err != nil {
+		t.Fatalf("load pending relation after scan: %v", err)
+	}
+	if relation != "related" || status != "pending" || confidence != 0.2 || reason != "awaiting judgment" {
+		t.Errorf("pending relation mutated: relation=%q status=%q confidence=%v reason=%q", relation, status, confidence, reason)
+	}
+
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count sync mutations after scan: %v", err)
+	}
+	if mutationsAfter != mutationsBefore {
+		t.Errorf("sync mutation count = %d, want unchanged %d", mutationsAfter, mutationsBefore)
+	}
+	syncStateAfter, err := s.GetSyncState(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("GetSyncState after scan: %v", err)
+	}
+	if syncStateAfter.LastEnqueuedSeq != syncStateBefore.LastEnqueuedSeq || syncStateAfter.Lifecycle != syncStateBefore.Lifecycle {
+		t.Errorf("sync state changed: before last_enqueued_seq=%d lifecycle=%q; after last_enqueued_seq=%d lifecycle=%q", syncStateBefore.LastEnqueuedSeq, syncStateBefore.Lifecycle, syncStateAfter.LastEnqueuedSeq, syncStateAfter.Lifecycle)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #590

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Prevent semantic dry-run scans from persisting valid verdicts through `JudgeBySemantic`.
- Preserve semantic evaluation, counters, validation errors, and applied-scan behavior.
- Cover relation, pending-judgment, sync-mutation, and sync-state non-persistence.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/relations.go` | Gate semantic persistence on `ScanOptions.Apply`. |
| `internal/store/scan_semantic_test.go` | Verify semantic dry-runs evaluate without changing relation or sync state. |

## 🧪 Test Plan

- [x] Focused semantic tests: `go test ./internal/store -run '^TestScanProject_Semantic_(DryRunDoesNotPersist|HappyPath)$' -count=1`
- [ ] Unit tests pass locally: `go test ./...` — exhausted the 10-minute local limit without output; CI is required for the complete result.
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] `git diff --check` passed before commit.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #590`).
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran the complete unit suite locally; it timed out and is delegated to CI.
- [x] I ran E2E tests locally.
- [x] Docs are not required; behavior is documented in code and regression tests.
- [x] Commits follow conventional commits format.
- [x] No `Co-Authored-By` trailers in commits.

---

## 💬 Notes for Reviewers

- Native RDD approved the exact committed tree with four lenses.
- RDD recorded one non-blocking readability warning about duplicated verdict validation; no correction was opened.
- Commit: `1e8f3bc9d651c3c0ffc33b0351ce33d7d179b1e7`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Semantic dry-run scans now evaluate relationships and report verdicts without modifying stored relationships or synchronization state.
  * Invalid, non-finite verdict confidence values are rejected and reported as semantic errors.
  * Applied scans continue to persist valid scan results as expected.

* **Tests**
  * Added coverage for dry-run data preservation and rejection of invalid confidence values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->