### PR TITLE
feat(cli): add isolated binary self-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run unit tests
         run: go test ./...
 
+      - name: Run binary quick self-test
+        run: go build -o engram-selftest ./cmd/engram && ./engram-selftest test --quick
+
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Navigate with `j`/`k`, use `Enter` to drill in, `c` to copy content to the clipb
 | [Team Usage](docs/TEAM-USAGE.md) | Shared-memory conventions |
 | [Engram Cloud](docs/engram-cloud/README.md) | Cloud quickstart, deployment, and technical links |
 | [Doctor](docs/DOCTOR.md) | Operational diagnosis and repair workflows |
+| [Binary self-testing](docs/SELF-TESTING.md) | Isolated reliability and performance checks for released binaries |
 | [Beta Testing](docs/BETA_TESTING.md) | Isolated beta testing flows and cleanup guidance |
 | [Comparison](docs/COMPARISON.md) | Engram compared with claude-mem |
 | [Obsidian Brain](docs/beta/obsidian-brain.md) | Export memories as an Obsidian knowledge graph (beta) |

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -597,6 +597,14 @@ func main() {
 		printUsage()
 		exitFunc(1)
 	}
+	// Self-tests must run before update checks, configuration resolution, orphan
+	// migration, and autosync setup so released binaries cannot touch user data.
+	if strings.EqualFold(strings.TrimSpace(os.Args[1]), "test") {
+		if code := cmdTest(os.Args[2:]); code != testExitSuccess {
+			exitFunc(code)
+		}
+		return
+	}
 
 	if shouldCheckForUpdates(os.Args[1:]) {
 		printUpdateCheckResult(checkForUpdates(version))
@@ -2814,6 +2822,9 @@ Commands:
                        --project NAME  Set process-level default project (overrides cwd detection).
                                        Also accepted as ENGRAM_PROJECT=NAME env var.
   tui                Launch interactive terminal UI
+  test [suite] [--quick] [--json]
+                     Run isolated local reliability and performance self-tests
+                       suites: reliability, performance (default: both)
   search <query>     Search memories [--type TYPE] [--project PROJECT] [--scope SCOPE] [--limit N]
   save <title> <msg> Save a memory  [--type TYPE] [--project PROJECT] [--scope SCOPE]
   delete <obs_id>    Delete an observation [--hard] (soft-delete by default; --hard removes permanently)

--- a/cmd/engram/test.go
+++ b/cmd/engram/test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Gentleman-Programming/engram/internal/selftest"
+)
+
+const (
+	testExitSuccess = 0
+	testExitUsage   = 1
+	testExitFailure = 2
+)
+
+var runSelfTest = selftest.Run
+
+// cmdTest runs the local, isolated binary self-test command. It intentionally
+// takes explicit arguments so main can dispatch it before configuration setup.
+func cmdTest(args []string) int {
+	options, jsonOutput, help, err := parseTestArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n\n", err)
+		printTestUsage()
+		return testExitUsage
+	}
+	if help {
+		printTestUsage()
+		return testExitSuccess
+	}
+
+	report := runSelfTest(options)
+	if jsonOutput {
+		if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+			fmt.Fprintf(os.Stderr, "error: write JSON self-test report: %v\n", err)
+			return testExitFailure
+		}
+	} else {
+		printTestReport(report)
+	}
+	if report.Passed {
+		return testExitSuccess
+	}
+	return testExitFailure
+}
+
+func parseTestArgs(args []string) (selftest.Options, bool, bool, error) {
+	options := selftest.Options{Suite: selftest.SuiteAll}
+	jsonOutput := false
+	help := false
+	suiteSeen := false
+
+	for _, arg := range args {
+		switch arg {
+		case "--quick":
+			options.Quick = true
+		case "--json":
+			jsonOutput = true
+		case "--help", "-h", "help":
+			help = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return selftest.Options{}, false, false, fmt.Errorf("unknown test flag %q", arg)
+			}
+			if suiteSeen {
+				return selftest.Options{}, false, false, fmt.Errorf("only one test suite may be selected")
+			}
+			suite := strings.ToLower(strings.TrimSpace(arg))
+			switch suite {
+			case selftest.SuiteAll, selftest.SuiteReliability, selftest.SuitePerformance:
+				options.Suite = suite
+				suiteSeen = true
+			default:
+				return selftest.Options{}, false, false, fmt.Errorf("unknown test suite %q", arg)
+			}
+		}
+	}
+	return options, jsonOutput, help, nil
+}
+
+func printTestUsage() {
+	fmt.Println("usage: engram test [reliability|performance] [--quick] [--json]")
+	fmt.Println()
+	fmt.Println("Run isolated local reliability and performance self-tests.")
+	fmt.Println("Without a suite, runs reliability and performance. --quick bounds the smoke run.")
+	fmt.Println("--json writes the stable engram-self-test/v1 report to stdout.")
+	fmt.Println("The test uses a fresh temporary directory and never reads configured data or cloud settings.")
+}
+
+func printTestReport(report selftest.Report) {
+	mode := "full"
+	if report.Quick {
+		mode = "quick"
+	}
+	fmt.Printf("Engram self-test (%s suite, %s mode)\n", report.Suite, mode)
+	for _, scenario := range report.Scenarios {
+		status := "PASS"
+		if !scenario.Passed {
+			status = "FAIL"
+		}
+		fmt.Printf("%s  %s/%s  %dms", status, scenario.Suite, scenario.Name, scenario.DurationMS)
+		if operations, ok := scenario.Metrics["operations"]; ok {
+			fmt.Printf("  %.0f operations", operations)
+		}
+		if throughput, ok := scenario.Metrics["throughput_ops_per_second"]; ok {
+			fmt.Printf("  %.1f ops/s", throughput)
+		}
+		if scenario.Error != "" {
+			fmt.Printf("  %s", scenario.Error)
+		}
+		fmt.Println()
+	}
+	status := "PASS"
+	if !report.Passed {
+		status = "FAIL"
+	}
+	fmt.Printf("Result: %s (%dms)\n", status, report.DurationMS)
+}

--- a/cmd/engram/test_test.go
+++ b/cmd/engram/test_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gentleman-Programming/engram/internal/selftest"
+	versioncheck "github.com/Gentleman-Programming/engram/internal/version"
+)
+
+func TestParseTestArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantSuite  string
+		wantQuick  bool
+		wantJSON   bool
+		wantHelp   bool
+		wantErrMsg string
+	}{
+		{name: "default", wantSuite: selftest.SuiteAll},
+		{name: "performance quick JSON", args: []string{"performance", "--quick", "--json"}, wantSuite: selftest.SuitePerformance, wantQuick: true, wantJSON: true},
+		{name: "help", args: []string{"--help"}, wantSuite: selftest.SuiteAll, wantHelp: true},
+		{name: "unknown suite", args: []string{"load"}, wantErrMsg: "unknown test suite"},
+		{name: "multiple suites", args: []string{"reliability", "performance"}, wantErrMsg: "only one test suite"},
+		{name: "unknown flag", args: []string{"--keep"}, wantErrMsg: "unknown test flag"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			options, jsonOutput, help, err := parseTestArgs(tc.args)
+			if tc.wantErrMsg != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Fatalf("parseTestArgs(%v) error = %v, want %q", tc.args, err, tc.wantErrMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTestArgs(%v): %v", tc.args, err)
+			}
+			if options.Suite != tc.wantSuite || options.Quick != tc.wantQuick || jsonOutput != tc.wantJSON || help != tc.wantHelp {
+				t.Fatalf("parseTestArgs(%v) = (%#v, %t, %t), want suite=%q quick=%t json=%t help=%t", tc.args, options, jsonOutput, help, tc.wantSuite, tc.wantQuick, tc.wantJSON, tc.wantHelp)
+			}
+		})
+	}
+}
+
+func TestCmdTestJSONShapeAndSuiteSelection(t *testing.T) {
+	oldRunSelfTest := runSelfTest
+	var gotOptions selftest.Options
+	runSelfTest = func(options selftest.Options) selftest.Report {
+		gotOptions = options
+		return selftest.Report{
+			SchemaVersion: "engram-self-test/v1",
+			Suite:         options.Suite,
+			Quick:         options.Quick,
+			Passed:        true,
+			Scenarios: []selftest.Scenario{{
+				Name: "store_search", Suite: selftest.SuitePerformance, Passed: true,
+				Metrics: map[string]float64{"operations": 20, "throughput_ops_per_second": 100},
+			}},
+		}
+	}
+	t.Cleanup(func() { runSelfTest = oldRunSelfTest })
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := cmdTest([]string{"performance", "--quick", "--json"}); code != testExitSuccess {
+			t.Fatalf("cmdTest exit code = %d, want %d", code, testExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if gotOptions.Suite != selftest.SuitePerformance || !gotOptions.Quick {
+		t.Fatalf("run options = %#v", gotOptions)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("JSON output %q: %v", stdout, err)
+	}
+	for _, key := range []string{"schema_version", "suite", "quick", "passed", "duration_ms", "scenarios"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("JSON report missing top-level key %q: %#v", key, got)
+		}
+	}
+	if got["schema_version"] != "engram-self-test/v1" || got["suite"] != selftest.SuitePerformance || got["passed"] != true {
+		t.Fatalf("unexpected JSON report: %#v", got)
+	}
+}
+
+func TestCmdTestFailureAndUsageExitCodes(t *testing.T) {
+	oldRunSelfTest := runSelfTest
+	runSelfTest = func(selftest.Options) selftest.Report {
+		return selftest.Report{Suite: selftest.SuiteAll, Scenarios: []selftest.Scenario{{Name: "store_search", Suite: selftest.SuitePerformance, Error: "injected failure"}}}
+	}
+	t.Cleanup(func() { runSelfTest = oldRunSelfTest })
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := cmdTest(nil); code != testExitFailure {
+			t.Fatalf("failed self-test exit code = %d, want %d", code, testExitFailure)
+		}
+	})
+	if stderr != "" || !strings.Contains(stdout, "FAIL") || !strings.Contains(stdout, "injected failure") {
+		t.Fatalf("failed self-test output = (%q, %q)", stdout, stderr)
+	}
+
+	stdout, stderr = captureOutput(t, func() {
+		if code := cmdTest([]string{"--keep"}); code != testExitUsage {
+			t.Fatalf("invalid usage exit code = %d, want %d", code, testExitUsage)
+		}
+	})
+	if !strings.Contains(stderr, "unknown test flag") || !strings.Contains(stdout, "usage: engram test") {
+		t.Fatalf("invalid usage output = (%q, %q)", stdout, stderr)
+	}
+}
+
+func TestCmdTestHelpDoesNotRunScenarios(t *testing.T) {
+	oldRunSelfTest := runSelfTest
+	runSelfTest = func(selftest.Options) selftest.Report {
+		t.Fatal("self-test runner must not run for help")
+		return selftest.Report{}
+	}
+	t.Cleanup(func() { runSelfTest = oldRunSelfTest })
+
+	stdout, stderr := captureOutput(t, func() {
+		if code := cmdTest([]string{"--help"}); code != testExitSuccess {
+			t.Fatalf("help exit code = %d", code)
+		}
+	})
+	if stderr != "" || !strings.Contains(stdout, "usage: engram test") {
+		t.Fatalf("help output = (%q, %q)", stdout, stderr)
+	}
+}
+
+func TestMainTestDispatchDoesNotTouchConfiguredDataOrCheckUpdates(t *testing.T) {
+	dataDir := t.TempDir()
+	sentinel := filepath.Join(dataDir, "must-remain-untouched")
+	if err := os.WriteFile(sentinel, []byte("sentinel"), 0600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	t.Setenv("ENGRAM_DATA_DIR", dataDir)
+	withArgs(t, "engram", "test", "--quick")
+
+	oldRunSelfTest, oldCheckForUpdates := runSelfTest, checkForUpdates
+	runSelfTest = func(options selftest.Options) selftest.Report {
+		if !options.Quick {
+			t.Fatal("quick option was not forwarded")
+		}
+		return selftest.Report{Suite: selftest.SuiteAll, Quick: true, Passed: true}
+	}
+	checkForUpdates = func(string) versioncheck.CheckResult {
+		t.Fatal("update check must not run before self-test dispatch")
+		return versioncheck.CheckResult{}
+	}
+	t.Cleanup(func() {
+		runSelfTest, checkForUpdates = oldRunSelfTest, oldCheckForUpdates
+	})
+
+	_, stderr := captureOutput(t, main)
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		t.Fatalf("read configured data directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(sentinel) {
+		t.Fatalf("configured data directory changed: %v", entries)
+	}
+}

--- a/docs/SELF-TESTING.md
+++ b/docs/SELF-TESTING.md
@@ -1,0 +1,53 @@
+[← Back to README](../README.md)
+
+# Binary self-testing
+
+Released Engram binaries include a local self-test command for RC performance and reliability reports. It is safe to run alongside an existing installation:
+
+```bash
+engram test
+```
+
+The default run executes both suites. Use `--quick` for a bounded smoke run, or select one suite when investigating a result:
+
+```bash
+engram test --quick
+engram test reliability --quick
+engram test performance
+```
+
+`engram test` prints a result for every scenario. A passing run exits `0`; an executed suite with one or more failed scenarios exits `2`; invalid command usage exits `1`. Performance results report elapsed time and throughput for comparison between runs, but have no hardware-dependent pass/fail threshold.
+
+## What the suites exercise
+
+- **Reliability** initializes and migrates a fresh local SQLite database, then verifies save, full-text search, formatted context, and concurrent local writes.
+- **Performance** seeds a representative local search corpus and reports repeated store-search throughput. A full run uses 1,000 records and 200 searches; `--quick` uses 100 records and 20 searches.
+
+## JSON reports
+
+Use `--json` for CI, issue attachments, or RC reports:
+
+```bash
+engram test --quick --json > engram-self-test.json
+```
+
+The stable top-level shape is `engram-self-test/v1`:
+
+```json
+{
+  "schema_version": "engram-self-test/v1",
+  "suite": "all",
+  "quick": true,
+  "passed": true,
+  "duration_ms": 0,
+  "scenarios": []
+}
+```
+
+Each scenario contains `name`, `suite`, `passed`, and `duration_ms`. Failed scenarios also contain `error`; performance scenarios contain `metrics.operations` and `metrics.throughput_ops_per_second`.
+
+## Isolation and limitations
+
+Each run creates a new temporary directory and removes it after completion. The command does not resolve or use `ENGRAM_DATA_DIR`, your `~/.engram` database, cloud credentials, configured endpoints, or user databases. All scenarios are local and offline; they open no network connection and start no service.
+
+Run the command on the same supported Windows, macOS, or Linux platform as the released binary. It requires permission to create temporary files and a working local filesystem. It does **not** validate live Engram Cloud, Postgres, remote sync, agent plugins, or production-network reliability. Use the platform binary and the relevant cloud or end-to-end procedures for those checks.

--- a/internal/selftest/selftest.go
+++ b/internal/selftest/selftest.go
@@ -1,0 +1,310 @@
+// Package selftest runs isolated local checks included in the Engram binary.
+package selftest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Gentleman-Programming/engram/internal/store"
+)
+
+const (
+	SuiteAll         = "all"
+	SuiteReliability = "reliability"
+	SuitePerformance = "performance"
+)
+
+// Options controls an isolated self-test run.
+type Options struct {
+	Suite string
+	Quick bool
+}
+
+// Report is the stable top-level JSON shape emitted by `engram test --json`.
+type Report struct {
+	SchemaVersion string     `json:"schema_version"`
+	Suite         string     `json:"suite"`
+	Quick         bool       `json:"quick"`
+	Passed        bool       `json:"passed"`
+	DurationMS    int64      `json:"duration_ms"`
+	Scenarios     []Scenario `json:"scenarios"`
+}
+
+// Scenario records one self-test result. Performance scenarios include their
+// operation count and throughput in Metrics; no timing threshold determines pass or fail.
+type Scenario struct {
+	Name       string             `json:"name"`
+	Suite      string             `json:"suite"`
+	Passed     bool               `json:"passed"`
+	DurationMS int64              `json:"duration_ms"`
+	Error      string             `json:"error,omitempty"`
+	Metrics    map[string]float64 `json:"metrics,omitempty"`
+}
+
+var (
+	newTempDir = os.MkdirTemp
+	removeAll  = os.RemoveAll
+)
+
+// Run executes the selected local-only self-test suite. Every run owns a new
+// temporary directory and never reads the configured Engram data directory.
+func Run(options Options) Report {
+	suite := normalizeSuite(options.Suite)
+	started := time.Now()
+	report := Report{
+		SchemaVersion: "engram-self-test/v1",
+		Suite:         suite,
+		Quick:         options.Quick,
+		Passed:        true,
+		Scenarios:     make([]Scenario, 0, 3),
+	}
+
+	root, err := newTempDir("", "engram-self-test-*")
+	if err != nil {
+		report.Passed = false
+		report.Scenarios = append(report.Scenarios, failedScenario("setup", suite, started, fmt.Errorf("create temporary directory: %w", err)))
+		report.DurationMS = durationMS(time.Since(started))
+		return report
+	}
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		_ = removeAll(root)
+		report.Passed = false
+		report.Scenarios = append(report.Scenarios, failedScenario("setup", suite, started, fmt.Errorf("resolve temporary directory: %w", err)))
+		report.DurationMS = durationMS(time.Since(started))
+		return report
+	}
+	root = absoluteRoot
+	defer func() { _ = removeAll(root) }()
+
+	if suite == SuiteAll || suite == SuiteReliability {
+		report.add(runScenario("database_save_search_context", SuiteReliability, func() error {
+			return runDatabaseSaveSearchContext(filepath.Join(root, "reliability-core"))
+		}))
+		report.add(runScenario("concurrent_local_writes", SuiteReliability, func() error {
+			return runConcurrentLocalWrites(filepath.Join(root, "reliability-concurrent"), options.Quick)
+		}))
+	}
+	if suite == SuiteAll || suite == SuitePerformance {
+		report.add(runPerformanceScenario("store_search", func() (map[string]float64, error) {
+			return runStoreSearch(filepath.Join(root, "performance-search"), options.Quick)
+		}))
+	}
+
+	report.DurationMS = durationMS(time.Since(started))
+	return report
+}
+
+func (r *Report) add(scenario Scenario) {
+	r.Scenarios = append(r.Scenarios, scenario)
+	if !scenario.Passed {
+		r.Passed = false
+	}
+}
+
+func normalizeSuite(suite string) string {
+	switch strings.ToLower(strings.TrimSpace(suite)) {
+	case "", SuiteAll:
+		return SuiteAll
+	case SuiteReliability:
+		return SuiteReliability
+	case SuitePerformance:
+		return SuitePerformance
+	default:
+		return strings.ToLower(strings.TrimSpace(suite))
+	}
+}
+
+func runScenario(name, suite string, fn func() error) Scenario {
+	started := time.Now()
+	if err := fn(); err != nil {
+		return failedScenario(name, suite, started, err)
+	}
+	return Scenario{Name: name, Suite: suite, Passed: true, DurationMS: durationMS(time.Since(started))}
+}
+
+func failedScenario(name, suite string, started time.Time, err error) Scenario {
+	return Scenario{Name: name, Suite: suite, DurationMS: durationMS(time.Since(started)), Error: err.Error()}
+}
+
+func runPerformanceScenario(name string, fn func() (map[string]float64, error)) Scenario {
+	started := time.Now()
+	metrics, err := fn()
+	if err != nil {
+		return failedScenario(name, SuitePerformance, started, err)
+	}
+	return Scenario{
+		Name:       name,
+		Suite:      SuitePerformance,
+		Passed:     true,
+		DurationMS: durationMS(time.Since(started)),
+		Metrics:    metrics,
+	}
+}
+
+func runDatabaseSaveSearchContext(dataDir string) error {
+	s, err := openStore(dataDir)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	const sessionID = "selftest-reliability-session"
+	const project = "selftest-reliability"
+	if err := s.CreateSession(sessionID, project, dataDir); err != nil {
+		return fmt.Errorf("create session: %w", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     "Self-test database migration",
+		Content:   "Self-test verifies local database initialization, save, search, and context.",
+		Project:   project,
+		Scope:     "project",
+	}); err != nil {
+		return fmt.Errorf("save observation: %w", err)
+	}
+
+	results, err := s.Search("database migration", store.SearchOptions{Project: project, Scope: "project", Limit: 5})
+	if err != nil {
+		return fmt.Errorf("search observation: %w", err)
+	}
+	if len(results) == 0 || results[0].Title != "Self-test database migration" {
+		return fmt.Errorf("search did not return the saved observation")
+	}
+
+	context, err := s.FormatContext(project, "project")
+	if err != nil {
+		return fmt.Errorf("format context: %w", err)
+	}
+	if !strings.Contains(context, "Self-test database migration") {
+		return fmt.Errorf("context did not include the saved observation")
+	}
+	return nil
+}
+
+func runConcurrentLocalWrites(dataDir string, quick bool) error {
+	s, err := openStore(dataDir)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	workers, writesPerWorker := 8, 50
+	if quick {
+		workers, writesPerWorker = 4, 10
+	}
+	const project = "selftest-concurrent"
+	for worker := 0; worker < workers; worker++ {
+		if err := s.CreateSession(fmt.Sprintf("selftest-concurrent-%d", worker), project, dataDir); err != nil {
+			return fmt.Errorf("create session %d: %w", worker, err)
+		}
+	}
+
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for write := 0; write < writesPerWorker; write++ {
+				_, err := s.AddObservation(store.AddObservationParams{
+					SessionID: fmt.Sprintf("selftest-concurrent-%d", worker),
+					Type:      "note",
+					Title:     fmt.Sprintf("Concurrent local write %d-%d", worker, write),
+					Content:   fmt.Sprintf("Self-test concurrent local write %d-%d", worker, write),
+					Project:   project,
+					Scope:     "project",
+				})
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			return fmt.Errorf("concurrent write: %w", err)
+		}
+	}
+
+	stats, err := s.Stats()
+	if err != nil {
+		return fmt.Errorf("read stats: %w", err)
+	}
+	want := workers * writesPerWorker
+	if stats.TotalObservations != want {
+		return fmt.Errorf("stored %d concurrent observations, want %d", stats.TotalObservations, want)
+	}
+	return nil
+}
+
+func runStoreSearch(dataDir string, quick bool) (map[string]float64, error) {
+	s, err := openStore(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+
+	records, searches := 1_000, 200
+	if quick {
+		records, searches = 100, 20
+	}
+	const sessionID = "selftest-performance-session"
+	const project = "selftest-performance"
+	if err := s.CreateSession(sessionID, project, dataDir); err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+	for i := 0; i < records; i++ {
+		if _, err := s.AddObservation(store.AddObservationParams{
+			SessionID: sessionID,
+			Type:      "note",
+			Title:     fmt.Sprintf("Self-test search record %04d", i),
+			Content:   fmt.Sprintf("Self-test search corpus shared keyword record %04d", i),
+			Project:   project,
+			Scope:     "project",
+		}); err != nil {
+			return nil, fmt.Errorf("seed record %d: %w", i, err)
+		}
+	}
+
+	started := time.Now()
+	for i := 0; i < searches; i++ {
+		results, err := s.Search("shared keyword", store.SearchOptions{Project: project, Scope: "project", Limit: 20})
+		if err != nil {
+			return nil, fmt.Errorf("search %d: %w", i, err)
+		}
+		if len(results) == 0 {
+			return nil, fmt.Errorf("search %d returned no seeded records", i)
+		}
+	}
+	duration := time.Since(started)
+	throughput := 0.0
+	if duration > 0 {
+		throughput = float64(searches) / duration.Seconds()
+	}
+	return map[string]float64{
+		"operations":                float64(searches),
+		"throughput_ops_per_second": throughput,
+	}, nil
+}
+
+func openStore(dataDir string) (*store.Store, error) {
+	absoluteDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve temporary data directory: %w", err)
+	}
+	return store.New(store.FallbackConfig(absoluteDir))
+}
+
+func durationMS(duration time.Duration) int64 {
+	return duration.Milliseconds()
+}

--- a/internal/selftest/selftest_test.go
+++ b/internal/selftest/selftest_test.go
@@ -1,0 +1,96 @@
+package selftest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunQuickAllSuitesPass(t *testing.T) {
+	report := Run(Options{Quick: true})
+	if !report.Passed {
+		t.Fatalf("quick report failed: %#v", report)
+	}
+	if report.SchemaVersion != "engram-self-test/v1" || report.Suite != SuiteAll || len(report.Scenarios) != 3 {
+		t.Fatalf("unexpected report shape: %#v", report)
+	}
+	for _, scenario := range report.Scenarios {
+		if !scenario.Passed || scenario.Name == "" || scenario.Suite == "" {
+			t.Fatalf("unexpected scenario: %#v", scenario)
+		}
+		if scenario.Suite == SuitePerformance && (scenario.Metrics["operations"] != 20 || scenario.Metrics["throughput_ops_per_second"] <= 0) {
+			t.Fatalf("performance scenario did not report quick-run metrics: %#v", scenario)
+		}
+	}
+}
+
+func TestRunSelectsOneSuite(t *testing.T) {
+	tests := []struct {
+		suite        string
+		wantScenario []string
+	}{
+		{
+			suite:        SuiteReliability,
+			wantScenario: []string{"database_save_search_context", "concurrent_local_writes"},
+		},
+		{
+			suite:        SuitePerformance,
+			wantScenario: []string{"store_search"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.suite, func(t *testing.T) {
+			report := Run(Options{Suite: tt.suite, Quick: true})
+			if !report.Passed || report.Suite != tt.suite {
+				t.Fatalf("report = %#v", report)
+			}
+			if len(report.Scenarios) != len(tt.wantScenario) {
+				t.Fatalf("scenario count = %d, want %d: %#v", len(report.Scenarios), len(tt.wantScenario), report.Scenarios)
+			}
+
+			gotScenarios := make(map[string]bool, len(report.Scenarios))
+			for _, scenario := range report.Scenarios {
+				if scenario.Suite != tt.suite {
+					t.Fatalf("scenario %q has suite %q, want %q", scenario.Name, scenario.Suite, tt.suite)
+				}
+				gotScenarios[scenario.Name] = true
+			}
+			for _, wantScenario := range tt.wantScenario {
+				if !gotScenarios[wantScenario] {
+					t.Fatalf("scenarios = %#v, missing %q", report.Scenarios, wantScenario)
+				}
+			}
+		})
+	}
+}
+
+func TestRunUsesFreshAbsoluteTemporaryDirectoryAndCleansUp(t *testing.T) {
+	root := t.TempDir()
+	oldNewTempDir, oldRemoveAll := newTempDir, removeAll
+	newTempDir = func(dir, pattern string) (string, error) {
+		if dir != "" {
+			t.Fatalf("temporary directory parent = %q, want system temporary directory", dir)
+		}
+		return os.MkdirTemp(root, pattern)
+	}
+	removeAll = os.RemoveAll
+	t.Cleanup(func() {
+		newTempDir, removeAll = oldNewTempDir, oldRemoveAll
+	})
+
+	report := Run(Options{Quick: true})
+	if !report.Passed {
+		t.Fatalf("report = %#v", report)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read temporary root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("self-test temporary directory was not removed: %v", entries)
+	}
+	if !filepath.IsAbs(root) {
+		t.Fatalf("test root is not absolute: %q", root)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #867

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add an isolated `engram test` command to released binaries for reliability and performance checks.
- Protect configured user data by dispatching before update, configuration, migration, and autosync setup.
- Document stable JSON reports and run a bounded binary smoke test in CI.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/selftest/` | Run isolated SQLite reliability scenarios and store-search measurements. |
| `cmd/engram/test.go` | Expose suite selection, quick mode, JSON output, and stable exit codes. |
| `cmd/engram/test_test.go` | Prove CLI behavior and configured-data isolation. |
| `docs/SELF-TESTING.md` | Document RC usage, interpretation, privacy guarantees, and limitations. |
| `.github/workflows/ci.yml` | Build the binary and run the bounded quick self-test. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` — attempted; blocked by pre-existing Windows/environment-specific failures outside this change.
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — not run locally; required CI remains authoritative.
- [x] Manually tested the affected functionality.

Validated locally:

- `go test -count=1 ./internal/selftest`
- focused `cmd/engram` self-test command tests
- `go vet ./internal/selftest ./cmd/engram`
- `go run ./cmd/engram test --quick --json`
- `go run ./cmd/engram test --json`
- reliability-only and performance-only JSON smoke runs
- help and invalid-usage behavior
- `git diff --check`

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #867`).
- [x] I will add exactly **one** `type:*` label to this PR.
- [ ] I ran the complete unit suite locally; focused affected tests pass, while the full Windows run has unrelated existing failures.
- [ ] I ran E2E tests locally; CI will run the required E2E job.
- [x] Docs updated for the new behavior.
- [x] Commits follow Conventional Commits format.
- [x] No `Co-Authored-By` trailers in commits.

---

## 💬 Notes for Reviewers

The maintainer explicitly accepted a `size:exception` for this cohesive 767-line feature so the internal runner, binary CLI, behavior tests, documentation, and CI proof remain reviewable together. Performance measurements are informational and never use hardware-sensitive pass/fail thresholds. The command is local and offline and does not validate live Cloud or Postgres behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `engram test` command for isolated reliability and performance checks.
  - Supports reliability, performance, and combined suites, with optional quick execution.
  - Provides human-readable results or structured JSON output with clear exit codes.
  - Runs checks in a temporary environment without affecting configured data.

- **Documentation**
  - Added self-testing documentation covering usage, suites, reports, exit codes, and limitations.

- **Tests**
  - Added automated coverage for command behavior, reporting, suite execution, isolation, and cleanup.
  - CI now runs a quick binary self-test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->