### PR TITLE
fix(cloud): bind project grant principal as bigint

### DIFF
--- a/internal/cloud/cloudstore/identity.go
+++ b/internal/cloud/cloudstore/identity.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -761,7 +762,12 @@ func (cs *CloudStore) ListProjectGrants(ctx context.Context, principalID string)
 	if cs == nil || cs.db == nil {
 		return nil, fmt.Errorf("cloudstore: not initialized")
 	}
-	rows, err := cs.db.QueryContext(ctx, `SELECT principal_id::text, project, COALESCE(granted_by_principal_id::text, ''), created_at FROM cloud_project_grants WHERE principal_id = $1 ORDER BY project ASC`, strings.TrimSpace(principalID))
+	principalID = strings.TrimSpace(principalID)
+	numericPrincipalID, err := strconv.ParseInt(principalID, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("cloudstore: parse principal id: %w", err)
+	}
+	rows, err := cs.db.QueryContext(ctx, `SELECT principal_id::text, project, COALESCE(granted_by_principal_id::text, ''), created_at FROM cloud_project_grants WHERE principal_id = $1 ORDER BY project ASC`, numericPrincipalID)
 	if err != nil {
 		return nil, fmt.Errorf("cloudstore: list project grants: %w", err)
 	}

--- a/internal/cloud/cloudstore/identity.go
+++ b/internal/cloud/cloudstore/identity.go
@@ -762,10 +762,9 @@ func (cs *CloudStore) ListProjectGrants(ctx context.Context, principalID string)
 	if cs == nil || cs.db == nil {
 		return nil, fmt.Errorf("cloudstore: not initialized")
 	}
-	principalID = strings.TrimSpace(principalID)
-	numericPrincipalID, err := strconv.ParseInt(principalID, 10, 64)
+	numericPrincipalID, err := parseCloudPrincipalID(principalID)
 	if err != nil {
-		return nil, fmt.Errorf("cloudstore: parse principal id: %w", err)
+		return nil, err
 	}
 	rows, err := cs.db.QueryContext(ctx, `SELECT principal_id::text, project, COALESCE(granted_by_principal_id::text, ''), created_at FROM cloud_project_grants WHERE principal_id = $1 ORDER BY project ASC`, numericPrincipalID)
 	if err != nil {
@@ -790,8 +789,12 @@ func (cs *CloudStore) RevokeProjectGrant(ctx context.Context, principalID, proje
 	if cs == nil || cs.db == nil {
 		return fmt.Errorf("cloudstore: not initialized")
 	}
+	numericPrincipalID, err := parseCloudPrincipalID(principalID)
+	if err != nil {
+		return err
+	}
 	normalized := normalizeCloudProjectGrant(project)
-	res, err := cs.db.ExecContext(ctx, `DELETE FROM cloud_project_grants WHERE principal_id = $1 AND project = $2`, strings.TrimSpace(principalID), normalized)
+	res, err := cs.db.ExecContext(ctx, `DELETE FROM cloud_project_grants WHERE principal_id = $1 AND project = $2`, numericPrincipalID, normalized)
 	if err != nil {
 		return fmt.Errorf("cloudstore: revoke project grant: %w", err)
 	}
@@ -921,6 +924,14 @@ func scanPrincipalToken(scanner interface{ Scan(dest ...any) error }) (Principal
 		return PrincipalToken{}, err
 	}
 	return token, nil
+}
+
+func parseCloudPrincipalID(principalID string) (int64, error) {
+	numericPrincipalID, err := strconv.ParseInt(strings.TrimSpace(principalID), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cloudstore: parse principal id: %w", err)
+	}
+	return numericPrincipalID, nil
 }
 
 func scanProjectGrant(scanner interface{ Scan(dest ...any) error }) (ProjectGrant, error) {

--- a/internal/cloud/cloudstore/project_grants_binding_test.go
+++ b/internal/cloud/cloudstore/project_grants_binding_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"io"
 	"testing"
+	"time"
 )
 
 const projectGrantBindingDriverName = "cloudstore-project-grant-binding"
@@ -19,6 +20,8 @@ func init() {
 type capturingProjectGrantDriver struct {
 	argument   any
 	queryCalls int
+	execCalls  int
+	grants     map[int64]map[string]struct{}
 }
 
 func (d *capturingProjectGrantDriver) Open(string) (driver.Conn, error) {
@@ -40,16 +43,64 @@ func (projectGrantBindingConn) Begin() (driver.Tx, error) { return nil, driver.E
 func (c projectGrantBindingConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
 	c.driver.queryCalls++
 	c.driver.argument = args[0].Value
-	return projectGrantBindingRows{}, nil
+
+	principalID, ok := args[0].Value.(int64)
+	if !ok {
+		return &projectGrantBindingRows{}, nil
+	}
+	grants := c.driver.grants[principalID]
+	rows := make([][]driver.Value, 0, len(grants))
+	for project := range grants {
+		rows = append(rows, []driver.Value{principalID, project, "", time.Unix(0, 0).UTC()})
+	}
+	return &projectGrantBindingRows{values: rows}, nil
 }
 
-type projectGrantBindingRows struct{}
+func (c projectGrantBindingConn) ExecContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Result, error) {
+	c.driver.execCalls++
+	c.driver.argument = args[0].Value
 
-func (projectGrantBindingRows) Columns() []string { return nil }
+	principalID, ok := args[0].Value.(int64)
+	if !ok {
+		return driver.RowsAffected(0), nil
+	}
+	project := args[1].Value.(string)
+	delete(c.driver.grants[principalID], project)
+	return driver.RowsAffected(1), nil
+}
+
+type projectGrantBindingRows struct {
+	values [][]driver.Value
+}
+
+func (projectGrantBindingRows) Columns() []string {
+	return []string{"principal_id", "project", "granted_by_principal_id", "created_at"}
+}
 
 func (projectGrantBindingRows) Close() error { return nil }
 
-func (projectGrantBindingRows) Next([]driver.Value) error { return io.EOF }
+func (r *projectGrantBindingRows) Next(dest []driver.Value) error {
+	if len(r.values) == 0 {
+		return io.EOF
+	}
+	copy(dest, r.values[0])
+	r.values = r.values[1:]
+	return nil
+}
+
+func resetProjectGrantBindingDriver() {
+	projectGrantBindingDriver.argument = nil
+	projectGrantBindingDriver.queryCalls = 0
+	projectGrantBindingDriver.execCalls = 0
+	projectGrantBindingDriver.grants = make(map[int64]map[string]struct{})
+}
+
+func seedProjectGrantBindingDriver(principalID int64, project string) {
+	if projectGrantBindingDriver.grants[principalID] == nil {
+		projectGrantBindingDriver.grants[principalID] = make(map[string]struct{})
+	}
+	projectGrantBindingDriver.grants[principalID][project] = struct{}{}
+}
 
 func TestListProjectGrantsBindsNumericPrincipalID(t *testing.T) {
 	tests := []struct {
@@ -67,8 +118,7 @@ func TestListProjectGrantsBindsNumericPrincipalID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			projectGrantBindingDriver.argument = nil
-			projectGrantBindingDriver.queryCalls = 0
+			resetProjectGrantBindingDriver()
 			db, err := sql.Open(projectGrantBindingDriverName, "")
 			if err != nil {
 				t.Fatalf("open capture database: %v", err)
@@ -100,5 +150,85 @@ func TestListProjectGrantsBindsNumericPrincipalID(t *testing.T) {
 				t.Fatalf("ListProjectGrants bound principal ID as %d; want %d", bound, tt.want)
 			}
 		})
+	}
+}
+
+func TestRevokeProjectGrantBindsNumericPrincipalID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{name: "trims padded ID", input: " 3 ", want: 3},
+		{name: "accepts maximum signed bigint", input: "9223372036854775807", want: 9223372036854775807},
+		{name: "accepts minimum signed bigint", input: "-9223372036854775808", want: -9223372036854775808},
+		{name: "rejects non-numeric ID", input: "not-a-number", wantErr: true},
+		{name: "rejects out-of-range ID", input: "9223372036854775808", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetProjectGrantBindingDriver()
+			db, err := sql.Open(projectGrantBindingDriverName, "")
+			if err != nil {
+				t.Fatalf("open capture database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+
+			store := &CloudStore{db: db}
+			err = store.RevokeProjectGrant(context.Background(), tt.input, "alpha-project")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("RevokeProjectGrant returned nil error")
+				}
+				if projectGrantBindingDriver.execCalls != 0 {
+					t.Fatalf("ExecContext called %d times; want 0", projectGrantBindingDriver.execCalls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("revoke project grant: %v", err)
+			}
+			if projectGrantBindingDriver.execCalls != 1 {
+				t.Fatalf("ExecContext called %d times; want 1", projectGrantBindingDriver.execCalls)
+			}
+			bound, ok := projectGrantBindingDriver.argument.(int64)
+			if !ok {
+				t.Fatalf("RevokeProjectGrant bound principal ID as %T; want int64", projectGrantBindingDriver.argument)
+			}
+			if bound != tt.want {
+				t.Fatalf("RevokeProjectGrant bound principal ID as %d; want %d", bound, tt.want)
+			}
+		})
+	}
+}
+
+func TestRevokeProjectGrantRemovesGrantedRow(t *testing.T) {
+	resetProjectGrantBindingDriver()
+	seedProjectGrantBindingDriver(3, "alpha-project")
+	db, err := sql.Open(projectGrantBindingDriverName, "")
+	if err != nil {
+		t.Fatalf("open capture database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := &CloudStore{db: db}
+	grants, err := store.ListProjectGrants(context.Background(), " 3 ")
+	if err != nil {
+		t.Fatalf("list project grants before revoke: %v", err)
+	}
+	if len(grants) != 1 || grants[0].Project != "alpha-project" {
+		t.Fatalf("expected granted project before revoke, got %+v", grants)
+	}
+	if err := store.RevokeProjectGrant(context.Background(), " 3 ", "alpha-project"); err != nil {
+		t.Fatalf("revoke project grant: %v", err)
+	}
+	grants, err = store.ListProjectGrants(context.Background(), " 3 ")
+	if err != nil {
+		t.Fatalf("list project grants after revoke: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("revoked grant should not list, got %+v", grants)
 	}
 }

--- a/internal/cloud/cloudstore/project_grants_binding_test.go
+++ b/internal/cloud/cloudstore/project_grants_binding_test.go
@@ -17,7 +17,8 @@ func init() {
 }
 
 type capturingProjectGrantDriver struct {
-	argument any
+	argument   any
+	queryCalls int
 }
 
 func (d *capturingProjectGrantDriver) Open(string) (driver.Conn, error) {
@@ -37,6 +38,7 @@ func (projectGrantBindingConn) Close() error { return nil }
 func (projectGrantBindingConn) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
 
 func (c projectGrantBindingConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
+	c.driver.queryCalls++
 	c.driver.argument = args[0].Value
 	return projectGrantBindingRows{}, nil
 }
@@ -50,19 +52,53 @@ func (projectGrantBindingRows) Close() error { return nil }
 func (projectGrantBindingRows) Next([]driver.Value) error { return io.EOF }
 
 func TestListProjectGrantsBindsNumericPrincipalID(t *testing.T) {
-	projectGrantBindingDriver.argument = nil
-	db, err := sql.Open(projectGrantBindingDriverName, "")
-	if err != nil {
-		t.Fatalf("open capture database: %v", err)
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{name: "trims padded ID", input: " 3 ", want: 3},
+		{name: "accepts maximum signed bigint", input: "9223372036854775807", want: 9223372036854775807},
+		{name: "accepts minimum signed bigint", input: "-9223372036854775808", want: -9223372036854775808},
+		{name: "rejects non-numeric ID", input: "not-a-number", wantErr: true},
+		{name: "rejects out-of-range ID", input: "9223372036854775808", wantErr: true},
 	}
-	t.Cleanup(func() { _ = db.Close() })
 
-	store := &CloudStore{db: db}
-	if _, err := store.ListProjectGrants(context.Background(), " 3 "); err != nil {
-		t.Fatalf("list project grants: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectGrantBindingDriver.argument = nil
+			projectGrantBindingDriver.queryCalls = 0
+			db, err := sql.Open(projectGrantBindingDriverName, "")
+			if err != nil {
+				t.Fatalf("open capture database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
 
-	if _, ok := projectGrantBindingDriver.argument.(int64); !ok {
-		t.Fatalf("ListProjectGrants bound principal ID as %T; want int64", projectGrantBindingDriver.argument)
+			store := &CloudStore{db: db}
+			_, err = store.ListProjectGrants(context.Background(), tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ListProjectGrants returned nil error")
+				}
+				if projectGrantBindingDriver.queryCalls != 0 {
+					t.Fatalf("QueryContext called %d times; want 0", projectGrantBindingDriver.queryCalls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("list project grants: %v", err)
+			}
+			if projectGrantBindingDriver.queryCalls != 1 {
+				t.Fatalf("QueryContext called %d times; want 1", projectGrantBindingDriver.queryCalls)
+			}
+			bound, ok := projectGrantBindingDriver.argument.(int64)
+			if !ok {
+				t.Fatalf("ListProjectGrants bound principal ID as %T; want int64", projectGrantBindingDriver.argument)
+			}
+			if bound != tt.want {
+				t.Fatalf("ListProjectGrants bound principal ID as %d; want %d", bound, tt.want)
+			}
+		})
 	}
 }

--- a/internal/cloud/cloudstore/project_grants_binding_test.go
+++ b/internal/cloud/cloudstore/project_grants_binding_test.go
@@ -1,0 +1,68 @@
+package cloudstore
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"testing"
+)
+
+const projectGrantBindingDriverName = "cloudstore-project-grant-binding"
+
+var projectGrantBindingDriver = &capturingProjectGrantDriver{}
+
+func init() {
+	sql.Register(projectGrantBindingDriverName, projectGrantBindingDriver)
+}
+
+type capturingProjectGrantDriver struct {
+	argument any
+}
+
+func (d *capturingProjectGrantDriver) Open(string) (driver.Conn, error) {
+	return projectGrantBindingConn{driver: d}, nil
+}
+
+type projectGrantBindingConn struct {
+	driver *capturingProjectGrantDriver
+}
+
+func (c projectGrantBindingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (projectGrantBindingConn) Close() error { return nil }
+
+func (projectGrantBindingConn) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
+
+func (c projectGrantBindingConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
+	c.driver.argument = args[0].Value
+	return projectGrantBindingRows{}, nil
+}
+
+type projectGrantBindingRows struct{}
+
+func (projectGrantBindingRows) Columns() []string { return nil }
+
+func (projectGrantBindingRows) Close() error { return nil }
+
+func (projectGrantBindingRows) Next([]driver.Value) error { return io.EOF }
+
+func TestListProjectGrantsBindsNumericPrincipalID(t *testing.T) {
+	projectGrantBindingDriver.argument = nil
+	db, err := sql.Open(projectGrantBindingDriverName, "")
+	if err != nil {
+		t.Fatalf("open capture database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := &CloudStore{db: db}
+	if _, err := store.ListProjectGrants(context.Background(), " 3 "); err != nil {
+		t.Fatalf("list project grants: %v", err)
+	}
+
+	if _, ok := projectGrantBindingDriver.argument.(int64); !ok {
+		t.Fatalf("ListProjectGrants bound principal ID as %T; want int64", projectGrantBindingDriver.argument)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #657

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Parse project grant principal IDs as `int64` before binding them to PostgreSQL `BIGINT` queries.
- Add a deterministic regression test that captures and asserts the database argument type.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudstore/identity.go` | Parse and bind project grant principal IDs as numeric values. |
| `internal/cloud/cloudstore/project_grants_binding_test.go` | Add credential-free regression coverage for the query binding type. |

## 🧪 Test Plan

- [x] `go test ./internal/cloud/cloudstore -run '^TestListProjectGrantsBindsNumericPrincipalID$' -count=1 -timeout=9m`
- [x] `go test ./internal/cloud/cloudstore -count=1 -timeout=9m`
- [ ] Full unit suite (not run locally; CI will run it)
- [ ] E2E suite (not applicable to the focused cloudstore change; CI will run repository-required checks)

---

## 🤖 Automated Checks

All repository-required checks are expected to run in CI.

---

## ✅ Contributor Checklist

- [x] I linked approved issue #657 above.
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran the full unit suite locally (focused and affected-package tests passed; CI will run the full suite).
- [ ] I ran the E2E suite locally (not applicable to this focused cloudstore change).
- [x] Docs are not required for this internal bug fix.
- [x] Commits follow Conventional Commits format.
- [x] No `Co-Authored-By` trailers are present.

---

## 💬 Notes for Reviewers

The regression test uses a small `database/sql` capture driver, so it proves the bound Go value is `int64` without requiring PostgreSQL credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project grant lookups and revocations by accepting surrounding whitespace in principal IDs.
  * Invalid or out-of-range principal IDs now return clear validation errors instead of causing invalid queries.
  * Ensured revoking a project grant removes it from subsequent listings.

* **Tests**
  * Added coverage for numeric principal IDs, boundary values, whitespace, invalid input, and grant removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->