### PR TITLE
fix(projects): prevent unsafe consolidation merges

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1087,11 +1087,11 @@ Do not skip step 1. Without it, everything done before compaction is lost from m
 
 ## Project Name Normalization
 
-Engram automatically prevents project name drift — the same project saved under different names (`"engram"` vs `"Engram"` vs `"engram-memory"`) by different clients or users.
+Engram automatically prevents project name drift — the same project saved under different names (`"engram"` vs `"Engram"` vs `"  ENGRAM  "`) by different clients or users.
 
 ### Automatic normalization
 
-All project names are normalized on write and read: **lowercase**, **trimmed**, **collapsed hyphens/underscores**. If a name is changed during normalization, a warning is included in the response.
+All project names are normalized on write and read: **lowercase**, **trimmed**, **collapsed hyphens/underscores**. Hyphens and underscores are not interchangeable, so `"engram-memory"` and `"engram_memory"` are not equivalent. If a name is changed during normalization, a warning is included in the response.
 
 ### Auto-detection
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -1112,7 +1112,7 @@ When saving to a project that doesn't exist yet, Engram checks for similar exist
 
 ### Retroactive cleanup
 
-Use `engram projects consolidate` to interactively merge variant project names, or `mem_merge_projects` for agent-driven consolidation.
+Use `engram projects consolidate` to interactively merge legacy project names that are equivalent after normalization, or `mem_merge_projects` for agent-driven consolidation.
 
 ---
 

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1897,95 +1897,40 @@ type projectGroup struct {
 	Canonical string // suggested canonical (most observations)
 }
 
-// groupSimilarProjects groups projects by name similarity and shared directories.
-// Uses a simple union-find approach.
+// groupSimilarProjects groups only project names that normalize to the same value.
+// Similarity signals and shared directories are deliberately not merge eligibility.
 func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
-	n := len(projects)
-	if n == 0 {
-		return nil
-	}
-
-	// parent[i] holds the root of i's component
-	parent := make([]int, n)
-	for i := range parent {
-		parent[i] = i
-	}
-
-	var find func(int) int
-	find = func(x int) int {
-		if parent[x] != x {
-			parent[x] = find(parent[x])
-		}
-		return parent[x]
-	}
-	union := func(x, y int) {
-		rx, ry := find(x), find(y)
-		if rx != ry {
-			parent[rx] = ry
+	byNormalizedName := make(map[string][]store.ProjectStats)
+	for _, p := range projects {
+		normalized, _ := store.NormalizeProject(p.Name)
+		if normalized != "" {
+			byNormalizedName[normalized] = append(byNormalizedName[normalized], p)
 		}
 	}
 
-	// Build name-only slice and index map for FindSimilar
-	names := make([]string, n)
-	nameToIndex := make(map[string]int, n)
-	for i, p := range projects {
-		names[i] = p.Name
-		nameToIndex[p.Name] = i
-	}
-
-	// Group by name similarity
-	for i := 0; i < n; i++ {
-		similar := project.FindSimilar(projects[i].Name, names, 3)
-		for _, sm := range similar {
-			if j, ok := nameToIndex[sm.Name]; ok {
-				union(i, j)
-			}
-		}
-	}
-
-	// Group by shared directory
-	dirToProjects := make(map[string][]int)
-	for i, p := range projects {
-		for _, dir := range p.Directories {
-			if dir != "" {
-				dirToProjects[dir] = append(dirToProjects[dir], i)
-			}
-		}
-	}
-	for _, idxs := range dirToProjects {
-		for k := 1; k < len(idxs); k++ {
-			union(idxs[0], idxs[k])
-		}
-	}
-
-	// Collect components
-	components := make(map[int][]int)
-	for i := 0; i < n; i++ {
-		root := find(i)
-		components[root] = append(components[root], i)
-	}
-
-	// Build groups — skip singletons (no duplicates)
+	// Build groups — skip singletons (no normalization-equivalent names).
 	var groups []projectGroup
-	for _, idxs := range components {
-		if len(idxs) < 2 {
+	for _, members := range byNormalizedName {
+		if len(members) < 2 {
 			continue
 		}
-		// Suggest the one with most observations as canonical
-		bestIdx := idxs[0]
-		for _, idx := range idxs[1:] {
-			if projects[idx].ObservationCount > projects[bestIdx].ObservationCount {
-				bestIdx = idx
+		// ListProjectNames uses alphabetical ordering. Use the same stable order
+		// when observation counts do not distinguish a canonical project.
+		best := members[0]
+		for _, member := range members[1:] {
+			if member.ObservationCount > best.ObservationCount ||
+				(member.ObservationCount == best.ObservationCount && member.Name < best.Name) {
+				best = member
 			}
 		}
-		grpNames := make([]string, len(idxs))
-		for k, idx := range idxs {
-			grpNames[k] = projects[idx].Name
+		grpNames := make([]string, len(members))
+		for i, member := range members {
+			grpNames[i] = member.Name
 		}
 		sort.Strings(grpNames)
 		groups = append(groups, projectGroup{
 			Names:     grpNames,
-			Canonical: projects[bestIdx].Name,
+			Canonical: best.Name,
 		})
 	}
 	// Sort groups by canonical name for deterministic output
@@ -1993,6 +1938,26 @@ func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
 		return groups[i].Canonical < groups[j].Canonical
 	})
 	return groups
+}
+
+func findNormalizationEquivalentProjects(name string, existing []string) []project.ProjectMatch {
+	normalized, _ := store.NormalizeProject(name)
+	if normalized == "" {
+		return nil
+	}
+
+	var matches []project.ProjectMatch
+	for _, candidate := range existing {
+		candidateNormalized, _ := store.NormalizeProject(candidate)
+		if candidate == name || candidateNormalized != normalized {
+			continue
+		}
+		matches = append(matches, project.ProjectMatch{
+			Name:      candidate,
+			MatchType: "normalization-equivalent",
+		})
+	}
+	return matches
 }
 
 func cmdProjectsConsolidate(cfg store.Config) {
@@ -2019,7 +1984,7 @@ func cmdProjectsConsolidate(cfg store.Config) {
 		if err != nil {
 			fatal(err)
 		}
-		canonical := detectProject(cwd)
+		canonical, _ := store.NormalizeProject(detectProject(cwd))
 
 		allNames, err := s.ListProjectNames()
 		if err != nil {
@@ -2038,43 +2003,13 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			fmt.Printf("Note: %q has no existing memories. Merging will move memories into this new project name.\n", canonical)
 		}
 
-		// Find candidates by name similarity
-		similar := project.FindSimilar(canonical, allNames, 3)
+		// Only normalization-equivalent legacy names are safe automatic candidates.
+		similar := findNormalizationEquivalentProjects(canonical, allNames)
 
-		// Also find candidates by shared directory (catches renames like sdd-agent-team → agent-teams-lite)
 		allStats, _ := s.ListProjectsWithStats()
 		statsMap := make(map[string]store.ProjectStats)
-		var cwdDirs []string // directories for the canonical project
 		for _, ps := range allStats {
 			statsMap[ps.Name] = ps
-			if ps.Name == canonical {
-				cwdDirs = ps.Directories
-			}
-		}
-		// If canonical has no stats yet, use cwd as its directory
-		if len(cwdDirs) == 0 {
-			cwdDirs = []string{cwd}
-		}
-		// Find projects sharing a directory with the canonical
-		similarNames := make(map[string]bool)
-		for _, sm := range similar {
-			similarNames[sm.Name] = true
-		}
-		for _, ps := range allStats {
-			if ps.Name == canonical || similarNames[ps.Name] {
-				continue
-			}
-			for _, d := range ps.Directories {
-				for _, cd := range cwdDirs {
-					if d == cd {
-						similar = append(similar, project.ProjectMatch{
-							Name:      ps.Name,
-							MatchType: "shared directory",
-						})
-						similarNames[ps.Name] = true
-					}
-				}
-			}
 		}
 
 		if len(similar) == 0 {
@@ -2143,7 +2078,7 @@ func cmdProjectsConsolidate(cfg store.Config) {
 		return
 	}
 
-	// --all mode: group all projects by similarity + shared directories
+	// --all mode: group all projects by normalization equivalence.
 	projects, err := s.ListProjectsWithStats()
 	if err != nil {
 		fatal(err)
@@ -2213,12 +2148,13 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			}
 			answer = "all" // after rename, merge everything into the new name
 		}
+		mergeCanonical, _ := store.NormalizeProject(canonical)
 
 		// Determine which sources to merge
 		var sources []string
 		if answer == "all" || answer == "a" || answer == "y" || answer == "yes" {
 			for _, name := range g.Names {
-				if name != canonical {
+				if name != mergeCanonical {
 					sources = append(sources, name)
 				}
 			}
@@ -2233,7 +2169,7 @@ func cmdProjectsConsolidate(cfg store.Config) {
 					continue
 				}
 				selected := g.Names[idx-1]
-				if selected != canonical {
+				if selected != mergeCanonical {
 					sources = append(sources, selected)
 				}
 			}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1894,7 +1894,7 @@ func cmdProjectsList(cfg store.Config) {
 // projectGroup represents a set of project names that should be merged.
 type projectGroup struct {
 	Names     []string
-	Canonical string // suggested canonical (most observations)
+	Canonical string // normalized operational canonical
 }
 
 // groupSimilarProjects groups only project names that normalize to the same value.
@@ -1910,18 +1910,9 @@ func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
 
 	// Build groups — skip singletons (no normalization-equivalent names).
 	var groups []projectGroup
-	for _, members := range byNormalizedName {
+	for canonical, members := range byNormalizedName {
 		if len(members) < 2 {
 			continue
-		}
-		// ListProjectNames uses alphabetical ordering. Use the same stable order
-		// when observation counts do not distinguish a canonical project.
-		best := members[0]
-		for _, member := range members[1:] {
-			if member.ObservationCount > best.ObservationCount ||
-				(member.ObservationCount == best.ObservationCount && member.Name < best.Name) {
-				best = member
-			}
 		}
 		grpNames := make([]string, len(members))
 		for i, member := range members {
@@ -1930,7 +1921,7 @@ func groupSimilarProjects(projects []store.ProjectStats) []projectGroup {
 		sort.Strings(grpNames)
 		groups = append(groups, projectGroup{
 			Names:     grpNames,
-			Canonical: best.Name,
+			Canonical: canonical,
 		})
 	}
 	// Sort groups by canonical name for deterministic output

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2128,16 +2128,22 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			continue
 		}
 
+		renameTarget := ""
 		if answer == "rename" || answer == "r" {
 			fmt.Printf("  Enter canonical name: ")
-			scanInputLine(&canonical)
-			canonical = strings.TrimSpace(canonical)
-			if canonical == "" {
+			var input string
+			scanInputLine(&input)
+			input = strings.TrimSpace(input)
+			if input == "" {
 				fmt.Println("  Empty input, skipping.")
 				fmt.Println()
 				continue
 			}
-			answer = "all" // after rename, merge everything into the new name
+			// Merging only ever targets the group's normalization-equivalent
+			// canonical; the rename is applied afterwards as an explicit
+			// project migration so sync identity follows the new name.
+			renameTarget, _ = store.NormalizeProject(input)
+			answer = "all" // after rename, merge everything then migrate
 		}
 		mergeCanonical, _ := store.NormalizeProject(canonical)
 
@@ -2171,14 +2177,27 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			continue
 		}
 
-		result, err := s.MergeProjects(sources, canonical)
+		result, err := s.MergeProjects(sources, mergeCanonical)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  Error merging: %v\n", err)
 			fmt.Println()
 			continue
 		}
-		fmt.Printf("  Merged: %d obs, %d sessions, %d prompts\n\n",
+		fmt.Printf("  Merged: %d obs, %d sessions, %d prompts\n",
 			result.ObservationsUpdated, result.SessionsUpdated, result.PromptsUpdated)
+
+		if renameTarget != "" && renameTarget != mergeCanonical {
+			migrateResult, err := s.MigrateProject(mergeCanonical, renameTarget)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  Error renaming %q → %q: %v\n", mergeCanonical, renameTarget, err)
+				fmt.Println()
+				continue
+			}
+			fmt.Printf("  Renamed %q → %q: %d obs, %d sessions, %d prompts\n",
+				mergeCanonical, renameTarget,
+				migrateResult.ObservationsUpdated, migrateResult.SessionsUpdated, migrateResult.PromptsUpdated)
+		}
+		fmt.Println()
 	}
 }
 

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -124,6 +126,22 @@ func mustSeedObservation(t *testing.T, cfg store.Config, sessionID, project, typ
 	}
 
 	return id
+}
+
+func rewriteLegacyProjectName(t *testing.T, cfg store.Config, from, to string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer db.Close()
+
+	for _, table := range []string{"observations", "sessions", "user_prompts"} {
+		if _, err := db.Exec("UPDATE "+table+" SET project = ? WHERE project = ?", to, from); err != nil {
+			t.Fatalf("rewrite %s project: %v", table, err)
+		}
+	}
 }
 
 func TestTruncate(t *testing.T) {
@@ -908,12 +926,46 @@ func TestCmdProjectsConsolidateNoSimilar(t *testing.T) {
 	}
 }
 
+func TestCmdProjectsConsolidateRejectsWeakCandidates(t *testing.T) {
+	tests := []struct {
+		name      string
+		canonical string
+		candidate string
+	}{
+		{name: "shared directory", canonical: "alpha", candidate: "beta"},
+		{name: "substring", canonical: "engram", candidate: "engram-memory"},
+		{name: "levenshtein", canonical: "engram", candidate: "engramm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig(t)
+			mustSeedObservation(t, cfg, "s-canonical", tt.canonical, "note", "canonical", "content", "project")
+			mustSeedObservation(t, cfg, "s-candidate", tt.candidate, "note", "candidate", "content", "project")
+
+			old := detectProject
+			detectProject = func(string) string { return tt.canonical }
+			t.Cleanup(func() { detectProject = old })
+
+			withArgs(t, "engram", "projects", "consolidate")
+			stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+			if stderr != "" {
+				t.Fatalf("expected no stderr, got: %q", stderr)
+			}
+			if !strings.Contains(stdout, "No similar") {
+				t.Fatalf("expected no-candidate message, got: %q", stdout)
+			}
+		})
+	}
+}
+
 func TestCmdProjectsConsolidateDryRun(t *testing.T) {
 	cfg := testConfig(t)
 
-	// Seed a canonical and a similar variant (substring match, distinct after normalize)
+	// Seed a canonical name and rewrite a second project's records as a legacy case variant.
 	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
-	mustSeedObservation(t, cfg, "s-engm", "engram-memory", "note", "engm note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
 
 	old := detectProject
 	detectProject = func(string) string { return "engram" }
@@ -927,7 +979,7 @@ func TestCmdProjectsConsolidateDryRun(t *testing.T) {
 	if !strings.Contains(stdout, "dry-run") {
 		t.Fatalf("expected dry-run message, got: %q", stdout)
 	}
-	// Verify no actual merge happened (both projects still exist)
+	// Verify no actual merge happened (both project names still exist).
 	s, err := store.New(cfg)
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
@@ -938,17 +990,18 @@ func TestCmdProjectsConsolidateDryRun(t *testing.T) {
 		t.Fatalf("ListProjectNames: %v", err)
 	}
 	// Should still have both names (no merge happened)
-	if len(names) < 2 {
-		t.Fatalf("expected 2 project names after dry-run, got: %v", names)
+	if len(names) != 2 || names[0] != "ENGRAM" || names[1] != "engram" {
+		t.Fatalf("expected legacy and canonical names after dry-run, got: %v", names)
 	}
 }
 
 func TestCmdProjectsConsolidateSingleProject(t *testing.T) {
 	cfg := testConfig(t)
 
-	// Seed canonical and a similar variant (substring match, distinct after normalize)
+	// Seed canonical and normalization-equivalent legacy records.
 	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
-	mustSeedObservation(t, cfg, "s-engm", "engram-memory", "note", "engm note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
 
 	old := detectProject
 	detectProject = func(string) string { return "engram" }
@@ -973,7 +1026,7 @@ func TestCmdProjectsConsolidateSingleProject(t *testing.T) {
 		t.Fatalf("expected merge result, got: %q", stdout)
 	}
 
-	// Verify engram-memory was merged into engram
+	// Verify the legacy variant was merged into engram.
 	s, err := store.New(cfg)
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
@@ -991,9 +1044,10 @@ func TestCmdProjectsConsolidateSingleProject(t *testing.T) {
 func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	cfg := testConfig(t)
 
-	// Seed similar projects (substring match, stays distinct after normalize)
+	// Seed normalization-equivalent legacy project records.
 	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
-	mustSeedObservation(t, cfg, "s-engm", "engram-memory", "note", "engm note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
 
 	withArgs(t, "engram", "projects", "consolidate", "--all", "--dry-run")
 	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
@@ -1005,22 +1059,40 @@ func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	}
 }
 
-func TestCmdProjectsAllNoGroups(t *testing.T) {
+func TestCmdProjectsAllRejectsWeakAndTransitiveGroups(t *testing.T) {
 	cfg := testConfig(t)
 
-	// Seed completely unrelated projects
-	mustSeedObservation(t, cfg, "s-foo", "fooproject", "note", "foo", "content", "project")
-	mustSeedObservation(t, cfg, "s-bar", "barproject", "note", "bar", "content", "project")
-	mustSeedObservation(t, cfg, "s-qux", "quxproject", "note", "qux", "content", "project")
+	// These names form substring and Levenshtein weak edges and all share /tmp.
+	mustSeedObservation(t, cfg, "s-client", "client", "note", "client", "content", "project")
+	mustSeedObservation(t, cfg, "s-client-api", "client-api", "note", "client api", "content", "project")
+	mustSeedObservation(t, cfg, "s-client-apj", "client-apj", "note", "client apj", "content", "project")
 
 	withArgs(t, "engram", "projects", "consolidate", "--all")
 	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
 	if stderr != "" {
 		t.Fatalf("expected no stderr, got: %q", stderr)
 	}
-	// The three "project"-suffixed names might be grouped by similarity.
-	// We just verify it runs without error and produces readable output.
-	_ = stdout
+	if !strings.Contains(stdout, "No similar") {
+		t.Fatalf("expected no weak-edge group, got: %q", stdout)
+	}
+}
+
+func TestGroupSimilarProjectsUsesNormalizationEquivalenceAndStableTieBreak(t *testing.T) {
+	groups := groupSimilarProjects([]store.ProjectStats{
+		{Name: "engram", ObservationCount: 1, Directories: []string{"/shared"}},
+		{Name: "ENGRAM", ObservationCount: 1, Directories: []string{"/shared"}},
+		{Name: "engram-memory", ObservationCount: 100, Directories: []string{"/shared"}},
+	})
+
+	if len(groups) != 1 {
+		t.Fatalf("expected one normalization-equivalent group, got: %#v", groups)
+	}
+	if got, want := groups[0].Names, []string{"ENGRAM", "engram"}; !slices.Equal(got, want) {
+		t.Fatalf("group names = %v, want %v", got, want)
+	}
+	if groups[0].Canonical != "ENGRAM" {
+		t.Fatalf("canonical = %q, want stable alphabetical tie winner %q", groups[0].Canonical, "ENGRAM")
+	}
 }
 
 func TestCmdMCPDetectsProjectFromFlag(t *testing.T) {

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1062,6 +1062,56 @@ func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	}
 }
 
+func TestCmdProjectsConsolidateAllRenameMigratesMergedIdentity(t *testing.T) {
+	cfg := testConfig(t)
+
+	// Seed a canonical project and a normalization-equivalent legacy variant.
+	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
+
+	// Answer "rename" first, then provide the new canonical name.
+	answers := []string{"rename", "Engram Core"}
+	oldScan := scanInputLine
+	t.Cleanup(func() { scanInputLine = oldScan })
+	scanInputLine = func(a ...any) (int, error) {
+		answer := ""
+		if len(answers) > 0 {
+			answer = answers[0]
+			answers = answers[1:]
+		}
+		if ptr, ok := a[0].(*string); ok {
+			*ptr = answer
+		}
+		return 1, nil
+	}
+
+	withArgs(t, "engram", "projects", "consolidate", "--all")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stdout, "Merged") {
+		t.Fatalf("expected merge output, got: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"engram core"`) {
+		t.Fatalf("expected rename output mentioning new canonical, got: %q", stdout)
+	}
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+	names, err := s.ListProjectNames()
+	if err != nil {
+		t.Fatalf("ListProjectNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "engram core" {
+		t.Fatalf("expected all records under renamed canonical, got: %v", names)
+	}
+}
+
 func TestCmdProjectsAllRejectsWeakAndTransitiveGroups(t *testing.T) {
 	cfg := testConfig(t)
 

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1057,6 +1057,9 @@ func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	if !strings.Contains(stdout, "dry-run") || !strings.Contains(stdout, "Group") {
 		t.Fatalf("expected dry-run group output, got: %q", stdout)
 	}
+	if !strings.Contains(stdout, `Would merge into "engram"`) {
+		t.Fatalf("expected normalized canonical in dry-run output, got: %q", stdout)
+	}
 }
 
 func TestCmdProjectsAllRejectsWeakAndTransitiveGroups(t *testing.T) {
@@ -1077,7 +1080,7 @@ func TestCmdProjectsAllRejectsWeakAndTransitiveGroups(t *testing.T) {
 	}
 }
 
-func TestGroupSimilarProjectsUsesNormalizationEquivalenceAndStableTieBreak(t *testing.T) {
+func TestGroupSimilarProjectsUsesNormalizationEquivalenceAndNormalizedCanonical(t *testing.T) {
 	groups := groupSimilarProjects([]store.ProjectStats{
 		{Name: "engram", ObservationCount: 1, Directories: []string{"/shared"}},
 		{Name: "ENGRAM", ObservationCount: 1, Directories: []string{"/shared"}},
@@ -1090,8 +1093,8 @@ func TestGroupSimilarProjectsUsesNormalizationEquivalenceAndStableTieBreak(t *te
 	if got, want := groups[0].Names, []string{"ENGRAM", "engram"}; !slices.Equal(got, want) {
 		t.Fatalf("group names = %v, want %v", got, want)
 	}
-	if groups[0].Canonical != "ENGRAM" {
-		t.Fatalf("canonical = %q, want stable alphabetical tie winner %q", groups[0].Canonical, "ENGRAM")
+	if groups[0].Canonical != "engram" {
+		t.Fatalf("canonical = %q, want normalized group key %q", groups[0].Canonical, "engram")
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,7 +287,7 @@ engram cloud bootstrap admin --username <name> [--email <email>]
                           Create the first managed admin (see DOCS.md for details
                           and the current server-side auth wiring limitation)
 engram projects list      Show all projects with obs/session/prompt counts
-engram projects consolidate  Interactive merge of similar project names [--all] [--dry-run]
+engram projects consolidate  Interactive merge of normalization-equivalent project names [--all] [--dry-run]
 engram projects prune     Remove projects with 0 observations [--dry-run]
 engram obsidian-export    Export memories to Obsidian vault (beta)
 engram version            Show version

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -98,6 +98,40 @@ func TestNewServerRegistersTools(t *testing.T) {
 	}
 }
 
+func TestHandleMergeProjectsRejectsNonEquivalentSourceWithoutMutation(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("merge-source", "engram-memory", "/tmp/engram-memory"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "merge-source",
+		Type:      "decision",
+		Title:     "Unrelated project",
+		Content:   "This record must not be merged.",
+		Project:   "engram-memory",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	result, err := handleMergeProjects(s)(context.Background(), mcppkg.CallToolRequest{
+		Params: mcppkg.CallToolParams{Arguments: map[string]any{"from": "engram-memory", "to": "engram"}},
+	})
+	if err != nil {
+		t.Fatalf("handle merge projects: %v", err)
+	}
+	if !result.IsError || !strings.Contains(callResultText(t, result), "must normalize") {
+		t.Fatalf("merge result = %q, want normalization rejection", callResultText(t, result))
+	}
+	observations, err := s.RecentObservations("engram-memory", "", 10)
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("source observations = %d, want 1", len(observations))
+	}
+}
+
 func TestHandleSuggestTopicKeyReturnsFamilyBasedKey(t *testing.T) {
 	h := handleSuggestTopicKey()
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
@@ -3023,7 +3057,7 @@ func TestHandleSaveNoSimilarWarningWhenProjectExists(t *testing.T) {
 func TestHandleMergeProjects(t *testing.T) {
 	s := newMCPTestStore(t)
 
-	// Set up observations under different project name variants
+	// Set up an observation under the canonical project.
 	if err := s.CreateSession("s-Engram", "Engram", ""); err != nil {
 		t.Fatalf("create session Engram: %v", err)
 	}
@@ -3037,23 +3071,10 @@ func TestHandleMergeProjects(t *testing.T) {
 		t.Fatalf("add observation Engram: %v", err)
 	}
 
-	if err := s.CreateSession("s-engram-memory", "engram-memory", ""); err != nil {
-		t.Fatalf("create session engram-memory: %v", err)
-	}
-	if _, err := s.AddObservation(store.AddObservationParams{
-		SessionID: "s-engram-memory",
-		Type:      "decision",
-		Title:     "From engram-memory",
-		Content:   "Content from engram-memory",
-		Project:   "engram-memory",
-	}); err != nil {
-		t.Fatalf("add observation engram-memory: %v", err)
-	}
-
 	h := handleMergeProjects(s)
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
-		"from": "engram-memory, ENGRAM", // comma-separated, with spaces and uppercase
+		"from": "ENGRAM", // uppercase normalization-equivalent source
 		"to":   "engram",
 	}}}
 
@@ -3073,14 +3094,13 @@ func TestHandleMergeProjects(t *testing.T) {
 		t.Fatalf("expected observations count in result, got %q", text)
 	}
 
-	// Verify that engram-memory observations are now under "engram"
+	// Verify that the canonical observation remains available.
 	obs, err := s.RecentObservations("engram", "project", 10)
 	if err != nil {
 		t.Fatalf("recent observations: %v", err)
 	}
-	// Should have both: original "engram" obs + migrated "engram-memory" obs
-	if len(obs) < 2 {
-		t.Fatalf("expected at least 2 observations after merge, got %d", len(obs))
+	if len(obs) != 1 {
+		t.Fatalf("expected 1 observation after merge, got %d", len(obs))
 	}
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +20,11 @@ import (
 )
 
 func newMCPTestStore(t *testing.T) *store.Store {
+	s, _ := newMCPTestStoreWithDataDir(t)
+	return s
+}
+
+func newMCPTestStoreWithDataDir(t *testing.T) (*store.Store, string) {
 	t.Helper()
 	cfg, err := store.DefaultConfig()
 	if err != nil {
@@ -33,7 +39,7 @@ func newMCPTestStore(t *testing.T) *store.Store {
 	t.Cleanup(func() {
 		_ = s.Close()
 	})
-	return s
+	return s, cfg.DataDir
 }
 
 func callResultText(t *testing.T, res *mcppkg.CallToolResult) string {
@@ -3055,26 +3061,23 @@ func TestHandleSaveNoSimilarWarningWhenProjectExists(t *testing.T) {
 }
 
 func TestHandleMergeProjects(t *testing.T) {
-	s := newMCPTestStore(t)
-
-	// Set up an observation under the canonical project.
-	if err := s.CreateSession("s-Engram", "Engram", ""); err != nil {
-		t.Fatalf("create session Engram: %v", err)
+	s, dataDir := newMCPTestStoreWithDataDir(t)
+	rawDB, err := sql.Open("sqlite", filepath.Join(dataDir, "engram.db"))
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
 	}
-	if _, err := s.AddObservation(store.AddObservationParams{
-		SessionID: "s-Engram",
-		Type:      "decision",
-		Title:     "From Engram",
-		Content:   "Content from Engram",
-		Project:   "engram", // store normalizes to lowercase
-	}); err != nil {
-		t.Fatalf("add observation Engram: %v", err)
+	t.Cleanup(func() { _ = rawDB.Close() })
+	if _, err := rawDB.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, "s-legacy", "ENGRAM", ""); err != nil {
+		t.Fatalf("insert legacy session: %v", err)
+	}
+	if _, err := rawDB.Exec(`INSERT INTO observations (sync_id, session_id, type, title, content, project, scope, normalized_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "legacy-obs", "s-legacy", "decision", "From legacy Engram", "Content from legacy Engram", "ENGRAM", "project", "legacy-hash"); err != nil {
+		t.Fatalf("insert legacy observation: %v", err)
 	}
 
 	h := handleMergeProjects(s)
 
 	req := mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
-		"from": "ENGRAM", // uppercase normalization-equivalent source
+		"from": "ENGRAM",
 		"to":   "engram",
 	}}}
 
@@ -3090,17 +3093,26 @@ func TestHandleMergeProjects(t *testing.T) {
 	if !strings.Contains(text, "engram") {
 		t.Fatalf("expected merge result mentioning canonical project, got %q", text)
 	}
-	if !strings.Contains(text, "Observations moved") {
-		t.Fatalf("expected observations count in result, got %q", text)
+	if !strings.Contains(text, "Observations moved: 1") {
+		t.Fatalf("expected positive observations count in result, got %q", text)
 	}
 
-	// Verify that the canonical observation remains available.
 	obs, err := s.RecentObservations("engram", "project", 10)
 	if err != nil {
 		t.Fatalf("recent observations: %v", err)
 	}
 	if len(obs) != 1 {
-		t.Fatalf("expected 1 observation after merge, got %d", len(obs))
+		t.Fatalf("canonical observations = %d, want 1", len(obs))
+	}
+	var legacyRows, canonicalRows int
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM observations WHERE project = ?`, "ENGRAM").Scan(&legacyRows); err != nil {
+		t.Fatalf("count legacy observations: %v", err)
+	}
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM observations WHERE project = ?`, "engram").Scan(&canonicalRows); err != nil {
+		t.Fatalf("count canonical observations: %v", err)
+	}
+	if legacyRows != 0 || canonicalRows != 1 {
+		t.Fatalf("observation projects after merge: legacy=%d canonical=%d, want 0 and 1", legacyRows, canonicalRows)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4943,28 +4943,39 @@ type MergeResult struct {
 }
 
 // MergeProjects migrates all records from each source project name into the
-// canonical name. Sources that equal the canonical (after normalization) or
-// have no records are silently skipped — the operation is idempotent.
+// canonical name. Every source must normalize to the canonical name; sources
+// that exactly equal the canonical name or have no records are skipped.
 // All updates are performed inside a single transaction for atomicity.
 func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult, error) {
 	canonical, _ = NormalizeProject(canonical)
 	if canonical == "" {
 		return nil, fmt.Errorf("canonical project name must not be empty")
 	}
+	validatedSources := make([]string, len(sources))
+	for i, source := range sources {
+		normalizedSource, _ := NormalizeProject(source)
+		if normalizedSource == "" {
+			return nil, fmt.Errorf("source project name must not be empty")
+		}
+		if normalizedSource != canonical {
+			return nil, fmt.Errorf("source project %q must normalize to canonical project %q", source, canonical)
+		}
+		validatedSources[i] = normalizedSource
+	}
 
 	result := &MergeResult{Canonical: canonical}
 
 	err := s.withTx(func(tx *sql.Tx) error {
 		seenSources := make(map[string]struct{})
-		for _, srcInput := range sources {
-			srcNormalized, _ := NormalizeProject(srcInput)
-			if srcNormalized == "" || srcNormalized == canonical {
+		for i, srcInput := range sources {
+			srcNormalized := validatedSources[i]
+			if srcInput == canonical {
 				continue
 			}
-			if _, seen := seenSources[srcNormalized]; seen {
+			if _, seen := seenSources[srcInput]; seen {
 				continue
 			}
-			seenSources[srcNormalized] = struct{}{}
+			seenSources[srcInput] = struct{}{}
 
 			sourceVariants := projectMergeSourceVariants(srcInput, srcNormalized, canonical)
 			if len(sourceVariants) == 0 {
@@ -4977,6 +4988,7 @@ func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult,
 			for _, variant := range sourceVariants {
 				args = append(args, variant)
 			}
+			sourceUpdated := false
 
 			res, err := s.execHook(tx, `UPDATE observations SET project = ? WHERE project IN (`+placeholders+`)`, args...)
 			if err != nil {
@@ -4984,6 +4996,7 @@ func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult,
 			}
 			n, _ := res.RowsAffected()
 			result.ObservationsUpdated += n
+			sourceUpdated = sourceUpdated || n > 0
 
 			res, err = s.execHook(tx, `UPDATE sessions SET project = ? WHERE project IN (`+placeholders+`)`, args...)
 			if err != nil {
@@ -4991,6 +5004,7 @@ func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult,
 			}
 			n, _ = res.RowsAffected()
 			result.SessionsUpdated += n
+			sourceUpdated = sourceUpdated || n > 0
 
 			res, err = s.execHook(tx, `UPDATE user_prompts SET project = ? WHERE project IN (`+placeholders+`)`, args...)
 			if err != nil {
@@ -4998,8 +5012,11 @@ func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult,
 			}
 			n, _ = res.RowsAffected()
 			result.PromptsUpdated += n
+			sourceUpdated = sourceUpdated || n > 0
 
-			result.SourcesMerged = append(result.SourcesMerged, srcNormalized)
+			if sourceUpdated {
+				result.SourcesMerged = append(result.SourcesMerged, srcNormalized)
+			}
 		}
 		// Enqueue sync mutations so cloud sync picks up the merged records.
 		// Same pattern used by EnrollProject.
@@ -5020,35 +5037,11 @@ func sqlPlaceholders(count int) string {
 }
 
 func projectMergeSourceVariants(rawSource, normalizedSource, canonical string) []string {
-	seen := make(map[string]struct{})
-	variants := make([]string, 0, 5)
-	// Match both the historical raw project name and its normalized form so
-	// legacy rows are migrated without reintroducing canonical-source churn.
-	candidates := []string{strings.TrimSpace(rawSource), normalizedSource}
-	parts := strings.FieldsFunc(normalizedSource, func(r rune) bool {
-		return r == ' ' || r == '-' || r == '_'
-	})
-	if len(parts) > 1 {
-		for _, sep := range []string{" ", "-", "_"} {
-			candidates = append(candidates, strings.Join(parts, sep))
-		}
+	rawSource = strings.TrimSpace(rawSource)
+	if rawSource == "" || rawSource == canonical || normalizedSource != canonical {
+		return nil
 	}
-	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" || candidate == canonical {
-			continue
-		}
-		candidateNormalized, _ := NormalizeProject(candidate)
-		if candidateNormalized == canonical {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
-		variants = append(variants, candidate)
-	}
-	return variants
+	return []string{rawSource}
 }
 
 // ─── Project Pruning ─────────────────────────────────────────────────────────

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4781,9 +4781,11 @@ func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) 
 
 		// Migrate the old name's sync identity — pending journal rows and
 		// enrollment — so renaming a project (including one that was
-		// consolidated) keeps a single deliverable sync identity.
-		normalizedOld, _ := NormalizeProject(oldName)
-		if err := s.migrateProjectSyncIdentityTx(tx, []string{oldName, normalizedOld}, newName); err != nil {
+		// consolidated) keeps a single deliverable sync identity. Only the
+		// exact spelling whose records moved above is migrated: a distinct
+		// project stored under the normalized spelling keeps its own journal
+		// rows and enrollment.
+		if err := s.migrateProjectSyncIdentityTx(tx, []string{oldName}, newName); err != nil {
 			return fmt.Errorf("migrate sync identity: %w", err)
 		}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5015,7 +5015,7 @@ func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult,
 			sourceUpdated = sourceUpdated || n > 0
 
 			if sourceUpdated {
-				result.SourcesMerged = append(result.SourcesMerged, srcNormalized)
+				result.SourcesMerged = append(result.SourcesMerged, sourceVariants[0])
 			}
 		}
 		// Enqueue sync mutations so cloud sync picks up the merged records.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4731,6 +4731,10 @@ type MigrateResult struct {
 }
 
 func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) {
+	// The rename lands on the migrated (normalized) identity — every other
+	// write path normalizes project names, so a rename must as well or the
+	// renamed records would carry a spelling no other route can produce.
+	newName, _ = NormalizeProject(newName)
 	if oldName == "" || newName == "" || oldName == newName {
 		return &MigrateResult{}, nil
 	}
@@ -4774,6 +4778,14 @@ func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) 
 			return fmt.Errorf("migrate prompts: %w", err)
 		}
 		result.PromptsUpdated, _ = res.RowsAffected()
+
+		// Migrate the old name's sync identity — pending journal rows and
+		// enrollment — so renaming a project (including one that was
+		// consolidated) keeps a single deliverable sync identity.
+		normalizedOld, _ := NormalizeProject(oldName)
+		if err := s.migrateProjectSyncIdentityTx(tx, []string{oldName, normalizedOld}, newName); err != nil {
+			return fmt.Errorf("migrate sync identity: %w", err)
+		}
 
 		// Enqueue sync mutations so cloud sync picks up the migrated records.
 		// Same pattern used by EnrollProject and MergeProjects.
@@ -5036,6 +5048,13 @@ func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult,
 			result.PromptsUpdated += n
 			sourceUpdated = sourceUpdated || n > 0
 
+			// Migrate the source's sync identity — pending journal rows and
+			// enrollment — so no legacy mutation suppresses canonical backfill
+			// or is later skip-acked as belonging to a non-enrolled project.
+			if err := s.migrateProjectSyncIdentityTx(tx, sourceVariants, canonical); err != nil {
+				return fmt.Errorf("merge sync identity %q → %q: %w", srcNormalized, canonical, err)
+			}
+
 			if sourceUpdated {
 				result.SourcesMerged = append(result.SourcesMerged, sourceVariants[0])
 			}
@@ -5064,6 +5083,84 @@ func projectMergeSourceVariants(rawSource, normalizedSource, canonical string) [
 		return nil
 	}
 	return []string{rawSource}
+}
+
+// migrateProjectSyncIdentityTx moves the pending sync journal rows and the
+// cloud sync enrollment of the given source project spellings onto the
+// canonical name, so a merged or renamed project keeps a single deliverable
+// sync identity. Pending mutations are migrated in place — journal project
+// column and payload project field — which preserves their entity coverage
+// (so backfill correctly skips those entities) while making them deliverable
+// under the canonical enrollment instead of being skip-acked as non-enrolled.
+// Acked journal rows are immutable history and stay untouched.
+func (s *Store) migrateProjectSyncIdentityTx(tx *sql.Tx, sources []string, canonical string) error {
+	seen := make(map[string]struct{}, len(sources))
+	variants := make([]string, 0, len(sources))
+	for _, source := range sources {
+		source = strings.TrimSpace(source)
+		if source == "" || source == canonical {
+			continue
+		}
+		if _, ok := seen[source]; ok {
+			continue
+		}
+		seen[source] = struct{}{}
+		variants = append(variants, source)
+	}
+	if len(variants) == 0 {
+		return nil
+	}
+
+	placeholders := sqlPlaceholders(len(variants))
+	variantArgs := make([]any, 0, len(variants))
+	for _, variant := range variants {
+		variantArgs = append(variantArgs, variant)
+	}
+
+	// Migrate pending journal rows: both rows whose project column carries a
+	// source spelling and rows whose payload still embeds one.
+	args := make([]any, 0, 3*len(variants)+2)
+	args = append(args, variantArgs...)
+	args = append(args, canonical, canonical)
+	args = append(args, variantArgs...)
+	args = append(args, variantArgs...)
+	if _, err := s.execHook(tx, `
+		UPDATE sync_mutations
+		SET payload = CASE
+				WHEN json_valid(payload) AND json_extract(payload, '$.project') IN (`+placeholders+`)
+				THEN json_set(payload, '$.project', ?)
+				ELSE payload
+			END,
+			project = ?
+		WHERE acked_at IS NULL
+		  AND (project IN (`+placeholders+`)
+		       OR (json_valid(payload) AND json_extract(payload, '$.project') IN (`+placeholders+`)))`,
+		args...,
+	); err != nil {
+		return fmt.Errorf("migrate pending sync mutations: %w", err)
+	}
+
+	// Carry enrollment: if any source spelling was enrolled, the canonical
+	// name becomes (or stays) enrolled and the source rows are superseded.
+	insertArgs := make([]any, 0, len(variants)+1)
+	insertArgs = append(insertArgs, canonical)
+	insertArgs = append(insertArgs, variantArgs...)
+	if _, err := s.execHook(tx, `
+		INSERT OR IGNORE INTO sync_enrolled_projects (project)
+		SELECT ? WHERE EXISTS (
+			SELECT 1 FROM sync_enrolled_projects WHERE project IN (`+placeholders+`)
+		)`,
+		insertArgs...,
+	); err != nil {
+		return fmt.Errorf("carry sync enrollment: %w", err)
+	}
+	if _, err := s.execHook(tx,
+		`DELETE FROM sync_enrolled_projects WHERE project IN (`+placeholders+`)`,
+		variantArgs...,
+	); err != nil {
+		return fmt.Errorf("supersede source sync enrollment: %w", err)
+	}
+	return nil
 }
 
 // ─── Project Pruning ─────────────────────────────────────────────────────────

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7116,8 +7116,8 @@ func TestListProjectsWithStats(t *testing.T) {
 func TestMergeProjects(t *testing.T) {
 	s := newTestStore(t)
 
-	// Set up three source projects
-	sources := []string{"engram", "Engram", "engram-memory"}
+	// Set up normalization-equivalent source projects.
+	sources := []string{"engram", "Engram"}
 	canonical := "engram"
 
 	if err := s.CreateSession("s1", "engram", "/work"); err != nil {
@@ -7125,7 +7125,7 @@ func TestMergeProjects(t *testing.T) {
 	}
 
 	// Add observations to each source
-	for _, src := range []string{"engram", "engram-memory"} {
+	for _, src := range []string{"engram"} {
 		for i := 0; i < 2; i++ {
 			_, err := s.AddObservation(AddObservationParams{
 				SessionID: "s1",
@@ -7150,26 +7150,23 @@ func TestMergeProjects(t *testing.T) {
 		t.Errorf("canonical = %q, want \"engram\"", result.Canonical)
 	}
 
-	// "Engram" normalizes to "engram" (same as canonical) → skipped
-	// "engram-memory" is different → merged
-	// Only "engram-memory" should appear in SourcesMerged (and possibly "engram" if it had records,
-	// but it equals canonical after normalization → skipped)
+	// Equivalent sources are allowed, while the exact canonical source is skipped.
 	for _, merged := range result.SourcesMerged {
 		if merged == "engram" {
 			t.Error("canonical 'engram' should not appear in SourcesMerged")
 		}
 	}
 
-	// All records from engram-memory should now be under "engram"
+	// All records remain under "engram".
 	obs, err := s.RecentObservations("engram", "", 20)
 	if err != nil {
 		t.Fatalf("RecentObservations: %v", err)
 	}
-	if len(obs) < 4 {
-		t.Errorf("expected ≥4 observations under 'engram' after merge, got %d", len(obs))
+	if len(obs) != 2 {
+		t.Errorf("expected 2 observations under 'engram', got %d", len(obs))
 	}
 
-	// engram-memory should have 0 observations
+	// An unrelated project name is untouched.
 	obsMerged, err := s.RecentObservations("engram-memory", "", 10)
 	if err != nil {
 		t.Fatalf("RecentObservations engram-memory: %v", err)
@@ -7182,8 +7179,8 @@ func TestMergeProjects(t *testing.T) {
 func TestMergeProjectsIdempotent(t *testing.T) {
 	s := newTestStore(t)
 
-	// Merge a nonexistent source — should not error
-	result, err := s.MergeProjects([]string{"ghost-project"}, "engram")
+	// Merge an equivalent nonexistent source — should not error.
+	result, err := s.MergeProjects([]string{"Engram"}, "engram")
 	if err != nil {
 		t.Fatalf("MergeProjects with nonexistent source: %v", err)
 	}
@@ -7240,7 +7237,7 @@ func TestMergeProjectsNormalizesAliasSourcesWithoutLosingLegacyRows(t *testing.T
 		t.Fatalf("seed legacy prompt: %v", err)
 	}
 
-	result, err := s.MergeProjects([]string{"Engram Memory"}, "engram")
+	result, err := s.MergeProjects([]string{"Engram Memory"}, "engram memory")
 	if err != nil {
 		t.Fatalf("MergeProjects: %v", err)
 	}
@@ -7265,7 +7262,7 @@ func TestMergeProjectsNormalizesAliasSourcesWithoutLosingLegacyRows(t *testing.T
 func TestMergeProjectsConsolidatesDeterministicAliasSpellings(t *testing.T) {
 	s := newTestStore(t)
 
-	for i, project := range []string{"Engram Memory", "engram memory", "engram-memory", "engram_memory"} {
+	for i, project := range []string{"Engram Memory", "engram memory"} {
 		sessionID := fmt.Sprintf("alias-session-%d", i)
 		if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, sessionID, project, "/work/engram"); err != nil {
 			t.Fatalf("seed alias session %q: %v", project, err)
@@ -7278,11 +7275,11 @@ func TestMergeProjectsConsolidatesDeterministicAliasSpellings(t *testing.T) {
 		}
 	}
 
-	result, err := s.MergeProjects([]string{"Engram Memory"}, "engram")
+	result, err := s.MergeProjects([]string{"Engram Memory"}, "engram memory")
 	if err != nil {
 		t.Fatalf("MergeProjects: %v", err)
 	}
-	if result.ObservationsUpdated != 4 || result.SessionsUpdated != 4 || result.PromptsUpdated != 4 {
+	if result.ObservationsUpdated != 1 || result.SessionsUpdated != 1 || result.PromptsUpdated != 1 {
 		t.Fatalf("unexpected merge result: %+v", result)
 	}
 }
@@ -7290,14 +7287,14 @@ func TestMergeProjectsConsolidatesDeterministicAliasSpellings(t *testing.T) {
 func TestMergeProjectsAliasVariantsDoNotRewriteCanonicalProject(t *testing.T) {
 	s := newTestStore(t)
 
-	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, "canonical-session", "engram-memory", "/work/engram"); err != nil {
+	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, "canonical-session", "engram memory", "/work/engram"); err != nil {
 		t.Fatalf("seed canonical session: %v", err)
 	}
 	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, "source-session", "Engram Memory", "/work/engram"); err != nil {
 		t.Fatalf("seed source session: %v", err)
 	}
 
-	result, err := s.MergeProjects([]string{"Engram Memory"}, "engram-memory")
+	result, err := s.MergeProjects([]string{"Engram Memory"}, "engram memory")
 	if err != nil {
 		t.Fatalf("MergeProjects: %v", err)
 	}
@@ -7305,11 +7302,99 @@ func TestMergeProjectsAliasVariantsDoNotRewriteCanonicalProject(t *testing.T) {
 		t.Fatalf("SessionsUpdated = %d, want 1", result.SessionsUpdated)
 	}
 	var canonicalRows int
-	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE project = ?`, "engram-memory").Scan(&canonicalRows); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE project = ?`, "engram memory").Scan(&canonicalRows); err != nil {
 		t.Fatalf("count canonical rows: %v", err)
 	}
 	if canonicalRows != 2 {
 		t.Fatalf("canonical rows = %d, want 2", canonicalRows)
+	}
+}
+
+func TestMergeProjectsRejectsNonEquivalentSources(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		errorPart string
+	}{
+		{name: "empty", source: "", errorPart: "must not be empty"},
+		{name: "substring", source: "engram-memory", errorPart: "must normalize"},
+		{name: "levenshtein", source: "engramm", errorPart: "must normalize"},
+		{name: "shared directory", source: "other-project", errorPart: "must normalize"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestStore(t)
+			if tt.name == "shared directory" {
+				if err := s.CreateSession("shared-directory", tt.source, "/shared"); err != nil {
+					t.Fatalf("create source session: %v", err)
+				}
+			}
+			if _, err := s.MergeProjects([]string{tt.source}, "engram"); err == nil || !strings.Contains(err.Error(), tt.errorPart) {
+				t.Fatalf("MergeProjects error = %v, want normalization rejection", err)
+			}
+		})
+	}
+}
+
+func TestMergeProjectsRejectsSeparatorVariants(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.MergeProjects([]string{"foo-bar"}, "foo_bar"); err == nil || !strings.Contains(err.Error(), "must normalize") {
+		t.Fatalf("MergeProjects error = %v, want separator variant rejection", err)
+	}
+}
+
+func TestMergeProjectsRejectsMixedSourcesWithoutMutation(t *testing.T) {
+	s := newTestStore(t)
+	for _, statement := range []string{
+		`INSERT INTO sessions (id, project, directory) VALUES ('legacy-session', 'Engram', '/work/engram')`,
+		`INSERT INTO observations (sync_id, session_id, type, title, content, project, scope, normalized_hash) VALUES ('legacy-obs', 'legacy-session', 'decision', 'legacy', 'content', 'Engram', 'project', 'legacy-hash')`,
+		`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES ('legacy-prompt', 'legacy-session', 'prompt', 'Engram')`,
+	} {
+		if _, err := s.db.Exec(statement); err != nil {
+			t.Fatalf("seed legacy record: %v", err)
+		}
+	}
+
+	var beforeMutations int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_mutations`).Scan(&beforeMutations); err != nil {
+		t.Fatalf("count sync mutations before merge: %v", err)
+	}
+	_, err := s.MergeProjects([]string{"Engram", "engram-memory"}, "engram")
+	if err == nil || !strings.Contains(err.Error(), "must normalize") {
+		t.Fatalf("MergeProjects error = %v, want normalization rejection", err)
+	}
+
+	for _, table := range []string{"sessions", "observations", "user_prompts"} {
+		var count int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM ` + table + ` WHERE project = 'Engram'`).Scan(&count); err != nil {
+			t.Fatalf("count %s legacy records: %v", table, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s legacy records = %d, want 1", table, count)
+		}
+	}
+	var afterMutations int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_mutations`).Scan(&afterMutations); err != nil {
+		t.Fatalf("count sync mutations after merge: %v", err)
+	}
+	if afterMutations != beforeMutations {
+		t.Fatalf("sync mutations = %d, want %d", afterMutations, beforeMutations)
+	}
+}
+
+func TestProjectMergeSourceVariantsStayNormalizationEquivalent(t *testing.T) {
+	for _, rawSource := range []string{"Engram", " ENGRAM ", "engram", "foo-bar"} {
+		normalizedSource, _ := NormalizeProject(rawSource)
+		variants := projectMergeSourceVariants(rawSource, normalizedSource, "engram")
+		for _, variant := range variants {
+			normalizedVariant, _ := NormalizeProject(variant)
+			if normalizedVariant != "engram" {
+				t.Fatalf("variant %q normalizes to %q, want engram", variant, normalizedVariant)
+			}
+		}
+	}
+	if variants := projectMergeSourceVariants("foo-bar", "foo-bar", "foo_bar"); len(variants) != 0 {
+		t.Fatalf("separator variants = %v, want none", variants)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7555,6 +7555,370 @@ func TestProjectMergeSourceVariantsStayNormalizationEquivalent(t *testing.T) {
 	}
 }
 
+func seedLegacyMergeRecords(t *testing.T, s *Store, project string) {
+	t.Helper()
+	for _, statement := range []struct {
+		query string
+		args  []any
+	}{
+		{`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, []any{"legacy-session", project, "/work/engram"}},
+		{`INSERT INTO observations (sync_id, session_id, type, title, content, project, scope, normalized_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, []any{"legacy-obs", "legacy-session", "decision", "legacy", "content", project, "project", "legacy-hash"}},
+	} {
+		if _, err := s.db.Exec(statement.query, statement.args...); err != nil {
+			t.Fatalf("seed legacy record: %v", err)
+		}
+	}
+}
+
+func seedPendingLegacyMutations(t *testing.T, s *Store, project string) {
+	t.Helper()
+	sessionPayload := fmt.Sprintf(`{"id":"legacy-session","project":%q,"directory":"/work/engram"}`, project)
+	obsPayload := fmt.Sprintf(`{"sync_id":"legacy-obs","session_id":"legacy-session","type":"decision","title":"legacy","content":"content","project":%q,"scope":"project"}`, project)
+	for _, row := range []struct {
+		entity, entityKey, payload string
+	}{
+		{SyncEntitySession, "legacy-session", sessionPayload},
+		{SyncEntityObservation, "legacy-obs", obsPayload},
+	} {
+		if _, err := s.db.Exec(
+			`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			DefaultSyncTargetKey, row.entity, row.entityKey, SyncOpUpsert, row.payload, SyncSourceLocal, project,
+		); err != nil {
+			t.Fatalf("seed pending legacy mutation: %v", err)
+		}
+	}
+}
+
+func pendingMutationsByEntityKey(t *testing.T, s *Store) map[string]SyncMutation {
+	t.Helper()
+	mutations, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 100)
+	if err != nil {
+		t.Fatalf("list pending sync mutations: %v", err)
+	}
+	byKey := make(map[string]SyncMutation, len(mutations))
+	for _, mutation := range mutations {
+		byKey[mutation.EntityKey] = mutation
+	}
+	return byKey
+}
+
+func payloadProject(t *testing.T, payload string) string {
+	t.Helper()
+	var decoded struct {
+		Project string `json:"project"`
+	}
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		t.Fatalf("decode mutation payload %q: %v", payload, err)
+	}
+	return decoded.Project
+}
+
+func TestMergeProjectsMigratesPendingSyncMutationsToCanonicalIdentity(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMergeRecords(t, s, "Engram")
+	seedPendingLegacyMutations(t, s, "Engram")
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("enroll canonical: %v", err)
+	}
+
+	if _, err := s.MergeProjects([]string{"Engram"}, "engram"); err != nil {
+		t.Fatalf("MergeProjects: %v", err)
+	}
+
+	var legacyPending int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE project = 'Engram' AND acked_at IS NULL`).Scan(&legacyPending); err != nil {
+		t.Fatalf("count legacy pending mutations: %v", err)
+	}
+	if legacyPending != 0 {
+		t.Fatalf("legacy pending mutations = %d, want 0", legacyPending)
+	}
+
+	pending := pendingMutationsByEntityKey(t, s)
+	for _, entityKey := range []string{"legacy-session", "legacy-obs"} {
+		mutation, ok := pending[entityKey]
+		if !ok {
+			t.Fatalf("pending mutation for %q not deliverable after merge; got %v", entityKey, pending)
+		}
+		if mutation.Project != "engram" {
+			t.Fatalf("mutation %q project = %q, want %q", entityKey, mutation.Project, "engram")
+		}
+		if got := payloadProject(t, mutation.Payload); got != "engram" {
+			t.Fatalf("mutation %q payload project = %q, want %q", entityKey, got, "engram")
+		}
+	}
+
+	skipped, err := s.SkipAckNonEnrolledMutations(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("SkipAckNonEnrolledMutations: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skip-acked mutations = %d, want 0 — merged mutations must not vanish from sync", skipped)
+	}
+}
+
+func TestMergeProjectsDoesNotLetLegacyMutationsSuppressCanonicalBackfill(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMergeRecords(t, s, "Engram")
+	seedPendingLegacyMutations(t, s, "Engram")
+	// A second legacy record with no journal coverage at all.
+	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, "legacy-session-2", "Engram", "/work/engram"); err != nil {
+		t.Fatalf("seed uncovered legacy session: %v", err)
+	}
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("enroll canonical: %v", err)
+	}
+
+	if _, err := s.MergeProjects([]string{"Engram"}, "engram"); err != nil {
+		t.Fatalf("MergeProjects: %v", err)
+	}
+
+	pending := pendingMutationsByEntityKey(t, s)
+	for _, entityKey := range []string{"legacy-session", "legacy-obs", "legacy-session-2"} {
+		mutation, ok := pending[entityKey]
+		if !ok {
+			t.Fatalf("no deliverable canonical mutation for %q after merge", entityKey)
+		}
+		if mutation.Project != "engram" {
+			t.Fatalf("mutation %q project = %q, want %q", entityKey, mutation.Project, "engram")
+		}
+	}
+
+	needs, err := s.projectNeedsBackfill("engram")
+	if err != nil {
+		t.Fatalf("projectNeedsBackfill: %v", err)
+	}
+	if needs {
+		t.Fatal("canonical project still needs backfill after merge")
+	}
+}
+
+func TestMergeProjectsCarriesLegacyEnrollmentToCanonical(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMergeRecords(t, s, "Engram")
+	// Legacy enrollment row under the raw spelling, before normalization existed.
+	if _, err := s.db.Exec(`INSERT INTO sync_enrolled_projects (project) VALUES ('Engram')`); err != nil {
+		t.Fatalf("seed legacy enrollment: %v", err)
+	}
+
+	if _, err := s.MergeProjects([]string{"Engram"}, "engram"); err != nil {
+		t.Fatalf("MergeProjects: %v", err)
+	}
+
+	enrolled, err := s.IsProjectEnrolled("engram")
+	if err != nil {
+		t.Fatalf("IsProjectEnrolled: %v", err)
+	}
+	if !enrolled {
+		t.Fatal("canonical project not enrolled after merge carried legacy enrollment")
+	}
+	var legacyEnrollment int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_enrolled_projects WHERE project = 'Engram'`).Scan(&legacyEnrollment); err != nil {
+		t.Fatalf("count legacy enrollment: %v", err)
+	}
+	if legacyEnrollment != 0 {
+		t.Fatalf("legacy enrollment rows = %d, want 0", legacyEnrollment)
+	}
+}
+
+func TestMergeProjectsSupersedesLegacyEnrollmentWhenCanonicalEnrolled(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMergeRecords(t, s, "Engram")
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("enroll canonical: %v", err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO sync_enrolled_projects (project) VALUES ('Engram')`); err != nil {
+		t.Fatalf("seed legacy enrollment: %v", err)
+	}
+
+	if _, err := s.MergeProjects([]string{"Engram"}, "engram"); err != nil {
+		t.Fatalf("MergeProjects: %v", err)
+	}
+
+	var rows int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_enrolled_projects`).Scan(&rows); err != nil {
+		t.Fatalf("count enrollment rows: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("enrollment rows = %d, want 1 (canonical only)", rows)
+	}
+	enrolled, err := s.IsProjectEnrolled("engram")
+	if err != nil {
+		t.Fatalf("IsProjectEnrolled: %v", err)
+	}
+	if !enrolled {
+		t.Fatal("canonical project must stay enrolled after merge")
+	}
+}
+
+func TestMergeProjectsLeavesUnrelatedEnrollmentAndMutationsUntouched(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMergeRecords(t, s, "Engram")
+	if err := s.EnrollProject("other-project"); err != nil {
+		t.Fatalf("enroll unrelated project: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		DefaultSyncTargetKey, SyncEntitySession, "other-session", SyncOpUpsert, `{"id":"other-session","project":"other-project"}`, SyncSourceLocal, "other-project",
+	); err != nil {
+		t.Fatalf("seed unrelated mutation: %v", err)
+	}
+
+	if _, err := s.MergeProjects([]string{"Engram"}, "engram"); err != nil {
+		t.Fatalf("MergeProjects: %v", err)
+	}
+
+	var project, payload string
+	if err := s.db.QueryRow(`SELECT project, payload FROM sync_mutations WHERE entity_key = 'other-session'`).Scan(&project, &payload); err != nil {
+		t.Fatalf("read unrelated mutation: %v", err)
+	}
+	if project != "other-project" || payloadProject(t, payload) != "other-project" {
+		t.Fatalf("unrelated mutation rewritten: project=%q payload=%q", project, payload)
+	}
+	enrolled, err := s.IsProjectEnrolled("other-project")
+	if err != nil {
+		t.Fatalf("IsProjectEnrolled: %v", err)
+	}
+	if !enrolled {
+		t.Fatal("unrelated enrollment must survive the merge")
+	}
+}
+
+func TestMigrateProjectMigratesSyncIdentityForRename(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("enroll: %v", err)
+	}
+	if err := s.CreateSession("rename-session", "engram", "/work/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "rename-session",
+		Type:      "decision",
+		Title:     "Renamed identity",
+		Content:   "Rename must keep sync identity.",
+		Project:   "engram",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	result, err := s.MigrateProject("engram", "engram-v2")
+	if err != nil {
+		t.Fatalf("MigrateProject: %v", err)
+	}
+	if !result.Migrated {
+		t.Fatal("expected migration to happen")
+	}
+
+	var stalePending int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE project = 'engram' AND acked_at IS NULL`).Scan(&stalePending); err != nil {
+		t.Fatalf("count stale pending mutations: %v", err)
+	}
+	if stalePending != 0 {
+		t.Fatalf("stale pending mutations under old name = %d, want 0", stalePending)
+	}
+
+	pending := pendingMutationsByEntityKey(t, s)
+	mutation, ok := pending["rename-session"]
+	if !ok {
+		t.Fatalf("session mutation not deliverable after rename; got %v", pending)
+	}
+	if mutation.Project != "engram-v2" {
+		t.Fatalf("session mutation project = %q, want %q", mutation.Project, "engram-v2")
+	}
+	if got := payloadProject(t, mutation.Payload); got != "engram-v2" {
+		t.Fatalf("session mutation payload project = %q, want %q", got, "engram-v2")
+	}
+
+	oldEnrolled, err := s.IsProjectEnrolled("engram")
+	if err != nil {
+		t.Fatalf("IsProjectEnrolled old: %v", err)
+	}
+	newEnrolled, err := s.IsProjectEnrolled("engram-v2")
+	if err != nil {
+		t.Fatalf("IsProjectEnrolled new: %v", err)
+	}
+	if oldEnrolled || !newEnrolled {
+		t.Fatalf("enrollment after rename: old=%v new=%v, want old=false new=true", oldEnrolled, newEnrolled)
+	}
+
+	skipped, err := s.SkipAckNonEnrolledMutations(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("SkipAckNonEnrolledMutations: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skip-acked mutations = %d, want 0 after rename", skipped)
+	}
+}
+
+func TestMigrateProjectNormalizesNewName(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s1", "old-name", "/tmp/old"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	result, err := s.MigrateProject("old-name", " New--Name ")
+	if err != nil {
+		t.Fatalf("MigrateProject: %v", err)
+	}
+	if !result.Migrated || result.SessionsUpdated != 1 {
+		t.Fatalf("unexpected migrate result: %+v", result)
+	}
+
+	var project string
+	if err := s.db.QueryRow(`SELECT project FROM sessions WHERE id = 's1'`).Scan(&project); err != nil {
+		t.Fatalf("read migrated session: %v", err)
+	}
+	if project != "new-name" {
+		t.Fatalf("migrated project = %q, want normalized %q", project, "new-name")
+	}
+}
+
+func TestMergeThenRenameKeepsSyncLifecycle(t *testing.T) {
+	s := newTestStore(t)
+	seedLegacyMergeRecords(t, s, "Engram")
+	seedPendingLegacyMutations(t, s, "Engram")
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("enroll canonical: %v", err)
+	}
+
+	if _, err := s.MergeProjects([]string{"Engram"}, "engram"); err != nil {
+		t.Fatalf("MergeProjects: %v", err)
+	}
+	if _, err := s.MigrateProject("engram", "engram-core"); err != nil {
+		t.Fatalf("MigrateProject after merge: %v", err)
+	}
+
+	pending := pendingMutationsByEntityKey(t, s)
+	for _, entityKey := range []string{"legacy-session", "legacy-obs"} {
+		mutation, ok := pending[entityKey]
+		if !ok {
+			t.Fatalf("no deliverable mutation for %q after merge+rename; got %v", entityKey, pending)
+		}
+		if mutation.Project != "engram-core" {
+			t.Fatalf("mutation %q project = %q, want %q", entityKey, mutation.Project, "engram-core")
+		}
+		if got := payloadProject(t, mutation.Payload); got != "engram-core" {
+			t.Fatalf("mutation %q payload project = %q, want %q", entityKey, got, "engram-core")
+		}
+	}
+
+	enrolled, err := s.IsProjectEnrolled("engram-core")
+	if err != nil {
+		t.Fatalf("IsProjectEnrolled: %v", err)
+	}
+	if !enrolled {
+		t.Fatal("renamed project must be enrolled after merge+rename")
+	}
+	skipped, err := s.SkipAckNonEnrolledMutations(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("SkipAckNonEnrolledMutations: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skip-acked mutations = %d, want 0 after merge+rename", skipped)
+	}
+}
+
 func TestNewLimitsSQLiteConnectionPoolToSingleOpenConnection(t *testing.T) {
 	s := newTestStore(t)
 	stats := s.db.Stats()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7851,6 +7851,63 @@ func TestMigrateProjectMigratesSyncIdentityForRename(t *testing.T) {
 	}
 }
 
+func TestMigrateProjectLeavesCoexistingNormalizedProjectUntouched(t *testing.T) {
+	s := newTestStore(t)
+	// A legacy row can carry a non-normalized spelling that no current write
+	// path produces. Renaming it moves only its own records, so it must not
+	// seize the sync identity of the live project stored under the normalized
+	// spelling either.
+	if err := s.CreateSession("live-session", "engram", "/work/live"); err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("enroll live: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, ?, datetime('now'))`,
+		"legacy-session", "Engram", "/work/legacy",
+	); err != nil {
+		t.Fatalf("seed legacy session: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO sync_enrolled_projects (project) VALUES (?)`, "Engram",
+	); err != nil {
+		t.Fatalf("seed legacy enrollment: %v", err)
+	}
+
+	if _, err := s.MigrateProject("Engram", "engram-v2"); err != nil {
+		t.Fatalf("MigrateProject: %v", err)
+	}
+
+	pending := pendingMutationsByEntityKey(t, s)
+	live, ok := pending["live-session"]
+	if !ok {
+		t.Fatalf("coexisting project mutation missing after rename; got %v", pending)
+	}
+	if live.Project != "engram" {
+		t.Fatalf("coexisting mutation project = %q, want %q", live.Project, "engram")
+	}
+	if got := payloadProject(t, live.Payload); got != "engram" {
+		t.Fatalf("coexisting mutation payload project = %q, want %q", got, "engram")
+	}
+
+	stillEnrolled, err := s.IsProjectEnrolled("engram")
+	if err != nil {
+		t.Fatalf("IsProjectEnrolled coexisting: %v", err)
+	}
+	if !stillEnrolled {
+		t.Fatal("coexisting project lost its enrollment to the rename")
+	}
+
+	skipped, err := s.SkipAckNonEnrolledMutations(DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("SkipAckNonEnrolledMutations: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skip-acked mutations = %d, want 0", skipped)
+	}
+}
+
 func TestMigrateProjectNormalizesNewName(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.CreateSession("s1", "old-name", "/tmp/old"); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7224,7 +7224,7 @@ func TestMergeProjectsCanonicalInSources(t *testing.T) {
 	}
 }
 
-func TestMergeProjectsNormalizesAliasSourcesWithoutLosingLegacyRows(t *testing.T) {
+func TestMergeProjectsReportsTrimmedLegacySourceWithoutLosingRows(t *testing.T) {
 	s := newTestStore(t)
 
 	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, "legacy-session", "Engram Memory", "/work/engram"); err != nil {
@@ -7237,15 +7237,15 @@ func TestMergeProjectsNormalizesAliasSourcesWithoutLosingLegacyRows(t *testing.T
 		t.Fatalf("seed legacy prompt: %v", err)
 	}
 
-	result, err := s.MergeProjects([]string{"Engram Memory"}, "engram memory")
+	result, err := s.MergeProjects([]string{" Engram Memory "}, "engram memory")
 	if err != nil {
 		t.Fatalf("MergeProjects: %v", err)
 	}
 	if result.ObservationsUpdated != 1 || result.SessionsUpdated != 1 || result.PromptsUpdated != 1 {
 		t.Fatalf("unexpected merge result: %+v", result)
 	}
-	if len(result.SourcesMerged) != 1 || result.SourcesMerged[0] != "engram memory" {
-		t.Fatalf("SourcesMerged = %v, want [engram memory]", result.SourcesMerged)
+	if len(result.SourcesMerged) != 1 || result.SourcesMerged[0] != "Engram Memory" {
+		t.Fatalf("SourcesMerged = %v, want [Engram Memory]", result.SourcesMerged)
 	}
 
 	for _, table := range []string{"sessions", "observations", "user_prompts"} {
@@ -7383,18 +7383,30 @@ func TestMergeProjectsRejectsMixedSourcesWithoutMutation(t *testing.T) {
 }
 
 func TestProjectMergeSourceVariantsStayNormalizationEquivalent(t *testing.T) {
-	for _, rawSource := range []string{"Engram", " ENGRAM ", "engram", "foo-bar"} {
-		normalizedSource, _ := NormalizeProject(rawSource)
-		variants := projectMergeSourceVariants(rawSource, normalizedSource, "engram")
-		for _, variant := range variants {
-			normalizedVariant, _ := NormalizeProject(variant)
-			if normalizedVariant != "engram" {
-				t.Fatalf("variant %q normalizes to %q, want engram", variant, normalizedVariant)
-			}
-		}
+	tests := []struct {
+		name             string
+		rawSource        string
+		normalizedSource string
+		canonical        string
+		want             []string
+	}{
+		{name: "legacy case spelling", rawSource: "Engram", normalizedSource: "engram", canonical: "engram", want: []string{"Engram"}},
+		{name: "whitespace input uses trimmed SQL target", rawSource: " ENGRAM ", normalizedSource: "engram", canonical: "engram", want: []string{"ENGRAM"}},
+		{name: "canonical is excluded", rawSource: "engram", normalizedSource: "engram", canonical: "engram", want: nil},
+		{name: "non-equivalent source is excluded", rawSource: "foo-bar", normalizedSource: "foo-bar", canonical: "foo_bar", want: nil},
 	}
-	if variants := projectMergeSourceVariants("foo-bar", "foo-bar", "foo_bar"); len(variants) != 0 {
-		t.Fatalf("separator variants = %v, want none", variants)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := projectMergeSourceVariants(tt.rawSource, tt.normalizedSource, tt.canonical)
+			if len(got) != len(tt.want) {
+				t.Fatalf("variant count = %d, want %d; variants = %v", len(got), len(tt.want), got)
+			}
+			for i, want := range tt.want {
+				if got[i] != want {
+					t.Fatalf("variant[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #578

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Restrict automatic consolidation to normalization-equivalent project names.
- Enforce the same fail-closed contract at the store boundary used by CLI and MCP.
- Add deterministic grouping, atomic rejection, MCP, and regression coverage.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Remove weak similarity/shared-directory merge eligibility and stabilize canonical selection. |
| `internal/store/store.go` | Validate every source before mutation and restrict source variants to the identity contract. |
| `cmd/engram/main_test.go` | Cover weak-edge rejection, dry-run, and deterministic grouping. |
| `internal/store/store_test.go` | Cover fail-closed validation, separator rejection, and atomic no-mutation behavior. |
| `internal/mcp/mcp_test.go` | Cover MCP rejection of non-equivalent merges. |
| `DOCS.md`, `docs/ARCHITECTURE.md` | Document normalization-equivalent consolidation. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

Focused store, MCP, and CLI consolidation regressions pass. `go test ./internal/mcp -count=1` passes. The full store package still hits existing Windows SQLite cleanup-lock failures in `TestMigrate_Idempotent` and `TestNewErrorBranches`; the full CLI package exceeded the 240-second local bound. CI remains authoritative for the complete unit suite.

---

## 🤖 Automated Checks

These run automatically and all must pass before merge.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #578`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The maintainer explicitly accepted a single-PR size exception for this 520-line candidate because it has one causal invariant and rollback boundary. RDD reviewed the exact committed tree and completed with approval; its remaining findings are non-blocking follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project consolidation now merges only names equivalent after normalization.
  * Prevents unrelated, similar, substring-based, shared-directory, and separator-variant names from being merged.
  * Invalid merge requests are rejected without modifying stored records.
  * Preserves synchronization state when projects are merged or renamed.
  * Consolidation and merge results now report only sources that changed data.

* **Documentation**
  * Updated CLI and cleanup guidance to describe normalization-equivalent project names.
  * Clarified that hyphens and underscores are not interchangeable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->