### PR TITLE
fix(pi): preserve runtime session id with explicit project

### DIFF
--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -652,7 +652,7 @@ async function callMemoryTool(toolName: string, params: Record<string, unknown>,
   const sessionId = getSessionId(ctx);
   const requestedProject = typeof params.project === "string" && params.project ? params.project : undefined;
   const activeProject = requestedProject || project;
-  const activeSessionId = String(params.session_id || (requestedProject ? `manual-save-${requestedProject}` : sessionId) || `manual-save-${project}`);
+  const activeSessionId = String(params.session_id || sessionId || `manual-save-${requestedProject || project}`);
 
   switch (toolName) {
     case "mem_search":

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -115,6 +115,12 @@ test("mem_session_summary accepts explicit project fallback", () => {
   assert.match(source, /case "mem_session_summary":[\s\S]*if \(!requestedProject\) requireResolvedProject\(\);[\s\S]*ensureSession\(activeSessionId, activeProject\)[\s\S]*project: activeProject/);
 });
 
+test("manual saves prefer explicit and runtime session IDs before synthetic project fallback", () => {
+  assert.match(source, /const activeSessionId = String\(params\.session_id \|\| sessionId \|\| `manual-save-\$\{requestedProject \|\| project\}`\);/);
+  assert.match(source, /params\.session_id \|\| sessionId/);
+  assert.match(source, /sessionId \|\| `manual-save-\$\{requestedProject \|\| project\}`/);
+});
+
 test("mem_search exposes and forwards match_mode and all_projects", () => {
   assert.match(source, /mem_search: Type\.Object\(\{[\s\S]*all_projects: optionalBoolean\("Search across every project; when true project is ignored"\)/);
   assert.match(source, /mem_search: Type\.Object\(\{[\s\S]*match_mode: optionalString\("Match mode: all \(default\) or any for broader recall"\)/);


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #680

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Preserve the authoritative Pi runtime session ID when memory calls also pass an explicit project.
- Use a synthetic `manual-save-*` session only when neither an explicit nor runtime session ID exists.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Reorders session-ID fallback precedence for Pi memory tools. |
| `plugin/pi/test/index-source.test.mjs` | Adds focused regression coverage for explicit project calls with a runtime session. |

## 🧪 Test Plan

- [x] Focused Pi regression: `node --test --test-name-pattern="manual saves prefer explicit and runtime session IDs before synthetic project fallback" plugin/pi/test/index-source.test.mjs` (1 passed, 0 failed).
- [ ] Unit tests pass locally: `go test ./...` (timed out after 600 seconds without output).
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`.
- [ ] Manually tested the affected functionality.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #680`).
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran unit tests locally: `go test ./...` (timed out after 600 seconds).
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`.
- [ ] Docs updated (not required for this internal fallback correction).
- [x] Commits follow conventional commits format.
- [x] No `Co-Authored-By` trailers in commits.

---

## 💬 Notes for Reviewers

Native RDD approved the exact committed candidate. The focused Pi regression and server E2E suite pass locally. The broad Go suite did not complete within the 600-second local budget, so this PR is opened as a draft and leaves that item unchecked for CI verification.
