### PR TITLE
fix(store): escape quotes in any-mode FTS queries

### DIFF
--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -1080,7 +1080,20 @@ func sanitizeFTSCandidates(title string) string {
 	for _, w := range words {
 		w = strings.Trim(w, `"`)
 		if w != "" {
-			quoted = append(quoted, `"`+w+`"`)
+			var escaped strings.Builder
+			for i := 0; i < len(w); i++ {
+				if w[i] == '"' {
+					// FTS5 escapes a literal quote by doubling it. Preserve an
+					// already escaped pair so callers do not get double escaped.
+					escaped.WriteString(`""`)
+					if i+1 < len(w) && w[i+1] == '"' {
+						i++
+					}
+					continue
+				}
+				escaped.WriteByte(w[i])
+			}
+			quoted = append(quoted, `"`+escaped.String()+`"`)
 		}
 	}
 	return strings.Join(quoted, " OR ")

--- a/internal/store/relations_test.go
+++ b/internal/store/relations_test.go
@@ -110,6 +110,25 @@ func TestFindCandidates_HappyPath(t *testing.T) {
 	}
 }
 
+func TestFindCandidates_EscapesInteriorQuotes(t *testing.T) {
+	s := setupRelationsStore(t)
+	_, _ = addTestObs(t, s, `hello"world candidate`, "decision", "testproject", "project")
+	savedID, _ := addTestObs(t, s, `hello"world source`, "decision", "testproject", "project")
+
+	candidates, err := s.FindCandidates(savedID, CandidateOptions{
+		Project:   "testproject",
+		Scope:     "project",
+		Limit:     3,
+		BM25Floor: ptrFloat64(-10.0),
+	})
+	if err != nil {
+		t.Fatalf("FindCandidates: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(candidates))
+	}
+}
+
 // TestFindCandidates_EarlyBreakDoesNotSelfBlockWithSingleConnection verifies
 // that FindCandidates closes its FTS rows before follow-up QueryRow/Exec calls.
 // With SetMaxOpenConns(1), leaving rows open after the early-break path can

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9396,6 +9396,35 @@ func TestSearchMatchMode_Any(t *testing.T) {
 	}
 }
 
+func TestSearchMatchMode_AnyEscapesInteriorQuotes(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-matchmode-quotes", "engram", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-matchmode-quotes",
+		Type:      "decision",
+		Title:     `hello"world`,
+		Content:   "quoted search target",
+		Project:   "engram",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	for _, query := range []string{`hello"world`, `"hello""world"`} {
+		t.Run(query, func(t *testing.T) {
+			results, err := s.SearchContext(context.Background(), query, SearchOptions{Project: "engram", Limit: 10, MatchMode: "any"})
+			if err != nil {
+				t.Fatalf("SearchContext(%q): %v", query, err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result for %q, got %d", query, len(results))
+			}
+		})
+	}
+}
+
 // TestSearchMatchMode_InvalidReturnsError verifies that an unrecognised
 // match_mode value returns an explicit error regardless of query shape.
 func TestSearchMatchMode_InvalidReturnsError(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #664

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Escape embedded double quotes in shared FTS candidate sanitization.
- Preserve already doubled FTS5 quote escapes.
- Cover `match_mode="any"` and relation candidate lookup regressions.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/relations.go` | Double raw interior quotes while preserving existing escaped pairs. |
| `internal/store/store_test.go` | Add any-mode quoted-query regression and escaped-query negative control. |
| `internal/store/relations_test.go` | Add `FindCandidates` regression for interior quotes. |

## 🧪 Test Plan

- [x] Focused regressions pass: `go test ./internal/store -run '^(TestSearchMatchMode_AnyEscapesInteriorQuotes|TestFindCandidates_EscapesInteriorQuotes)$' -count=1`
- [x] Pre-fix regressions reproduced `unterminated string`; post-fix regressions pass.
- [ ] Full local package suite: blocked on Windows by pre-existing temp SQLite file locks in `TestMigrate_Idempotent` and `TestNewErrorBranches/fails_when_migration_encounters_conflicting_object`.
- [ ] E2E tests: not applicable to this local store sanitizer change.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #664`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran the full unit suite locally; focused candidate verification passed and the unrelated Windows blocker is documented above
- [ ] I ran e2e tests locally; they are not applicable to this store-only correction
- [x] Docs updated (not required; no user-facing contract changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The frozen candidate completed the native four-lens RDD review successfully. The broad local package run was blocked only by unrelated Windows temp-database cleanup locks; a candidate-specific substitute verifier passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search reliability for titles containing double quotes.
  * Queries with embedded quotation marks now return the expected matches without errors.

* **Tests**
  * Added coverage for quoted titles in candidate finding and search matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->