### PR TITLE
fix(mcp): count preview threshold by runes

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1045,7 +1045,7 @@ func handleSearch(s *store.Store, cfg MCPConfig, activity *SessionActivity) serv
 				projectDisplay = fmt.Sprintf(" | project: %s", *r.Project)
 			}
 			preview := truncate(r.Content, 300)
-			if len(r.Content) > 300 {
+			if len([]rune(r.Content)) > 300 {
 				anyTruncated = true
 				preview += " [preview]"
 			}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1096,6 +1096,71 @@ func TestHelperArgsAndTruncate(t *testing.T) {
 	}
 }
 
+func TestHandleSearchPreviewUsesRuneCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantContent string
+		wantPreview bool
+	}{
+		{
+			name:        "multibyte content below rune limit remains complete",
+			content:     strings.Repeat("é", 250),
+			wantContent: strings.Repeat("é", 250),
+			wantPreview: false,
+		},
+		{
+			name:        "multibyte content above rune limit is truncated",
+			content:     strings.Repeat("é", 301),
+			wantContent: strings.Repeat("é", 300) + "...",
+			wantPreview: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newMCPTestStore(t)
+			if err := s.CreateSession("search-preview", "engram", "/tmp/engram"); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			if _, err := s.AddObservation(store.AddObservationParams{
+				SessionID: "search-preview",
+				Type:      "bugfix",
+				Title:     tt.name,
+				Content:   tt.content,
+				Project:   "engram",
+				Scope:     "project",
+			}); err != nil {
+				t.Fatalf("add observation: %v", err)
+			}
+
+			result, err := handleSearch(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{
+				Params: mcppkg.CallToolParams{Arguments: map[string]any{
+					"query":   "multibyte",
+					"project": "engram",
+				}},
+			})
+			if err != nil {
+				t.Fatalf("handle search: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected search error: %s", callResultText(t, result))
+			}
+
+			text := callResultText(t, result)
+			if !strings.Contains(text, tt.wantContent) {
+				t.Errorf("search result did not contain expected preview content")
+			}
+			if got := strings.Contains(text, "[preview]"); got != tt.wantPreview {
+				t.Errorf("preview marker present = %t, want %t", got, tt.wantPreview)
+			}
+			if got := strings.Contains(text, "Results above are previews (300 chars)"); got != tt.wantPreview {
+				t.Errorf("preview footer present = %t, want %t", got, tt.wantPreview)
+			}
+		})
+	}
+}
+
 func TestHandleSearchAndCRUDHandlers(t *testing.T) {
 	s := newMCPTestStore(t)
 	if err := s.CreateSession("s-mcp", "engram", "/tmp/engram"); err != nil {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1110,6 +1110,12 @@ func TestHandleSearchPreviewUsesRuneCount(t *testing.T) {
 			wantPreview: false,
 		},
 		{
+			name:        "multibyte content at rune limit remains complete",
+			content:     strings.Repeat("é", 300),
+			wantContent: strings.Repeat("é", 300),
+			wantPreview: false,
+		},
+		{
 			name:        "multibyte content above rune limit is truncated",
 			content:     strings.Repeat("é", 301),
 			wantContent: strings.Repeat("é", 300) + "...",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #751

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Align MCP search preview labeling with the existing rune-based truncation boundary.
- Prevent complete multibyte content from being incorrectly marked as a preview.
- Cover both sides of the 300-rune boundary with handler-level regression tests.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/mcp/mcp.go` | Count runes when deciding whether to append the preview marker and footer. |
| `internal/mcp/mcp_test.go` | Add runtime regressions for multibyte content below and above 300 runes. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality
- [x] Focused regression passed: `go test ./internal/mcp -run '^TestHandleSearchPreviewUsesRuneCount$' -count=1`
- [x] Affected package passed: `go test ./internal/mcp -count=1`

The focused regression was first observed failing against the byte-count predicate, then passed after the rune-count correction. The affected-package run completed in 61.969 seconds.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #751`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] Docs updated (not required: this fixes labeling to match the existing documented 300-character preview behavior)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Receipt-driven review was requested, but the installed provider could not represent the target-bound STATUS continuation after START. The occurrence was recorded on the canonical provider tracker; this PR relies on the focused and affected-package verification reported above, with CI authoritative for repository-wide checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search previews now correctly enforce the 300-character limit for content containing emoji, CJK characters, and other Unicode text.
  * Multibyte text is no longer truncated prematurely or counted incorrectly.
  * Content at or below the limit is displayed in full, while longer content is clearly marked as a preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->