### PR TITLE
fix(codex): release hook pipes after prompt capture

### DIFF
--- a/plugin/codex/scripts/user-prompt-submit.sh
+++ b/plugin/codex/scripts/user-prompt-submit.sh
@@ -46,7 +46,7 @@ if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
       -H 'Content-Type: application/json' \
       -d "$(jq -n --arg s "$SESSION_ID" --arg p "$PROJECT" --arg c "$PROMPT" \
             '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
-  ) &
+  ) </dev/null >/dev/null 2>&1 &
 fi
 
 parse_epoch() {

--- a/plugin/codex_unix_user_prompt_test.go
+++ b/plugin/codex_unix_user_prompt_test.go
@@ -1,0 +1,180 @@
+package plugin_test
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCodexUnixUserPromptSubmitDetachesPromptPersistencePipes(t *testing.T) {
+	bashPath := codexTestBash(t)
+	requireCodexUnixTools(t, bashPath)
+	adapterPath := filepath.Join(repoRoot(t), "plugin", "codex", "scripts", "user-prompt-submit.sh")
+
+	postStarted := make(chan struct{})
+	releasePost := make(chan struct{})
+	var postOnce sync.Once
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/project/current":
+			_, _ = io.WriteString(w, `{"project":"test-project","project_source":"config"}`)
+		case "/prompts":
+			postOnce.Do(func() { close(postStarted) })
+			<-releasePost
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	})}
+	defer func() {
+		close(releasePost)
+		_ = server.Close()
+	}()
+	go func() { _ = server.Serve(listener) }()
+	port := strings.TrimPrefix(listener.Addr().String(), "127.0.0.1:")
+
+	inputReader, inputWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	defer inputWriter.Close()
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer stdoutReader.Close()
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	defer stderrReader.Close()
+
+	run := exec.Command(bashPath, adapterPath)
+	run.Env = codexPromptTestEnv(port)
+	run.Stdin = inputReader
+	run.Stdout = stdoutWriter
+	run.Stderr = stderrWriter
+	if err := run.Start(); err != nil {
+		t.Fatalf("start adapter: %v", err)
+	}
+	_ = inputReader.Close()
+	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
+	if _, err := io.WriteString(inputWriter, `{"cwd":"/tmp/test","session_id":"pipe-test-`+time.Now().Format("150405.000000000")+`","prompt":"capture this"}`); err != nil {
+		t.Fatalf("write hook input: %v", err)
+	}
+	if err := inputWriter.Close(); err != nil {
+		t.Fatalf("close hook input: %v", err)
+	}
+
+	type hookOutput struct {
+		stdout []byte
+		stderr []byte
+	}
+	outputDone := make(chan hookOutput, 1)
+	go func() {
+		stdout, _ := io.ReadAll(stdoutReader)
+		stderr, _ := io.ReadAll(stderrReader)
+		outputDone <- hookOutput{stdout: stdout, stderr: stderr}
+	}()
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- run.Wait() }()
+
+	select {
+	case <-postStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("prompt persistence did not reach the delayed loopback server")
+	}
+
+	select {
+	case output := <-outputDone:
+		if !json.Valid(output.stdout) {
+			t.Fatalf("stdout is not valid hook JSON: %q", output.stdout)
+		}
+		if string(output.stderr) != "" {
+			t.Fatalf("stderr = %q, want immediate EOF without output", output.stderr)
+		}
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("stdout or stderr remained open while the delayed prompt POST was in flight")
+	}
+
+	select {
+	case err := <-waitDone:
+		if err != nil {
+			t.Fatalf("adapter exit: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("foreground hook did not complete before the delayed POST response")
+	}
+}
+
+func TestCodexUnixUserPromptSubmitDetachesPromptPersistenceStdin(t *testing.T) {
+	bashPath := codexTestBash(t)
+	requireCodexUnixTools(t, bashPath)
+	adapterPath := filepath.Join(repoRoot(t), "plugin", "codex", "scripts", "user-prompt-submit.sh")
+	binDir := t.TempDir()
+	markerPath := filepath.Join(binDir, "stdin-result")
+	writeCodexPromptProbeCommand(t, filepath.Join(binDir, "cat"), "#!/bin/bash\nprintf '%s' '{\"cwd\":\"/tmp/test\",\"session_id\":\"stdin-pipe-test\",\"prompt\":\"capture this\"}'\n")
+	writeCodexPromptProbeCommand(t, filepath.Join(binDir, "curl"), "#!/bin/bash\ncase \"$*\" in\n  *'/project/current'*) printf '%s' '{\"project\":\"test-project\",\"project_source\":\"config\"}' ;;\n  *) if IFS= read -r -t 0.2 _; then printf data > \"$PROMPT_STDIN_MARKER\"; else printf eof > \"$PROMPT_STDIN_MARKER\"; fi ;;\nesac\n")
+
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	defer stdinWriter.Close()
+	run := exec.Command(bashPath, "-c", `PATH="$1:$PATH"; export PATH; "$2"`, "codex-test", binDir, adapterPath)
+	run.Env = append(codexPromptTestEnv("7437"), "PROMPT_STDIN_MARKER="+markerPath)
+	run.Stdin = stdinReader
+	if output, err := run.CombinedOutput(); err != nil {
+		t.Fatalf("run adapter: %v: %s", err, output)
+	}
+	_ = stdinReader.Close()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		result, err := os.ReadFile(markerPath)
+		if err == nil {
+			if string(result) != "eof" {
+				t.Fatalf("detached curl stdin = %q, want EOF from /dev/null", result)
+			}
+			return
+		}
+		if !os.IsNotExist(err) {
+			t.Fatalf("read stdin probe result: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("prompt persistence did not finish the stdin probe")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func writeCodexPromptProbeCommand(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write probe command %s: %v", path, err)
+	}
+}
+
+func codexPromptTestEnv(port string) []string {
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, item := range os.Environ() {
+		if strings.HasPrefix(strings.ToUpper(item), "ENGRAM_PORT=") {
+			continue
+		}
+		env = append(env, item)
+	}
+	return append(env, "ENGRAM_PORT="+port)
+}

--- a/plugin/codex_unix_user_prompt_test.go
+++ b/plugin/codex_unix_user_prompt_test.go
@@ -127,27 +127,47 @@ func TestCodexUnixUserPromptSubmitDetachesPromptPersistenceStdin(t *testing.T) {
 	binDir := t.TempDir()
 	markerPath := filepath.Join(binDir, "stdin-result")
 	writeCodexPromptProbeCommand(t, filepath.Join(binDir, "cat"), "#!/bin/bash\nprintf '%s' '{\"cwd\":\"/tmp/test\",\"session_id\":\"stdin-pipe-test\",\"prompt\":\"capture this\"}'\n")
-	writeCodexPromptProbeCommand(t, filepath.Join(binDir, "curl"), "#!/bin/bash\ncase \"$*\" in\n  *'/project/current'*) printf '%s' '{\"project\":\"test-project\",\"project_source\":\"config\"}' ;;\n  *) if IFS= read -r -t 0.2 _; then printf data > \"$PROMPT_STDIN_MARKER\"; else printf eof > \"$PROMPT_STDIN_MARKER\"; fi ;;\nesac\n")
+	writeCodexPromptProbeCommand(t, filepath.Join(binDir, "curl"), "#!/bin/bash\ncase \"$*\" in\n  *'/project/current'*) printf '%s' '{\"project\":\"test-project\",\"project_source\":\"config\"}' ;;\n  *'/prompts'*) if IFS= read -r _; then printf data > \"$PROMPT_STDIN_MARKER\"; else printf eof > \"$PROMPT_STDIN_MARKER\"; fi ;;\n  *) exit 0 ;;\nesac\n")
 
 	stdinReader, stdinWriter, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("create stdin pipe: %v", err)
 	}
-	defer stdinWriter.Close()
 	run := exec.Command(bashPath, "-c", `PATH="$1:$PATH"; export PATH; "$2"`, "codex-test", binDir, adapterPath)
 	run.Env = append(codexPromptTestEnv("7437"), "PROMPT_STDIN_MARKER="+markerPath)
 	run.Stdin = stdinReader
-	if output, err := run.CombinedOutput(); err != nil {
-		t.Fatalf("run adapter: %v: %s", err, output)
+	if err := run.Start(); err != nil {
+		_ = stdinWriter.Close()
+		t.Fatalf("start adapter: %v", err)
 	}
 	_ = stdinReader.Close()
 
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- run.Wait() }()
+	waited := false
+	defer func() {
+		_ = stdinWriter.Close()
+		if !waited {
+			_ = run.Process.Kill()
+			<-waitDone
+		}
+	}()
+
 	deadline := time.Now().Add(time.Second)
 	for {
-		result, err := os.ReadFile(markerPath)
+		marker, err := os.ReadFile(markerPath)
 		if err == nil {
-			if string(result) != "eof" {
-				t.Fatalf("detached curl stdin = %q, want EOF from /dev/null", result)
+			if string(marker) != "eof" {
+				t.Fatalf("detached curl stdin = %q, want EOF from /dev/null", marker)
+			}
+			select {
+			case err := <-waitDone:
+				waited = true
+				if err != nil {
+					t.Fatalf("run adapter: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("adapter did not exit after the stdin probe")
 			}
 			return
 		}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #731

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Detach background Codex prompt persistence from inherited hook stdin, stdout, and stderr.
- Add real-script regressions for immediate pipe EOF and stdin isolation.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/codex/scripts/user-prompt-submit.sh` | Redirect all detached subshell descriptors to `/dev/null`. |
| `plugin/codex_unix_user_prompt_test.go` | Cover delayed loopback pipe release and detached stdin behavior. |

## 🧪 Test Plan

- [x] Focused tests: `go test ./plugin -run '^TestCodexUnixUserPromptSubmit' -count=1`
- [x] Affected package: `go test ./plugin -count=1`
- [ ] Unit tests pass locally: `go test ./...` — timed out after 10 minutes without a result; CI required
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — not reached after the unit-test timeout; CI required
- [ ] Shellcheck — unavailable in the local environment; CI required
- [x] Native four-lens RDD approved the exact committed tree

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #731` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #731`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally to completion — timed out; CI required
- [ ] I ran e2e tests locally — CI required
- [x] Docs are not required for this internal bug fix
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The local environment did not provide `shellcheck`, and the full unit suite exceeded the 10-minute local budget. Focused and affected-package tests passed. Please rely on the required CI checks for shellcheck, full unit, and E2E proof before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt submission reliability by ensuring background persistence no longer inherits or blocks on the hook’s input and output streams.
  * Prompt submission now completes promptly while persistence continues independently, reducing delays and preventing unexpected stream-related interruptions.
  * Detached persistence receives a clean end-of-input signal, improving consistency across supported environments.

* **Tests**
  * Added coverage verifying prompt persistence continues asynchronously and receives a clean end-of-input signal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->