### PR TITLE
fix(mcp): make omitted session fallback worktree-safe

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -805,6 +805,7 @@ Guardrails:
 - An unbacked explicit `project` fails loudly and does not create a new bucket.
 - If a non-empty `session_id` is supplied and no session exists, `mem_save` fails with a structured error and does not write.
 - If both explicit `project` and `session_id` are supplied, they must resolve to the same normalized project or `mem_save` fails with a structured error and does not write.
+- When a write omits `session_id`, Engram uses the current process directory only to narrow active non-manual runtime sessions for the resolved project. It attaches to a session only when exactly one candidate remains, uses the project manual-save session when none remain, and rejects multiple candidates rather than selecting by recency. Directory is not session identity; callers with concurrent sessions must supply `session_id`.
 - `project_choice_reason=user_selected_after_ambiguous_project` is only honored when cwd resolution is actually ambiguous. On a non-ambiguous cwd, stale recovery flags do not override explicit-project precedence or session mismatch validation.
 - If ambiguous-project recovery is active, `project` must exactly match one of the previously returned `available_projects`; invented or normalized guesses are rejected.
 - Exact ambiguous-project choices can still fail with `project_name_collision` when multiple available names collapse to the same stored project bucket after normalization. Rename or disambiguate the colliding projects before retrying.

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -87,15 +87,22 @@ func ensureImplicitSessionWithCWD(s *store.Store, sessionID, project string) err
 	return s.CreateSession(sessionID, project, currentWorkingDirectory())
 }
 
-// runtimeSessionDirectory derives the worktree key through the shared project
-// detector for omitted-directory registration and omitted-session lookup.
+// runtimeSessionDirectory derives the worktree-specific key for omitted
+// registration and omitted-session lookup without changing project identity.
 func runtimeSessionDirectory(directory string) string {
+	if strings.TrimSpace(directory) == "" {
+		directory = currentWorkingDirectory()
+	}
+	return projectpkg.RuntimeWorktreeDirectory(directory)
+}
+
+func absoluteRuntimeDirectory(directory string) string {
 	directory = strings.TrimSpace(directory)
 	if directory == "" {
 		directory = currentWorkingDirectory()
 	}
-	if detected := strings.TrimSpace(projectpkg.DetectProjectFull(directory).Path); detected != "" {
-		return detected
+	if absoluteDirectory, err := filepath.Abs(directory); err == nil {
+		return absoluteDirectory
 	}
 	return directory
 }
@@ -341,7 +348,7 @@ Examples:
 					mcp.Description("Category: decision, architecture, bugfix, pattern, config, discovery, learning (default: manual)"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with (default: manual-save-{project})"),
+					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("scope",
 					mcp.Description("Scope for this observation: project (default) or personal"),
@@ -485,7 +492,7 @@ Examples:
 					mcp.Description("The user's prompt text"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with (default: manual-save-{project})"),
+					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("project",
 					mcp.Description("Optional recovery target only after ambiguous_project. Ignored unless project_choice_reason is user_selected_after_ambiguous_project."),
@@ -669,7 +676,7 @@ GUIDELINES:
 					mcp.Description("Full session summary using the Goal/Instructions/Discoveries/Accomplished/Next Steps/Relevant Files format"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID (default: manual-save-{project})"),
+					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("project",
 					mcp.Description("Optional explicit project for this memory. Accepted only when backed by known context (existing project, matching session, repo config, or ambiguous-project recovery); invalid or unbacked names fail loudly."),
@@ -751,7 +758,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 					mcp.Description("The text output containing a '## Key Learnings:' section with numbered or bulleted items"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID (default: manual-save-{project})"),
+					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("source",
 					mcp.Description("Source identifier (e.g. 'subagent-stop', 'session-end')"),
@@ -1974,6 +1981,8 @@ func handleSessionStart(s *store.Store, cfg MCPConfig, activity *SessionActivity
 		activity.RecordToolCall(defaultSessionID(project))
 		if resolvedDirectory == "" {
 			resolvedDirectory = runtimeSessionDirectory("")
+		} else if !filepath.IsAbs(resolvedDirectory) {
+			resolvedDirectory = absoluteRuntimeDirectory(resolvedDirectory)
 		}
 
 		if err := s.CreateSession(id, project, resolvedDirectory); err != nil {
@@ -3039,7 +3048,7 @@ func defaultSessionID(project string) string {
 // candidates; a persisted session ID remains the sole identity.
 func resolveFallbackSessionID(s *store.Store, project string) (string, error) {
 	if s != nil {
-		directory := currentWorkingDirectory()
+		directory := absoluteRuntimeDirectory("")
 		ids, err := s.ActiveRuntimeSessions(project, directory, runtimeSessionDirectory(directory))
 		if err == nil {
 			switch len(ids) {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -96,17 +96,6 @@ func runtimeSessionDirectory(directory string) string {
 	return projectpkg.RuntimeWorktreeDirectory(directory)
 }
 
-func absoluteRuntimeDirectory(directory string) string {
-	directory = strings.TrimSpace(directory)
-	if directory == "" {
-		directory = currentWorkingDirectory()
-	}
-	if absoluteDirectory, err := filepath.Abs(directory); err == nil {
-		return absoluteDirectory
-	}
-	return directory
-}
-
 // ─── Tool Profiles ───────────────────────────────────────────────────────────
 //
 // "agent" — tools AI agents use during coding sessions:
@@ -1979,11 +1968,7 @@ func handleSessionStart(s *store.Store, cfg MCPConfig, activity *SessionActivity
 		project, _ := store.NormalizeProject(detRes.Project)
 
 		activity.RecordToolCall(defaultSessionID(project))
-		if resolvedDirectory == "" {
-			resolvedDirectory = runtimeSessionDirectory("")
-		} else if !filepath.IsAbs(resolvedDirectory) {
-			resolvedDirectory = absoluteRuntimeDirectory(resolvedDirectory)
-		}
+		resolvedDirectory = runtimeSessionDirectory(resolvedDirectory)
 
 		if err := s.CreateSession(id, project, resolvedDirectory); err != nil {
 			return mcp.NewToolResultError("Failed to start session: " + err.Error()), nil
@@ -3048,8 +3033,7 @@ func defaultSessionID(project string) string {
 // candidates; a persisted session ID remains the sole identity.
 func resolveFallbackSessionID(s *store.Store, project string) (string, error) {
 	if s != nil {
-		directory := absoluteRuntimeDirectory("")
-		ids, err := s.ActiveRuntimeSessions(project, directory, runtimeSessionDirectory(directory))
+		ids, err := s.ActiveRuntimeSessions(project, runtimeSessionDirectory(""))
 		if err == nil {
 			switch len(ids) {
 			case 0:

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -75,7 +75,7 @@ func truncationWarning(metadata store.TruncationMetadata) string {
 	return fmt.Sprintf("\n⚠ WARNING: Content was truncated from %d to %d bytes. Consider splitting into smaller observations.", metadata.OriginalBytes, metadata.LimitBytes)
 }
 
-func currentWorkingDirectory() string {
+var currentWorkingDirectory = func() string {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
@@ -1221,7 +1221,10 @@ func handleSave(s *store.Store, cfg MCPConfig, activity *SessionActivity) server
 			typ = "manual"
 		}
 		if sessionID == "" {
-			sessionID = resolveFallbackSessionID(s, project)
+			sessionID, err = resolveFallbackSessionID(s, project)
+			if err != nil {
+				return mcp.NewToolResultError("Failed to save: " + err.Error()), nil
+			}
 		}
 		suggestedTopicKey := suggestTopicKey(typ, title, content)
 
@@ -1597,7 +1600,10 @@ func handleSavePrompt(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 		project, _ := store.NormalizeProject(detRes.Project)
 
 		if sessionID == "" {
-			sessionID = resolveFallbackSessionID(s, project)
+			sessionID, err = resolveFallbackSessionID(s, project)
+			if err != nil {
+				return mcp.NewToolResultError("Failed to save prompt: " + err.Error()), nil
+			}
 		}
 
 		// Ensure the implicit MCP session exists with the current working directory.
@@ -1910,7 +1916,10 @@ func handleSessionSummary(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		project, _ = store.NormalizeProject(project)
 
 		if sessionID == "" {
-			sessionID = resolveFallbackSessionID(s, project)
+			sessionID, err = resolveFallbackSessionID(s, project)
+			if err != nil {
+				return mcp.NewToolResultError("Failed to save session summary: " + err.Error()), nil
+			}
 		}
 
 		// Ensure the implicit MCP session exists with the current working directory.
@@ -2030,7 +2039,10 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		}
 
 		if sessionID == "" {
-			sessionID = resolveFallbackSessionID(s, project)
+			sessionID, err = resolveFallbackSessionID(s, project)
+			if err != nil {
+				return mcp.NewToolResultError("Passive capture failed: " + err.Error()), nil
+			}
 			_ = ensureImplicitSessionWithCWD(s, sessionID, project)
 		}
 
@@ -3012,25 +3024,24 @@ func defaultSessionID(project string) string {
 	return "manual-save-" + project
 }
 
-// resolveFallbackSessionID resolves the session a write should attach to when
-// the caller did not provide an explicit session_id.
-//
-// It first consults the persisted sessions table for the most recent active
-// (un-ended) session of the project (issue #386). The SessionStart hook
-// registers a UUID session via the HTTP server, a SEPARATE process from this
-// MCP (stdio) server; the two share only the SQLite store, so the active
-// session must be resolved from disk rather than from any in-process map.
-//
-// When no active session exists for the project (or the store query fails for
-// any reason), it falls back to the manual-save-{project} session, preserving
-// the prior behavior for projects with no live session.
-func resolveFallbackSessionID(s *store.Store, project string) string {
+// resolveFallbackSessionID resolves an omitted session_id without guessing
+// between concurrent runtime sessions. The working directory only narrows
+// candidates; a persisted session ID remains the sole identity.
+func resolveFallbackSessionID(s *store.Store, project string) (string, error) {
 	if s != nil {
-		if id, ok, err := s.MostRecentActiveSession(project); err == nil && ok {
-			return id
+		ids, err := s.ActiveRuntimeSessions(project, currentWorkingDirectory())
+		if err == nil {
+			switch len(ids) {
+			case 0:
+				return defaultSessionID(project), nil
+			case 1:
+				return ids[0], nil
+			default:
+				return "", fmt.Errorf("multiple active runtime sessions match project %q and the current directory; provide session_id", project)
+			}
 		}
 	}
-	return defaultSessionID(project)
+	return defaultSessionID(project), nil
 }
 
 func intArg(req mcp.CallToolRequest, key string, defaultVal int) int {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -87,6 +87,19 @@ func ensureImplicitSessionWithCWD(s *store.Store, sessionID, project string) err
 	return s.CreateSession(sessionID, project, currentWorkingDirectory())
 }
 
+// runtimeSessionDirectory derives the worktree key through the shared project
+// detector for omitted-directory registration and omitted-session lookup.
+func runtimeSessionDirectory(directory string) string {
+	directory = strings.TrimSpace(directory)
+	if directory == "" {
+		directory = currentWorkingDirectory()
+	}
+	if detected := strings.TrimSpace(projectpkg.DetectProjectFull(directory).Path); detected != "" {
+		return detected
+	}
+	return directory
+}
+
 // ─── Tool Profiles ───────────────────────────────────────────────────────────
 //
 // "agent" — tools AI agents use during coding sessions:
@@ -1960,10 +1973,7 @@ func handleSessionStart(s *store.Store, cfg MCPConfig, activity *SessionActivity
 
 		activity.RecordToolCall(defaultSessionID(project))
 		if resolvedDirectory == "" {
-			resolvedDirectory = strings.TrimSpace(detRes.Path)
-			if resolvedDirectory == "" {
-				resolvedDirectory = strings.TrimSpace(currentWorkingDirectory())
-			}
+			resolvedDirectory = runtimeSessionDirectory("")
 		}
 
 		if err := s.CreateSession(id, project, resolvedDirectory); err != nil {
@@ -3029,7 +3039,8 @@ func defaultSessionID(project string) string {
 // candidates; a persisted session ID remains the sole identity.
 func resolveFallbackSessionID(s *store.Store, project string) (string, error) {
 	if s != nil {
-		ids, err := s.ActiveRuntimeSessions(project, currentWorkingDirectory())
+		directory := currentWorkingDirectory()
+		ids, err := s.ActiveRuntimeSessions(project, directory, runtimeSessionDirectory(directory))
 		if err == nil {
 			switch len(ids) {
 			case 0:

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -659,6 +659,9 @@ func TestHandleSaveRecordsActivityForExplicitSessionID(t *testing.T) {
 // store-based resolution is the only thing that survives the process split.
 func TestHandleSaveResolvesActiveSessionFromStore(t *testing.T) {
 	s := newMCPTestStore(t)
+	originalWorkingDirectory := currentWorkingDirectory
+	currentWorkingDirectory = func() string { return "/work/engram" }
+	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
 
 	// Simulate the SessionStart hook registering a UUID session (POST /sessions
 	// ultimately calls store.CreateSession).
@@ -726,47 +729,71 @@ func TestHandleSaveFallsBackToManualSaveWhenNoActiveSession(t *testing.T) {
 	}
 }
 
-// TestHandleSaveResolvesMostRecentActiveSession covers the multi-session edge
-// case: two un-ended sessions exist; mem_save must attach to the most recent.
-func TestHandleSaveResolvesMostRecentActiveSession(t *testing.T) {
+// TestHandleSaveRejectsAmbiguousActiveSessions ensures an omitted session_id
+// never selects one of several active runtime sessions in the same directory.
+func TestHandleSaveRejectsAmbiguousActiveSessions(t *testing.T) {
 	s := newMCPTestStore(t)
+	originalWorkingDirectory := currentWorkingDirectory
+	currentWorkingDirectory = func() string { return "/work/engram" }
+	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
 
-	if err := s.CreateSession("uuid-older", "engram", "/work/engram"); err != nil {
-		t.Fatalf("create older session: %v", err)
+	if err := s.CreateSession("uuid-first", "engram", "/work/engram"); err != nil {
+		t.Fatalf("create first session: %v", err)
 	}
-	if _, err := s.DB().Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, "2025-01-01 00:00:00", "uuid-older"); err != nil {
-		t.Fatalf("backdate older session: %v", err)
-	}
-	if err := s.CreateSession("uuid-newer", "engram", "/work/engram"); err != nil {
-		t.Fatalf("create newer session: %v", err)
-	}
-	if _, err := s.DB().Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, "2025-06-01 00:00:00", "uuid-newer"); err != nil {
-		t.Fatalf("set newer session started_at: %v", err)
+	if err := s.CreateSession("uuid-second", "engram", "/work/engram"); err != nil {
+		t.Fatalf("create second session: %v", err)
 	}
 
 	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
-		"title":   "Most recent active session",
-		"content": "**What**: saved with two active sessions\n**Why**: multi-session edge case",
+		"title":   "Ambiguous active sessions",
+		"content": "**What**: saved without session_id\n**Why**: ambiguous runtime sessions must fail",
 		"type":    "bugfix",
 		"project": "engram",
 	}}})
 	if err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
-	if res.IsError {
-		t.Fatalf("unexpected save error: %s", callResultText(t, res))
+	if !res.IsError {
+		t.Fatal("expected ambiguous omitted session_id to fail")
+	}
+	if got := callResultText(t, res); !strings.Contains(got, "multiple active runtime sessions") {
+		t.Fatalf("expected ambiguity error, got %q", got)
+	}
+	obs, err := s.RecentObservations("engram", "project", 5)
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Fatalf("expected no write after ambiguous session resolution, got %#v", obs)
+	}
+}
+
+func TestHandleSaveFallsBackWhenActiveSessionIsInAnotherDirectory(t *testing.T) {
+	s := newMCPTestStore(t)
+	originalWorkingDirectory := currentWorkingDirectory
+	currentWorkingDirectory = func() string { return "/work/current" }
+	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
+	if err := s.CreateSession("other-worktree-session", "engram", "/work/other"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Different worktree fallback",
+		"content": "**What**: saved without session_id\n**Why**: worktree regression guard",
+		"project": "engram",
+	}}})
+	if err != nil || res.IsError {
+		t.Fatalf("save failed: err=%v text=%q", err, callResultText(t, res))
 	}
 
 	obs, err := s.RecentObservations("engram", "project", 5)
 	if err != nil {
 		t.Fatalf("recent observations: %v", err)
 	}
-	if len(obs) == 0 {
-		t.Fatalf("expected at least one observation, got none")
-	}
-	if obs[0].SessionID != "uuid-newer" {
-		t.Fatalf("expected most recent active session uuid-newer, got %q", obs[0].SessionID)
+	if len(obs) != 1 || obs[0].SessionID != defaultSessionID("engram") {
+		t.Fatalf("expected manual fallback, got %#v", obs)
 	}
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -662,11 +662,12 @@ func TestHandleSaveResolvesActiveSessionFromStore(t *testing.T) {
 	originalWorkingDirectory := currentWorkingDirectory
 	currentWorkingDirectory = func() string { return "/work/engram" }
 	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
+	runtimeDirectory := runtimeSessionDirectory("/work/engram")
 
 	// Simulate the SessionStart hook registering a UUID session (POST /sessions
 	// ultimately calls store.CreateSession).
 	const uuidSession = "0c8e7f2a-1b34-4d9e-9a77-aaaabbbbcccc"
-	if err := s.CreateSession(uuidSession, "engram", "/work/engram"); err != nil {
+	if err := s.CreateSession(uuidSession, "engram", runtimeDirectory); err != nil {
 		t.Fatalf("create UUID session: %v", err)
 	}
 
@@ -694,6 +695,98 @@ func TestHandleSaveResolvesActiveSessionFromStore(t *testing.T) {
 	}
 	if obs[0].SessionID != uuidSession {
 		t.Fatalf("expected observation to attach to active UUID session %q, got %q (regression #386: fell back to manual-save)", uuidSession, obs[0].SessionID)
+	}
+}
+
+func TestHandleSaveBindsNestedWriteToSessionRegisteredAtRepositoryRoot(t *testing.T) {
+	s := newMCPTestStore(t)
+	repository := project.DetectProjectFull(".")
+	if repository.Error != nil {
+		t.Fatalf("detect repository: %v", repository.Error)
+	}
+	if repository.Path == "" {
+		t.Fatal("expected repository detection to provide a canonical root")
+	}
+
+	nestedDirectory := filepath.Join(repository.Path, "internal", "mcp")
+	nested := project.DetectProjectFull(nestedDirectory)
+	if nested.Error != nil {
+		t.Fatalf("detect nested directory: %v", nested.Error)
+	}
+	if nested.Path != repository.Path {
+		t.Fatalf("nested directory resolved to %q, want repository root %q", nested.Path, repository.Path)
+	}
+	t.Chdir(repository.Path)
+
+	start := handleSessionStart(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	startResult, err := start(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id": "jd-runtime-session",
+	}}})
+	if err != nil || startResult.IsError {
+		t.Fatalf("start session: err=%v text=%q", err, callResultText(t, startResult))
+	}
+
+	originalWorkingDirectory := currentWorkingDirectory
+	currentWorkingDirectory = func() string { return nestedDirectory }
+	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
+
+	save := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	saveResult, err := save(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Nested runtime save",
+		"content": "**What**: saved from a nested directory\n**Why**: runtime session binding regression",
+		"type":    "bugfix",
+		"project": repository.Project,
+	}}})
+	if err != nil || saveResult.IsError {
+		t.Fatalf("save: err=%v text=%q", err, callResultText(t, saveResult))
+	}
+
+	observations, err := s.RecentObservations(repository.Project, "project", 1)
+	if err != nil {
+		t.Fatalf("recent observations: %v", err)
+	}
+	if len(observations) != 1 || observations[0].SessionID != "jd-runtime-session" {
+		t.Fatalf("nested write attached to %#v, want session %q", observations, "jd-runtime-session")
+	}
+}
+
+func TestHandleSaveBindsNestedWriteToExplicitNestedRuntimeSession(t *testing.T) {
+	s := newMCPTestStore(t)
+	repository := t.TempDir()
+	nestedDirectory := filepath.Join(repository, "nested")
+	if err := os.MkdirAll(nestedDirectory, 0o755); err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	initTestGitRepo(t, repository)
+	projectResult := project.DetectProjectFull(nestedDirectory)
+
+	start := handleSessionStart(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	startResult, err := start(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":        "jd-explicit-nested-runtime-session",
+		"directory": nestedDirectory,
+	}}})
+	if err != nil || startResult.IsError {
+		t.Fatalf("start session: err=%v text=%q", err, callResultText(t, startResult))
+	}
+	if session, err := s.GetSession("jd-explicit-nested-runtime-session"); err != nil || session.Directory != nestedDirectory {
+		t.Fatalf("explicit session directory = %#v, err=%v; want %q", session, err, nestedDirectory)
+	}
+
+	originalWorkingDirectory := currentWorkingDirectory
+	currentWorkingDirectory = func() string { return nestedDirectory }
+	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
+	saveResult, err := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Explicit nested runtime save",
+		"content": "**What**: saved from an explicit nested runtime directory\n**Why**: runtime session binding regression",
+		"type":    "bugfix",
+		"project": projectResult.Project,
+	}}})
+	if err != nil || saveResult.IsError {
+		t.Fatalf("save: err=%v text=%q", err, callResultText(t, saveResult))
+	}
+	observations, err := s.RecentObservations(projectResult.Project, "project", 1)
+	if err != nil || len(observations) != 1 || observations[0].SessionID != "jd-explicit-nested-runtime-session" {
+		t.Fatalf("nested write attached to %#v, err=%v", observations, err)
 	}
 }
 
@@ -736,11 +829,12 @@ func TestHandleSaveRejectsAmbiguousActiveSessions(t *testing.T) {
 	originalWorkingDirectory := currentWorkingDirectory
 	currentWorkingDirectory = func() string { return "/work/engram" }
 	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
+	runtimeDirectory := runtimeSessionDirectory("/work/engram")
 
-	if err := s.CreateSession("uuid-first", "engram", "/work/engram"); err != nil {
+	if err := s.CreateSession("uuid-first", "engram", runtimeDirectory); err != nil {
 		t.Fatalf("create first session: %v", err)
 	}
-	if err := s.CreateSession("uuid-second", "engram", "/work/engram"); err != nil {
+	if err := s.CreateSession("uuid-second", "engram", runtimeDirectory); err != nil {
 		t.Fatalf("create second session: %v", err)
 	}
 
@@ -774,7 +868,7 @@ func TestHandleSaveFallsBackWhenActiveSessionIsInAnotherDirectory(t *testing.T) 
 	originalWorkingDirectory := currentWorkingDirectory
 	currentWorkingDirectory = func() string { return "/work/current" }
 	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
-	if err := s.CreateSession("other-worktree-session", "engram", "/work/other"); err != nil {
+	if err := s.CreateSession("other-worktree-session", "engram", runtimeSessionDirectory("/work/other")); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -768,12 +768,13 @@ func TestHandleSaveBindsNestedWriteToExplicitNestedRuntimeSession(t *testing.T) 
 	if err != nil || startResult.IsError {
 		t.Fatalf("start session: err=%v text=%q", err, callResultText(t, startResult))
 	}
-	if session, err := s.GetSession("jd-explicit-nested-runtime-session"); err != nil || session.Directory != nestedDirectory {
-		t.Fatalf("explicit session directory = %#v, err=%v; want %q", session, err, nestedDirectory)
+	wantDirectory := runtimeSessionDirectory(repository)
+	if session, err := s.GetSession("jd-explicit-nested-runtime-session"); err != nil || session.Directory != wantDirectory {
+		t.Fatalf("explicit session directory = %#v, err=%v; want worktree root %q", session, err, wantDirectory)
 	}
 
 	originalWorkingDirectory := currentWorkingDirectory
-	currentWorkingDirectory = func() string { return nestedDirectory }
+	currentWorkingDirectory = func() string { return repository }
 	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
 	saveResult, err := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
 		"title":   "Explicit nested runtime save",
@@ -809,10 +810,7 @@ func TestHandleSaveBindsRelativeDirectoryRuntimeSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get session: %v", err)
 	}
-	wantDirectory, err := filepath.Abs(".")
-	if err != nil {
-		t.Fatalf("resolve relative directory: %v", err)
-	}
+	wantDirectory := runtimeSessionDirectory(".")
 	if session.Directory != wantDirectory {
 		t.Fatalf("relative session directory = %q, want stable absolute directory %q", session.Directory, wantDirectory)
 	}
@@ -4235,8 +4233,9 @@ func TestSessionStartWithExplicitDirectoryPreservesDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get session: %v", err)
 	}
-	if sess.Directory != explicitDir {
-		t.Fatalf("expected directory=%q, got %q", explicitDir, sess.Directory)
+	wantDirectory := runtimeSessionDirectory(explicitDir)
+	if sess.Directory != wantDirectory {
+		t.Fatalf("expected directory=%q, got %q", wantDirectory, sess.Directory)
 	}
 }
 
@@ -4285,8 +4284,9 @@ func TestSessionStartWithExplicitDirectoryResolvesProjectFromDirectory(t *testin
 	if sess.Project != "explicit-session-project" {
 		t.Fatalf("expected explicit directory project, got %q", sess.Project)
 	}
-	if sess.Directory != explicitDir {
-		t.Fatalf("expected persisted directory=%q, got %q", explicitDir, sess.Directory)
+	wantDirectory := runtimeSessionDirectory(rightRepo)
+	if sess.Directory != wantDirectory {
+		t.Fatalf("expected persisted worktree root=%q, got %q", wantDirectory, sess.Directory)
 	}
 }
 
@@ -4326,8 +4326,9 @@ func TestSessionStartWithExplicitDirectoryTrimsWhitespaceBeforePersisting(t *tes
 	if sess.Project != "trimmed-session-project" {
 		t.Fatalf("expected trimmed explicit directory project, got %q", sess.Project)
 	}
-	if sess.Directory != trimmedDir {
-		t.Fatalf("expected trimmed persisted directory=%q, got %q", trimmedDir, sess.Directory)
+	wantDirectory := runtimeSessionDirectory(repoDir)
+	if sess.Directory != wantDirectory {
+		t.Fatalf("expected trimmed persisted worktree root=%q, got %q", wantDirectory, sess.Directory)
 	}
 }
 
@@ -4371,8 +4372,9 @@ func TestSessionStartWithExplicitPlainDirectoryUsesDirectoryBasenameProject(t *t
 	if sess.Project != "plain-session-target" {
 		t.Fatalf("expected explicit plain directory project, got %q", sess.Project)
 	}
-	if sess.Directory != explicitDir {
-		t.Fatalf("expected persisted directory=%q, got %q", explicitDir, sess.Directory)
+	wantDirectory := runtimeSessionDirectory(explicitDir)
+	if sess.Directory != wantDirectory {
+		t.Fatalf("expected persisted directory=%q, got %q", wantDirectory, sess.Directory)
 	}
 
 	body := callResultJSON(t, res)

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -790,6 +790,51 @@ func TestHandleSaveBindsNestedWriteToExplicitNestedRuntimeSession(t *testing.T) 
 	}
 }
 
+func TestHandleSaveBindsRelativeDirectoryRuntimeSession(t *testing.T) {
+	s := newMCPTestStore(t)
+	repository := t.TempDir()
+	initTestGitRepo(t, repository)
+	t.Chdir(repository)
+
+	start := handleSessionStart(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	startResult, err := start(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id":        "relative-runtime-session",
+		"directory": ".",
+	}}})
+	if err != nil || startResult.IsError {
+		t.Fatalf("start session: err=%v text=%q", err, callResultText(t, startResult))
+	}
+
+	session, err := s.GetSession("relative-runtime-session")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	wantDirectory, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve relative directory: %v", err)
+	}
+	if session.Directory != wantDirectory {
+		t.Fatalf("relative session directory = %q, want stable absolute directory %q", session.Directory, wantDirectory)
+	}
+
+	originalWorkingDirectory := currentWorkingDirectory
+	currentWorkingDirectory = func() string { return repository }
+	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
+	saveResult, err := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Relative runtime save",
+		"content": "**What**: saved from a relative runtime directory\n**Why**: runtime session binding regression",
+		"type":    "bugfix",
+		"project": session.Project,
+	}}})
+	if err != nil || saveResult.IsError {
+		t.Fatalf("save: err=%v text=%q", err, callResultText(t, saveResult))
+	}
+	observations, err := s.RecentObservations(session.Project, "project", 1)
+	if err != nil || len(observations) != 1 || observations[0].SessionID != "relative-runtime-session" {
+		t.Fatalf("relative runtime write attached to %#v, err=%v", observations, err)
+	}
+}
+
 // TestHandleSaveFallsBackToManualSaveWhenNoActiveSession is the regression
 // guard for the preserved behavior: when there is no un-ended session for the
 // project, mem_save with no session_id must still use manual-save-{project}.
@@ -888,6 +933,58 @@ func TestHandleSaveFallsBackWhenActiveSessionIsInAnotherDirectory(t *testing.T) 
 	}
 	if len(obs) != 1 || obs[0].SessionID != defaultSessionID("engram") {
 		t.Fatalf("expected manual fallback, got %#v", obs)
+	}
+}
+
+func TestHandleSaveExcludesRuntimeSessionInSiblingLinkedWorktree(t *testing.T) {
+	s := newMCPTestStore(t)
+	parent := t.TempDir()
+	primary := filepath.Join(parent, "primary")
+	sibling := filepath.Join(parent, "sibling")
+	if err := os.MkdirAll(primary, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initTestGitRepo(t, primary)
+	commit := exec.Command("git", "-C", primary, "commit", "--allow-empty", "-m", "initial commit")
+	if out, err := commit.CombinedOutput(); err != nil {
+		t.Fatalf("create initial commit: %v\n%s", err, out)
+	}
+	addWorktree := exec.Command("git", "-C", primary, "worktree", "add", "-b", "sibling", sibling)
+	if out, err := addWorktree.CombinedOutput(); err != nil {
+		t.Fatalf("add sibling worktree: %v\n%s", err, out)
+	}
+	t.Chdir(primary)
+
+	start := handleSessionStart(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	startResult, err := start(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"id": "primary-runtime-session",
+	}}})
+	if err != nil || startResult.IsError {
+		t.Fatalf("start primary session: err=%v text=%q", err, callResultText(t, startResult))
+	}
+	primarySession, err := s.GetSession("primary-runtime-session")
+	if err != nil {
+		t.Fatalf("get primary session: %v", err)
+	}
+	if primarySession.Directory == runtimeSessionDirectory(sibling) {
+		t.Fatalf("primary runtime directory %q collapsed to sibling worktree", primarySession.Directory)
+	}
+
+	originalWorkingDirectory := currentWorkingDirectory
+	currentWorkingDirectory = func() string { return sibling }
+	t.Cleanup(func() { currentWorkingDirectory = originalWorkingDirectory })
+	saveResult, err := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "Sibling worktree runtime save",
+		"content": "**What**: saved from a sibling worktree\n**Why**: runtime sessions must not cross worktree boundaries",
+		"type":    "bugfix",
+		"project": primarySession.Project,
+	}}})
+	if err != nil || saveResult.IsError {
+		t.Fatalf("save: err=%v text=%q", err, callResultText(t, saveResult))
+	}
+	observations, err := s.RecentObservations(primarySession.Project, "project", 1)
+	if err != nil || len(observations) != 1 || observations[0].SessionID != defaultSessionID(primarySession.Project) {
+		t.Fatalf("sibling worktree write attached to %#v, err=%v", observations, err)
 	}
 }
 

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -296,6 +296,24 @@ func canonicalizePath(path string) string {
 	return filepath.Clean(resolved)
 }
 
+// RuntimeWorktreeDirectory returns the stable directory identity for runtime
+// session binding. Unlike DetectProjectFull's Path, linked worktrees retain
+// their individual checkout roots while their project identity may remain
+// shared with the primary checkout.
+func RuntimeWorktreeDirectory(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		dir = "."
+	}
+	if absolute, err := filepath.Abs(dir); err == nil {
+		dir = absolute
+	}
+	if worktreeRoot := detectGitWorktreeDir(dir); worktreeRoot != "" {
+		return canonicalizePath(worktreeRoot)
+	}
+	return canonicalizePath(dir)
+}
+
 func normalizeConfigProjectName(projectName string) (string, error) {
 	trimmed := strings.TrimSpace(projectName)
 	if trimmed == "" {

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -309,9 +310,17 @@ func RuntimeWorktreeDirectory(dir string) string {
 		dir = absolute
 	}
 	if worktreeRoot := detectGitWorktreeDir(dir); worktreeRoot != "" {
-		return canonicalizePath(worktreeRoot)
+		return runtimeCanonicalizePath(worktreeRoot)
 	}
-	return canonicalizePath(dir)
+	return runtimeCanonicalizePath(dir)
+}
+
+func runtimeCanonicalizePath(path string) string {
+	path = canonicalizePath(path)
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(path)
+	}
+	return path
 }
 
 func normalizeConfigProjectName(projectName string) (string, error) {

--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -788,6 +788,33 @@ func TestDetectProjectFull_WorktreeUsesPrimaryRepositoryIdentity(t *testing.T) {
 	}
 }
 
+func TestRuntimeWorktreeDirectoryKeepsLinkedWorktreesDistinct(t *testing.T) {
+	parent := t.TempDir()
+	primary := filepath.Join(parent, "primary")
+	sibling := filepath.Join(parent, "sibling")
+	if err := os.MkdirAll(primary, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, primary)
+	commitEmptyGit(t, primary)
+	addGitWorktree(t, primary, sibling, "sibling")
+	if err := os.MkdirAll(filepath.Join(sibling, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	primaryDirectory := RuntimeWorktreeDirectory(primary)
+	siblingDirectory := RuntimeWorktreeDirectory(filepath.Join(sibling, "nested"))
+	if primaryDirectory != canonicalizePath(primary) {
+		t.Fatalf("primary runtime directory = %q, want %q", primaryDirectory, canonicalizePath(primary))
+	}
+	if siblingDirectory != canonicalizePath(sibling) {
+		t.Fatalf("sibling runtime directory = %q, want %q", siblingDirectory, canonicalizePath(sibling))
+	}
+	if primaryDirectory == siblingDirectory {
+		t.Fatalf("linked worktree runtime directories collapsed to %q", primaryDirectory)
+	}
+}
+
 func TestDetectProjectFull_WorktreeRemoteUsesPrimaryRepositoryPath(t *testing.T) {
 	parent := t.TempDir()
 	repo := filepath.Join(parent, "canonical-repo")

--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -804,14 +805,31 @@ func TestRuntimeWorktreeDirectoryKeepsLinkedWorktreesDistinct(t *testing.T) {
 
 	primaryDirectory := RuntimeWorktreeDirectory(primary)
 	siblingDirectory := RuntimeWorktreeDirectory(filepath.Join(sibling, "nested"))
-	if primaryDirectory != canonicalizePath(primary) {
-		t.Fatalf("primary runtime directory = %q, want %q", primaryDirectory, canonicalizePath(primary))
+	if primaryDirectory != runtimeCanonicalizePath(primary) {
+		t.Fatalf("primary runtime directory = %q, want %q", primaryDirectory, runtimeCanonicalizePath(primary))
 	}
-	if siblingDirectory != canonicalizePath(sibling) {
-		t.Fatalf("sibling runtime directory = %q, want %q", siblingDirectory, canonicalizePath(sibling))
+	if siblingDirectory != runtimeCanonicalizePath(sibling) {
+		t.Fatalf("sibling runtime directory = %q, want %q", siblingDirectory, runtimeCanonicalizePath(sibling))
 	}
 	if primaryDirectory == siblingDirectory {
 		t.Fatalf("linked worktree runtime directories collapsed to %q", primaryDirectory)
+	}
+}
+
+func TestRuntimeWorktreeDirectoryNormalizesCaseOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path case normalization")
+	}
+	dir := filepath.Join(t.TempDir(), "CaseSensitive")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, dir)
+
+	actual := RuntimeWorktreeDirectory(dir)
+	equivalent := RuntimeWorktreeDirectory(strings.ToLower(dir))
+	if equivalent != actual {
+		t.Fatalf("case-equivalent worktree directory = %q, want %q", equivalent, actual)
 	}
 }
 

--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -833,6 +833,24 @@ func TestRuntimeWorktreeDirectoryNormalizesCaseOnWindows(t *testing.T) {
 	}
 }
 
+func TestRuntimeWorktreeDirectoryFallsBackToNonGitDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if got, want := RuntimeWorktreeDirectory("."), runtimeCanonicalizePath(dir); got != want {
+		t.Fatalf("non-Git runtime directory = %q, want %q", got, want)
+	}
+}
+
+func TestRuntimeWorktreeDirectoryUsesCurrentDirectoryForWhitespaceInput(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if got, want := RuntimeWorktreeDirectory(" \t "), runtimeCanonicalizePath(dir); got != want {
+		t.Fatalf("whitespace runtime directory = %q, want %q", got, want)
+	}
+}
+
 func TestDetectProjectFull_WorktreeRemoteUsesPrimaryRepositoryPath(t *testing.T) {
 	parent := t.TempDir()
 	repo := filepath.Join(parent, "canonical-repo")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -311,7 +311,7 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.CreateSession(body.ID, body.Project, body.Directory); err != nil {
+	if err := s.store.CreateSession(body.ID, body.Project, projectpkg.RuntimeWorktreeDirectory(body.Directory)); err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -12,12 +12,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	projectpkg "github.com/Gentleman-Programming/engram/internal/project"
 	"github.com/Gentleman-Programming/engram/internal/store"
 	_ "modernc.org/sqlite"
 )
@@ -314,6 +316,45 @@ func TestClaudeSaveNudgeCompatibilityRoutes(t *testing.T) {
 	h.ServeHTTP(missingSessionRec, missingSessionReq)
 	if missingSessionRec.Code != http.StatusNotFound {
 		t.Fatalf("expected missing session 404, got %d", missingSessionRec.Code)
+	}
+}
+
+func TestHandleCreateSessionStoresRuntimeWorktreeDirectory(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested", "child")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("create nested directory: %v", err)
+	}
+	if output, err := exec.Command("git", "init", root).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, output)
+	}
+	t.Chdir(root)
+
+	st := newServerTestStore(t)
+	h := New(st, 0).Handler()
+	for _, tc := range []struct {
+		id        string
+		directory string
+	}{
+		{id: "nested-trailing", directory: nested + string(os.PathSeparator)},
+		{id: "nested-relative", directory: filepath.Join("nested", "child")},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(fmt.Sprintf(`{"id":%q,"project":"engram","directory":%q}`, tc.id, tc.directory)))
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusCreated {
+				t.Fatalf("create session = %d, want 201: %s", rec.Code, rec.Body.String())
+			}
+
+			session, err := st.GetSession(tc.id)
+			if err != nil {
+				t.Fatalf("get session: %v", err)
+			}
+			if want := projectpkg.RuntimeWorktreeDirectory(root); session.Directory != want {
+				t.Fatalf("stored directory = %q, want worktree root %q", session.Directory, want)
+			}
+		})
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -338,10 +338,16 @@ func TestHandleCreateSessionStoresRuntimeWorktreeDirectory(t *testing.T) {
 	}{
 		{id: "nested-trailing", directory: nested + string(os.PathSeparator)},
 		{id: "nested-relative", directory: filepath.Join("nested", "child")},
+		{id: "omitted-directory"},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(fmt.Sprintf(`{"id":%q,"project":"engram","directory":%q}`, tc.id, tc.directory)))
+			body := fmt.Sprintf(`{"id":%q,"project":"engram"`, tc.id)
+			if tc.directory != "" {
+				body += fmt.Sprintf(`,"directory":%q`, tc.directory)
+			}
+			body += `}`
+			req := httptest.NewRequest(http.MethodPost, "/sessions", strings.NewReader(body))
 			h.ServeHTTP(rec, req)
 			if rec.Code != http.StatusCreated {
 				t.Fatalf("create session = %d, want 201: %s", rec.Code, rec.Body.String())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2338,38 +2338,50 @@ func (s *Store) GetSession(id string) (*Session, error) {
 // share only the SQLite store, so the active session must be read from disk —
 // never from in-memory state.
 //
-// Selection rules:
+// Candidate rules:
 //   - Scope to the (normalized) project.
+//   - Scope to the current runtime directory.
 //   - Require ended_at IS NULL — ended sessions are never returned, so stale
 //     sessions naturally fall out without any explicit clearing step.
 //   - Exclude the manual-save fallback sessions (id LIKE 'manual-save%'); those
 //     are created by the fallback path itself and must not be resolved as "the
 //     active session", which would make resolution circular.
-//   - When multiple un-ended sessions exist, pick the MOST RECENT by
-//     started_at DESC, with id DESC as a deterministic tie-breaker.
-func (s *Store) MostRecentActiveSession(project string) (string, bool, error) {
+//
+// ActiveRuntimeSessions returns active, non-manual sessions for a project and
+// runtime directory. The directory narrows candidates; callers must not treat
+// it as session identity.
+func (s *Store) ActiveRuntimeSessions(project, directory string) ([]string, error) {
 	project, _ = NormalizeProject(project)
-	if project == "" {
-		return "", false, nil
+	if project == "" || directory == "" {
+		return nil, nil
 	}
 
-	var id string
-	err := s.db.QueryRow(`
+	rows, err := s.db.Query(`
 		SELECT id
 		FROM sessions
 		WHERE LOWER(project) = ?
+		  AND directory = ?
 		  AND ended_at IS NULL
 		  AND id NOT LIKE 'manual-save%'
-		ORDER BY datetime(started_at) DESC, id DESC
-		LIMIT 1
-	`, project).Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", false, nil
-	}
+		ORDER BY id
+	`, project, directory)
 	if err != nil {
-		return "", false, err
+		return nil, err
 	}
-	return id, true, nil
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 // A database upgraded from the schema where sessions.project was nullable still

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2348,23 +2348,39 @@ func (s *Store) GetSession(id string) (*Session, error) {
 //     active session", which would make resolution circular.
 //
 // ActiveRuntimeSessions returns active, non-manual sessions for a project and
-// runtime directory. The directory narrows candidates; callers must not treat
-// it as session identity.
-func (s *Store) ActiveRuntimeSessions(project, directory string) ([]string, error) {
+// runtime directories. The directories narrow candidates; callers must not
+// treat them as session identity.
+func (s *Store) ActiveRuntimeSessions(project string, directories ...string) ([]string, error) {
 	project, _ = NormalizeProject(project)
-	if project == "" || directory == "" {
+	if project == "" {
 		return nil, nil
+	}
+	directorySet := make(map[string]struct{}, len(directories))
+	for _, directory := range directories {
+		if directory != "" {
+			directorySet[directory] = struct{}{}
+		}
+	}
+	if len(directorySet) == 0 {
+		return nil, nil
+	}
+	args := make([]any, 0, len(directorySet)+1)
+	args = append(args, project)
+	placeholders := make([]string, 0, len(directorySet))
+	for directory := range directorySet {
+		placeholders = append(placeholders, "?")
+		args = append(args, directory)
 	}
 
 	rows, err := s.db.Query(`
-		SELECT id
+		SELECT DISTINCT id
 		FROM sessions
 		WHERE LOWER(project) = ?
-		  AND directory = ?
+		  AND directory IN (`+strings.Join(placeholders, ", ")+`)
 		  AND ended_at IS NULL
 		  AND id NOT LIKE 'manual-save%'
 		ORDER BY id
-	`, project, directory)
+	`, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2372,7 +2372,7 @@ func (s *Store) ActiveRuntimeSessions(project string, directories ...string) ([]
 		args = append(args, directory)
 	}
 
-	rows, err := s.db.Query(`
+	rows, err := s.queryHook(s.db, `
 		SELECT DISTINCT id
 		FROM sessions
 		WHERE LOWER(project) = ?

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -11737,24 +11737,27 @@ func TestDeleteProjectOrphansMemoryRelations(t *testing.T) {
 	}
 }
 
-func TestMostRecentActiveSessionReturnsUnEndedSession(t *testing.T) {
+func TestActiveRuntimeSessionsReturnsUnendedSession(t *testing.T) {
 	s := newTestStore(t)
 
 	// A hook-registered UUID session, never ended.
 	if err := s.CreateSession("uuid-active-1", "engram", "/work/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-
-	id, ok, err := s.MostRecentActiveSession("engram")
-	if err != nil {
-		t.Fatalf("MostRecentActiveSession: %v", err)
+	if err := s.CreateSession("uuid-other-directory", "engram", "/work/other"); err != nil {
+		t.Fatalf("create session in other directory: %v", err)
 	}
-	if !ok || id != "uuid-active-1" {
-		t.Fatalf("expected active session uuid-active-1, got id=%q ok=%v", id, ok)
+
+	ids, err := s.ActiveRuntimeSessions("engram", "/work/engram")
+	if err != nil {
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "uuid-active-1" {
+		t.Fatalf("expected active session uuid-active-1, got %#v", ids)
 	}
 }
 
-func TestMostRecentActiveSessionSkipsEndedSessions(t *testing.T) {
+func TestActiveRuntimeSessionsSkipsEndedSessions(t *testing.T) {
 	s := newTestStore(t)
 
 	if err := s.CreateSession("uuid-ended-1", "engram", "/work/engram"); err != nil {
@@ -11764,54 +11767,48 @@ func TestMostRecentActiveSessionSkipsEndedSessions(t *testing.T) {
 		t.Fatalf("end session: %v", err)
 	}
 
-	_, ok, err := s.MostRecentActiveSession("engram")
+	ids, err := s.ActiveRuntimeSessions("engram", "/work/engram")
 	if err != nil {
-		t.Fatalf("MostRecentActiveSession: %v", err)
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
 	}
-	if ok {
-		t.Fatalf("expected no active session when the only session is ended, got ok=%v", ok)
+	if len(ids) != 0 {
+		t.Fatalf("expected no active sessions when the only session is ended, got %#v", ids)
 	}
 }
 
-func TestMostRecentActiveSessionNoSessionsReturnsFalse(t *testing.T) {
+func TestActiveRuntimeSessionsNoSessionsReturnsEmpty(t *testing.T) {
 	s := newTestStore(t)
 
-	_, ok, err := s.MostRecentActiveSession("engram")
+	ids, err := s.ActiveRuntimeSessions("engram", "/work/engram")
 	if err != nil {
-		t.Fatalf("MostRecentActiveSession: %v", err)
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
 	}
-	if ok {
-		t.Fatalf("expected ok=false for a project with no sessions, got ok=%v", ok)
+	if len(ids) != 0 {
+		t.Fatalf("expected no sessions, got %#v", ids)
 	}
 }
 
-func TestMostRecentActiveSessionPicksMostRecentWhenMultipleActive(t *testing.T) {
+func TestActiveRuntimeSessionsReturnsAllMatchingActiveSessions(t *testing.T) {
 	s := newTestStore(t)
 
-	// Two un-ended UUID sessions for the same project; the newer started_at wins.
+	// Two un-ended UUID sessions for the same project and directory are ambiguous.
 	if err := s.CreateSession("uuid-old", "engram", "/work/engram"); err != nil {
 		t.Fatalf("create old session: %v", err)
-	}
-	if _, err := s.db.Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, "2025-01-01 00:00:00", "uuid-old"); err != nil {
-		t.Fatalf("backdate old session: %v", err)
 	}
 	if err := s.CreateSession("uuid-new", "engram", "/work/engram"); err != nil {
 		t.Fatalf("create new session: %v", err)
 	}
-	if _, err := s.db.Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, "2025-06-01 00:00:00", "uuid-new"); err != nil {
-		t.Fatalf("set new session started_at: %v", err)
-	}
 
-	id, ok, err := s.MostRecentActiveSession("engram")
+	ids, err := s.ActiveRuntimeSessions("engram", "/work/engram")
 	if err != nil {
-		t.Fatalf("MostRecentActiveSession: %v", err)
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
 	}
-	if !ok || id != "uuid-new" {
-		t.Fatalf("expected most recent active session uuid-new, got id=%q ok=%v", id, ok)
+	if !reflect.DeepEqual(ids, []string{"uuid-new", "uuid-old"}) {
+		t.Fatalf("expected both matching active sessions, got %#v", ids)
 	}
 }
 
-func TestMostRecentActiveSessionIgnoresManualSaveSessions(t *testing.T) {
+func TestActiveRuntimeSessionsIgnoresManualSaveSessions(t *testing.T) {
 	s := newTestStore(t)
 
 	// The manual-save fallback session is also un-ended, but it must NOT be
@@ -11820,28 +11817,28 @@ func TestMostRecentActiveSessionIgnoresManualSaveSessions(t *testing.T) {
 		t.Fatalf("create manual-save session: %v", err)
 	}
 
-	_, ok, err := s.MostRecentActiveSession("engram")
+	ids, err := s.ActiveRuntimeSessions("engram", "/work/engram")
 	if err != nil {
-		t.Fatalf("MostRecentActiveSession: %v", err)
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
 	}
-	if ok {
-		t.Fatalf("expected manual-save session to be ignored, got ok=%v", ok)
+	if len(ids) != 0 {
+		t.Fatalf("expected manual-save session to be ignored, got %#v", ids)
 	}
 }
 
-func TestMostRecentActiveSessionScopedByProject(t *testing.T) {
+func TestActiveRuntimeSessionsScopedByProjectAndDirectory(t *testing.T) {
 	s := newTestStore(t)
 
 	if err := s.CreateSession("uuid-other-proj", "other", "/work/other"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
 
-	_, ok, err := s.MostRecentActiveSession("engram")
+	ids, err := s.ActiveRuntimeSessions("engram", "/work/engram")
 	if err != nil {
-		t.Fatalf("MostRecentActiveSession: %v", err)
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
 	}
-	if ok {
-		t.Fatalf("expected no active session for engram when only 'other' has one, got ok=%v", ok)
+	if len(ids) != 0 {
+		t.Fatalf("expected no active session for engram in the requested directory, got %#v", ids)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -11842,6 +11842,46 @@ func TestActiveRuntimeSessionsScopedByProjectAndDirectory(t *testing.T) {
 	}
 }
 
+func TestActiveRuntimeSessionsReturnsNoResultsForEmptyProject(t *testing.T) {
+	s := newTestStore(t)
+
+	ids, err := s.ActiveRuntimeSessions("", "/work/engram")
+	if err != nil {
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
+	}
+	if ids != nil {
+		t.Fatalf("empty project IDs = %#v, want nil", ids)
+	}
+}
+
+func TestActiveRuntimeSessionsReturnsNoResultsForEmptyDirectory(t *testing.T) {
+	s := newTestStore(t)
+
+	ids, err := s.ActiveRuntimeSessions("engram", "")
+	if err != nil {
+		t.Fatalf("ActiveRuntimeSessions: %v", err)
+	}
+	if ids != nil {
+		t.Fatalf("empty directory IDs = %#v, want nil", ids)
+	}
+}
+
+func TestActiveRuntimeSessionsReturnsQueryError(t *testing.T) {
+	s := newTestStore(t)
+	wantErr := errors.New("query failed")
+	s.hooks.query = func(queryer, string, ...any) (*sql.Rows, error) {
+		return nil, wantErr
+	}
+
+	ids, err := s.ActiveRuntimeSessions("engram", "/work/engram")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ActiveRuntimeSessions error = %v, want %v", err, wantErr)
+	}
+	if ids != nil {
+		t.Fatalf("query error IDs = %#v, want nil", ids)
+	}
+}
+
 // ─── match_mode tests (issue #352) ──────────────────────────────────────────
 
 // seedMatchModeFixture creates a session and three observations with partial


### PR DESCRIPTION
## Linked Issue

Closes #660

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Replace project-wide recency fallback with deterministic project and runtime-worktree selection.
- Use the same canonical actual Git worktree root when registering sessions through MCP or HTTP and resolving omitted `session_id` writes.
- Keep explicit session IDs authoritative, use `manual-save-{project}` when no candidate matches, and reject ambiguity instead of selecting by recency.

## Changes

| File | Change |
|------|--------|
| `internal/project/detect.go` | Add a dedicated runtime worktree identity that preserves linked-worktree boundaries, resolves filesystem aliases when available, and folds path case only on Windows. |
| `internal/project/detect_test.go` | Cover linked-worktree isolation and Windows-equivalent root casing. |
| `internal/store/store.go` | Enumerate active non-manual runtime sessions for an exact normalized project and directory key. |
| `internal/store/store_test.go` | Cover candidate filtering, ambiguity inputs, and deterministic enumeration. |
| `internal/mcp/mcp.go` | Register and query sessions with the same canonical worktree root and apply zero/one/many fallback semantics across attributed write tools. |
| `internal/mcp/mcp_test.go` | Cover unique, absent, ambiguous, nested, relative, explicit-directory, and sibling-worktree behavior. |
| `internal/server/server.go` | Canonicalize `POST /sessions` directory values through the shared runtime worktree detector before persistence. |
| `internal/server/server_test.go` | Cover nested, trailing-separator, relative, and omitted-directory HTTP runtime registration. |
| `DOCS.md` | Document omitted-ID selection, manual fallback, and ambiguity rejection. |

## Test Plan

- [x] Focused runtime-root tests: `go test ./internal/project -run '^(TestRuntimeWorktreeDirectoryKeepsLinkedWorktreesDistinct|TestRuntimeWorktreeDirectoryNormalizesCaseOnWindows)$'`
- [x] Focused MCP root-binding regressions for nested, relative, explicit, and sibling-worktree sessions.
- [x] Focused Store edge/error coverage: `go test ./internal/store -run '^TestActiveRuntimeSessions' -count=1`
- [x] Focused project fallback coverage: `go test ./internal/project -run '^TestRuntimeWorktreeDirectory' -count=1`
- [x] Focused HTTP registration coverage, including omitted `directory`: `go test ./internal/server -run '^TestHandleCreateSessionStoresRuntimeWorktreeDirectory$' -count=1`
- [x] Final-head affected packages passed: `internal/project`, `internal/store`, `internal/server`, and `internal/mcp`.
- [x] Final-head affected packages passed during `go test -count=1 ./...`; the only Windows environment failure was `internal/setup` with `sh` absent from `PATH`, and that exact test passed with the installed Git Bash path.
- [x] `git diff --check`
- [x] GitHub checks for final head
- [x] CodeRabbit review for final head

## Compatibility and Non-goals

- This PR intentionally does not add a database migration, legacy-session backfill, sync payload versioning, or project-wide legacy-directory scan.
- A runtime session left active by a pre-upgrade binary under a nested raw directory may require an explicit `session_id` until a current session is registered or the old session is ended.
- Broad legacy matching is intentionally avoided because old directory strings do not reliably prove linked-worktree ownership and could reintroduce cross-worktree attribution.

## Contributor Checklist

- [x] Linked approved issue: `Closes #660`
- [x] Exactly one `type:*` label: `type:bug`
- [x] Relevant focused and full tests pass
- [x] Documentation matches behavior
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

## Notes for Reviewers

- Final head: `f9f8d1f6204c97accd112e494bf9d947f9a11f37`
- The root-only follow-up canonicalizes the remaining HTTP runtime-registration ingress and adds focused edge/error coverage.
- No store schema, migration, sync/import, or server compatibility machinery was added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic session selection for memory saves and session-related actions.
  * Sessions now consistently recognize repository worktrees, including nested directories and linked worktrees.
  * Omitted session IDs use the matching active runtime session when exactly one exists.

* **Bug Fixes**
  * Ambiguous active sessions are rejected instead of selected by recency.
  * Saves fall back safely to the manual-save session when no matching runtime session exists.

* **Documentation**
  * Updated tool guidance to describe session-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->