### PR TITLE
fix(autosync): retry after failure ceiling

### DIFF
--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -749,9 +749,12 @@ func (m *Manager) computeBackoff(failures int) time.Duration {
 	// ±25% jitter: uniform in [-base/4, +base/4].
 	// rand.Int63n(int64(base/2)+1) gives [0, base/2]; subtracting base/4 shifts to [-base/4, +base/4].
 	jitter := time.Duration(rand.Int63n(int64(base/2)+1)) - time.Duration(base/4)
-	result := base + jitter
-	if result > m.cfg.MaxBackoff {
+	result := base
+	const maxDuration = time.Duration(1<<63 - 1)
+	if jitter > 0 && (base > m.cfg.MaxBackoff-jitter || base > maxDuration-jitter) {
 		result = m.cfg.MaxBackoff
+	} else {
+		result += jitter
 	}
 	// Floor at BaseBackoff/2 to avoid extremely short intervals on large negative jitter.
 	if result < m.cfg.BaseBackoff/2 {

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -749,18 +749,20 @@ func (m *Manager) computeBackoff(failures int) time.Duration {
 	// ±25% jitter: uniform in [-base/4, +base/4].
 	// rand.Int63n(int64(base/2)+1) gives [0, base/2]; subtracting base/4 shifts to [-base/4, +base/4].
 	jitter := time.Duration(rand.Int63n(int64(base/2)+1)) - time.Duration(base/4)
-	result := base
-	const maxDuration = time.Duration(1<<63 - 1)
-	if jitter > 0 && (base > m.cfg.MaxBackoff-jitter || base > maxDuration-jitter) {
-		result = m.cfg.MaxBackoff
-	} else {
-		result += jitter
-	}
+	result := saturatingAddBackoffJitter(base, jitter, m.cfg.MaxBackoff)
 	// Floor at BaseBackoff/2 to avoid extremely short intervals on large negative jitter.
 	if result < m.cfg.BaseBackoff/2 {
 		result = m.cfg.BaseBackoff / 2
 	}
 	return result
+}
+
+func saturatingAddBackoffJitter(base, jitter, maxBackoff time.Duration) time.Duration {
+	const maxDuration = time.Duration(1<<63 - 1)
+	if jitter > 0 && (base > maxBackoff-jitter || base > maxDuration-jitter) {
+		return maxBackoff
+	}
+	return base + jitter
 }
 
 func (m *Manager) releaseLease() {

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math"
 	"math/rand"
 	"runtime/debug"
 	"sort"
@@ -394,8 +393,8 @@ func (m *Manager) cycle(ctx context.Context) {
 		return
 	}
 
-	// Check if we've exceeded the failure ceiling — enters PhaseBackoff.
-	if failures >= m.cfg.MaxConsecutiveFailures {
+	// At the failure ceiling, remain in backoff only until the current deadline expires.
+	if failures >= m.cfg.MaxConsecutiveFailures && backoffUntil != nil && time.Now().Before(*backoffUntil) {
 		m.setPhase(PhaseBackoff)
 		return
 	}
@@ -736,10 +735,16 @@ func (m *Manager) computeBackoff(failures int) time.Duration {
 	if failures <= 0 {
 		return m.cfg.BaseBackoff
 	}
-	exp := math.Pow(2, float64(failures-1))
-	base := time.Duration(float64(m.cfg.BaseBackoff) * exp)
+	base := m.cfg.BaseBackoff
 	if base > m.cfg.MaxBackoff {
 		base = m.cfg.MaxBackoff
+	}
+	for i := 1; i < failures && base < m.cfg.MaxBackoff; i++ {
+		if base > m.cfg.MaxBackoff/2 {
+			base = m.cfg.MaxBackoff
+		} else {
+			base *= 2
+		}
 	}
 	// ±25% jitter: uniform in [-base/4, +base/4].
 	// rand.Int63n(int64(base/2)+1) gives [0, base/2]; subtracting base/4 shifts to [-base/4, +base/4].

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -989,6 +989,21 @@ func TestManagerBackoffSaturatesBeforeDurationConversion(t *testing.T) {
 	}
 }
 
+func TestManagerBackoffSaturatesPositiveJitterBeforeDurationOverflow(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.BaseBackoff = time.Duration(1<<63 - 1)
+	cfg.MaxBackoff = time.Duration(1<<63 - 1)
+	mgr := &Manager{cfg: cfg}
+	minExpected := cfg.MaxBackoff - cfg.MaxBackoff/4
+
+	for i := 0; i < 1024; i++ {
+		d := mgr.computeBackoff(1)
+		if d < minExpected || d > cfg.MaxBackoff {
+			t.Fatalf("backoff %v outside expected range [%v, %v] at iteration %d", d, minExpected, cfg.MaxBackoff, i)
+		}
+	}
+}
+
 func TestManagerBackoffResetOnSuccess(t *testing.T) {
 	ls := newFakeLocalStore()
 	tr := newFakeTransport()

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -990,17 +990,32 @@ func TestManagerBackoffSaturatesBeforeDurationConversion(t *testing.T) {
 }
 
 func TestManagerBackoffSaturatesPositiveJitterBeforeDurationOverflow(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.BaseBackoff = time.Duration(1<<63 - 1)
-	cfg.MaxBackoff = time.Duration(1<<63 - 1)
-	mgr := &Manager{cfg: cfg}
-	minExpected := cfg.MaxBackoff - cfg.MaxBackoff/4
+	const maxDuration = time.Duration(1<<63 - 1)
 
-	for i := 0; i < 1024; i++ {
-		d := mgr.computeBackoff(1)
-		if d < minExpected || d > cfg.MaxBackoff {
-			t.Fatalf("backoff %v outside expected range [%v, %v] at iteration %d", d, minExpected, cfg.MaxBackoff, i)
-		}
+	for _, tc := range []struct {
+		name   string
+		base   time.Duration
+		jitter time.Duration
+		want   time.Duration
+	}{
+		{
+			name:   "saturates overflowing positive jitter",
+			base:   maxDuration - 1,
+			jitter: 2,
+			want:   maxDuration,
+		},
+		{
+			name:   "adds positive jitter below ceiling",
+			base:   maxDuration - 2,
+			jitter: 1,
+			want:   maxDuration - 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := saturatingAddBackoffJitter(tc.base, tc.jitter, maxDuration); got != tc.want {
+				t.Fatalf("saturatingAddBackoffJitter(%v, %v, %v) = %v, want %v", tc.base, tc.jitter, maxDuration, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -21,6 +21,7 @@ type fakeLocalStore struct {
 	mutations         []store.SyncMutation
 	syncState         *store.SyncState
 	leaseOwner        string
+	leaseCalls        int
 	pushErr           error
 	pullErr           error
 	failureMessage    string
@@ -95,6 +96,7 @@ func (s *fakeLocalStore) AckSyncMutationSeqs(_ string, seqs []int64) error {
 func (s *fakeLocalStore) AcquireSyncLease(_, owner string, ttl time.Duration, now time.Time) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.leaseCalls++
 	if !s.acquireGranted {
 		return false, nil
 	}
@@ -856,6 +858,134 @@ func TestManagerBackoffCeiling(t *testing.T) {
 	d := mgr.computeBackoff(cfg.MaxConsecutiveFailures)
 	if d > cfg.MaxBackoff {
 		t.Fatalf("backoff exceeds ceiling: %v > %v", d, cfg.MaxBackoff)
+	}
+}
+
+func TestManagerCycleAtFailureCeilingWithActiveBackoffSkipsWork(t *testing.T) {
+	ls := newFakeLocalStore()
+	tr := newFakeTransport()
+	cfg := DefaultConfig()
+	cfg.MaxConsecutiveFailures = 3
+	mgr := New(ls, tr, cfg)
+	backoffUntil := time.Now().Add(time.Minute)
+
+	mgr.mu.Lock()
+	mgr.status.Phase = PhasePushFailed
+	mgr.status.ConsecutiveFailures = cfg.MaxConsecutiveFailures
+	mgr.status.BackoffUntil = &backoffUntil
+	mgr.mu.Unlock()
+
+	mgr.cycle(context.Background())
+
+	ls.mu.Lock()
+	leaseCalls := ls.leaseCalls
+	ls.mu.Unlock()
+	if leaseCalls != 0 {
+		t.Fatalf("expected no lease work during active ceiling backoff, got %d attempts", leaseCalls)
+	}
+	if got := atomic.LoadInt32(&tr.pushCalls); got != 0 {
+		t.Fatalf("expected no push work during active ceiling backoff, got %d calls", got)
+	}
+	if got := atomic.LoadInt32(&tr.pullCalls); got != 0 {
+		t.Fatalf("expected no pull work during active ceiling backoff, got %d calls", got)
+	}
+	if got := mgr.Status().Phase; got != PhaseBackoff {
+		t.Fatalf("expected PhaseBackoff during active ceiling backoff, got %q", got)
+	}
+}
+
+func TestManagerCycleAtFailureCeilingAfterBackoffExpiryRecovers(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.mutations = []store.SyncMutation{{Seq: 1, Entity: "obs", EntityKey: "k1", Project: "proj-a"}}
+	tr := newFakeTransport()
+	tr.pushResult = &PushMutationsResult{AcceptedSeqs: []int64{1}}
+	cfg := DefaultConfig()
+	cfg.MaxConsecutiveFailures = 3
+	mgr := New(ls, tr, cfg)
+	backoffUntil := time.Now().Add(-time.Second)
+
+	mgr.mu.Lock()
+	mgr.status.Phase = PhasePushFailed
+	mgr.status.ConsecutiveFailures = cfg.MaxConsecutiveFailures
+	mgr.status.BackoffUntil = &backoffUntil
+	mgr.mu.Unlock()
+
+	mgr.cycle(context.Background())
+
+	ls.mu.Lock()
+	leaseCalls := ls.leaseCalls
+	healthyCalls := ls.healthyCalls
+	ls.mu.Unlock()
+	if leaseCalls != 1 {
+		t.Fatalf("expected one lease attempt after backoff expiry, got %d", leaseCalls)
+	}
+	if got := atomic.LoadInt32(&tr.pushCalls); got != 1 {
+		t.Fatalf("expected one push after backoff expiry, got %d calls", got)
+	}
+	if got := atomic.LoadInt32(&tr.pullCalls); got != 1 {
+		t.Fatalf("expected one pull after backoff expiry, got %d calls", got)
+	}
+	if healthyCalls != 1 {
+		t.Fatalf("expected healthy state to be persisted once, got %d calls", healthyCalls)
+	}
+	st := mgr.Status()
+	if st.Phase != PhaseHealthy || st.ConsecutiveFailures != 0 || st.BackoffUntil != nil {
+		t.Fatalf("expected healthy reset after backoff expiry, got %+v", st)
+	}
+}
+
+func TestManagerCycleAfterBackoffExpirySchedulesAnotherBackoff(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.mutations = []store.SyncMutation{{Seq: 1, Entity: "obs", EntityKey: "k1", Project: "proj-a"}}
+	tr := newFakeTransport()
+	tr.pushErr = errors.New("transport down")
+	cfg := DefaultConfig()
+	cfg.MaxConsecutiveFailures = 3
+	cfg.BaseBackoff = time.Second
+	cfg.MaxBackoff = 5 * time.Second
+	mgr := New(ls, tr, cfg)
+	backoffUntil := time.Now().Add(-time.Second)
+
+	mgr.mu.Lock()
+	mgr.status.Phase = PhasePushFailed
+	mgr.status.ConsecutiveFailures = cfg.MaxConsecutiveFailures
+	mgr.status.BackoffUntil = &backoffUntil
+	mgr.mu.Unlock()
+
+	mgr.cycle(context.Background())
+
+	if got := atomic.LoadInt32(&tr.pushCalls); got != 1 {
+		t.Fatalf("expected one push after backoff expiry, got %d calls", got)
+	}
+	st := mgr.Status()
+	if st.Phase != PhasePushFailed || st.ConsecutiveFailures != cfg.MaxConsecutiveFailures+1 || st.BackoffUntil == nil {
+		t.Fatalf("expected another failed backoff after expiry, got %+v", st)
+	}
+	remaining := time.Until(*st.BackoffUntil)
+	if remaining <= 0 || remaining > cfg.MaxBackoff {
+		t.Fatalf("expected bounded future backoff, got remaining duration %v", remaining)
+	}
+}
+
+func TestManagerBackoffSaturatesBeforeDurationConversion(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.BaseBackoff = time.Second
+	cfg.MaxBackoff = 5 * time.Minute
+	mgr := &Manager{cfg: cfg}
+
+	for _, failures := range []int{34, 35, 1000} {
+		t.Run(fmt.Sprintf("failures=%d", failures), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("computeBackoff panicked: %v", r)
+				}
+			}()
+
+			d := mgr.computeBackoff(failures)
+			if d < cfg.BaseBackoff/2 || d > cfg.MaxBackoff {
+				t.Fatalf("backoff %v outside configured bounds [%v, %v]", d, cfg.BaseBackoff/2, cfg.MaxBackoff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #778

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Resume autosync lease acquisition and replication after a ceiling-level backoff expires.
- Saturate exponential backoff before duration overflow while preserving jitter and maximum bounds.
- Add regressions for active backoff, expired recovery, repeated failure, and high failure counts.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/autosync/manager.go` | Make the retry ceiling time-bounded and compute exponential backoff with saturating duration arithmetic. |
| `internal/cloud/autosync/manager_test.go` | Cover lease/transport suppression, recovery, continued failure, and large failure counts. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] Focused autosync tests pass locally: `go test ./internal/cloud/autosync -count=1`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

The full unit command was attempted twice. The first run exhausted local disk space. After an authorized Go cache cleanup, the second run reached unrelated failures: `internal/setup` could not find `sh` on Windows, and two `plugin` tests reported unfinished stdin probes/open streams. The changed autosync package and server E2E suite both pass. CI is expected to provide the authoritative full-suite result.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #778`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (attempted; unrelated failures documented above)
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs reviewed; existing REQ-205 already specifies retry after the backoff interval, so no update is required
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The exact candidate completed four-lens RDD with an approved result before publication. RDD reported only non-blocking advisory observations in test assertions and offered no correction transition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic synchronization now resumes after a backoff period expires instead of remaining paused indefinitely.
  * Retry delays grow predictably and remain within the configured maximum, including after repeated failures.
  * Synchronization avoids unnecessary work while an active retry delay is in effect.
* **Reliability**
  * Improved recovery behavior after failed synchronization attempts, with failure tracking reset once synchronization succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->