### PR TITLE
fix(cloud): validate chunk relation payloads

### DIFF
--- a/internal/cloud/chunkcodec/chunkcodec.go
+++ b/internal/cloud/chunkcodec/chunkcodec.go
@@ -278,6 +278,34 @@ type mutationRelationPayload struct {
 	UpdatedAt      string   `json:"updated_at,omitempty"`
 }
 
+// ValidateRelationPayload reports the first required relation payload field that
+// is absent, not a string, or empty after trimming whitespace.
+func ValidateRelationPayload(payload json.RawMessage) (string, bool) {
+	var fields map[string]any
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return "sync_id", false
+	}
+	for _, field := range []string{
+		"sync_id",
+		"source_id",
+		"target_id",
+		"relation",
+		"judgment_status",
+		"marked_by_actor",
+		"marked_by_kind",
+	} {
+		value, ok := fields[field]
+		if !ok {
+			return field, false
+		}
+		text, ok := value.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return field, false
+		}
+	}
+	return "", true
+}
+
 func normalizeChunkMutation(raw map[string]any, project string) (map[string]any, error) {
 	mutationJSON, err := json.Marshal(raw)
 	if err != nil {

--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Gentleman-Programming/engram/internal/cloud/chunkcodec"
 	"github.com/Gentleman-Programming/engram/internal/cloud/cloudstore"
 	"github.com/Gentleman-Programming/engram/internal/cloud/constants"
 	"github.com/Gentleman-Programming/engram/internal/project"
@@ -316,41 +317,12 @@ func (s *CloudServer) handleMutationPull(w http.ResponseWriter, r *http.Request)
 
 // ─── REQ-006 / REQ-008: Per-entity payload validation ────────────────────────
 
-// relationRequiredFields lists the fields that MUST be present and non-empty
-// in every relation mutation payload (REQ-006). This list is the stable
-// validation contract — Phase 3 MUST NOT remove or rename these fields without
-// a wire-format version bump.
-var relationRequiredFields = []string{
-	"sync_id",
-	"source_id",
-	"target_id",
-	"relation",
-	"judgment_status",
-	"marked_by_actor",
-	"marked_by_kind",
-}
-
 // validateRelationPayload checks that all required relation fields are present
-// and non-empty in the decoded payload map.
+// and non-empty in the decoded payload map using the canonical chunk validator.
 // Returns (missingField, false) when any required field is absent or empty,
 // or ("", true) when all required fields are present.
 func validateRelationPayload(payload json.RawMessage) (string, bool) {
-	var fields map[string]any
-	if err := json.Unmarshal(payload, &fields); err != nil {
-		// Malformed JSON: treat sync_id as missing (first required field).
-		return "sync_id", false
-	}
-	for _, field := range relationRequiredFields {
-		v, ok := fields[field]
-		if !ok {
-			return field, false
-		}
-		s, isStr := v.(string)
-		if !isStr || strings.TrimSpace(s) == "" {
-			return field, false
-		}
-	}
-	return "", true
+	return chunkcodec.ValidateRelationPayload(payload)
 }
 
 // validateLegacyPayload is a no-op for legacy entities (session, observation,

--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -415,6 +415,9 @@ func materializedChunkMutations(project string, chunk engramsync.ChunkData) ([]M
 		if len(payload) == 0 {
 			payload = json.RawMessage("{}")
 		}
+		if field, ok := chunkcodec.ValidateRelationPayload(payload); !ok {
+			return nil, fmt.Errorf("cloudstore: materialize chunk: mutations[%d].payload.%s is required for relation", i, field)
+		}
 		entries = append(entries, MutationEntry{Project: project, Entity: store.SyncEntityRelation, EntityKey: entityKey, Op: op, Payload: payload})
 	}
 

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -595,7 +595,7 @@ func TestWriteChunkMaterializesRelationMutationIntoCloudMutations(t *testing.T) 
 
 func TestWriteChunkRejectsIncompleteRelationBeforePersistence(t *testing.T) {
 	cs := openTestCloudStore(t)
-	project := "test-invalid-chunk-relation-" + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "-")
+	project := "test-invalid-chunk-relation-" + strings.ReplaceAll(t.Name(), "/", "-")
 	payload := []byte(`{
 		"mutations":[
 			{"entity":"relation","entity_key":"rel-1","op":"upsert","payload":"{\"source_id\":\"obs-a\",\"target_id\":\"obs-b\",\"relation\":\"related\",\"judgment_status\":\"judged\",\"marked_by_actor\":\"agent-a\",\"marked_by_kind\":\"agent\"}"}

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -490,7 +490,7 @@ func TestMaterializedChunkMutationsRejectsMissingSyncIDs(t *testing.T) {
 
 func TestMaterializedChunkMutationsCarriesRelationFromChunkMutations(t *testing.T) {
 	project := "proj-materialize-rel"
-	relationPayload := `{"sync_id":"rel-1","source_id":"obs-a","target_id":"obs-b","relation":"related","project":"proj-materialize-rel"}`
+	relationPayload := `{"sync_id":"rel-1","source_id":"obs-a","target_id":"obs-b","relation":"related","judgment_status":"judged","marked_by_actor":"agent-a","marked_by_kind":"agent","project":"proj-materialize-rel"}`
 	chunk := engramsync.ChunkData{
 		Observations: []store.Observation{{SyncID: "obs-a"}, {SyncID: "obs-b"}},
 		Mutations: []store.SyncMutation{
@@ -545,7 +545,7 @@ func TestWriteChunkMaterializesRelationMutationIntoCloudMutations(t *testing.T) 
 			{"sync_id":"obs-b","session_id":"s-1","type":"decision","title":"B","content":"B","scope":"project","created_at":"2026-04-29T10:01:00Z","updated_at":"2026-04-29T10:01:00Z"}
 		],
 		"mutations":[
-			{"entity":"relation","entity_key":"rel-1","op":"upsert","payload":"{\"sync_id\":\"rel-1\",\"source_id\":\"obs-a\",\"target_id\":\"obs-b\",\"relation\":\"related\"}"}
+			{"entity":"relation","entity_key":"rel-1","op":"upsert","payload":"{\"sync_id\":\"rel-1\",\"source_id\":\"obs-a\",\"target_id\":\"obs-b\",\"relation\":\"related\",\"judgment_status\":\"judged\",\"marked_by_actor\":\"agent-a\",\"marked_by_kind\":\"agent\"}"}
 		]
 	}`), project)
 	if err != nil {
@@ -590,6 +590,32 @@ func TestWriteChunkMaterializesRelationMutationIntoCloudMutations(t *testing.T) 
 	}
 	if relCount != 1 {
 		t.Fatalf("expected exactly one relation row after replay, got %d", relCount)
+	}
+}
+
+func TestWriteChunkRejectsIncompleteRelationBeforePersistence(t *testing.T) {
+	cs := openTestCloudStore(t)
+	project := "test-invalid-chunk-relation-" + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "-")
+	payload := []byte(`{
+		"mutations":[
+			{"entity":"relation","entity_key":"rel-1","op":"upsert","payload":"{\"source_id\":\"obs-a\",\"target_id\":\"obs-b\",\"relation\":\"related\",\"judgment_status\":\"judged\",\"marked_by_actor\":\"agent-a\",\"marked_by_kind\":\"agent\"}"}
+		]
+	}`)
+
+	err := cs.WriteChunk(context.Background(), project, chunkIDFromPayload(payload), "tester", "2026-04-29T10:03:00Z", payload)
+	if err == nil || !strings.Contains(err.Error(), "mutations[0].payload.sync_id is required") {
+		t.Fatalf("expected missing relation sync_id error, got %v", err)
+	}
+
+	var chunks, mutations int
+	if err := cs.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM cloud_chunks WHERE project_name = $1`, project).Scan(&chunks); err != nil {
+		t.Fatalf("count chunks: %v", err)
+	}
+	if err := cs.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM cloud_mutations WHERE project = $1`, project).Scan(&mutations); err != nil {
+		t.Fatalf("count mutations: %v", err)
+	}
+	if chunks != 0 || mutations != 0 {
+		t.Fatalf("expected no persisted chunk or mutation after validation failure, got chunks=%d mutations=%d", chunks, mutations)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #601

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Centralizes the seven-field relation payload contract in `chunkcodec`.
- Applies the same validation to mutation push and chunk materialization before persistence.
- Adds regression coverage for rejecting incomplete relation chunks without persisted rows.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/chunkcodec/chunkcodec.go` | Add the shared relation payload validator. |
| `internal/cloud/cloudserver/mutations.go` | Reuse the shared validator for mutation push. |
| `internal/cloud/cloudstore/cloudstore.go` | Reject incomplete relation payloads before chunk persistence. |
| `internal/cloud/cloudstore/cloudstore_test.go` | Cover complete relations and atomic rejection. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Focused cloudserver and cloudstore tests pass locally
- [x] Affected package tests pass: `go test ./internal/cloud/cloudserver ./internal/cloud/cloudstore`

The full Windows suite was executed but did not pass because of unrelated environment/platform failures in `cmd/engram`, `internal/setup`, `internal/store`, and `internal/sync` (including a timeout, unavailable `sh`, locked temporary SQLite files, and Windows filesystem expectation differences). The changed cloud packages passed. The database-backed atomicity case compiled but skipped because `CLOUDSTORE_TEST_DSN` is unset.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | Server E2E tests pass | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #601`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated if needed (no documentation change required)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The frozen 95-line candidate passed the native `review-reliability` RDD review before commit. Delivery remains governed by normal repository checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for relation mutation payloads.
  * Missing, empty, or invalid required fields are now detected consistently.
  * Invalid relation mutations are rejected before data is persisted.
  * Validation errors identify the affected field for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->