### PR TITLE
fix(store): detect and reject stale WAL/SHM generation on critical writes

### DIFF
--- a/internal/store/generation.go
+++ b/internal/store/generation.go
@@ -1,0 +1,125 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// ErrDBGenerationReplaced is returned when the live SQLite generation this
+// Store opened no longer matches the database files on disk. Per the #571
+// maintainer direction, the store keeps the single-connection design and never
+// reopens transparently: callers must surface this error loudly and restart
+// the process. It covers both halves of the #477 failure mode:
+//
+//   - the database file at dbPath was replaced or removed (prevented before
+//     any critical write commits into a dead generation), or
+//   - a committed row is invisible to a fresh independent connection
+//     (detected after commit, instead of silently acknowledging a write that
+//     a future process will never see).
+var ErrDBGenerationReplaced = errors.New("database generation was replaced under the running Engram process: restart Engram to reopen the current database")
+
+// openVerifyDB is the seam for the fresh independent verification connection.
+// Production uses sql.Open so every verification actually opens the database
+// files as they exist on disk right now.
+var openVerifyDB = sql.Open
+
+// checkGeneration is the deterministic prevention gate for critical writes:
+// it refuses to write when the database file at dbPath is no longer the
+// generation this Store opened. It uses os.SameFile, so it works wherever a
+// stable file identity exists and silently passes elsewhere (windows paths
+// without identity still get post-commit verification).
+func (s *Store) checkGeneration() error {
+	if s.dbPath == "" || s.dbIdent == nil {
+		return nil
+	}
+	st, err := os.Stat(s.dbPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%w: database file %s was removed", ErrDBGenerationReplaced, s.dbPath)
+		}
+		return err
+	}
+	if !os.SameFile(s.dbIdent, st) {
+		return fmt.Errorf("%w: database file %s was replaced", ErrDBGenerationReplaced, s.dbPath)
+	}
+	return nil
+}
+
+// verifyVisible is the post-commit detection gate for critical writes: it
+// confirms the just-committed row is observable from a fresh independent
+// connection. A fresh open of the current generation always sees committed
+// WAL data, so an invisible row or a missing schema means the live connection
+// is operating on a divergent generation (#477) and the write must not be
+// acknowledged.
+func (s *Store) verifyVisible(query string, args ...any) error {
+	if s.dbPath == "" {
+		return nil
+	}
+	vdb, err := openVerifyDB("sqlite", s.dbPath)
+	if err != nil {
+		return err
+	}
+	defer vdb.Close()
+	vdb.SetMaxOpenConns(1)
+	if _, err := vdb.Exec("PRAGMA busy_timeout = 5000"); err != nil {
+		return err
+	}
+
+	var one int
+	err = vdb.QueryRow(query, args...).Scan(&one)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, sql.ErrNoRows):
+		return fmt.Errorf("%w: committed row is invisible to a fresh connection", ErrDBGenerationReplaced)
+	case isNoSuchTableError(err):
+		return fmt.Errorf("%w: schema is missing from a fresh connection", ErrDBGenerationReplaced)
+	case isSQLiteIOErr(err):
+		// The live connection just committed successfully, so failing media
+		// would have surfaced there. A fresh reader hitting an I/O error while
+		// the live connection succeeds is the divergent-generation pattern
+		// (#477): a stale WAL-index that only a restart can clear.
+		return fmt.Errorf("%w: a fresh connection cannot read the current generation (%v)", ErrDBGenerationReplaced, err)
+	default:
+		return err
+	}
+}
+
+// isNoSuchTableError reports whether err is SQLite's "no such table" error,
+// which is how a fresh open of a replaced, unmigrated generation surfaces.
+func isNoSuchTableError(err error) bool {
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == 1 { // SQLITE_ERROR
+		return strings.Contains(err.Error(), "no such table")
+	}
+	return false
+}
+
+// isSQLiteIOErr reports whether err is an SQLite I/O-class error. A live
+// single connection whose WAL/SHM generation was replaced often surfaces
+// these (disk I/O error, short read) instead of failing politely.
+func isSQLiteIOErr(err error) bool {
+	var sqliteErr *sqlite.Error
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == 10 // SQLITE_IOERR class
+}
+
+// classifyWriteErr turns I/O-class transaction failures on critical writes
+// into ErrDBGenerationReplaced when the evidence says the live connection is
+// the stale party: a fresh independent connection can still read the current
+// generation while the live one cannot. If the fresh connection is also
+// failing, the error is a real disk problem and is returned untouched, so
+// genuine hardware failures never get restart guidance.
+func (s *Store) classifyWriteErr(err error) error {
+	if err == nil || !isSQLiteIOErr(err) {
+		return err
+	}
+	if probe := s.verifyVisible(`SELECT 1 FROM sqlite_master LIMIT 1`); probe == nil {
+		return fmt.Errorf("%w: live connection failed (%v) while a fresh connection reads the current generation", ErrDBGenerationReplaced, err)
+	}
+	return err
+}

--- a/internal/store/generation_test.go
+++ b/internal/store/generation_test.go
@@ -1,0 +1,152 @@
+package store // generation guards: prevention via file identity, detection via fresh connections (#477/#571)
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// replaceDBFile simulates an external actor replacing the live database file
+// with a fresh generation at the same path.
+func replaceDBFile(t *testing.T, dbPath string) {
+	t.Helper()
+	tmp := dbPath + ".replacement"
+	if err := os.WriteFile(tmp, nil, 0o644); err != nil {
+		t.Fatalf("write replacement file: %v", err)
+	}
+	if err := os.Rename(tmp, dbPath); err != nil {
+		t.Fatalf("rename replacement over live db: %v", err)
+	}
+}
+
+func requireUnixFileIdentity(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("file identity check is unix-only; post-commit verification still runs on windows")
+	}
+}
+
+// TestCheckGeneration_RejectsCriticalWritesAfterDBFileReplaced proves the
+// deterministic prevention gate: once the database file at dbPath is a
+// different generation than the one this Store opened, critical writes fail
+// loudly instead of writing into a dead generation (#477 silent write loss).
+func TestCheckGeneration_RejectsCriticalWritesAfterDBFileReplaced(t *testing.T) {
+	requireUnixFileIdentity(t)
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session on healthy store: %v", err)
+	}
+
+	replaceDBFile(t, s.dbPath)
+
+	err := s.CreateSession("s2", "engram", "/tmp/engram")
+	if !errors.Is(err, ErrDBGenerationReplaced) {
+		t.Fatalf("CreateSession after replacement: got %v, want ErrDBGenerationReplaced", err)
+	}
+
+	_, err = s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "bugfix",
+		Title:     "Lost write",
+		Content:   "This write must be rejected, not silently lost",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if !errors.Is(err, ErrDBGenerationReplaced) {
+		t.Fatalf("AddObservation after replacement: got %v, want ErrDBGenerationReplaced", err)
+	}
+}
+
+// TestCriticalWrites_VerifyFreshConnectionNoFalsePositive proves the healthy
+// path: with verification active, committed rows are visible to a fresh
+// independent connection and every critical write still succeeds.
+func TestCriticalWrites_VerifyFreshConnectionNoFalsePositive(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "session_summary",
+		Title:     "Session",
+		Content:   "Summary committed while the WAL is live",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("observation id must be set")
+	}
+}
+
+// TestVerifyVisible_MapsMissingTableToGenerationReplaced proves a replaced
+// generation without schema (empty file) surfaces as ErrDBGenerationReplaced,
+// not as a raw sqlite error (#571 loud failure contract).
+func TestVerifyVisible_MapsMissingTableToGenerationReplaced(t *testing.T) {
+	s := newTestStore(t)
+
+	// Point verification at a fresh empty file: same situation as an external
+	// replacement with a new, unmigrated generation.
+	empty := filepath.Join(t.TempDir(), "empty.db")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatalf("write empty db: %v", err)
+	}
+	saved := s.dbPath
+	s.dbPath = empty
+	t.Cleanup(func() { s.dbPath = saved })
+
+	err := s.verifyVisible(`SELECT 1 FROM observations WHERE id = ?`, int64(1))
+	if !errors.Is(err, ErrDBGenerationReplaced) {
+		t.Fatalf("verifyVisible against schemaless generation: got %v, want ErrDBGenerationReplaced", err)
+	}
+}
+
+// TestAddObservation_DetectsInvisibleCommitAfterWALReplaced reproduces the
+// #477 failure mode deterministically: the db file identity is unchanged, the
+// write commits on the live connection, but the committed row is invisible to
+// a fresh connection because the WAL generation was replaced underneath. The
+// store must fail loudly with restart guidance instead of acknowledging the
+// write.
+func TestAddObservation_DetectsInvisibleCommitAfterWALReplaced(t *testing.T) {
+	requireUnixFileIdentity(t)
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "bugfix",
+		Title:     "Anchor",
+		Content:   "Keeps the WAL uncheckpointed",
+		Project:   "engram",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("anchor observation: %v", err)
+	}
+
+	// External actor walks away with the live WAL: the db file identity is
+	// unchanged, so only post-commit verification can catch this.
+	walPath := s.dbPath + "-wal"
+	if err := os.Rename(walPath, walPath+".gone"); err != nil {
+		t.Fatalf("rename wal away: %v", err)
+	}
+
+	_, err := s.AddObservation(AddObservationParams{
+		SessionID: "s1",
+		Type:      "session_summary",
+		Title:     "Would be lost",
+		Content:   "Committed on the live connection, invisible to fresh readers",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if !errors.Is(err, ErrDBGenerationReplaced) {
+		t.Fatalf("AddObservation after WAL replacement: got %v, want ErrDBGenerationReplaced", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -541,9 +541,11 @@ func (s *Store) MaxObservationLength() int {
 // ─── Store ───────────────────────────────────────────────────────────────────
 
 type Store struct {
-	db    *sql.DB
-	cfg   Config
-	hooks storeHooks
+	db      *sql.DB
+	dbPath  string
+	dbIdent os.FileInfo
+	cfg     Config
+	hooks   storeHooks
 
 	repairMu        sync.Mutex
 	repairDone      bool
@@ -727,7 +729,10 @@ func New(cfg Config) (*Store, error) {
 		}
 	}
 
-	s := &Store{db: db, cfg: cfg, hooks: defaultStoreHooks()}
+	s := &Store{db: db, cfg: cfg, hooks: defaultStoreHooks(), dbPath: dbPath}
+	if st, err := os.Stat(dbPath); err == nil {
+		s.dbIdent = st
+	}
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("engram: migration: %w", err)
 	}
@@ -765,7 +770,10 @@ func newWithoutRepair(cfg Config) (*Store, error) {
 		}
 	}
 
-	s := &Store{db: db, cfg: cfg, hooks: defaultStoreHooks()}
+	s := &Store{db: db, cfg: cfg, hooks: defaultStoreHooks(), dbPath: dbPath}
+	if st, err := os.Stat(dbPath); err == nil {
+		s.dbIdent = st
+	}
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("engram: migration: %w", err)
 	}
@@ -2244,13 +2252,17 @@ func (s *Store) CreateSession(id, project, directory string) error {
 	if err := validateSessionID(id); err != nil {
 		return err
 	}
+	// Deterministic prevention gate (#571): refuse to write into a dead generation.
+	if err := s.checkGeneration(); err != nil {
+		return err
+	}
 	// Normalize project name before storing
 	project, _ = NormalizeProject(project)
 	if strings.TrimSpace(project) == "" {
 		return ErrProjectRequired
 	}
 
-	return s.withTx(func(tx *sql.Tx) error {
+	err := s.withTx(func(tx *sql.Tx) error {
 		if err := s.createSessionTx(tx, id, project, directory); err != nil {
 			return err
 		}
@@ -2272,6 +2284,12 @@ func (s *Store) CreateSession(id, project, directory string) error {
 			Summary:   persisted.Summary,
 		})
 	})
+	if err != nil {
+		return s.classifyWriteErr(err)
+	}
+	// Post-commit detection gate (#477): never acknowledge a write a fresh
+	// independent connection cannot observe.
+	return s.verifyVisible(`SELECT 1 FROM sessions WHERE id = ?`, id)
 }
 
 func (s *Store) EndSession(id string, summary string) error {
@@ -2527,6 +2545,10 @@ func ValidateObservationTitle(title string) error {
 }
 
 func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
+	// Deterministic prevention gate (#571): refuse to write into a dead generation.
+	if err := s.checkGeneration(); err != nil {
+		return 0, err
+	}
 	// Normalize project name (lowercase + trim) before any persistence
 	p.Project, _ = NormalizeProject(p.Project)
 
@@ -2682,6 +2704,11 @@ func (s *Store) AddObservation(p AddObservationParams) (int64, error) {
 		return s.enqueueSyncMutationTx(tx, SyncEntityObservation, obs.SyncID, SyncOpUpsert, observationPayloadFromObservation(obs))
 	})
 	if err != nil {
+		return 0, s.classifyWriteErr(err)
+	}
+	// Post-commit detection gate (#477): never acknowledge a write a fresh
+	// independent connection cannot observe.
+	if err := s.verifyVisible(`SELECT 1 FROM observations WHERE id = ?`, observationID); err != nil {
 		return 0, err
 	}
 	return observationID, nil


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #477

Direction coordinated in #571 (maintainer direction recorded there: keep the single-connection design, deterministic prevention and detection, fail loudly with restart guidance, no transparent reopen).

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

---

## 📝 Summary

- Adds deterministic generation guards to the Store so an external replacement of the live database or WAL/SHM generation can no longer cause silent write loss (#477) or a zombie daemon that only fails with raw `SQLITE_BUSY`/`disk I/O error` surfaces (#571).
- Fails loudly with a typed `ErrDBGenerationReplaced` carrying restart guidance, per the #571 maintainer direction. No transparent reopen, no retry loop.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/generation.go` | New: `ErrDBGenerationReplaced` sentinel, `checkGeneration` prevention gate (file identity via `os.SameFile`), `verifyVisible` post-commit detection gate (fresh independent connection), `classifyWriteErr` (live-conn I/O error + healthy fresh reader = divergent generation) |
| `internal/store/store.go` | Store captures `dbPath`/`dbIdent` at open; `CreateSession` and `AddObservation` get the prevention gate before the tx and the detection gate after commit |
| `internal/store/generation_test.go` | Deterministic tests: replaced db file rejected pre-write; WAL replacement after commit detected post-commit; schemaless generation mapped to the typed error; healthy-store no-false-positive path |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Deterministic reproduction of the #477 failure mode (no forensic multi-day uptime needed): with the WAL renamed away, the live single connection still acknowledges the write (proven in tests), while a fresh connection cannot see it; the detection gate converts that into `ErrDBGenerationReplaced` instead of a silently lost write. Package coverage: `internal/store` 78.6% of statements.

---

## Design notes (bounded per #571 direction)

- **Prevention** (`checkGeneration`): refuses critical writes when the database file at `dbPath` is no longer the generation the Store opened (`os.SameFile`, stdlib-only, works wherever a stable file identity exists; passes elsewhere so Windows never gets false positives, while still keeping post-commit verification).
- **Detection** (`verifyVisible`): after a critical write commits, the row must be observable from a fresh independent connection. ErrNoRows, missing schema, or a fresh-reader I/O error after a successful live commit all map to `ErrDBGenerationReplaced`.
- **Honest classification** (`classifyWriteErr`): a live-connection I/O-class failure maps to the typed error only when a fresh connection reads the current generation healthy; genuine media failures stay raw so restart guidance is never misleading.
- `fsnotify` stays an indirect dependency: no new dependencies, no watcher, no reopen.
- DB-aware health behavior stays out of scope as its own follow-up, per the direction.

## 📋 Contributor Checklist

- [x] Linked an approved issue (#477 has `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Ran unit tests locally
- [x] Ran e2e tests locally
- [x] Docs updated if behavior changed (no user-facing behavior change beyond the new error surface)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against database file replacement or removal during critical writes.
  * Prevented successful reports when committed data cannot be seen by fresh database connections.
  * Preserved genuine disk errors while providing a clear restart-required error for replaced database generations.

* **Reliability**
  * Added safeguards to reduce data consistency issues during database replacement and WAL-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->