### PR TITLE
fix(sync): propagate prompt deletes to the cloud

### DIFF
--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -396,32 +396,56 @@ func materializedChunkMutations(project string, chunk engramsync.ChunkData) ([]M
 
 	// Relations travel only as relation-entity entries in chunk.Mutations — there is no
 	// typed collection for them like Sessions/Observations/Prompts — so materialize them
-	// here to mirror the mutation-push path (#379). Session/observation/prompt mutations
-	// are already materialized from the typed collections above, so they are skipped to
-	// avoid duplicate cloud_mutations rows.
+	// here to mirror the mutation-push path (#379).
+	//
+	// Session/observation/prompt UPSERTS are already materialized from the typed
+	// collections above, so they are skipped to avoid duplicate cloud_mutations rows.
+	// Their DELETES are not, and must be materialized here (#837): a hard-deleted row is
+	// gone locally, so it cannot ride in a typed collection at all, and a soft-deleted one
+	// only rides as an upsert carrying deleted_at, which a cloud_mutations replay reads as
+	// still present. Appending the delete after the typed entries gives it the higher seq,
+	// so the tombstone wins on replay.
 	for i, mutation := range chunk.Mutations {
-		if strings.TrimSpace(mutation.Entity) != store.SyncEntityRelation {
+		entity := strings.TrimSpace(mutation.Entity)
+		op := strings.TrimSpace(mutation.Op)
+		if op == "" {
+			op = store.SyncOpUpsert
+		}
+		if !materializableChunkMutation(entity, op) {
 			continue
 		}
 		entityKey := strings.TrimSpace(mutation.EntityKey)
 		if entityKey == "" {
-			return nil, fmt.Errorf("cloudstore: materialize chunk: mutations[%d].entity_key is required for relation", i)
-		}
-		op := strings.TrimSpace(mutation.Op)
-		if op == "" {
-			op = store.SyncOpUpsert
+			return nil, fmt.Errorf("cloudstore: materialize chunk: mutations[%d].entity_key is required for %s", i, entity)
 		}
 		payload := json.RawMessage(strings.TrimSpace(mutation.Payload))
 		if len(payload) == 0 {
 			payload = json.RawMessage("{}")
 		}
-		if field, ok := chunkcodec.ValidateRelationPayload(payload); !ok {
-			return nil, fmt.Errorf("cloudstore: materialize chunk: mutations[%d].payload.%s is required for relation", i, field)
+		if entity == store.SyncEntityRelation {
+			if field, ok := chunkcodec.ValidateRelationPayload(payload); !ok {
+				return nil, fmt.Errorf("cloudstore: materialize chunk: mutations[%d].payload.%s is required for relation", i, field)
+			}
 		}
-		entries = append(entries, MutationEntry{Project: project, Entity: store.SyncEntityRelation, EntityKey: entityKey, Op: op, Payload: payload})
+		entries = append(entries, MutationEntry{Project: project, Entity: entity, EntityKey: entityKey, Op: op, Payload: payload})
 	}
 
 	return entries, nil
+}
+
+// materializableChunkMutation reports whether a chunk.Mutations entry still needs a
+// cloud_mutations row after the typed collections have been materialized.
+func materializableChunkMutation(entity, op string) bool {
+	switch entity {
+	case store.SyncEntityRelation:
+		// Relations have no typed collection, so every relation entry materializes.
+		return true
+	case store.SyncEntitySession, store.SyncEntityObservation, store.SyncEntityPrompt:
+		// Upserts already came from the typed collections; only tombstones are missing.
+		return op == store.SyncOpDelete
+	default:
+		return false
+	}
 }
 
 func insertMaterializedMutations(ctx context.Context, tx *sql.Tx, entries []MutationEntry) error {

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -536,6 +536,144 @@ func TestMaterializedChunkMutationsCarriesRelationFromChunkMutations(t *testing.
 	}
 }
 
+// #837: a prompt is hard-deleted locally, so it cannot ride in chunk.Prompts.
+// Its delete travels only as a chunk.Mutations entry and must still materialize.
+func TestMaterializedChunkMutationsCarriesPromptDeleteFromChunkMutations(t *testing.T) {
+	project := "proj-materialize-prompt-delete"
+	deletePayload := `{"sync_id":"prompt-1","session_id":"s-1","project":"proj-materialize-prompt-delete","deleted":true,"hard_delete":true,"deleted_at":"2026-04-29T10:05:00Z"}`
+	chunk := engramsync.ChunkData{
+		Sessions: []store.Session{{ID: "s-1", Project: project}},
+		Mutations: []store.SyncMutation{
+			{Project: project, Entity: store.SyncEntityPrompt, EntityKey: "prompt-1", Op: store.SyncOpDelete, Payload: deletePayload},
+		},
+	}
+
+	entries, err := materializedChunkMutations(project, chunk)
+	if err != nil {
+		t.Fatalf("materializedChunkMutations: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected session upsert + prompt delete, got %d: %+v", len(entries), entries)
+	}
+
+	var promptDelete *MutationEntry
+	for i := range entries {
+		if entries[i].Entity == store.SyncEntityPrompt {
+			promptDelete = &entries[i]
+		}
+	}
+	if promptDelete == nil {
+		t.Fatalf("expected prompt delete materialized from chunk.Mutations, got %+v", entries)
+	}
+	if promptDelete.EntityKey != "prompt-1" || promptDelete.Op != store.SyncOpDelete || promptDelete.Project != project {
+		t.Fatalf("unexpected prompt delete entry: %+v", *promptDelete)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(promptDelete.Payload, &payload); err != nil {
+		t.Fatalf("prompt delete payload is not object JSON: %v", err)
+	}
+	if payload["sync_id"] != "prompt-1" {
+		t.Fatalf("prompt delete payload not preserved: %+v", payload)
+	}
+}
+
+// #837: DeleteObservation(id, hardDelete=true) removes the row exactly like
+// DeletePrompt, so its delete can only travel as a chunk.Mutations entry too.
+func TestMaterializedChunkMutationsCarriesObservationHardDeleteFromChunkMutations(t *testing.T) {
+	project := "proj-materialize-obs-hard-delete"
+	deletePayload := `{"sync_id":"obs-1","session_id":"s-1","project":"proj-materialize-obs-hard-delete","deleted":true,"hard_delete":true,"deleted_at":"2026-04-29T10:05:00Z"}`
+	chunk := engramsync.ChunkData{
+		Sessions: []store.Session{{ID: "s-1", Project: project}},
+		Mutations: []store.SyncMutation{
+			{Project: project, Entity: store.SyncEntityObservation, EntityKey: "obs-1", Op: store.SyncOpDelete, Payload: deletePayload},
+		},
+	}
+
+	entries, err := materializedChunkMutations(project, chunk)
+	if err != nil {
+		t.Fatalf("materializedChunkMutations: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected session upsert + observation delete, got %d: %+v", len(entries), entries)
+	}
+	var observationDelete *MutationEntry
+	for i := range entries {
+		if entries[i].Entity == store.SyncEntityObservation {
+			observationDelete = &entries[i]
+		}
+	}
+	if observationDelete == nil {
+		t.Fatalf("expected observation delete materialized from chunk.Mutations, got %+v", entries)
+	}
+	if observationDelete.EntityKey != "obs-1" || observationDelete.Op != store.SyncOpDelete || observationDelete.Project != project {
+		t.Fatalf("unexpected observation delete entry: %+v", *observationDelete)
+	}
+}
+
+// A soft-deleted observation still rides in chunk.Observations (its row survives
+// with deleted_at set), so it materializes an upsert. The paired delete mutation
+// must materialize after it, otherwise replaying cloud_mutations resurrects it.
+func TestMaterializedChunkMutationsOrdersObservationSoftDeleteAfterTypedUpsert(t *testing.T) {
+	project := "proj-materialize-obs-soft-delete"
+	deletedAt := "2026-04-29T10:05:00Z"
+	chunk := engramsync.ChunkData{
+		Observations: []store.Observation{{SyncID: "obs-1", SessionID: "s-1", DeletedAt: &deletedAt}},
+		Mutations: []store.SyncMutation{
+			{Project: project, Entity: store.SyncEntityObservation, EntityKey: "obs-1", Op: store.SyncOpDelete, Payload: `{"sync_id":"obs-1","session_id":"s-1","deleted":true,"deleted_at":"2026-04-29T10:05:00Z"}`},
+		},
+	}
+
+	entries, err := materializedChunkMutations(project, chunk)
+	if err != nil {
+		t.Fatalf("materializedChunkMutations: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected typed upsert + delete, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].Op != store.SyncOpUpsert || entries[1].Op != store.SyncOpDelete {
+		t.Fatalf("expected the delete to be materialized last, got %+v", entries)
+	}
+}
+
+// The skip that dropped prompt deletes exists to keep upserts from being
+// materialized twice — once from the typed collection and once from the
+// mirrored chunk.Mutations entry. That invariant must survive the fix.
+func TestMaterializedChunkMutationsMaterializesUpsertsExactlyOnce(t *testing.T) {
+	project := "proj-materialize-no-duplicates"
+	chunk := engramsync.ChunkData{
+		Sessions:     []store.Session{{ID: "s-1", Project: project}},
+		Observations: []store.Observation{{SyncID: "obs-1", SessionID: "s-1"}},
+		Prompts:      []store.Prompt{{SyncID: "prompt-1", SessionID: "s-1", Project: project}},
+		Mutations: []store.SyncMutation{
+			{Project: project, Entity: store.SyncEntitySession, EntityKey: "s-1", Op: store.SyncOpUpsert, Payload: `{"id":"s-1"}`},
+			{Project: project, Entity: store.SyncEntityObservation, EntityKey: "obs-1", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-1"}`},
+			{Project: project, Entity: store.SyncEntityPrompt, EntityKey: "prompt-1", Op: store.SyncOpUpsert, Payload: `{"sync_id":"prompt-1"}`},
+		},
+	}
+
+	entries, err := materializedChunkMutations(project, chunk)
+	if err != nil {
+		t.Fatalf("materializedChunkMutations: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected exactly one entry per typed row, got %d: %+v", len(entries), entries)
+	}
+	seen := make(map[string]int, len(entries))
+	for _, entry := range entries {
+		if entry.Op != store.SyncOpUpsert {
+			t.Fatalf("expected only upserts, got %+v", entry)
+		}
+		seen[entry.Entity+"/"+entry.EntityKey]++
+	}
+	for key, count := range seen {
+		if count != 1 {
+			t.Fatalf("entry %s materialized %d times, want exactly 1", key, count)
+		}
+	}
+}
+
 func TestWriteChunkMaterializesRelationMutationIntoCloudMutations(t *testing.T) {
 	cs := openTestCloudStore(t)
 	project := "test-chunk-relation-" + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "-")

--- a/internal/cloud/cloudstore/dashboard_queries_test.go
+++ b/internal/cloud/cloudstore/dashboard_queries_test.go
@@ -1722,3 +1722,193 @@ func TestDashboardCountsPiSavedPromptUnderItsProject(t *testing.T) {
 		}
 	}
 }
+
+// ─── #837: local deletes must reach the dashboard ────────────────────────────
+
+// materializeChunkRowsForDashboard mirrors what WriteChunk persists: every chunk
+// row is materialized into cloud_mutations rows with monotonically increasing
+// seqs, so dashboard assertions run against the same data the cloud would store.
+func materializeChunkRowsForDashboard(t *testing.T, chunks []dashboardChunkRow) []dashboardMutationRow {
+	t.Helper()
+	rows := make([]dashboardMutationRow, 0)
+	seq := int64(0)
+	for _, chunk := range chunks {
+		entries, err := materializedChunkMutations(chunk.project, chunk.parsed)
+		if err != nil {
+			t.Fatalf("materializedChunkMutations for chunk %q: %v", chunk.chunkID, err)
+		}
+		for _, entry := range entries {
+			seq++
+			rows = append(rows, dashboardMutationRow{
+				seq:        seq,
+				project:    entry.Project,
+				entity:     entry.Entity,
+				entityKey:  entry.EntityKey,
+				op:         entry.Op,
+				payload:    []byte(entry.Payload),
+				occurredAt: chunk.createdAt,
+			})
+		}
+	}
+	return rows
+}
+
+// TestDeletedPromptDisappearsFromDashboard drives the full cloud-side path for
+// #837: a first sync uploads the prompt, a second sync uploads only the delete
+// mutation (the local row is hard-deleted, so it cannot ride in chunk.Prompts).
+// The dashboard must stop listing the prompt.
+func TestDeletedPromptDisappearsFromDashboard(t *testing.T) {
+	const project = "proj-prompt-delete"
+	chunks := []dashboardChunkRow{
+		{
+			chunkID: "chunk-prompt-save", project: project, createdBy: "dev",
+			createdAt: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"sess-1","project":"proj-prompt-delete","started_at":"2026-04-29T09:00:00Z"}],
+				"prompts":[{"sync_id":"prompt-1","session_id":"sess-1","project":"proj-prompt-delete","content":"Keep me?","created_at":"2026-04-29T09:10:00Z"}],
+				"mutations":[
+					{"project":"proj-prompt-delete","entity":"session","entity_key":"sess-1","op":"upsert","payload":"{\"id\":\"sess-1\",\"project\":\"proj-prompt-delete\",\"started_at\":\"2026-04-29T09:00:00Z\"}"},
+					{"project":"proj-prompt-delete","entity":"prompt","entity_key":"prompt-1","op":"upsert","payload":"{\"sync_id\":\"prompt-1\",\"session_id\":\"sess-1\",\"project\":\"proj-prompt-delete\",\"content\":\"Keep me?\",\"created_at\":\"2026-04-29T09:10:00Z\"}"}
+				]
+			}`)),
+		},
+		{
+			chunkID: "chunk-prompt-delete", project: project, createdBy: "dev",
+			createdAt: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"sess-1","project":"proj-prompt-delete","started_at":"2026-04-29T09:00:00Z"}],
+				"mutations":[
+					{"project":"proj-prompt-delete","entity":"prompt","entity_key":"prompt-1","op":"delete","payload":"{\"sync_id\":\"prompt-1\",\"session_id\":\"sess-1\",\"project\":\"proj-prompt-delete\",\"deleted\":true,\"hard_delete\":true,\"deleted_at\":\"2026-04-29T10:30:00Z\"}"}
+				]
+			}`)),
+		},
+	}
+
+	model, err := buildDashboardReadModelFromRows(chunks, materializeChunkRowsForDashboard(t, chunks))
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+	cs := &CloudStore{
+		dashboardReadModelLoad: func() (dashboardReadModel, error) { return model, nil },
+	}
+
+	prompts, err := cs.ListRecentPrompts(project, "", 10)
+	if err != nil {
+		t.Fatalf("ListRecentPrompts: %v", err)
+	}
+	for _, prompt := range prompts {
+		if prompt.SyncID == "prompt-1" {
+			t.Fatalf("deleted prompt still listed on the dashboard: %+v", prompt)
+		}
+	}
+
+	if _, _, _, err := cs.GetPromptDetail(project, "sess-1", "prompt-1"); !errors.Is(err, ErrDashboardPromptNotFound) {
+		t.Fatalf("expected ErrDashboardPromptNotFound for the deleted prompt, got %v", err)
+	}
+
+	detail, err := cs.ProjectDetail(project)
+	if err != nil {
+		t.Fatalf("ProjectDetail: %v", err)
+	}
+	if detail.Stats.Prompts != 0 {
+		t.Fatalf("expected 0 prompts in project stats, got %d", detail.Stats.Prompts)
+	}
+}
+
+// TestHardDeletedObservationDisappearsFromDashboard covers the sibling path:
+// DeleteObservation(id, hardDelete=true) removes the row, so the delete also
+// travels only as a chunk.Mutations entry.
+func TestHardDeletedObservationDisappearsFromDashboard(t *testing.T) {
+	const project = "proj-obs-hard-delete"
+	chunks := []dashboardChunkRow{
+		{
+			chunkID: "chunk-obs-save", project: project, createdBy: "dev",
+			createdAt: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"sess-1","project":"proj-obs-hard-delete","started_at":"2026-04-29T09:00:00Z"}],
+				"observations":[{"sync_id":"obs-1","session_id":"sess-1","project":"proj-obs-hard-delete","type":"decision","title":"Keep me?","content":"Body","created_at":"2026-04-29T09:10:00Z"}],
+				"mutations":[
+					{"project":"proj-obs-hard-delete","entity":"observation","entity_key":"obs-1","op":"upsert","payload":"{\"sync_id\":\"obs-1\",\"session_id\":\"sess-1\",\"project\":\"proj-obs-hard-delete\",\"type\":\"decision\",\"title\":\"Keep me?\",\"content\":\"Body\",\"created_at\":\"2026-04-29T09:10:00Z\"}"}
+				]
+			}`)),
+		},
+		{
+			chunkID: "chunk-obs-delete", project: project, createdBy: "dev",
+			createdAt: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"sess-1","project":"proj-obs-hard-delete","started_at":"2026-04-29T09:00:00Z"}],
+				"mutations":[
+					{"project":"proj-obs-hard-delete","entity":"observation","entity_key":"obs-1","op":"delete","payload":"{\"sync_id\":\"obs-1\",\"session_id\":\"sess-1\",\"project\":\"proj-obs-hard-delete\",\"deleted\":true,\"hard_delete\":true}"}
+				]
+			}`)),
+		},
+	}
+
+	model, err := buildDashboardReadModelFromRows(chunks, materializeChunkRowsForDashboard(t, chunks))
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+	cs := &CloudStore{
+		dashboardReadModelLoad: func() (dashboardReadModel, error) { return model, nil },
+	}
+
+	observations, err := cs.ListRecentObservations(project, "", 10)
+	if err != nil {
+		t.Fatalf("ListRecentObservations: %v", err)
+	}
+	for _, observation := range observations {
+		if observation.SyncID == "obs-1" {
+			t.Fatalf("hard-deleted observation still listed on the dashboard: %+v", observation)
+		}
+	}
+}
+
+// TestSoftDeletedObservationDisappearsFromDashboard covers the default
+// DeleteObservation path: the row survives with deleted_at set, so it still
+// rides in chunk.Observations and materializes an upsert. The paired delete
+// mutation must be materialized after it so the replay does not resurrect it.
+func TestSoftDeletedObservationDisappearsFromDashboard(t *testing.T) {
+	const project = "proj-obs-soft-delete"
+	chunks := []dashboardChunkRow{
+		{
+			chunkID: "chunk-obs-save", project: project, createdBy: "dev",
+			createdAt: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"sess-1","project":"proj-obs-soft-delete","started_at":"2026-04-29T09:00:00Z"}],
+				"observations":[{"sync_id":"obs-1","session_id":"sess-1","project":"proj-obs-soft-delete","type":"decision","title":"Keep me?","content":"Body","created_at":"2026-04-29T09:10:00Z"}],
+				"mutations":[
+					{"project":"proj-obs-soft-delete","entity":"observation","entity_key":"obs-1","op":"upsert","payload":"{\"sync_id\":\"obs-1\",\"session_id\":\"sess-1\",\"project\":\"proj-obs-soft-delete\",\"type\":\"decision\",\"title\":\"Keep me?\",\"content\":\"Body\",\"created_at\":\"2026-04-29T09:10:00Z\"}"}
+				]
+			}`)),
+		},
+		{
+			chunkID: "chunk-obs-delete", project: project, createdBy: "dev",
+			createdAt: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			parsed: parseMustChunk(t, []byte(`{
+				"sessions":[{"id":"sess-1","project":"proj-obs-soft-delete","started_at":"2026-04-29T09:00:00Z"}],
+				"observations":[{"sync_id":"obs-1","session_id":"sess-1","project":"proj-obs-soft-delete","type":"decision","title":"Keep me?","content":"Body","created_at":"2026-04-29T09:10:00Z","deleted_at":"2026-04-29T10:30:00Z"}],
+				"mutations":[
+					{"project":"proj-obs-soft-delete","entity":"observation","entity_key":"obs-1","op":"delete","payload":"{\"sync_id\":\"obs-1\",\"session_id\":\"sess-1\",\"project\":\"proj-obs-soft-delete\",\"deleted\":true}"}
+				]
+			}`)),
+		},
+	}
+
+	model, err := buildDashboardReadModelFromRows(chunks, materializeChunkRowsForDashboard(t, chunks))
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+	cs := &CloudStore{
+		dashboardReadModelLoad: func() (dashboardReadModel, error) { return model, nil },
+	}
+
+	observations, err := cs.ListRecentObservations(project, "", 10)
+	if err != nil {
+		t.Fatalf("ListRecentObservations: %v", err)
+	}
+	for _, observation := range observations {
+		if observation.SyncID == "obs-1" {
+			t.Fatalf("soft-deleted observation still listed on the dashboard: %+v", observation)
+		}
+	}
+}

--- a/internal/cloud/cloudstore/prompt_delete_propagation_test.go
+++ b/internal/cloud/cloudstore/prompt_delete_propagation_test.go
@@ -1,0 +1,207 @@
+package cloudstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Gentleman-Programming/engram/internal/store"
+	engramsync "github.com/Gentleman-Programming/engram/internal/sync"
+)
+
+// captureTransport is a minimal engramsync.Transport that keeps every chunk the
+// cloud exporter produces, in manifest order, so the cloud-side materialization
+// can be replayed against real client output.
+type captureTransport struct {
+	manifest *engramsync.Manifest
+	chunks   map[string][]byte
+}
+
+func newCaptureTransport() *captureTransport {
+	return &captureTransport{
+		manifest: &engramsync.Manifest{Version: 1},
+		chunks:   map[string][]byte{},
+	}
+}
+
+func (c *captureTransport) ReadManifest() (*engramsync.Manifest, error) { return c.manifest, nil }
+
+func (c *captureTransport) WriteManifest(m *engramsync.Manifest) error {
+	c.manifest = m
+	return nil
+}
+
+func (c *captureTransport) WriteChunk(chunkID string, data []byte, _ engramsync.ChunkEntry) error {
+	stored := make([]byte, len(data))
+	copy(stored, data)
+	c.chunks[chunkID] = stored
+	return nil
+}
+
+func (c *captureTransport) ReadChunk(chunkID string) ([]byte, error) {
+	return c.chunks[chunkID], nil
+}
+
+// dashboardRows converts everything uploaded so far into the rows the cloud
+// dashboard reads: the chunk payloads themselves plus the cloud_mutations rows
+// WriteChunk materializes from them.
+func (c *captureTransport) dashboardRows(t *testing.T, project string) ([]dashboardChunkRow, []dashboardMutationRow) {
+	t.Helper()
+	chunkRows := make([]dashboardChunkRow, 0, len(c.manifest.Chunks))
+	for i, entry := range c.manifest.Chunks {
+		payload, ok := c.chunks[entry.ID]
+		if !ok {
+			t.Fatalf("manifest references chunk %q that was never written", entry.ID)
+		}
+		chunkRows = append(chunkRows, dashboardChunkRow{
+			chunkID:   entry.ID,
+			project:   project,
+			createdBy: entry.CreatedBy,
+			// Manifest timestamps have second precision, so derive a strictly
+			// increasing order from the manifest itself.
+			createdAt: time.Date(2026, 4, 29, 10, 0, i, 0, time.UTC),
+			parsed:    parseMustChunk(t, payload),
+		})
+	}
+	return chunkRows, materializeChunkRowsForDashboard(t, chunkRows)
+}
+
+func newPropagationTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func promptListedOnDashboard(t *testing.T, transport *captureTransport, project, content string) bool {
+	t.Helper()
+	chunkRows, mutationRows := transport.dashboardRows(t, project)
+	model, err := buildDashboardReadModelFromRows(chunkRows, mutationRows)
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+	cs := &CloudStore{
+		dashboardReadModelLoad: func() (dashboardReadModel, error) { return model, nil },
+	}
+	prompts, err := cs.ListRecentPrompts(project, "", 50)
+	if err != nil {
+		t.Fatalf("ListRecentPrompts: %v", err)
+	}
+	for _, prompt := range prompts {
+		if prompt.Content == content {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPromptDeletePropagatesFromLocalStoreToDashboard is the end-to-end check for
+// #837: save a prompt, sync it, delete it locally, sync again, and confirm the
+// dashboard stops listing it. It runs the real local store and the real cloud
+// exporter; only the network is replaced, and the cloud side is driven through
+// the same materialization and dashboard read model a Postgres deployment uses.
+func TestPromptDeletePropagatesFromLocalStoreToDashboard(t *testing.T) {
+	const project = "proj-e2e-prompt-delete"
+	const promptContent = "delete me after sync"
+
+	local := newPropagationTestStore(t)
+	transport := newCaptureTransport()
+	syncer := engramsync.NewCloudWithTransport(local, transport, project)
+
+	if err := local.EnrollProject(project); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := local.CreateSession("sess-e2e", project, "/tmp/"+project); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	promptID, err := local.AddPrompt(store.AddPromptParams{SessionID: "sess-e2e", Content: promptContent, Project: project})
+	if err != nil {
+		t.Fatalf("add prompt: %v", err)
+	}
+
+	if result, err := syncer.Export("dev", project); err != nil {
+		t.Fatalf("first export: %v", err)
+	} else if result.IsEmpty {
+		t.Fatal("expected the first export to upload the prompt")
+	}
+	if !promptListedOnDashboard(t, transport, project, promptContent) {
+		t.Fatal("expected the synced prompt to be listed on the dashboard before deletion")
+	}
+
+	if err := local.DeletePrompt(promptID); err != nil {
+		t.Fatalf("delete prompt: %v", err)
+	}
+	if result, err := syncer.Export("dev", project); err != nil {
+		t.Fatalf("second export: %v", err)
+	} else if result.IsEmpty {
+		t.Fatal("expected the second export to upload the prompt delete")
+	}
+
+	if promptListedOnDashboard(t, transport, project, promptContent) {
+		t.Fatal("deleted prompt is still listed on the dashboard after syncing the delete")
+	}
+}
+
+// TestHardDeletedObservationPropagatesFromLocalStoreToDashboard covers the sibling
+// path flagged in #837: DeleteObservation(id, hardDelete=true) removes the row, so
+// its delete can only travel as a chunk.Mutations entry.
+func TestHardDeletedObservationPropagatesFromLocalStoreToDashboard(t *testing.T) {
+	const project = "proj-e2e-obs-hard-delete"
+
+	local := newPropagationTestStore(t)
+	transport := newCaptureTransport()
+	syncer := engramsync.NewCloudWithTransport(local, transport, project)
+
+	if err := local.EnrollProject(project); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := local.CreateSession("sess-e2e", project, "/tmp/"+project); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obsID, err := local.AddObservation(store.AddObservationParams{
+		SessionID: "sess-e2e",
+		Type:      "decision",
+		Title:     "delete me after sync",
+		Content:   "body",
+		Project:   project,
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+
+	if _, err := syncer.Export("dev", project); err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+	if err := local.DeleteObservation(obsID, true); err != nil {
+		t.Fatalf("hard-delete observation: %v", err)
+	}
+	if _, err := syncer.Export("dev", project); err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+
+	chunkRows, mutationRows := transport.dashboardRows(t, project)
+	model, err := buildDashboardReadModelFromRows(chunkRows, mutationRows)
+	if err != nil {
+		t.Fatalf("buildDashboardReadModelFromRows: %v", err)
+	}
+	cs := &CloudStore{
+		dashboardReadModelLoad: func() (dashboardReadModel, error) { return model, nil },
+	}
+	observations, err := cs.ListRecentObservations(project, "", 50)
+	if err != nil {
+		t.Fatalf("ListRecentObservations: %v", err)
+	}
+	for _, observation := range observations {
+		if observation.Title == "delete me after sync" {
+			t.Fatalf("hard-deleted observation is still listed on the dashboard: %+v", observation)
+		}
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #837

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- `materializedChunkMutations` skipped every `chunk.Mutations` entry whose entity was not `relation`, on the assumption that session/observation/prompt mutations always arrive through the typed collections. That holds for **upserts**, not for **deletes**: `DeletePrompt` hard-deletes the row, so the prompt cannot ride in `chunk.Prompts` and its tombstone was discarded — the prompt stayed on the dashboard forever.
- Non-relation **deletes** are now materialized from `chunk.Mutations`; non-relation **upserts** are still skipped, so the no-duplicate-`cloud_mutations`-rows invariant the skip existed to protect is preserved. Deletes are appended after the typed entries, so the tombstone gets the higher `seq` and wins the `cloud_mutations` replay.
- The same root cause was also dropping **hard-deleted observations** (`DeleteObservation(id, true)` removes the row exactly like `DeletePrompt`), and **resurrecting soft-deleted observations**: their surviving row still materializes an `upsert` whose `deleted_at` the dashboard's observation mutation payload does not read, so the replay put them back after the chunk pass had removed them. Both are fixed by the same change, as the issue asked us to check.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudstore/cloudstore.go` | `materializedChunkMutations` now materializes non-relation deletes from `chunk.Mutations`; new `materializableChunkMutation` helper states the rule (relations always; session/observation/prompt only for `delete`) |
| `internal/cloud/cloudstore/cloudstore_test.go` | Unit coverage: prompt delete and observation hard delete survive materialization; soft-delete tombstone is ordered after the typed upsert; upserts still materialize exactly once |
| `internal/cloud/cloudstore/dashboard_queries_test.go` | Dashboard read-model regressions for deleted prompt / hard-deleted observation / soft-deleted observation, driven through the same materialization the cloud performs |
| `internal/cloud/cloudstore/prompt_delete_propagation_test.go` | End-to-end propagation test: real local store + real cloud exporter → chunk payloads → cloud materialization → dashboard queries |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Written test-first. The reproduction from the issue — a chunk carrying one prompt `delete` mutation plus one session — failed with exactly one entry (the session upsert) and zero prompt entries before the fix.

End-to-end verification (`TestPromptDeletePropagatesFromLocalStoreToDashboard`): save a prompt → cloud export → assert it is listed on the dashboard → `DeletePrompt` → cloud export → assert it is gone. It runs the real SQLite store and the real cloud exporter; only the network transport is replaced, and the cloud side is driven through the same `materializedChunkMutations` + dashboard read model a Postgres deployment uses, because the DB-backed tests need `CLOUDSTORE_TEST_DSN` and no Postgres was reachable here. Both propagation tests were confirmed to fail with the fix reverted and pass with it applied.

9 new tests, all green; full `go test ./...` and `go test -tags e2e ./internal/server/...` are green.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #837`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The soft-deleted-observation resurrection is the same mechanism, not a separate bug: the tombstone was dropped from `cloud_mutations`, and the typed `upsert` that replaced it carries `deleted_at`, which `dashboardObservationMutationPayload` does not decode. Rather than teaching the dashboard payload about `deleted_at`, the fix keeps the tombstone in the journal where the rest of the delete semantics already live — so it is folded into this PR instead of a follow-up.

Session deletes travel the identical route (`DeleteSession` hard-deletes too) and are covered by the same rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization of deleted prompts, observations, and sessions so deletions are correctly reflected in the dashboard.
  * Prevented soft-deleted records from reappearing during replay.
  * Ensured deleted items no longer appear in listings, detail views, or project statistics.

* **Tests**
  * Added coverage for hard and soft deletion propagation across local storage, synchronization, and dashboard views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->