### PR TITLE
fix(doctor): report undeliverable cloud mutations

### DIFF
--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -50,6 +50,19 @@ func newDoctorGitRepo(t *testing.T, name string) string {
 	return dir
 }
 
+// initDoctorStore creates the schema so raw seeding helpers can insert rows
+// without going through a higher level command first.
+func initDoctorStore(t *testing.T, cfg store.Config) {
+	t.Helper()
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("store.Close: %v", err)
+	}
+}
+
 func seedDoctorPendingMutation(t *testing.T, cfg store.Config, project, entity, entityKey, op, payload string) {
 	t.Helper()
 	db, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
@@ -72,6 +85,44 @@ func enrollDoctorProject(t *testing.T, cfg store.Config, project string) {
 	if err := s.EnrollProject(project); err != nil {
 		t.Fatalf("EnrollProject: %v", err)
 	}
+}
+
+// doctorValidObservationPayload builds a sync payload that passes required
+// field validation, so the only findings a test can produce come from the
+// non-enrolled backlog rule.
+func doctorValidObservationPayload(syncID, project string) string {
+	return `{"sync_id":"` + syncID + `","session_id":"session-` + syncID + `","type":"decision","title":"Valid","content":"Pending mutation","project":"` + project + `","scope":"project"}`
+}
+
+func decodeDoctorReport(t *testing.T, out string) map[string]any {
+	t.Helper()
+	var report map[string]any
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("doctor json invalid: %v\n%s", err, out)
+	}
+	return report
+}
+
+// doctorNonEnrolledCounts collects the per-project pending mutation counts
+// reported by non_enrolled_pending_mutations findings, failing on any other
+// finding so unrelated regressions cannot pass silently.
+func doctorNonEnrolledCounts(t *testing.T, report map[string]any) map[string]float64 {
+	t.Helper()
+	checks, ok := report["checks"].([]any)
+	if !ok || len(checks) != 1 {
+		t.Fatalf("expected one check, got %v", report["checks"])
+	}
+	counts := map[string]float64{}
+	findings, _ := checks[0].(map[string]any)["findings"].([]any)
+	for _, raw := range findings {
+		finding := raw.(map[string]any)
+		if finding["reason_code"] != "non_enrolled_pending_mutations" {
+			t.Fatalf("unexpected finding reason_code: %v", finding)
+		}
+		evidence := finding["evidence"].(map[string]any)
+		counts[evidence["project"].(string)] = evidence["pending_mutations"].(float64)
+	}
+	return counts
 }
 
 func seedDoctorRepairRows(t *testing.T, cfg store.Config, id, project, directory string) {
@@ -362,5 +413,96 @@ func TestCmdDoctorNonEnrolledPendingMutationsBlockedEnvelope(t *testing.T) {
 	stdout, stderr = captureOutput(t, func() { cmdDoctor(cfg) })
 	if stderr != "" || !strings.Contains(stdout, "non_enrolled_pending_mutations") || !strings.Contains(stdout, "unmanaged") {
 		t.Fatalf("stderr=%q stdout=%q", stderr, stdout)
+	}
+}
+
+// TestCmdDoctorNonEnrolledPendingMutationsRespectsProjectScope proves that a
+// scoped run only reports the requested project, so a non-enrolled backlog in
+// another project never leaks into the findings.
+func TestCmdDoctorNonEnrolledPendingMutationsRespectsProjectScope(t *testing.T) {
+	cfg := testConfig(t)
+	initDoctorStore(t, cfg)
+	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-unmanaged", store.SyncOpUpsert, doctorValidObservationPayload("obs-unmanaged", "unmanaged"))
+	seedDoctorPendingMutation(t, cfg, "out-of-scope", store.SyncEntityObservation, "obs-out-of-scope", store.SyncOpUpsert, doctorValidObservationPayload("obs-out-of-scope", "out-of-scope"))
+
+	withArgs(t, "engram", "doctor", "--json", "--project", "unmanaged", "--check", "sync_mutation_required_fields")
+	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+
+	report := decodeDoctorReport(t, stdout)
+	if report["status"] != "blocked" || report["project"] != "unmanaged" {
+		t.Fatalf("unexpected report: %v", report)
+	}
+	counts := doctorNonEnrolledCounts(t, report)
+	if len(counts) != 1 || counts["unmanaged"] != 1 {
+		t.Fatalf("expected only the scoped project, got %v", counts)
+	}
+	if strings.Contains(stdout, "out-of-scope") {
+		t.Fatalf("out-of-scope project leaked into scoped report: %s", stdout)
+	}
+}
+
+// TestCmdDoctorNonEnrolledPendingMutationsReportsEveryProject proves an
+// unscoped run reports every non-enrolled project with its own backlog count,
+// and never reports enrolled projects.
+func TestCmdDoctorNonEnrolledPendingMutationsReportsEveryProject(t *testing.T) {
+	cfg := testConfig(t)
+	initDoctorStore(t, cfg)
+	seedDoctorPendingMutation(t, cfg, "alpha", store.SyncEntityObservation, "obs-alpha-1", store.SyncOpUpsert, doctorValidObservationPayload("obs-alpha-1", "alpha"))
+	seedDoctorPendingMutation(t, cfg, "alpha", store.SyncEntityObservation, "obs-alpha-2", store.SyncOpUpsert, doctorValidObservationPayload("obs-alpha-2", "alpha"))
+	seedDoctorPendingMutation(t, cfg, "beta", store.SyncEntityObservation, "obs-beta-1", store.SyncOpUpsert, doctorValidObservationPayload("obs-beta-1", "beta"))
+	seedDoctorPendingMutation(t, cfg, "beta", store.SyncEntityObservation, "obs-beta-2", store.SyncOpUpsert, doctorValidObservationPayload("obs-beta-2", "beta"))
+	seedDoctorPendingMutation(t, cfg, "beta", store.SyncEntityObservation, "obs-beta-3", store.SyncOpUpsert, doctorValidObservationPayload("obs-beta-3", "beta"))
+	seedDoctorPendingMutation(t, cfg, "enrolled", store.SyncEntityObservation, "obs-enrolled", store.SyncOpUpsert, doctorValidObservationPayload("obs-enrolled", "enrolled"))
+	enrollDoctorProject(t, cfg, "enrolled")
+
+	withArgs(t, "engram", "doctor", "--json", "--check", "sync_mutation_required_fields")
+	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+
+	report := decodeDoctorReport(t, stdout)
+	if report["status"] != "blocked" {
+		t.Fatalf("expected blocked report, got %v", report)
+	}
+	counts := doctorNonEnrolledCounts(t, report)
+	want := map[string]float64{"alpha": 2, "beta": 3}
+	if !reflect.DeepEqual(counts, want) {
+		t.Fatalf("counts=%v want %v", counts, want)
+	}
+	if strings.Contains(stdout, `"project": "enrolled"`) {
+		t.Fatalf("enrolled project reported as blocked: %s", stdout)
+	}
+}
+
+// TestCmdDoctorNonEnrolledPendingMutationsTextGuidance proves the human
+// readable output carries the enrollment guidance and the pending mutation
+// count, not just the machine readable envelope.
+func TestCmdDoctorNonEnrolledPendingMutationsTextGuidance(t *testing.T) {
+	cfg := testConfig(t)
+	initDoctorStore(t, cfg)
+	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-one", store.SyncOpUpsert, doctorValidObservationPayload("obs-one", "unmanaged"))
+	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-two", store.SyncOpUpsert, doctorValidObservationPayload("obs-two", "unmanaged"))
+
+	withArgs(t, "engram", "doctor", "--project", "unmanaged", "--check", "sync_mutation_required_fields")
+	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+
+	for _, want := range []string{
+		"Engram Doctor: blocked",
+		"[blocked] sync_mutation_required_fields",
+		"next: Run `engram cloud enroll <project>`",
+		"- non_enrolled_pending_mutations:",
+		`"pending_mutations":2`,
+		`"project":"unmanaged"`,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("doctor text missing %q\n%s", want, stdout)
+		}
 	}
 }

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -341,7 +341,6 @@ func TestCmdDoctorSyncMutationRequiredFieldsBlockedEnvelope(t *testing.T) {
 	cfg := testConfig(t)
 	seedDoctorSession(t, cfg, "manual-save-engram", "engram", "/work/engram")
 	seedDoctorPendingMutation(t, cfg, "engram", store.SyncEntityObservation, "obs-missing", store.SyncOpUpsert, `{"sync_id":"obs-missing"}`)
-	enrollDoctorProject(t, cfg, "engram")
 
 	withArgs(t, "engram", "doctor", "--json", "--project", "engram", "--check", "sync_mutation_required_fields")
 	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
@@ -382,6 +381,7 @@ func TestCmdDoctorNonEnrolledPendingMutationsBlockedEnvelope(t *testing.T) {
 	cfg := testConfig(t)
 	seedDoctorSession(t, cfg, "manual-save-bootstrap", "bootstrap", "/work/bootstrap")
 	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-valid", store.SyncOpUpsert, `{"sync_id":"obs-valid","session_id":"session-valid","type":"decision","title":"Valid","content":"Pending mutation","project":"unmanaged","scope":"project"}`)
+	enrollDoctorProject(t, cfg, "cloud-synced")
 
 	withArgs(t, "engram", "doctor", "--json", "--project", "unmanaged", "--check", "sync_mutation_required_fields")
 	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
@@ -424,6 +424,7 @@ func TestCmdDoctorNonEnrolledPendingMutationsRespectsProjectScope(t *testing.T) 
 	initDoctorStore(t, cfg)
 	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-unmanaged", store.SyncOpUpsert, doctorValidObservationPayload("obs-unmanaged", "unmanaged"))
 	seedDoctorPendingMutation(t, cfg, "out-of-scope", store.SyncEntityObservation, "obs-out-of-scope", store.SyncOpUpsert, doctorValidObservationPayload("obs-out-of-scope", "out-of-scope"))
+	enrollDoctorProject(t, cfg, "cloud-synced")
 
 	withArgs(t, "engram", "doctor", "--json", "--project", "unmanaged", "--check", "sync_mutation_required_fields")
 	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
@@ -486,6 +487,7 @@ func TestCmdDoctorNonEnrolledPendingMutationsTextGuidance(t *testing.T) {
 	initDoctorStore(t, cfg)
 	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-one", store.SyncOpUpsert, doctorValidObservationPayload("obs-one", "unmanaged"))
 	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-two", store.SyncOpUpsert, doctorValidObservationPayload("obs-two", "unmanaged"))
+	enrollDoctorProject(t, cfg, "cloud-synced")
 
 	withArgs(t, "engram", "doctor", "--project", "unmanaged", "--check", "sync_mutation_required_fields")
 	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
@@ -504,5 +506,35 @@ func TestCmdDoctorNonEnrolledPendingMutationsTextGuidance(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("doctor text missing %q\n%s", want, stdout)
 		}
+	}
+}
+
+// TestCmdDoctorLocalOnlyInstallIsNotBlockedByPendingMutations pins the local
+// only contract for issue #688: an install that never enrolled any project for
+// cloud sync keeps journaling mutations forever, so doctor must report a clean
+// bill of health instead of demanding `engram cloud enroll` for a feature the
+// user never opted into.
+func TestCmdDoctorLocalOnlyInstallIsNotBlockedByPendingMutations(t *testing.T) {
+	cfg := testConfig(t)
+	initDoctorStore(t, cfg)
+	seedDoctorPendingMutation(t, cfg, "local-only", store.SyncEntityObservation, "obs-one", store.SyncOpUpsert, doctorValidObservationPayload("obs-one", "local-only"))
+	seedDoctorPendingMutation(t, cfg, "local-only", store.SyncEntityObservation, "obs-two", store.SyncOpUpsert, doctorValidObservationPayload("obs-two", "local-only"))
+
+	withArgs(t, "engram", "doctor", "--json", "--check", "sync_mutation_required_fields")
+	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+
+	report := decodeDoctorReport(t, stdout)
+	if report["status"] != "ok" {
+		t.Fatalf("local-only install must not be blocked, got %v", report)
+	}
+	check := report["checks"].([]any)[0].(map[string]any)
+	if check["result"] != "ok" || check["findings"] != nil {
+		t.Fatalf("unexpected check envelope: %v", check)
+	}
+	if strings.Contains(stdout, "non_enrolled_pending_mutations") || strings.Contains(stdout, "engram cloud enroll") {
+		t.Fatalf("local-only doctor must not suggest cloud enrollment: %s", stdout)
 	}
 }

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -62,6 +62,18 @@ func seedDoctorPendingMutation(t *testing.T, cfg store.Config, project, entity, 
 	}
 }
 
+func enrollDoctorProject(t *testing.T, cfg store.Config, project string) {
+	t.Helper()
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+	if err := s.EnrollProject(project); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
+}
+
 func seedDoctorRepairRows(t *testing.T, cfg store.Config, id, project, directory string) {
 	t.Helper()
 	s, err := store.New(cfg)
@@ -278,6 +290,7 @@ func TestCmdDoctorSyncMutationRequiredFieldsBlockedEnvelope(t *testing.T) {
 	cfg := testConfig(t)
 	seedDoctorSession(t, cfg, "manual-save-engram", "engram", "/work/engram")
 	seedDoctorPendingMutation(t, cfg, "engram", store.SyncEntityObservation, "obs-missing", store.SyncOpUpsert, `{"sync_id":"obs-missing"}`)
+	enrollDoctorProject(t, cfg, "engram")
 
 	withArgs(t, "engram", "doctor", "--json", "--project", "engram", "--check", "sync_mutation_required_fields")
 	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
@@ -311,5 +324,43 @@ func TestCmdDoctorSyncMutationRequiredFieldsBlockedEnvelope(t *testing.T) {
 	evidence := finding["evidence"].(map[string]any)
 	if evidence["entity"] != store.SyncEntityObservation || evidence["entity_key"] != "obs-missing" {
 		t.Fatalf("unexpected evidence: %v", evidence)
+	}
+}
+
+func TestCmdDoctorNonEnrolledPendingMutationsBlockedEnvelope(t *testing.T) {
+	cfg := testConfig(t)
+	seedDoctorSession(t, cfg, "manual-save-bootstrap", "bootstrap", "/work/bootstrap")
+	seedDoctorPendingMutation(t, cfg, "unmanaged", store.SyncEntityObservation, "obs-valid", store.SyncOpUpsert, `{"sync_id":"obs-valid","session_id":"session-valid","type":"decision","title":"Valid","content":"Pending mutation","project":"unmanaged","scope":"project"}`)
+
+	withArgs(t, "engram", "doctor", "--json", "--project", "unmanaged", "--check", "sync_mutation_required_fields")
+	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+
+	var report map[string]any
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("doctor json invalid: %v\n%s", err, stdout)
+	}
+	if report["status"] != "blocked" {
+		t.Fatalf("expected blocked report, got %v", report)
+	}
+	check := report["checks"].([]any)[0].(map[string]any)
+	if check["result"] != "blocked" || check["severity"] != "blocking" || check["safe_next_step"] == "No action required." {
+		t.Fatalf("unexpected check envelope: %v", check)
+	}
+	finding := check["findings"].([]any)[0].(map[string]any)
+	if finding["reason_code"] != "non_enrolled_pending_mutations" || !strings.Contains(finding["safe_next_step"].(string), "engram cloud enroll <project>") {
+		t.Fatalf("unexpected finding: %v", finding)
+	}
+	evidence := finding["evidence"].(map[string]any)
+	if evidence["project"] != "unmanaged" || evidence["pending_mutations"] != float64(1) {
+		t.Fatalf("unexpected evidence: %v", evidence)
+	}
+
+	withArgs(t, "engram", "doctor", "--project", "unmanaged", "--check", "sync_mutation_required_fields")
+	stdout, stderr = captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" || !strings.Contains(stdout, "non_enrolled_pending_mutations") || !strings.Contains(stdout, "unmanaged") {
+		t.Fatalf("stderr=%q stdout=%q", stderr, stdout)
 	}
 }

--- a/docs/DOCTOR.md
+++ b/docs/DOCTOR.md
@@ -61,7 +61,7 @@ The CLI `--json` and MCP tool return:
 
 - `session_project_directory_mismatch` — warns when `sessions.project` disagrees with the project inferred from trusted repository evidence for the session directory. The MVP trusts `git_remote` and `git_root` only; it ignores basename fallback, ambiguous workspaces, missing directories, and child-repo auto-promotion to avoid noisy false positives.
 - `manual_session_name_project_mismatch` — warns when a `manual-save-{suffix}` session name disagrees with `sessions.project`.
-- `sync_mutation_required_fields` — blocks when a pending `sync_mutations.payload` is missing required fields or pending cloud mutations belong to a project that is not enrolled. The finding identifies the project and backlog count; enroll intended projects with `engram cloud enroll <project>` or review enrollment before retrying.
+- `sync_mutation_required_fields` — blocks when a pending `sync_mutations.payload` is missing required fields. On a device that uses cloud sync (at least one project enrolled), it also blocks when pending cloud mutations belong to a project that is not enrolled; the finding identifies the project and backlog count, so enroll intended projects with `engram cloud enroll <project>` or review enrollment before retrying. A local-only install with no enrolled project never reports that finding: the store journals mutations unconditionally, so a non-enrolled backlog is its normal steady state.
 - `sqlite_lock_contention` — warns on conservative SQLite contention signals; returns an error if lock state cannot be evaluated.
 
 ## Safety

--- a/docs/DOCTOR.md
+++ b/docs/DOCTOR.md
@@ -61,7 +61,7 @@ The CLI `--json` and MCP tool return:
 
 - `session_project_directory_mismatch` — warns when `sessions.project` disagrees with the project inferred from trusted repository evidence for the session directory. The MVP trusts `git_remote` and `git_root` only; it ignores basename fallback, ambiguous workspaces, missing directories, and child-repo auto-promotion to avoid noisy false positives.
 - `manual_session_name_project_mismatch` — warns when a `manual-save-{suffix}` session name disagrees with `sessions.project`.
-- `sync_mutation_required_fields` — blocks when a pending `sync_mutations.payload` is missing required fields.
+- `sync_mutation_required_fields` — blocks when a pending `sync_mutations.payload` is missing required fields or pending cloud mutations belong to a project that is not enrolled. The finding identifies the project and backlog count; enroll intended projects with `engram cloud enroll <project>` or review enrollment before retrying.
 - `sqlite_lock_contention` — warns on conservative SQLite contention signals; returns an error if lock state cannot be evaluated.
 
 ## Safety

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -134,6 +134,18 @@ func knownSessionProjects(scope Scope) (map[string]bool, error) {
 	return known, nil
 }
 
+// cloudSyncInUse reports whether this device opted into cloud sync. Enrollment
+// is the store level signal the cloud paths already use to decide whether a
+// project may be delivered, so at least one enrolled project is the evidence
+// that the operator asked for cloud sync at all.
+func cloudSyncInUse(scope Scope) (bool, error) {
+	enrolled, err := scope.Store.ListEnrolledProjects()
+	if err != nil {
+		return false, err
+	}
+	return len(enrolled) > 0, nil
+}
+
 func (c SyncMutationRequiredFieldsCheck) Run(ctx context.Context, scope Scope) (CheckResult, error) {
 	_ = ctx
 	mutations, err := scope.Store.ListPendingProjectMutations(scope.Project)
@@ -160,6 +172,20 @@ func (c SyncMutationRequiredFieldsCheck) Run(ctx context.Context, scope Scope) (
 			SafeNextStep:         nextStep,
 			RequiresConfirmation: true,
 		})
+	}
+	// A non-enrolled backlog is only a fault on a device that actually uses
+	// cloud sync. The store journals sync mutations unconditionally, so on a
+	// local-only install every pending mutation belongs to a non-enrolled
+	// project by definition — the normal steady state, not something doctor
+	// should block on and answer with `engram cloud enroll`. This mirrors the
+	// autosync manager, which owns the same reason code and only evaluates it
+	// while cloud sync is configured and running.
+	usesCloudSync, err := cloudSyncInUse(scope)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	if !usesCloudSync {
+		return resultFromFindings(c.Code(), map[string]any{"pending_mutations_evaluated": len(mutations)}, findings), nil
 	}
 	nonEnrolledCounts, err := scope.Store.CountPendingNonEnrolledSyncMutations(store.DefaultSyncTargetKey)
 	if err != nil {

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -2,9 +2,11 @@ package diagnostic
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
+	"github.com/Gentleman-Programming/engram/internal/cloud/constants"
 	projectpkg "github.com/Gentleman-Programming/engram/internal/project"
 	"github.com/Gentleman-Programming/engram/internal/store"
 )
@@ -156,6 +158,27 @@ func (c SyncMutationRequiredFieldsCheck) Run(ctx context.Context, scope Scope) (
 			Why:                  "A pending sync mutation with missing required fields can block safe cloud replication and must fail loudly instead of being silently dropped.",
 			Evidence:             mustJSON(map[string]any{"seq": mutation.Seq, "target_key": mutation.TargetKey, "project": mutation.Project, "entity": mutation.Entity, "op": mutation.Op, "entity_key": mutation.EntityKey, "missing_fields": validation.MissingFields}),
 			SafeNextStep:         nextStep,
+			RequiresConfirmation: true,
+		})
+	}
+	nonEnrolledCounts, err := scope.Store.CountPendingNonEnrolledSyncMutations(store.DefaultSyncTargetKey)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	scopedProject := normalizeProjectName(scope.Project)
+	for _, projectCount := range nonEnrolledCounts {
+		project := normalizeProjectName(projectCount.Project)
+		if scopedProject != "" && project != scopedProject {
+			continue
+		}
+		findings = append(findings, Finding{
+			CheckID:              c.Code(),
+			Severity:             SeverityBlocking,
+			ReasonCode:           constants.ReasonNonEnrolledPendingMutations,
+			Message:              fmt.Sprintf("Pending cloud sync mutations for project %q are blocked because it is not enrolled.", project),
+			Why:                  "Cloud delivery cannot continue while pending mutations belong to a project that is not enrolled.",
+			Evidence:             mustJSON(map[string]any{"project": project, "pending_mutations": projectCount.Count}),
+			SafeNextStep:         "Run `engram cloud enroll <project>` for each intended project or review enrollment, then rerun `engram doctor`.",
 			RequiresConfirmation: true,
 		})
 	}

--- a/internal/diagnostic/diagnostic_test.go
+++ b/internal/diagnostic/diagnostic_test.go
@@ -2,7 +2,9 @@ package diagnostic
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +13,12 @@ import (
 )
 
 func newDiagnosticTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, _ := newDiagnosticTestStoreWithConfig(t)
+	return s
+}
+
+func newDiagnosticTestStoreWithConfig(t *testing.T) (*store.Store, store.Config) {
 	t.Helper()
 	cfg, err := store.DefaultConfig()
 	if err != nil {
@@ -22,7 +30,7 @@ func newDiagnosticTestStore(t *testing.T) *store.Store {
 		t.Fatalf("store.New: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
-	return s
+	return s, cfg
 }
 
 func TestSQLiteLockContentionBranches(t *testing.T) {
@@ -126,6 +134,43 @@ func TestSessionProjectDirectoryMismatchFinding(t *testing.T) {
 	}
 	if report.Status != StatusWarning || len(report.Checks[0].Findings) != 1 {
 		t.Fatalf("report=%+v", report)
+	}
+}
+
+// TestSyncMutationRequiredFieldsSurfacesNonEnrolledCountFailure proves the
+// check fails loudly instead of reporting a clean bill of health when the
+// non-enrolled backlog query cannot run. The enrollment join target is dropped
+// after migrations so payload validation still succeeds and only
+// CountPendingNonEnrolledSyncMutations fails.
+func TestSyncMutationRequiredFieldsSurfacesNonEnrolledCountFailure(t *testing.T) {
+	s, cfg := newDiagnosticTestStoreWithConfig(t)
+
+	db, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE sync_enrolled_projects`); err != nil {
+		db.Close()
+		t.Fatalf("drop sync_enrolled_projects: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close probe db: %v", err)
+	}
+
+	report, err := NewRunner().RunOne(context.Background(), Scope{Store: s, Project: "engram"}, CheckSyncMutationRequiredFields)
+	if err == nil {
+		t.Fatalf("expected non-enrolled count failure, got report=%+v", report)
+	}
+	if !strings.Contains(err.Error(), "sync_enrolled_projects") {
+		t.Fatalf("expected error naming the enrollment table, got %v", err)
+	}
+
+	errReport := ErrorReport("engram", err)
+	if errReport.Status != StatusError || errReport.Summary.Errors != 1 {
+		t.Fatalf("expected error report, got %+v", errReport)
+	}
+	if errReport.Checks[0].ReasonCode != "diagnostic_error" || !strings.Contains(errReport.Checks[0].Message, "sync_enrolled_projects") {
+		t.Fatalf("expected surfaced query failure, got %+v", errReport.Checks[0])
 	}
 }
 

--- a/internal/diagnostic/diagnostic_test.go
+++ b/internal/diagnostic/diagnostic_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Gentleman-Programming/engram/internal/cloud/constants"
 	"github.com/Gentleman-Programming/engram/internal/store"
 )
 
@@ -139,9 +140,9 @@ func TestSessionProjectDirectoryMismatchFinding(t *testing.T) {
 
 // TestSyncMutationRequiredFieldsSurfacesNonEnrolledCountFailure proves the
 // check fails loudly instead of reporting a clean bill of health when the
-// non-enrolled backlog query cannot run. The enrollment join target is dropped
-// after migrations so payload validation still succeeds and only
-// CountPendingNonEnrolledSyncMutations fails.
+// enrollment evidence cannot be read. The enrollment table is dropped after
+// migrations so payload validation still succeeds and only the cloud sync
+// enrollment lookup fails.
 func TestSyncMutationRequiredFieldsSurfacesNonEnrolledCountFailure(t *testing.T) {
 	s, cfg := newDiagnosticTestStoreWithConfig(t)
 
@@ -174,13 +175,72 @@ func TestSyncMutationRequiredFieldsSurfacesNonEnrolledCountFailure(t *testing.T)
 	}
 }
 
-func TestRunnerRunAllHealthyEvaluatesEveryMVPCheck(t *testing.T) {
+// TestSyncMutationRequiredFieldsIgnoresBacklogWithoutCloudEnrollment proves a
+// local-only install is never reported as blocked for a non-enrolled backlog.
+// The store journals sync mutations unconditionally, so on a device that never
+// opted into cloud sync every pending mutation belongs to a non-enrolled
+// project: that is the normal steady state, not a fault.
+func TestSyncMutationRequiredFieldsIgnoresBacklogWithoutCloudEnrollment(t *testing.T) {
 	s := newDiagnosticTestStore(t)
 	if err := s.CreateSession("manual-save-engram", "engram", "/work/engram"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	if err := s.EnrollProject("engram"); err != nil {
+	pending, err := s.CountPendingNonEnrolledSyncMutations(store.DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("CountPendingNonEnrolledSyncMutations: %v", err)
+	}
+	if len(pending) == 0 {
+		t.Fatal("fixture must journal a non-enrolled pending mutation")
+	}
+
+	report, err := NewRunner().RunOne(context.Background(), Scope{Store: s, Project: "engram"}, CheckSyncMutationRequiredFields)
+	if err != nil {
+		t.Fatalf("RunOne: %v", err)
+	}
+	if report.Status != StatusOK || len(report.Checks[0].Findings) != 0 {
+		t.Fatalf("local-only install must not be blocked, got %+v", report)
+	}
+}
+
+// TestSyncMutationRequiredFieldsBlocksNonEnrolledBacklogWhenCloudSyncInUse
+// proves the issue #688 signal survives: once the device uses cloud sync, a
+// project whose pending mutations cannot be delivered is reported as blocked
+// with the enrollment guidance, while the enrolled project stays silent.
+func TestSyncMutationRequiredFieldsBlocksNonEnrolledBacklogWhenCloudSyncInUse(t *testing.T) {
+	s := newDiagnosticTestStore(t)
+	if err := s.CreateSession("manual-save-enrolled", "enrolled", "/work/enrolled"); err != nil {
+		t.Fatalf("CreateSession enrolled: %v", err)
+	}
+	if err := s.EnrollProject("enrolled"); err != nil {
 		t.Fatalf("EnrollProject: %v", err)
+	}
+	if err := s.CreateSession("manual-save-local", "local", "/work/local"); err != nil {
+		t.Fatalf("CreateSession local: %v", err)
+	}
+
+	report, err := NewRunner().RunOne(context.Background(), Scope{Store: s}, CheckSyncMutationRequiredFields)
+	if err != nil {
+		t.Fatalf("RunOne: %v", err)
+	}
+	if report.Status != StatusBlocked || len(report.Checks[0].Findings) != 1 {
+		t.Fatalf("expected one blocking finding, got %+v", report)
+	}
+	finding := report.Checks[0].Findings[0]
+	if finding.Severity != SeverityBlocking || finding.ReasonCode != constants.ReasonNonEnrolledPendingMutations {
+		t.Fatalf("unexpected finding: %+v", finding)
+	}
+	if !strings.Contains(string(finding.Evidence), `"project":"local"`) {
+		t.Fatalf("expected the non-enrolled project in evidence, got %s", finding.Evidence)
+	}
+	if !strings.Contains(finding.SafeNextStep, "engram cloud enroll <project>") {
+		t.Fatalf("expected enrollment guidance, got %q", finding.SafeNextStep)
+	}
+}
+
+func TestRunnerRunAllHealthyEvaluatesEveryMVPCheck(t *testing.T) {
+	s := newDiagnosticTestStore(t)
+	if err := s.CreateSession("manual-save-engram", "engram", "/work/engram"); err != nil {
+		t.Fatalf("CreateSession: %v", err)
 	}
 	report, err := NewRunner().RunAll(context.Background(), Scope{
 		Store:   s,

--- a/internal/diagnostic/diagnostic_test.go
+++ b/internal/diagnostic/diagnostic_test.go
@@ -134,6 +134,9 @@ func TestRunnerRunAllHealthyEvaluatesEveryMVPCheck(t *testing.T) {
 	if err := s.CreateSession("manual-save-engram", "engram", "/work/engram"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
+	if err := s.EnrollProject("engram"); err != nil {
+		t.Fatalf("EnrollProject: %v", err)
+	}
 	report, err := NewRunner().RunAll(context.Background(), Scope{
 		Store:   s,
 		Project: "engram",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #688

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Make `doctor` report pending cloud mutations that cannot be delivered because their project is not enrolled.
- Include project/count evidence and actionable enrollment guidance in JSON and text output.
- Add regression coverage and align the doctor documentation.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/diagnostic/checks.go` | Emit blocking findings for non-enrolled pending mutation backlogs. |
| `cmd/engram/doctor_test.go` | Cover JSON/text output and preserve malformed-payload isolation. |
| `docs/DOCTOR.md` | Document the expanded diagnostic behavior and recovery guidance. |

## 🧪 Test Plan

- [x] Focused regression: `go test -run '^TestCmdDoctorNonEnrolledPendingMutationsBlockedEnvelope$' ./cmd/engram`
- [x] Doctor test family: `go test -run '^TestCmdDoctor' ./cmd/engram`
- [ ] Full unit suite: `go test ./...` — blocked on Windows by the pre-existing `TestPrintUsage` output-capture deadlock tracked in #818.
- [ ] E2E suite — not run; this change does not modify a server route or transport boundary.
- [x] Native four-lens RDD review completed without blocking findings.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #688`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (blocked by #818 on Windows)
- [ ] I ran e2e tests locally (not applicable to this diagnostic-only change)
- [x] Docs updated because behavior changed
- [x] Commits follow Conventional Commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Issue #687 from the original observability group was verified as already fixed by current sync-health reset behavior and an existing regression, so this PR intentionally closes only #688. The package-wide Windows timeout was isolated to the unchanged `TestPrintUsage` capture path; the candidate-bound doctor verifier passed against the exact RDD-reviewed commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Doctor checks now flag pending cloud changes for projects that are not enrolled.
  * Reports identify the affected project, pending change count, and recommended enrollment steps.
  * JSON and text reports now provide consistent blocking details for missing enrollment and incomplete mutation data.

* **Documentation**
  * Updated doctor check documentation to describe enrollment-related blocking conditions and remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->