### PR TITLE
fix(pi): disambiguate saved prompt identity

### DIFF
--- a/internal/cloud/cloudstore/dashboard_queries_test.go
+++ b/internal/cloud/cloudstore/dashboard_queries_test.go
@@ -1594,3 +1594,131 @@ func TestPromptDetailNotFoundReturnsPromptNotFoundError(t *testing.T) {
 		t.Errorf("must NOT be ErrDashboardProjectNotFound for missing prompt in valid project")
 	}
 }
+
+// TestDashboardCountsPiSavedPromptUnderItsProject closes the last gap #706 named: the reporter's
+// prompt "saved" locally while the cloud dashboard kept showing 0 prompts for the project.
+//
+// It seeds the read model with a prompt delivered the way a locally saved prompt actually reaches
+// the cloud — an upsert mutation keyed by sync_id — and asserts the dashboard surfaces that
+// prompt under its own project: the project prompt count, the recent-prompts list, and the detail
+// page the sync_id addresses. A neighbouring project must not see it.
+func TestDashboardCountsPiSavedPromptUnderItsProject(t *testing.T) {
+	const (
+		targetProject = "paidosdep"
+		otherProject  = "skill-registry"
+		promptSyncID  = "prompt-paidosdep-1"
+		promptSession = "manual-save-paidosdep"
+		promptContent = "preserve this exact user prompt about auth token rotation"
+	)
+
+	// Mirrors the payload the local store enqueues for a prompt upsert.
+	mutationPayload, err := json.Marshal(map[string]any{
+		"sync_id":    promptSyncID,
+		"session_id": promptSession,
+		"content":    promptContent,
+		"project":    targetProject,
+		"created_at": "2026-04-23T08:20:00Z",
+	})
+	if err != nil {
+		t.Fatalf("marshal mutation payload: %v", err)
+	}
+
+	targetChunk, err := json.Marshal(map[string]any{
+		"sessions": []map[string]any{
+			{"id": promptSession, "project": targetProject, "started_at": "2026-04-23T08:00:00Z"},
+		},
+		"mutations": []map[string]any{
+			{"entity": "prompt", "entity_key": promptSyncID, "op": "upsert", "payload": string(mutationPayload)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal target chunk: %v", err)
+	}
+
+	chunks := []dashboardChunkRow{
+		{
+			chunkID: "chunk-paidosdep-1", project: targetProject, createdBy: "alice",
+			createdAt: time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+			parsed:    parseMustChunk(t, targetChunk),
+		},
+		{
+			chunkID: "chunk-skill-registry-1", project: otherProject, createdBy: "alice",
+			createdAt: time.Date(2026, 4, 23, 11, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"manual-save-skill-registry","project":"skill-registry","started_at":"2026-04-23T09:00:00Z"}],
+				"prompts":[{"sync_id":"prompt-skill-registry-1","session_id":"manual-save-skill-registry","project":"skill-registry","content":"an unrelated prompt","created_at":"2026-04-23T09:20:00Z"}]
+			}`)),
+		},
+	}
+
+	model, err := buildDashboardReadModel(chunks)
+	if err != nil {
+		t.Fatalf("buildDashboardReadModel: %v", err)
+	}
+	cs := &CloudStore{
+		dashboardReadModelLoad: func() (dashboardReadModel, error) { return model, nil },
+	}
+
+	// The symptom in #706: the project row kept reporting 0 prompts.
+	projects, err := cs.ListProjects("")
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	var targetRow *DashboardProjectRow
+	for i := range projects {
+		if projects[i].Project == targetProject {
+			targetRow = &projects[i]
+			break
+		}
+	}
+	if targetRow == nil {
+		t.Fatalf("project %q missing from the dashboard project list", targetProject)
+	}
+	if targetRow.Prompts != 1 {
+		t.Fatalf("expected 1 prompt on the %q dashboard row, got %d", targetProject, targetRow.Prompts)
+	}
+
+	prompts, err := cs.ListRecentPrompts(targetProject, "", 10)
+	if err != nil {
+		t.Fatalf("ListRecentPrompts: %v", err)
+	}
+	var listed *DashboardPromptRow
+	for i := range prompts {
+		if prompts[i].SyncID == promptSyncID {
+			listed = &prompts[i]
+			break
+		}
+	}
+	if listed == nil {
+		t.Fatalf("prompt %q not listed on the %q dashboard (got %d prompts)", promptSyncID, targetProject, len(prompts))
+	}
+	if listed.Content != promptContent {
+		t.Fatalf("dashboard prompt content changed: %q", listed.Content)
+	}
+	if listed.SessionID != promptSession {
+		t.Fatalf("expected dashboard prompt session %q, got %q", promptSession, listed.SessionID)
+	}
+	if listed.Project != targetProject {
+		t.Fatalf("expected dashboard prompt project %q, got %q", targetProject, listed.Project)
+	}
+
+	// The detail page is addressed by sync_id, so that identity must resolve.
+	detail, _, _, err := cs.GetPromptDetail(targetProject, promptSession, promptSyncID)
+	if err != nil {
+		t.Fatalf("GetPromptDetail: %v", err)
+	}
+	if detail.SyncID != promptSyncID || detail.Content != promptContent {
+		t.Fatalf("prompt detail does not describe the saved prompt: %+v", detail)
+	}
+
+	// Scope: the neighbouring project must not show this prompt.
+	otherPrompts, err := cs.ListRecentPrompts(otherProject, "", 10)
+	if err != nil {
+		t.Fatalf("ListRecentPrompts other project: %v", err)
+	}
+	for _, p := range otherPrompts {
+		if p.SyncID == promptSyncID {
+			t.Fatalf("prompt %q leaked onto the %q dashboard", promptSyncID, otherProject)
+		}
+	}
+}

--- a/internal/server/server_e2e_test.go
+++ b/internal/server/server_e2e_test.go
@@ -1046,3 +1046,158 @@ func TestStoreClosedExtraServerBranchesE2E(t *testing.T) {
 	}
 	exportResp.Body.Close()
 }
+
+// TestPiPromptPersistenceE2E replays the exact wire sequence the Pi plugin's mem_save_prompt
+// issues (POST /sessions, then POST /prompts) and proves the prompt is durably persisted,
+// retrievable, and scoped to its project.
+//
+// Regression for #706: the reported symptom was a "saved" response carrying an id that resolved
+// to an unrelated entry from another project. The id was never stale — prompts are numbered from
+// user_prompts, a sequence independent of observations — so the response id must read back as the
+// prompt that was just saved, and must not resolve as an observation.
+func TestPiPromptPersistenceE2E(t *testing.T) {
+	_, ts := newE2EServer(t)
+	client := ts.Client()
+
+	const (
+		targetProject = "paidosdep"
+		otherProject  = "skill-registry"
+		promptContent = "preserve this exact user prompt about auth token rotation"
+	)
+
+	// The plugin derives a stable per-project session id when the caller passes an explicit
+	// project, and creates that session before writing the prompt.
+	targetSession := "manual-save-" + targetProject
+	otherSession := "manual-save-" + otherProject
+
+	for _, s := range []struct{ id, project string }{
+		{targetSession, targetProject},
+		{otherSession, otherProject},
+	} {
+		sessionResp := postJSON(t, client, ts.URL+"/sessions", map[string]any{
+			"id":        s.id,
+			"project":   s.project,
+			"directory": "/tmp/" + s.project,
+		})
+		if sessionResp.StatusCode != http.StatusCreated {
+			t.Fatalf("expected 201 creating session %q, got %d", s.id, sessionResp.StatusCode)
+		}
+		sessionResp.Body.Close()
+	}
+
+	// An observation in the other project gives both id sequences live rows, so the namespace
+	// assertions below exercise the collision #706 actually hit rather than an empty table.
+	obsResp := postJSON(t, client, ts.URL+"/observations", map[string]any{
+		"session_id": otherSession,
+		"title":      "unrelated entry",
+		"content":    "an observation that must never answer for a prompt id",
+		"type":       "manual",
+		"project":    otherProject,
+		"scope":      "project",
+	})
+	if obsResp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating observation, got %d", obsResp.StatusCode)
+	}
+	obsResp.Body.Close()
+
+	promptResp := postJSON(t, client, ts.URL+"/prompts", map[string]any{
+		"session_id": targetSession,
+		"content":    promptContent,
+		"project":    targetProject,
+	})
+	if promptResp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 creating prompt, got %d", promptResp.StatusCode)
+	}
+	created := decodeJSON[map[string]any](t, promptResp)
+	if created["status"] != "saved" {
+		t.Fatalf("expected saved status, got %v", created["status"])
+	}
+	promptID, ok := created["id"].(float64)
+	if !ok || promptID <= 0 {
+		t.Fatalf("expected a positive prompt id, got %v", created["id"])
+	}
+
+	// The prompt is retrievable under its own project, and the returned id resolves to the
+	// content that was just written — not to some pre-existing row.
+	recentResp, err := client.Get(ts.URL + "/prompts/recent?project=" + targetProject)
+	if err != nil {
+		t.Fatalf("recent prompts: %v", err)
+	}
+	if recentResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 recent prompts, got %d", recentResp.StatusCode)
+	}
+	recent := decodeJSON[[]store.Prompt](t, recentResp)
+	var saved *store.Prompt
+	for i := range recent {
+		if recent[i].ID == int64(promptID) {
+			saved = &recent[i]
+			break
+		}
+	}
+	if saved == nil {
+		t.Fatalf("prompt id %d not retrievable from /prompts/recent for project %q (got %d prompts)", int64(promptID), targetProject, len(recent))
+	}
+	if saved.Content != promptContent {
+		t.Fatalf("prompt id %d resolved to unexpected content %q", int64(promptID), saved.Content)
+	}
+	if saved.Project != targetProject {
+		t.Fatalf("expected prompt project %q, got %q", targetProject, saved.Project)
+	}
+	if saved.SessionID != targetSession {
+		t.Fatalf("expected prompt session %q, got %q", targetSession, saved.SessionID)
+	}
+	// A sync_id is what carries this prompt to the cloud dashboard; without it the row is local-only.
+	if strings.TrimSpace(saved.SyncID) == "" {
+		t.Fatalf("expected prompt %d to carry a sync_id for cloud replication", int64(promptID))
+	}
+
+	// Project scoping: another project must not see this prompt.
+	otherResp, err := client.Get(ts.URL + "/prompts/recent?project=" + otherProject)
+	if err != nil {
+		t.Fatalf("recent prompts other project: %v", err)
+	}
+	if otherResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 recent prompts for other project, got %d", otherResp.StatusCode)
+	}
+	for _, p := range decodeJSON[[]store.Prompt](t, otherResp) {
+		if p.ID == int64(promptID) {
+			t.Fatalf("prompt %d leaked into project %q", int64(promptID), otherProject)
+		}
+	}
+
+	// Search is the other retrieval surface the dashboard and agents use.
+	searchResp, err := client.Get(ts.URL + "/prompts/search?q=rotation&project=" + targetProject + "&limit=5")
+	if err != nil {
+		t.Fatalf("search prompts: %v", err)
+	}
+	if searchResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 searching prompts, got %d", searchResp.StatusCode)
+	}
+	found := false
+	for _, p := range decodeJSON[[]store.Prompt](t, searchResp) {
+		if p.ID == int64(promptID) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("prompt %d not found via /prompts/search", int64(promptID))
+	}
+
+	// The disambiguation #706 asked for: the prompt id is not an observation id. Reading it as one
+	// must never answer with this prompt's content.
+	obsLookup, err := client.Get(ts.URL + "/observations/" + strconv.FormatInt(int64(promptID), 10))
+	if err != nil {
+		t.Fatalf("observation lookup: %v", err)
+	}
+	defer obsLookup.Body.Close()
+	if obsLookup.StatusCode == http.StatusOK {
+		raw, err := io.ReadAll(obsLookup.Body)
+		if err != nil {
+			t.Fatalf("read observation lookup: %v", err)
+		}
+		if strings.Contains(string(raw), promptContent) {
+			t.Fatalf("prompt id %d resolved to an observation carrying the prompt content", int64(promptID))
+		}
+	}
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -3771,3 +3771,169 @@ func TestChunkTrackingTargetKeyScopesBySyncTarget(t *testing.T) {
 		t.Fatalf("expected explicit normalized cloud project target key, got %q", got)
 	}
 }
+
+// TestCloudSyncPreservesPiPromptIdentityUnderProjectScope proves the second half of #706: a prompt
+// saved through the Pi plugin's wire shape does not stop at the local database. It must enqueue a
+// sync mutation under its own project scope and survive the cloud push/pull round trip with the
+// identity the dashboard addresses it by — its sync_id — intact.
+//
+// The dashboard resolves a prompt by sync_id (see TestPromptDetailURLUsesSyncID), so a prompt that
+// arrives without its sync_id, or under the wrong project, is a prompt the dashboard reports as
+// absent even though the local save succeeded.
+func TestCloudSyncPreservesPiPromptIdentityUnderProjectScope(t *testing.T) {
+	const (
+		targetProject = "paidosdep"
+		otherProject  = "skill-registry"
+		promptContent = "preserve this exact user prompt about auth token rotation"
+	)
+
+	// The Pi plugin derives a stable per-project session id when the caller names a project.
+	targetSession := "manual-save-" + targetProject
+	otherSession := "manual-save-" + otherProject
+
+	srcStore := newTestStore(t)
+	if err := srcStore.CreateSession(targetSession, targetProject, "/tmp/"+targetProject); err != nil {
+		t.Fatalf("create target session: %v", err)
+	}
+	if err := srcStore.CreateSession(otherSession, otherProject, "/tmp/"+otherProject); err != nil {
+		t.Fatalf("create other session: %v", err)
+	}
+
+	if _, err := srcStore.AddPrompt(store.AddPromptParams{
+		SessionID: targetSession,
+		Content:   promptContent,
+		Project:   targetProject,
+	}); err != nil {
+		t.Fatalf("add prompt: %v", err)
+	}
+	// A prompt in a neighbouring project keeps the scope assertions honest.
+	if _, err := srcStore.AddPrompt(store.AddPromptParams{
+		SessionID: otherSession,
+		Content:   "an unrelated prompt that must stay in its own project",
+		Project:   otherProject,
+	}); err != nil {
+		t.Fatalf("add other prompt: %v", err)
+	}
+
+	srcPrompts, err := srcStore.RecentPrompts(targetProject, 10)
+	if err != nil {
+		t.Fatalf("recent prompts: %v", err)
+	}
+	if len(srcPrompts) != 1 {
+		t.Fatalf("expected exactly one prompt in %q, got %d", targetProject, len(srcPrompts))
+	}
+	saved := srcPrompts[0]
+	if strings.TrimSpace(saved.SyncID) == "" {
+		t.Fatal("expected the saved prompt to carry a sync_id")
+	}
+
+	// The mutation the prompt enqueues must be filed under the prompt's own project, keyed by the
+	// sync_id, and carry the project inside the payload the cloud will materialize from.
+	pending, err := srcStore.ListPendingProjectMutations(targetProject)
+	if err != nil {
+		t.Fatalf("list pending mutations: %v", err)
+	}
+	var promptMutation *store.SyncMutation
+	for i := range pending {
+		if pending[i].Entity == store.SyncEntityPrompt && pending[i].EntityKey == saved.SyncID {
+			promptMutation = &pending[i]
+			break
+		}
+	}
+	if promptMutation == nil {
+		t.Fatalf("no pending prompt mutation for sync_id %q under project %q", saved.SyncID, targetProject)
+	}
+	if promptMutation.Op != store.SyncOpUpsert {
+		t.Fatalf("expected upsert op, got %q", promptMutation.Op)
+	}
+	if promptMutation.Project != targetProject {
+		t.Fatalf("expected mutation project %q, got %q", targetProject, promptMutation.Project)
+	}
+	var payload struct {
+		SyncID    string  `json:"sync_id"`
+		SessionID string  `json:"session_id"`
+		Content   string  `json:"content"`
+		Project   *string `json:"project"`
+	}
+	if err := json.Unmarshal([]byte(promptMutation.Payload), &payload); err != nil {
+		t.Fatalf("decode prompt mutation payload: %v", err)
+	}
+	if payload.SyncID != saved.SyncID || payload.Content != promptContent || payload.SessionID != targetSession {
+		t.Fatalf("prompt mutation payload does not describe the saved prompt: %+v", payload)
+	}
+	if payload.Project == nil || *payload.Project != targetProject {
+		t.Fatalf("expected payload project %q, got %v", targetProject, payload.Project)
+	}
+
+	// The neighbouring project must not have picked up this prompt's mutation.
+	otherPending, err := srcStore.ListPendingProjectMutations(otherProject)
+	if err != nil {
+		t.Fatalf("list other pending mutations: %v", err)
+	}
+	for _, m := range otherPending {
+		if m.EntityKey == saved.SyncID {
+			t.Fatalf("prompt mutation %q leaked into project %q", saved.SyncID, otherProject)
+		}
+	}
+
+	// Push the enrolled project to the cloud and pull it into a clean store.
+	if err := srcStore.EnrollProject(targetProject); err != nil {
+		t.Fatalf("enroll src project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	exportResult, err := NewCloudWithTransport(srcStore, transport, targetProject).Export("alice", targetProject)
+	if err != nil {
+		t.Fatalf("cloud export: %v", err)
+	}
+	if exportResult.IsEmpty {
+		t.Fatal("expected a non-empty cloud export carrying the prompt")
+	}
+
+	dstStore := newTestStore(t)
+	if err := dstStore.EnrollProject(targetProject); err != nil {
+		t.Fatalf("enroll dst project: %v", err)
+	}
+	importResult, err := NewCloudWithTransport(dstStore, transport, targetProject).Import()
+	if err != nil {
+		t.Fatalf("cloud import: %v", err)
+	}
+	if importResult.ChunksImported == 0 {
+		t.Fatalf("expected at least one imported chunk, got %+v", importResult)
+	}
+
+	// The pulled prompt keeps the identity the dashboard addresses it by.
+	pulled, err := dstStore.RecentPrompts(targetProject, 10)
+	if err != nil {
+		t.Fatalf("recent prompts after pull: %v", err)
+	}
+	var arrived *store.Prompt
+	for i := range pulled {
+		if pulled[i].SyncID == saved.SyncID {
+			arrived = &pulled[i]
+			break
+		}
+	}
+	if arrived == nil {
+		t.Fatalf("prompt %q did not survive the cloud round trip into project %q (got %d prompts)", saved.SyncID, targetProject, len(pulled))
+	}
+	if arrived.Content != promptContent {
+		t.Fatalf("pulled prompt content changed: %q", arrived.Content)
+	}
+	if arrived.Project != targetProject {
+		t.Fatalf("expected pulled prompt project %q, got %q", targetProject, arrived.Project)
+	}
+	if arrived.SessionID != targetSession {
+		t.Fatalf("expected pulled prompt session %q, got %q", targetSession, arrived.SessionID)
+	}
+
+	// The round trip must not have widened the prompt's scope.
+	strayed, err := dstStore.RecentPrompts(otherProject, 10)
+	if err != nil {
+		t.Fatalf("recent prompts for other project after pull: %v", err)
+	}
+	for _, p := range strayed {
+		if p.SyncID == saved.SyncID {
+			t.Fatalf("prompt %q strayed into project %q after the round trip", saved.SyncID, otherProject)
+		}
+	}
+}

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -707,10 +707,11 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
     case "mem_save_prompt":
       if (!requestedProject) requireResolvedProject();
       await ensureSession(activeSessionId, activeProject);
-      return engramFetch("/prompts", {
+      const response = await engramFetch<{ id: number }>("/prompts", {
         method: "POST",
         body: { session_id: activeSessionId, content: params.content, project: activeProject },
       });
+      return response ? { prompt_id: response.id, status: "saved" } : response;
     case "mem_session_summary":
       if (!requestedProject) requireResolvedProject();
       await ensureSession(activeSessionId, activeProject);

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -704,7 +704,7 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
       return engramFetch(`/observations/${encodeURIComponent(String(params.id))}${queryString({ hard: params.hard_delete })}`, { method: "DELETE" });
     case "mem_suggest_topic_key":
       return { topic_key: slugifyTopicKey(params) };
-    case "mem_save_prompt":
+    case "mem_save_prompt": {
       if (!requestedProject) requireResolvedProject();
       await ensureSession(activeSessionId, activeProject);
       const response = await engramFetch<{ id: number }>("/prompts", {
@@ -712,6 +712,7 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
         body: { session_id: activeSessionId, content: params.content, project: activeProject },
       });
       return response ? { prompt_id: response.id, status: "saved" } : response;
+    }
     case "mem_session_summary":
       if (!requestedProject) requireResolvedProject();
       await ensureSession(activeSessionId, activeProject);

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -115,6 +115,11 @@ test("mem_session_summary accepts explicit project fallback", () => {
   assert.match(source, /case "mem_session_summary":[\s\S]*if \(!requestedProject\) requireResolvedProject\(\);[\s\S]*ensureSession\(activeSessionId, activeProject\)[\s\S]*project: activeProject/);
 });
 
+test("mem_save_prompt returns a prompt-scoped identity", () => {
+  assert.match(source, /case "mem_save_prompt":[\s\S]*const response = await engramFetch<\{ id: number \}>\("\/prompts",/);
+  assert.match(source, /case "mem_save_prompt":[\s\S]*return response \? \{ prompt_id: response\.id, status: "saved" \} : response;/);
+});
+
 test("mem_search exposes and forwards match_mode and all_projects", () => {
   assert.match(source, /mem_search: Type\.Object\(\{[\s\S]*all_projects: optionalBoolean\("Search across every project; when true project is ignored"\)/);
   assert.match(source, /mem_search: Type\.Object\(\{[\s\S]*match_mode: optionalString\("Match mode: all \(default\) or any for broader recall"\)/);

--- a/plugin/pi/test/native-tool-contract.test.mjs
+++ b/plugin/pi/test/native-tool-contract.test.mjs
@@ -31,6 +31,108 @@ export const Type = new Proxy({}, { get: (_target, prop) => schema(String(prop))
   );
 }
 
+// Loads the extension in isolation and returns the tools it registers. Each call gets a fresh
+// module instance so module-level project/session state cannot leak between tests.
+async function loadRegisteredTools() {
+  const registeredTools = new Map();
+  const pluginUrl = pathToFileURL(join(ROOT, "index.ts"));
+  pluginUrl.search = `?contract=${Date.now()}-${Math.random()}`;
+  const { default: registerEngram } = await import(pluginUrl.href);
+  registerEngram({
+    registerTool(tool) {
+      registeredTools.set(tool.name, tool);
+    },
+    on() {},
+  });
+  return registeredTools;
+}
+
+// Records every request the extension issues so a test can assert the wire contract the Engram
+// HTTP server actually receives, instead of asserting over the extension source text.
+function recordingFetch(routes) {
+  const calls = [];
+  const fetchStub = async (url, init = {}) => {
+    const method = init.method ?? "GET";
+    const path = new URL(url).pathname + new URL(url).search;
+    const body = init.body ? JSON.parse(init.body) : undefined;
+    calls.push({ method, path, body });
+    const route = routes.find((candidate) => candidate.method === method && path.startsWith(candidate.path));
+    const status = route?.status ?? 200;
+    const payload = route?.body ?? {};
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return { calls, fetchStub };
+}
+
+test("registered Pi-native mem_save_prompt persists through the Engram /prompts endpoint", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.ENGRAM_URL;
+  process.env.ENGRAM_URL = "http://127.0.0.1:17437";
+
+  // The server assigns prompt ids from user_prompts, a table whose sequence is independent of
+  // observations. Issue #706 read one of these low ids as an observation id; the response must
+  // therefore name the namespace it belongs to.
+  const serverAssignedPromptID = 213;
+  const { calls, fetchStub } = recordingFetch([
+    { method: "GET", path: "/health", body: { status: "ok" } },
+    { method: "GET", path: "/project/current", body: { project: "paidosdep" } },
+    { method: "POST", path: "/sessions", body: { status: "ok" } },
+    { method: "POST", path: "/prompts", status: 201, body: { id: serverAssignedPromptID, status: "saved" } },
+  ]);
+  globalThis.fetch = fetchStub;
+
+  try {
+    await installRuntimeStubs();
+    const registeredTools = await loadRegisteredTools();
+    const memSavePrompt = registeredTools.get("mem_save_prompt");
+    assert.ok(memSavePrompt, "mem_save_prompt tool should be registered");
+
+    const result = await memSavePrompt.execute(
+      "tool-call-prompt",
+      { content: "preserve this exact user prompt", project: "paidosdep" },
+      undefined,
+      undefined,
+      {
+        cwd: ROOT,
+        sessionManager: { getSessionId: () => "test-session" },
+        ui: { setStatus() {} },
+      },
+    );
+
+    assert.notEqual(result.isError, true, "a successful prompt save must not surface as a tool error");
+
+    // The prompt must reach POST /prompts carrying the requested project scope, and the session it
+    // references must have been created under that same project first.
+    const promptCall = calls.find((call) => call.method === "POST" && call.path === "/prompts");
+    assert.ok(promptCall, "mem_save_prompt must POST to /prompts");
+    assert.equal(promptCall.body.project, "paidosdep");
+    assert.equal(promptCall.body.content, "preserve this exact user prompt");
+    assert.ok(promptCall.body.session_id, "the prompt must be attributed to a session");
+
+    const sessionCall = calls.find((call) => call.method === "POST" && call.path === "/sessions");
+    assert.ok(sessionCall, "mem_save_prompt must ensure its session exists before writing");
+    assert.equal(sessionCall.body.project, "paidosdep");
+    assert.equal(sessionCall.body.id, promptCall.body.session_id);
+    assert.ok(
+      calls.indexOf(sessionCall) < calls.indexOf(promptCall),
+      "the session must be created before the prompt that references it",
+    );
+
+    // The returned identity is prompt-scoped: it echoes the id the server assigned, and it is not
+    // offered under a name that mem_get_observation would accept.
+    assert.deepEqual(result.details.data, { prompt_id: serverAssignedPromptID, status: "saved" });
+    assert.equal(result.details.data.id, undefined, "an observation-shaped id must not be returned");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.ENGRAM_URL;
+    else process.env.ENGRAM_URL = originalUrl;
+    await rm(NODE_MODULES, { recursive: true, force: true });
+  }
+});
+
 test("registered Pi-native mem_search reports native provider transport failure", async () => {
   const originalFetch = globalThis.fetch;
   const originalUrl = process.env.ENGRAM_URL;


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #706

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

#706 reported two things: a `mem_save_prompt` response whose id resolved to an unrelated entry from another project, and a cloud dashboard that kept showing 0 prompts afterwards.

**The id was never stale.** Prompts are numbered from `user_prompts`, a sequence independent of `observations`, so a prompt id in the low hundreds is normal while observations are in the thousands. What made it look stale is that the response named the id `id`, which invited reading it back through `mem_get_observation` — where it landed on whatever unrelated observation happened to hold that row number. This PR returns `prompt_id` so the identity names its own namespace.

**The persistence was not broken.** The dashboard half of the report was untested rather than defective. This PR adds the end-to-end and project-scoped sync coverage that proves it, per review feedback, so the closure claim rests on evidence instead of inference.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Normalize successful prompt saves to `{ prompt_id, status: "saved" }`. |
| `plugin/pi/test/native-tool-contract.test.mjs` | Load the extension and execute `mem_save_prompt` against a recording fetch: assert the session is created under the requested project before the prompt is posted to `/prompts` with that scope, and that the response echoes the server-assigned id as `prompt_id`. |
| `plugin/pi/test/index-source.test.mjs` | Assert the prompt-scoped response identity. |
| `internal/server/server_e2e_test.go` | `TestPiPromptPersistenceE2E` — replay the Pi wire sequence, read the prompt back from `/prompts/recent` and `/prompts/search` under its own project, confirm the returned id resolves to the content just written, confirm it carries a `sync_id`, and confirm another project cannot see it or resolve it as an observation. |
| `internal/sync/sync_test.go` | `TestCloudSyncPreservesPiPromptIdentityUnderProjectScope` — the prompt enqueues an upsert mutation filed under its own project and keyed by its `sync_id`, then survives a cloud export/import round trip into a clean store with identity, content, session and project intact. |
| `internal/cloud/cloudstore/dashboard_queries_test.go` | `TestDashboardCountsPiSavedPromptUnderItsProject` — a prompt delivered as an upsert mutation is counted on the project's dashboard row, listed in recent prompts, and resolvable through the `sync_id` the detail page uses; a neighbouring project does not see it. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...` — 22 packages, all `ok`.
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — `ok`, including the new `TestPiPromptPersistenceE2E`.
- [x] Pi plugin suite passes locally: `npm test` in `plugin/pi` — 44 tests, 0 failures. The broad-suite hang noted on the first revision of this PR does not reproduce after merging `main`.
- [x] `gofmt -l` clean on every touched Go file; `go build ./...` and `go vet ./...` clean (including `-tags e2e`).
- [x] The new Pi test was verified to fail against the pre-fix `index.ts`, which returns `{ id: 213, status: "saved" }` instead of `{ prompt_id: 213, status: "saved" }` — it is a real regression guard, not a passing assertion.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue is approved | ⏳ |
| **Check PR Has type:* Label** | Exactly one type label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | E2E package tests pass | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #706`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] Docs updated (if behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Review feedback was that the rename removed the response ambiguity but did not prove the dashboard and cloud persistence #706 asked about, and that the closure claim should wait for that evidence. That evidence is now in the PR, across three layers: the Pi tool's actual HTTP calls, the server's `/prompts` retrieval surfaces, and the sync/cloud/dashboard path including project scoping in both directions.

Worth stating plainly for the record: **nothing in the persistence path turned out to be broken.** Every new test passed on first run against unmodified production code. The only production change in this PR remains the one-line `prompt_id` rename. If the reporter's dashboard genuinely showed 0 prompts, this coverage says the cause was not the local save, the mutation scope, the round trip, or the dashboard query — the most likely remaining explanation is the intermittent HTTP transport errors the issue itself notes, where the `POST /prompts` never reached the server at all. That is a separate concern from #706's identity defect and is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Saving prompts now returns a confirmation with the saved prompt ID.
  * Failed prompt-save requests continue to return no result.
  * Saved prompts now remain correctly associated with their project and session across retrieval and synchronization.

* **Tests**
  * Added coverage for prompt persistence, project scoping, search, retrieval, and synchronization.
  * Added coverage to verify prompt-saving responses are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
