### PR TITLE
fix(release): isolate prerelease channels

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,9 @@ version: 2
 
 project_name: engram
 
+release:
+  prerelease: auto
+
 before:
   hooks:
     - go mod tidy
@@ -49,6 +52,7 @@ brews:
       owner: Gentleman-Programming
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    skip_upload: auto
     directory: Formula
     name: engram
     homepage: "https://github.com/Gentleman-Programming/engram"


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #870

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Mark semantic-version RC tags as GitHub prereleases through GoReleaser.
- Skip Homebrew formula publication for prerelease tags while preserving stable releases.

## 📂 Changes

| File | Change |
|------|--------|
| `.goreleaser.yaml` | Add automatic prerelease classification and prerelease-only Homebrew upload skipping. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` — source behavior is unchanged; canonical CI will run the full suite.
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — source behavior is unchanged; canonical CI will run E2E.
- [x] Manually validated the affected configuration.

Validated locally:

- Full `.goreleaser.yaml` structural readback
- `git diff --check`
- Confirmed exactly one file and four lines changed
- Compared both keys against current GoReleaser v2 documentation

`goreleaser check` was not run because GoReleaser is not installed locally; no tool was downloaded or installed for this change.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #870`).
- [x] I will add exactly **one** `type:*` label to this PR.
- [ ] I ran the complete unit suite locally; canonical CI will run it.
- [ ] I ran E2E tests locally; canonical CI will run them.
- [x] Docs are not required because the user-facing release command is unchanged.
- [x] Commits follow Conventional Commits format.
- [x] No `Co-Authored-By` trailers in commits.

---

## 💬 Notes for Reviewers

This PR intentionally addresses only RC channel isolation. It does not add the broader release-provenance machinery used by Gentle AI's stable path. The `release.prerelease: auto` setting keeps RCs out of the stable/latest release path, while `brews.skip_upload: auto` leaves the stable Homebrew formula untouched for tags such as `v2.0.0-rc.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases are now automatically identified as pre-releases.
  * Homebrew tap uploads are automatically skipped for pre-releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->