### PR TITLE
fix(store): close SQLite handle on newWithoutRepair error paths

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -736,8 +736,10 @@ func New(cfg Config) (*Store, error) {
 	return s, nil
 }
 
-// newWithoutRepair is retained as a test helper alias for New. Enrolled-project
-// repair is deferred until the first synchronization operation in both cases.
+// newWithoutRepair is a test helper alias for New that defers enrolled-project
+// repair to the first synchronization operation. Like New, it closes the
+// database on every post-open failure path (pragma or migration error) via a
+// deferred db.Close() guarded by the succeeded flag, so no SQLite handle leaks.
 func newWithoutRepair(cfg Config) (*Store, error) {
 	if !filepath.IsAbs(cfg.DataDir) {
 		return nil, fmt.Errorf("engram: data directory must be an absolute path, got %q — set ENGRAM_DATA_DIR or ensure your home directory is resolvable", cfg.DataDir)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -752,6 +752,12 @@ func newWithoutRepair(cfg Config) (*Store, error) {
 		return nil, fmt.Errorf("engram: open database: %w", err)
 	}
 	db.SetMaxOpenConns(1)
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			_ = db.Close()
+		}
+	}()
 
 	pragmas := []string{
 		"PRAGMA journal_mode = WAL",
@@ -769,6 +775,8 @@ func newWithoutRepair(cfg Config) (*Store, error) {
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("engram: migration: %w", err)
 	}
+
+	succeeded = true
 	return s, nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -12443,6 +12443,13 @@ func TestNewWithoutRepairReleasesHandleOnOpenFailure(t *testing.T) {
 	if openErr == nil {
 		t.Fatalf("newWithoutRepair with corrupt db returned nil error; want non-nil (post-open failure)")
 	}
+	// Guard the regression: the failure must come from the post-open PRAGMA step
+	// (store.go wraps it as `engram: pragma "PRAGMA journal_mode = WAL": ...`), not
+	// from openDB. If openDB failed directly there is no handle to leak and the
+	// cleanup assertion below would be vacuous.
+	if !strings.Contains(openErr.Error(), "pragma") {
+		t.Fatalf("newWithoutRepair with corrupt db returned %v; want the post-open PRAGMA failure so the test exercises the cleanup path", openErr)
+	}
 
 	// On Windows, removing the file only succeeds if the leaked handle was
 	// closed by newWithoutRepair's deferred db.Close().

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -12410,5 +12411,42 @@ func TestUpdateObservationAcceptsPrivateTagOnlyTitle(t *testing.T) {
 	}
 	if payload["title"] != "[REDACTED]" {
 		t.Fatalf("expected redacted title in update payload, got %#v", payload["title"])
+	}
+}
+
+// TestNewWithoutRepairReleasesHandleOnOpenFailure proves that newWithoutRepair
+// closes the SQLite handle when it fails AFTER sql.Open (the post-open failure
+// path). Without the deferred db.Close(), the *sql.DB — and its open OS file
+// handle — leaks, so removing the db file on Windows fails. This reproduces the
+// #825 leak scenario and must fail if the deferred close is reverted.
+func TestNewWithoutRepairReleasesHandleOnOpenFailure(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("handle-release assertion is only meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "engram.db")
+
+	// Seed a non-SQLite file so the first PRAGMA after sql.Open fails, but the
+	// driver has already opened an OS handle against the path.
+	if err := os.WriteFile(dbPath, []byte("this file is deliberately not a sqlite database"), 0o644); err != nil {
+		t.Fatalf("seed corrupt db file: %v", err)
+	}
+
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.DataDir = dir
+
+	_, openErr := newWithoutRepair(cfg)
+	if openErr == nil {
+		t.Fatalf("newWithoutRepair with corrupt db returned nil error; want non-nil (post-open failure)")
+	}
+
+	// On Windows, removing the file only succeeds if the leaked handle was
+	// closed by newWithoutRepair's deferred db.Close().
+	if err := os.Remove(dbPath); err != nil {
+		t.Fatalf("os.Remove(%q) after failed newWithoutRepair: %v — leaked OS handle (deferred close missing)", dbPath, err)
 	}
 }


### PR DESCRIPTION
Closes #825

## Summary
- Fixes a SQLite handle leak in `newWithoutRepair` on Windows: the DB was not closed on post-open pragma/migration failure paths, leaking the OS file handle so `t.TempDir` cleanup failed with "The process cannot access the file because it is being used by another process."
- Mirrors the existing `succeeded` / `defer db.Close()` guard already present in `New`.
- Adds a Windows-only regression test (`TestNewWithoutRepairReleasesHandleOnOpenFailure`) that fails without the fix and passes with it, proving the handle is released.

## Changes
| File | Change |
|------|--------|
| `internal/store/store.go` | Add `succeeded` flag + `defer db.Close()` to `newWithoutRepair` on post-open failure paths |
| `internal/store/store_test.go` | Add Windows-only regression test for the handle-release behavior |

## Test Plan
- [x] Unit tests pass locally for the affected package: `go test ./internal/store` (incl. the new regression test, Windows)
- [x] `go build ./...` clean
- [x] `go vet ./internal/store` clean
- [x] Regression test verified to fail without the fix and pass with it (Windows)
- [x] Full `go test ./...` green except pre-existing `plugin` env failures (missing `jq`/`curl` on this Windows box; unrelated to this change, pass on Linux CI)

## Contributor Checklist
- [x] Linked an approved issue (#825, `status:approved`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Ran unit tests locally
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization error handling.
  * Prevented database handles from remaining open when setup fails, including on Windows.
  * Corrupt database files can now be removed or replaced after an initialization error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->