### PR TITLE
fix(cli): assert portable export failure

### DIFF
--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -2587,7 +2587,7 @@ func TestCmdExportDefaultAndCmdImportErrors(t *testing.T) {
 	badPath := filepath.Join(workDir, "missing", "out.json")
 	withArgs(t, "engram", "export", badPath)
 	_, stderr, recovered = captureOutputAndRecover(t, func() { cmdExport(cfg) })
-	if _, ok := recovered.(exitCode); !ok || !strings.Contains(stderr, "no such file or directory") {
+	if code, ok := recovered.(exitCode); !ok || code != 1 || !strings.Contains(stderr, badPath) {
 		t.Fatalf("expected export write fatal, panic=%v stderr=%q", recovered, stderr)
 	}
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #822

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Make the export-error assertion portable across Windows and Unix-like systems.
- Assert the stable exit code and requested failing path instead of platform-specific error text.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main_extra_test.go` | Require exit code `1` and the requested failing export path in stderr. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality
- [x] Focused Windows regression test previously passed: `go test ./cmd/engram -run TestCmdExportDefaultAndCmdImportErrors -count=1`
- [x] `git diff --check` passed before commit

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed) — N/A: test-only portability assertion
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

- Native four-lens RDD approved the exact frozen candidate before delivery.
- The latest delivery session did not execute a fresh broad unit or E2E suite; CI remains authoritative for those checks.