### PR TITLE
fix(projects): migrate case-only legacy project rows

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -974,18 +974,9 @@ func (s *Server) handleMigrateProject(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "old_project and new_project are required")
 		return
 	}
-	// Normalize both names using the same rules the store applies so that
-	// case-only differences (e.g. "repo_name" vs "Repo_Name") are treated as
-	// identical and do not trigger a migration that would create duplicates.
-	// See: https://github.com/Gentleman-Programming/engram/issues/438
-	normalizedOld, _ := store.NormalizeProject(body.OldProject)
 	normalizedNew, _ := store.NormalizeProject(body.NewProject)
-	if normalizedOld == normalizedNew {
-		jsonResponse(w, http.StatusOK, map[string]any{"status": "skipped", "reason": "names are identical"})
-		return
-	}
 
-	result, err := s.store.MigrateProject(body.OldProject, body.NewProject)
+	result, err := s.store.MigrateProject(body.OldProject, normalizedNew)
 	if err != nil {
 		log.Printf("[engram] project migration failed: %v", err)
 		jsonError(w, http.StatusInternalServerError, "migration failed")
@@ -1004,7 +995,7 @@ func (s *Server) handleMigrateProject(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusOK, map[string]any{
 		"status":       "migrated",
 		"old_project":  body.OldProject,
-		"new_project":  body.NewProject,
+		"new_project":  normalizedNew,
 		"observations": result.ObservationsUpdated,
 		"sessions":     result.SessionsUpdated,
 		"prompts":      result.PromptsUpdated,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2188,31 +2188,35 @@ func TestJudgeAndCompareRoutesValidateInput(t *testing.T) {
 	}
 }
 
-// TestMigrateProjectCaseOnlySkipped asserts that POST /projects/migrate
-// returns status "skipped" when old_project and new_project differ only by
-// case — fixing #438 where the exact-string comparison let case-only renames
-// slip through and create duplicate projects.
-//
-// The test seeds a session under "repo_name" so that the store would actually
-// migrate if the server did not guard against case-only differences first.
-func TestMigrateProjectCaseOnlySkipped(t *testing.T) {
-	st := newServerTestStore(t)
-	h := New(st, 0).Handler()
+func TestMigrateProjectCaseOnlyLegacySource(t *testing.T) {
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	st, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
 
-	// Seed a session under the lowercase project name so the store has data
-	// to migrate; without the fix the handler would call store.MigrateProject
-	// and rename "repo_name" → "Repo_Name", creating a duplicate.
-	seedReq := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(
-		`{"id":"s-case-migrate","project":"repo_name","directory":"/tmp/repo"}`,
-	))
-	seedReq.Header.Set("Content-Type", "application/json")
-	seedRec := httptest.NewRecorder()
-	h.ServeHTTP(seedRec, seedReq)
-	if seedRec.Code != http.StatusCreated {
-		t.Fatalf("seed session: expected 201, got %d body=%s", seedRec.Code, seedRec.Body.String())
+	db, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, query := range []string{
+		`INSERT INTO sessions (id, project, directory) VALUES ('s-case-migrate', 'Engram', '/tmp/repo')`,
+		`INSERT INTO observations (sync_id, session_id, type, title, content, project, scope, normalized_hash) VALUES ('case-obs', 's-case-migrate', 'decision', 'legacy', 'content', 'Engram', 'project', 'case-hash')`,
+		`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES ('case-prompt', 's-case-migrate', 'prompt', 'Engram')`,
+	} {
+		if _, err := db.Exec(query); err != nil {
+			t.Fatalf("seed legacy project: %v", err)
+		}
 	}
 
-	body := bytes.NewBufferString(`{"old_project":"repo_name","new_project":"Repo_Name"}`)
+	h := New(st, 0).Handler()
+	body := bytes.NewBufferString(`{"old_project":"Engram","new_project":"engram"}`)
 	req := httptest.NewRequest(http.MethodPost, "/projects/migrate", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -2227,7 +2231,35 @@ func TestMigrateProjectCaseOnlySkipped(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp["status"] != "skipped" {
-		t.Fatalf("expected status=skipped for case-only difference, got %v (full response: %#v)", resp["status"], resp)
+	if resp["status"] != "migrated" || resp["new_project"] != "engram" {
+		t.Fatalf("unexpected migration response: %#v", resp)
+	}
+
+	for _, table := range []string{"sessions", "observations", "user_prompts"} {
+		var legacyRows, canonicalRows int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE project = ?`, "Engram").Scan(&legacyRows); err != nil {
+			t.Fatalf("count legacy rows in %s: %v", table, err)
+		}
+		if err := db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE project = ?`, "engram").Scan(&canonicalRows); err != nil {
+			t.Fatalf("count canonical rows in %s: %v", table, err)
+		}
+		if legacyRows != 0 || canonicalRows != 1 {
+			t.Fatalf("%s rows: legacy=%d canonical=%d, want 0 and 1", table, legacyRows, canonicalRows)
+		}
+	}
+
+	identicalReq := httptest.NewRequest(http.MethodPost, "/projects/migrate", strings.NewReader(`{"old_project":"engram","new_project":"engram"}`))
+	identicalReq.Header.Set("Content-Type", "application/json")
+	identicalRec := httptest.NewRecorder()
+	h.ServeHTTP(identicalRec, identicalReq)
+	if identicalRec.Code != http.StatusOK {
+		t.Fatalf("identical migration: expected 200, got %d body=%s", identicalRec.Code, identicalRec.Body.String())
+	}
+	var identicalResp map[string]any
+	if err := json.NewDecoder(identicalRec.Body).Decode(&identicalResp); err != nil {
+		t.Fatalf("decode identical response: %v", err)
+	}
+	if identicalResp["status"] != "skipped" {
+		t.Fatalf("expected identical migration to be skipped, got %#v", identicalResp)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4943,8 +4943,8 @@ type MergeResult struct {
 }
 
 // MergeProjects migrates all records from each source project name into the
-// canonical name. Sources that equal the canonical (after normalization) or
-// have no records are silently skipped — the operation is idempotent.
+// canonical name. Exact canonical sources or sources with no records are
+// silently skipped — the operation is idempotent.
 // All updates are performed inside a single transaction for atomicity.
 func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult, error) {
 	canonical, _ = NormalizeProject(canonical)
@@ -4958,13 +4958,13 @@ func (s *Store) MergeProjects(sources []string, canonical string) (*MergeResult,
 		seenSources := make(map[string]struct{})
 		for _, srcInput := range sources {
 			srcNormalized, _ := NormalizeProject(srcInput)
-			if srcNormalized == "" || srcNormalized == canonical {
+			if srcNormalized == "" || srcInput == canonical {
 				continue
 			}
-			if _, seen := seenSources[srcNormalized]; seen {
+			if _, seen := seenSources[srcInput]; seen {
 				continue
 			}
-			seenSources[srcNormalized] = struct{}{}
+			seenSources[srcInput] = struct{}{}
 
 			sourceVariants := projectMergeSourceVariants(srcInput, srcNormalized, canonical)
 			if len(sourceVariants) == 0 {
@@ -5023,8 +5023,8 @@ func projectMergeSourceVariants(rawSource, normalizedSource, canonical string) [
 	seen := make(map[string]struct{})
 	variants := make([]string, 0, 5)
 	// Match both the historical raw project name and its normalized form so
-	// legacy rows are migrated without reintroducing canonical-source churn.
-	candidates := []string{strings.TrimSpace(rawSource), normalizedSource}
+	// legacy rows are migrated while exact canonical rows remain untouched.
+	candidates := []string{rawSource, normalizedSource}
 	parts := strings.FieldsFunc(normalizedSource, func(r rune) bool {
 		return r == ' ' || r == '-' || r == '_'
 	})
@@ -5034,12 +5034,7 @@ func projectMergeSourceVariants(rawSource, normalizedSource, canonical string) [
 		}
 	}
 	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" || candidate == canonical {
-			continue
-		}
-		candidateNormalized, _ := NormalizeProject(candidate)
-		if candidateNormalized == canonical {
+		if strings.TrimSpace(candidate) == "" || candidate == canonical {
 			continue
 		}
 		if _, ok := seen[candidate]; ok {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7116,8 +7116,8 @@ func TestListProjectsWithStats(t *testing.T) {
 func TestMergeProjects(t *testing.T) {
 	s := newTestStore(t)
 
-	// Set up three source projects
-	sources := []string{"engram", "Engram", "engram-memory"}
+	// Set up canonical and alias source projects.
+	sources := []string{"engram", "engram-memory"}
 	canonical := "engram"
 
 	if err := s.CreateSession("s1", "engram", "/work"); err != nil {
@@ -7150,10 +7150,9 @@ func TestMergeProjects(t *testing.T) {
 		t.Errorf("canonical = %q, want \"engram\"", result.Canonical)
 	}
 
-	// "Engram" normalizes to "engram" (same as canonical) → skipped
 	// "engram-memory" is different → merged
-	// Only "engram-memory" should appear in SourcesMerged (and possibly "engram" if it had records,
-	// but it equals canonical after normalization → skipped)
+	// Only "engram-memory" should appear in SourcesMerged because "engram"
+	// is the exact canonical source.
 	for _, merged := range result.SourcesMerged {
 		if merged == "engram" {
 			t.Error("canonical 'engram' should not appear in SourcesMerged")
@@ -7212,18 +7211,53 @@ func TestMergeProjectsCanonicalInSources(t *testing.T) {
 		t.Fatalf("AddObservation: %v", err)
 	}
 
-	// Sources include the canonical itself — should be silently skipped
-	result, err := s.MergeProjects([]string{"engram", "Engram"}, "engram")
+	// The exact canonical source is silently skipped.
+	result, err := s.MergeProjects([]string{"engram"}, "engram")
 	if err != nil {
 		t.Fatalf("MergeProjects: %v", err)
 	}
 
-	// Nothing should have been changed (engram and Engram both normalize to "engram" = canonical)
+	// Nothing should have been changed.
 	if result.ObservationsUpdated != 0 {
 		t.Errorf("expected 0 observations updated when sources equal canonical, got %d", result.ObservationsUpdated)
 	}
 	if len(result.SourcesMerged) != 0 {
 		t.Errorf("expected empty SourcesMerged when all sources equal canonical, got %v", result.SourcesMerged)
+	}
+}
+
+func TestMergeProjectsMigratesCaseOnlyLegacySource(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, "legacy-case-session", "Engram", "/work/engram"); err != nil {
+		t.Fatalf("seed legacy session: %v", err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO observations (sync_id, session_id, type, title, content, project, scope, normalized_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "legacy-case-obs", "legacy-case-session", "decision", "legacy", "legacy content", "Engram", "project", "legacy-case-hash"); err != nil {
+		t.Fatalf("seed legacy observation: %v", err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES (?, ?, ?, ?)`, "legacy-case-prompt", "legacy-case-session", "legacy prompt", "Engram"); err != nil {
+		t.Fatalf("seed legacy prompt: %v", err)
+	}
+
+	result, err := s.MergeProjects([]string{"Engram"}, "engram")
+	if err != nil {
+		t.Fatalf("MergeProjects: %v", err)
+	}
+	if result.Canonical != "engram" || result.ObservationsUpdated != 1 || result.SessionsUpdated != 1 || result.PromptsUpdated != 1 {
+		t.Fatalf("unexpected merge result: %+v", result)
+	}
+
+	for _, table := range []string{"sessions", "observations", "user_prompts"} {
+		var legacyRows, canonicalRows int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE project = ?`, "Engram").Scan(&legacyRows); err != nil {
+			t.Fatalf("count legacy rows in %s: %v", table, err)
+		}
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE project = ?`, "engram").Scan(&canonicalRows); err != nil {
+			t.Fatalf("count canonical rows in %s: %v", table, err)
+		}
+		if legacyRows != 0 || canonicalRows != 1 {
+			t.Fatalf("%s rows: legacy=%d canonical=%d, want 0 and 1", table, legacyRows, canonicalRows)
+		}
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #749

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Migrate legacy project rows whose stored name differs from the canonical project only by case.
- Preserve exact canonical rows while reporting the normalized destination through the project migration endpoint.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/server/server.go` | Pass the normalized destination to the store so case-only legacy sources are migrated. |
| `internal/server/server_test.go` | Cover endpoint migration of legacy case-only rows and the exact-canonical no-op. |
| `internal/store/store.go` | Treat only exact canonical inputs as skippable while retaining case-only legacy variants. |
| `internal/store/store_test.go` | Cover store-level migration of sessions, observations, and prompts from a case-only legacy source. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

Focused server/store case-only migration regressions passed previously (exit 0).

---

## 🤖 Automated Checks

These run automatically and all must pass before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Documentation not required; no user-facing workflow changed
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This migration is intentionally limited to legacy rows whose stored project name differs from the canonical name only by case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project migrations now correctly process legacy project names that differ from the destination only by capitalization.
  * Migrated records are consolidated under the normalized project name.
  * Exact matches continue to be skipped to avoid unnecessary migrations.
  * Migration responses now report the normalized destination name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->