### PR TITLE
fix(server): return empty array for no-hit searches

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -156,6 +156,8 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 ### Search
 
 - `GET /search` — FTS5 search. Query: `?q=QUERY&type=TYPE&project=PROJECT&scope=SCOPE&limit=N`
+  - `200` with a JSON array of search results
+  - No-result example: `GET /search?q=definitely-no-hit` returns `200` with `[]` (never `null`)
 
 ### Timeline
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -485,6 +485,9 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if results == nil {
+		results = []store.SearchResult{}
+	}
 
 	jsonResponse(w, http.StatusOK, results)
 }

--- a/internal/server/server_e2e_test.go
+++ b/internal/server/server_e2e_test.go
@@ -253,6 +253,27 @@ func TestPassiveCaptureEndpointEmptyContentE2E(t *testing.T) {
 	}
 }
 
+func TestSearchNoHitsReturnsEmptyArrayE2E(t *testing.T) {
+	_, ts := newE2EServer(t)
+
+	resp, err := ts.Client().Get(ts.URL + "/search?q=no-hits")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for no-hit search, got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read search response: %v", err)
+	}
+	if trimmed := strings.TrimSpace(string(body)); trimmed != "[]" {
+		t.Fatalf("expected no-hit search body [], got %q", trimmed)
+	}
+}
+
 func TestPassiveCaptureEndpointRequiresSessionID(t *testing.T) {
 	_, ts := newE2EServer(t)
 	client := ts.Client()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -669,6 +669,21 @@ func TestHandleSearchAllowsEmptyMatchMode(t *testing.T) {
 	}
 }
 
+func TestHandleSearchNoHitsReturnsEmptyArray(t *testing.T) {
+	srv := New(newServerTestStore(t), 0)
+	req := httptest.NewRequest(http.MethodGet, "/search?q=no-hits", nil)
+	rec := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for no-hit search, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if body := strings.TrimSpace(rec.Body.String()); body != "[]" {
+		t.Fatalf("expected no-hit search body [], got %q", body)
+	}
+}
+
 func TestHandleSearchRejectsInvalidMatchMode(t *testing.T) {
 	srv := New(newServerTestStore(t), 0)
 	req := httptest.NewRequest(http.MethodGet, "/search?q=aurora&match_mode=or", nil)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #473

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Normalize successful no-hit HTTP search results to an empty JSON array.
- Add focused and wire-level regression coverage for the raw response body.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/server/server.go` | Normalize nil successful search results before JSON serialization. |
| `internal/server/server_test.go` | Assert the focused handler returns raw body `[]`. |
| `internal/server/server_e2e_test.go` | Assert the real HTTP path returns raw body `[]`. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` — ran once; unrelated failures are documented below.
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually inspected the affected raw HTTP contract through focused handler and real HTTP E2E evidence.

Additional passing checks:

- `go test ./internal/server -run '^TestHandleSearchNoHitsReturnsEmptyArray$' -count=1`
- `go test -tags=e2e ./internal/server -run '^TestSearchNoHitsReturnsEmptyArrayE2E$' -count=1`
- `go test ./internal/server -count=1`
- `go test -tags=e2e ./internal/server -count=1`

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed) — no docs change is needed for this contract correction.
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The one local `go test ./...` run reported failures outside the changed package:

- `cmd/engram`: `TestCmdExportDefaultAndCmdImportErrors`
- `internal/setup`: `TestDefaultRunCommandExecutes` (`sh` unavailable)
- `internal/store`: `TestMigrate_Idempotent` (temporary SQLite file lock)

The affected server package and tagged E2E suite pass. Native four-lens RDD also completed with terminal approval and no correction required. CI should confirm the repository-wide state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search responses with no matching results to return an empty JSON array (`[]`) instead of `null`.
  * Preserved the successful HTTP 200 response for no-result searches.

* **Documentation**
  * Documented the response format for searches with no matching results.

* **Tests**
  * Added coverage for no-result search behavior in standard and end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->