### PR TITLE
fix(sync): repair observation mutation titles

### DIFF
--- a/cmd/engram/doctor.go
+++ b/cmd/engram/doctor.go
@@ -162,12 +162,33 @@ func cmdDoctorRepair(cfg store.Config) {
 	}
 	defer s.Close()
 	if check == diagnostic.CheckSyncMutationRequiredFields {
+		repairs, err := s.RepairObservationMutationTitles(project, mode == diagnostic.RepairModeApply)
+		if err != nil {
+			failDoctorRepair(err.Error())
+			return
+		}
 		report, err := s.QuarantineIrreparableSyncMutations(project, mode == diagnostic.RepairModeApply)
 		if err != nil {
 			failDoctorRepair(err.Error())
 			return
 		}
-		writeDoctorRepairJSON(report)
+		if mode != diagnostic.RepairModeApply && len(repairs.Actions) > 0 {
+			repairSeqs := make(map[int64]struct{}, len(repairs.Actions))
+			for _, action := range repairs.Actions {
+				repairSeqs[action.Seq] = struct{}{}
+			}
+			remaining := report.Actions[:0]
+			for _, action := range report.Actions {
+				if _, repaired := repairSeqs[action.Seq]; !repaired {
+					remaining = append(remaining, action)
+				}
+			}
+			report.Actions = remaining
+		}
+		writeDoctorRepairJSON(struct {
+			store.SyncMutationQuarantineReport
+			Repairs []store.SyncMutationTitleRepairAction `json:"repairs"`
+		}{report, repairs.Actions})
 		return
 	}
 

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -511,6 +511,33 @@ func TestCmdDoctorRepairRepairsTitleOnlyObservationMutation(t *testing.T) {
 	if err := s.Close(); err != nil {
 		t.Fatalf("close store: %v", err)
 	}
+	withArgs(t, "engram", "doctor", "repair", "--project", "engram", "--check", "sync_mutation_required_fields", "--plan")
+	planOut, planErr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if planErr != "" {
+		t.Fatalf("plan stderr=%q", planErr)
+	}
+	plan := decodeRepairPlan(t, planOut)
+	repairs := plan["repairs"].([]any)
+	if plan["applied"] != false || len(repairs) != 1 {
+		t.Fatalf("plan=%v", plan)
+	}
+	repairedSeq := repairs[0].(map[string]any)["seq"]
+	for _, action := range plan["actions"].([]any) {
+		if action.(map[string]any)["seq"] == repairedSeq {
+			t.Fatalf("repaired sequence %v remained in residual actions: %v", repairedSeq, plan)
+		}
+	}
+	s, err = store.New(cfg)
+	if err != nil {
+		t.Fatalf("reopen store after plan: %v", err)
+	}
+	planned, err := s.GetObservation(id)
+	if err != nil || planned.Title != "" {
+		t.Fatalf("plan mutated observation=%+v err=%v", planned, err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store after plan: %v", err)
+	}
 	withArgs(t, "engram", "doctor", "repair", "--project", "engram", "--check", "sync_mutation_required_fields", "--apply")
 	out, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
 	if stderr != "" {

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -485,6 +485,52 @@ func TestCmdDoctorRepairQuarantinesOnlyIrreparableMutations(t *testing.T) {
 	}
 }
 
+func TestCmdDoctorRepairRepairsTitleOnlyObservationMutation(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	if err := s.CreateSession("title-repair", "engram", "/work/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	id, err := s.AddObservation(store.AddObservationParams{SessionID: "title-repair", Type: "bugfix", Title: "valid", Content: "Recovered title. More detail.", Project: "engram", Scope: "project"})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	obs, err := s.GetObservation(id)
+	if err != nil {
+		t.Fatalf("get observation: %v", err)
+	}
+	if _, err := s.DB().Exec(`UPDATE observations SET title = '' WHERE id = ?`, id); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	if _, err := s.DB().Exec(`UPDATE sync_mutations SET payload = json_set(payload, '$.title', '') WHERE entity = ? AND entity_key = ?`, store.SyncEntityObservation, obs.SyncID); err != nil {
+		t.Fatalf("seed mutation: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	withArgs(t, "engram", "doctor", "repair", "--project", "engram", "--check", "sync_mutation_required_fields", "--apply")
+	out, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+	report := decodeRepairPlan(t, out)
+	if report["applied"] != true || len(report["repairs"].([]any)) != 1 {
+		t.Fatalf("report=%v", report)
+	}
+	s, err = store.New(cfg)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer s.Close()
+	updated, err := s.GetObservation(id)
+	if err != nil || updated.Title != "Recovered title." {
+		t.Fatalf("updated=%+v err=%v", updated, err)
+	}
+}
+
 func TestCmdDoctorRepairApplyUnblocksDoctorAndKeepsPendingWork(t *testing.T) {
 	cfg := testConfig(t)
 	s, err := store.New(cfg)

--- a/docs/DOCTOR.md
+++ b/docs/DOCTOR.md
@@ -69,17 +69,20 @@ The CLI `--json` and MCP tool return:
 
 Plain `engram doctor` remains diagnostic-only. Findings that imply data movement set `requires_confirmation=true` so agents know a human must review evidence before repair.
 
-`engram doctor repair` is intentionally narrow and local-first: local SQLite remains the source of truth. It supports project reclassification for:
+`engram doctor repair` is intentionally narrow and local-first: local SQLite remains the source of truth. Project reclassification supports:
 
 - `session_project_directory_mismatch`, using trusted `git_remote` or `git_root` evidence from doctor findings.
 - `manual_session_name_project_mismatch`, only for exact `manual-save-{known_project}` sessions, and only when trusted directory evidence does not contradict the manual-name target.
-- `sync_mutation_required_fields`, only when a pending observation upsert has a blank title as its sole missing field and the matching local titleless observation has non-empty content. Repair derives a sanitized, bounded title from that local content and rewrites the existing payload in place; all other invalid mutations remain quarantined on `--apply`.
+
+Title restoration supports `sync_mutation_required_fields` only when a pending observation upsert has a blank title as its sole missing field and the matching local titleless observation has non-empty content. It derives a sanitized, bounded title from that local content and updates `observations.title` and `sync_mutations.payload` in place; all other invalid mutations remain quarantined on `--apply`.
 
 Repair never deletes or deduplicates rows, never edits sync cursors, and never writes cloud state. `--plan` and `--dry-run` are non-mutating. `--apply` creates a SQLite backup under `<ENGRAM_DATA_DIR>/backups/` before a project reclassification transaction updates only:
 
 - `sessions.project`
 - `observations.project`
 - `user_prompts.project`
+
+Title restoration does not create a SQLite backup.
 
 ### Repair JSON envelope
 
@@ -130,4 +133,4 @@ ENGRAM_DATA_DIR=/tmp/engram-repair-clone engram doctor repair --project sias-app
 ENGRAM_DATA_DIR=/tmp/engram-repair-clone engram doctor repair --project sias-app --check session_project_directory_mismatch --apply
 ```
 
-After apply, verify that only the three allowed project columns changed for the planned session IDs and that a backup exists. If the repair is wrong, stop Engram processes and restore the `backup_path` database file manually.
+After a project reclassification apply, verify that only the three allowed project columns changed for the planned session IDs and that a backup exists. If the repair is wrong, stop Engram processes and restore the `backup_path` database file manually.

--- a/docs/DOCTOR.md
+++ b/docs/DOCTOR.md
@@ -69,12 +69,13 @@ The CLI `--json` and MCP tool return:
 
 Plain `engram doctor` remains diagnostic-only. Findings that imply data movement set `requires_confirmation=true` so agents know a human must review evidence before repair.
 
-`engram doctor repair` is intentionally narrow and local-first: local SQLite remains the source of truth, and cloud/sync repair is out of scope. The repair MVP only supports project reclassification for:
+`engram doctor repair` is intentionally narrow and local-first: local SQLite remains the source of truth. It supports project reclassification for:
 
 - `session_project_directory_mismatch`, using trusted `git_remote` or `git_root` evidence from doctor findings.
 - `manual_session_name_project_mismatch`, only for exact `manual-save-{known_project}` sessions, and only when trusted directory evidence does not contradict the manual-name target.
+- `sync_mutation_required_fields`, only when a pending observation upsert has a blank title as its sole missing field and the matching local titleless observation has non-empty content. Repair derives a sanitized, bounded title from that local content and rewrites the existing payload in place; all other invalid mutations remain quarantined on `--apply`.
 
-Repair never deletes or deduplicates rows, never edits sync cursors, never mutates `sync_state`/`sync_mutations`, and never writes cloud state. `--plan` and `--dry-run` are non-mutating. `--apply` creates a SQLite backup under `<ENGRAM_DATA_DIR>/backups/` before a transaction updates only:
+Repair never deletes or deduplicates rows, never edits sync cursors, and never writes cloud state. `--plan` and `--dry-run` are non-mutating. `--apply` creates a SQLite backup under `<ENGRAM_DATA_DIR>/backups/` before a project reclassification transaction updates only:
 
 - `sessions.project`
 - `observations.project`
@@ -83,6 +84,8 @@ Repair never deletes or deduplicates rows, never edits sync cursors, never mutat
 ### Repair JSON envelope
 
 All repair modes print stable JSON to stdout:
+
+For `sync_mutation_required_fields`, `repairs` lists title-only observation upserts that can be restored in place; `actions` continues to list residual rows quarantined on `--apply`.
 
 ```json
 {

--- a/internal/store/diagnostic.go
+++ b/internal/store/diagnostic.go
@@ -448,6 +448,7 @@ func (s *Store) RepairObservationMutationTitles(project string, apply bool) (Syn
 	project, _ = NormalizeProject(project)
 	project = strings.TrimSpace(project)
 	report := SyncMutationTitleRepairReport{Project: project, Applied: apply, Actions: []SyncMutationTitleRepairAction{}}
+	var actions []SyncMutationTitleRepairAction
 	err := s.withTx(func(tx *sql.Tx) error {
 		type titleRepair struct {
 			action        SyncMutationTitleRepairAction
@@ -455,6 +456,7 @@ func (s *Store) RepairObservationMutationTitles(project string, apply bool) (Syn
 			observationID int64
 			sourceTitle   string
 		}
+		attemptActions := make([]SyncMutationTitleRepairAction, 0)
 		repairs := make([]titleRepair, 0)
 		query := `SELECT seq, target_key, entity, entity_key, op, payload, source, project, occurred_at, acked_at
 			FROM sync_mutations WHERE target_key = ? AND acked_at IS NULL AND disposition = 'pending'`
@@ -480,13 +482,14 @@ func (s *Store) RepairObservationMutationTitles(project string, apply bool) (Syn
 			if !ok {
 				continue
 			}
-			report.Actions = append(report.Actions, action)
+			attemptActions = append(attemptActions, action)
 			repairs = append(repairs, titleRepair{action, payload, observationID, sourceTitle})
 		}
 		if err := closeRowsWithError(rows, rows.Err()); err != nil {
 			return err
 		}
 		if !apply {
+			actions = attemptActions
 			return nil
 		}
 		repairedObservations := make(map[int64]struct{})
@@ -512,11 +515,13 @@ func (s *Store) RepairObservationMutationTitles(project string, apply bool) (Syn
 				return fmt.Errorf("repair observation title mutation %d", repair.action.Seq)
 			}
 		}
+		actions = attemptActions
 		return nil
 	})
 	if err != nil {
 		return SyncMutationTitleRepairReport{}, fmt.Errorf("repair observation mutation titles: %w", err)
 	}
+	report.Actions = actions
 	return report, nil
 }
 
@@ -535,7 +540,7 @@ func (s *Store) observationMutationTitleRepairTx(tx *sql.Tx, mutation SyncMutati
 		return strings.TrimSpace(value)
 	}
 	entityKey := strings.TrimSpace(mutation.EntityKey)
-	if entityKey == "" || (payloadString("sync_id") != "" && payloadString("sync_id") != entityKey) || payloadString("content") == "" {
+	if entityKey == "" || payloadString("sync_id") != entityKey || payloadString("content") == "" {
 		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
 	}
 	observation, err := s.getObservationBySyncIDTx(tx, entityKey, false)

--- a/internal/store/diagnostic.go
+++ b/internal/store/diagnostic.go
@@ -31,6 +31,26 @@ type SyncMutationPayloadValidation struct {
 	Message       string   `json:"message,omitempty"`
 }
 
+// SyncMutationTitleRepairAction records a title restored from its matching
+// local observation without creating another sync mutation.
+type SyncMutationTitleRepairAction struct {
+	Seq       int64  `json:"seq"`
+	Project   string `json:"project"`
+	Entity    string `json:"entity"`
+	EntityKey string `json:"entity_key"`
+	Op        string `json:"op"`
+	Title     string `json:"title"`
+}
+
+// SyncMutationTitleRepairReport is the local recovery result for title-only
+// observation upserts. Repairs remain pending so the original sequence is
+// delivered normally.
+type SyncMutationTitleRepairReport struct {
+	Project string                          `json:"project,omitempty"`
+	Applied bool                            `json:"applied"`
+	Actions []SyncMutationTitleRepairAction `json:"actions"`
+}
+
 // InvalidSessionIdentityEvidence describes a corrupt source session and the
 // dependent local data that cannot be repaired without a canonical ID.
 type InvalidSessionIdentityEvidence struct {
@@ -418,6 +438,144 @@ func ValidateSyncMutationPayload(entity, op, payload, entityKey string) SyncMuta
 		result.Message = fmt.Sprintf("%s payload missing required fields: %s", entity, strings.Join(missing, ", "))
 	}
 	return result
+}
+
+// RepairObservationMutationTitles restores the single title field that can be
+// proved from a matching titleless local observation. It deliberately does not
+// enqueue a replacement mutation: the existing journal row keeps its sequence
+// and all delivery state while only its frozen payload is corrected.
+func (s *Store) RepairObservationMutationTitles(project string, apply bool) (SyncMutationTitleRepairReport, error) {
+	project, _ = NormalizeProject(project)
+	project = strings.TrimSpace(project)
+	report := SyncMutationTitleRepairReport{Project: project, Applied: apply, Actions: []SyncMutationTitleRepairAction{}}
+	err := s.withTx(func(tx *sql.Tx) error {
+		type titleRepair struct {
+			action        SyncMutationTitleRepairAction
+			payload       string
+			observationID int64
+			sourceTitle   string
+		}
+		repairs := make([]titleRepair, 0)
+		query := `SELECT seq, target_key, entity, entity_key, op, payload, source, project, occurred_at, acked_at
+			FROM sync_mutations WHERE target_key = ? AND acked_at IS NULL AND disposition = 'pending'`
+		args := []any{DefaultSyncTargetKey}
+		if project != "" {
+			query += ` AND project = ?`
+			args = append(args, project)
+		}
+		query += ` ORDER BY seq ASC`
+		rows, err := s.queryItHook(tx, query, args...)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			var mutation SyncMutation
+			if err := rows.Scan(&mutation.Seq, &mutation.TargetKey, &mutation.Entity, &mutation.EntityKey, &mutation.Op, &mutation.Payload, &mutation.Source, &mutation.Project, &mutation.OccurredAt, &mutation.AckedAt); err != nil {
+				return closeRowsWithError(rows, err)
+			}
+			action, payload, observationID, sourceTitle, ok, err := s.observationMutationTitleRepairTx(tx, mutation)
+			if err != nil {
+				return closeRowsWithError(rows, err)
+			}
+			if !ok {
+				continue
+			}
+			report.Actions = append(report.Actions, action)
+			repairs = append(repairs, titleRepair{action, payload, observationID, sourceTitle})
+		}
+		if err := closeRowsWithError(rows, rows.Err()); err != nil {
+			return err
+		}
+		if !apply {
+			return nil
+		}
+		repairedObservations := make(map[int64]struct{})
+		for _, repair := range repairs {
+			if _, repaired := repairedObservations[repair.observationID]; repaired {
+				continue
+			}
+			result, err := s.execHook(tx, `UPDATE observations SET title = ? WHERE id = ? AND sync_id = ? AND deleted_at IS NULL AND title = ?`, repair.action.Title, repair.observationID, repair.action.EntityKey, repair.sourceTitle)
+			if err != nil {
+				return err
+			}
+			if changed, _ := result.RowsAffected(); changed != 1 {
+				return fmt.Errorf("repair observation title source for mutation %d", repair.action.Seq)
+			}
+			repairedObservations[repair.observationID] = struct{}{}
+		}
+		for _, repair := range repairs {
+			result, err := s.execHook(tx, `UPDATE sync_mutations SET payload = ? WHERE target_key = ? AND seq = ? AND acked_at IS NULL AND disposition = 'pending'`, repair.payload, DefaultSyncTargetKey, repair.action.Seq)
+			if err != nil {
+				return err
+			}
+			if changed, _ := result.RowsAffected(); changed != 1 {
+				return fmt.Errorf("repair observation title mutation %d", repair.action.Seq)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return SyncMutationTitleRepairReport{}, fmt.Errorf("repair observation mutation titles: %w", err)
+	}
+	return report, nil
+}
+
+func (s *Store) observationMutationTitleRepairTx(tx *sql.Tx, mutation SyncMutation) (SyncMutationTitleRepairAction, string, int64, string, bool, error) {
+	validation := ValidateSyncMutationPayload(mutation.Entity, mutation.Op, mutation.Payload, mutation.EntityKey)
+	if mutation.Entity != SyncEntityObservation || mutation.Op != SyncOpUpsert || len(validation.MissingFields) != 1 || validation.MissingFields[0] != "title" {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
+	}
+	var payload map[string]json.RawMessage
+	if err := decodeSyncPayload([]byte(mutation.Payload), &payload); err != nil {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
+	}
+	payloadString := func(name string) string {
+		var value string
+		_ = json.Unmarshal(payload[name], &value)
+		return strings.TrimSpace(value)
+	}
+	entityKey := strings.TrimSpace(mutation.EntityKey)
+	if entityKey == "" || (payloadString("sync_id") != "" && payloadString("sync_id") != entityKey) || payloadString("content") == "" {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
+	}
+	observation, err := s.getObservationBySyncIDTx(tx, entityKey, false)
+	if err == sql.ErrNoRows {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
+	}
+	if err != nil {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, err
+	}
+	observationProject, _ := NormalizeProject(derefString(observation.Project))
+	mutationProject, _ := NormalizeProject(mutation.Project)
+	payloadProject, _ := NormalizeProject(payloadString("project"))
+	if strings.TrimSpace(observation.Title) != "" || (mutationProject != "" && mutationProject != observationProject) || (payloadProject != "" && payloadProject != observationProject) {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
+	}
+	title := deriveObservationRepairTitle(observation.Content)
+	if err := ValidateObservationTitle(title); err != nil {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
+	}
+	payload["title"], _ = json.Marshal(title)
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, err
+	}
+	if validation := ValidateSyncMutationPayload(mutation.Entity, mutation.Op, string(rewritten), mutation.EntityKey); validation.ReasonCode != "" {
+		return SyncMutationTitleRepairAction{}, "", 0, "", false, nil
+	}
+	return SyncMutationTitleRepairAction{Seq: mutation.Seq, Project: mutation.Project, Entity: mutation.Entity, EntityKey: mutation.EntityKey, Op: mutation.Op, Title: title}, string(rewritten), observation.ID, observation.Title, true, nil
+}
+
+func deriveObservationRepairTitle(content string) string {
+	content = strings.TrimSpace(stripPrivateTags(content))
+	runes := []rune(content)
+	for i, r := range runes {
+		if strings.ContainsRune(".!?。！？", r) {
+			runes = runes[:i+1]
+			break
+		}
+	}
+	return truncate(string(runes), 300)
 }
 
 // ReadSQLiteLockSnapshot returns SQLite lock-related PRAGMA values without

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -10162,6 +10162,125 @@ func TestRepairObservationMutationTitles(t *testing.T) {
 		})
 	}
 
+	t.Run("skips ineligible observations without mutation", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			mutate func(t *testing.T, s *Store, obs Observation, mutation SyncMutation)
+		}{
+			{
+				name: "missing payload sync ID",
+				mutate: func(t *testing.T, s *Store, _ Observation, mutation SyncMutation) {
+					t.Helper()
+					var payload map[string]json.RawMessage
+					if err := json.Unmarshal([]byte(mutation.Payload), &payload); err != nil {
+						t.Fatalf("decode payload: %v", err)
+					}
+					delete(payload, "sync_id")
+					body, err := json.Marshal(payload)
+					if err != nil {
+						t.Fatalf("encode payload: %v", err)
+					}
+					if _, err := s.db.Exec(`UPDATE sync_mutations SET payload = ? WHERE seq = ?`, string(body), mutation.Seq); err != nil {
+						t.Fatalf("remove payload sync ID: %v", err)
+					}
+				},
+			},
+			{
+				name: "mismatched payload sync ID",
+				mutate: func(t *testing.T, s *Store, _ Observation, mutation SyncMutation) {
+					t.Helper()
+					if _, err := s.db.Exec(`UPDATE sync_mutations SET payload = json_set(payload, '$.sync_id', 'other-observation') WHERE seq = ?`, mutation.Seq); err != nil {
+						t.Fatalf("mismatch payload sync ID: %v", err)
+					}
+				},
+			},
+			{
+				name: "payload project mismatch",
+				mutate: func(t *testing.T, s *Store, _ Observation, mutation SyncMutation) {
+					t.Helper()
+					if _, err := s.db.Exec(`UPDATE sync_mutations SET payload = json_set(payload, '$.project', 'project-b') WHERE seq = ?`, mutation.Seq); err != nil {
+						t.Fatalf("mismatch payload project: %v", err)
+					}
+				},
+			},
+			{
+				name: "mutation project mismatch",
+				mutate: func(t *testing.T, s *Store, _ Observation, mutation SyncMutation) {
+					t.Helper()
+					if _, err := s.db.Exec(`UPDATE sync_mutations SET project = 'project-b' WHERE seq = ?`, mutation.Seq); err != nil {
+						t.Fatalf("mismatch mutation project: %v", err)
+					}
+				},
+			},
+			{
+				name: "soft-deleted observation",
+				mutate: func(t *testing.T, s *Store, obs Observation, _ SyncMutation) {
+					t.Helper()
+					if _, err := s.db.Exec(`UPDATE observations SET deleted_at = datetime('now') WHERE id = ?`, obs.ID); err != nil {
+						t.Fatalf("soft-delete observation: %v", err)
+					}
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				s, obs, mutation, _ := seed(t, "Recovered title. More detail.", func(map[string]json.RawMessage) {})
+				tc.mutate(t, s, obs, mutation)
+
+				var title, payload string
+				var deletedAt sql.NullString
+				if err := s.db.QueryRow(`SELECT title, deleted_at FROM observations WHERE id = ?`, obs.ID).Scan(&title, &deletedAt); err != nil {
+					t.Fatalf("read source before repair: %v", err)
+				}
+				if err := s.db.QueryRow(`SELECT payload FROM sync_mutations WHERE seq = ?`, mutation.Seq).Scan(&payload); err != nil {
+					t.Fatalf("read mutation before repair: %v", err)
+				}
+
+				report, err := s.RepairObservationMutationTitles("project-a", true)
+				if err != nil || len(report.Actions) != 0 {
+					t.Fatalf("report=%+v err=%v", report, err)
+				}
+
+				var repairedTitle, repairedPayload string
+				var repairedDeletedAt sql.NullString
+				if err := s.db.QueryRow(`SELECT title, deleted_at FROM observations WHERE id = ?`, obs.ID).Scan(&repairedTitle, &repairedDeletedAt); err != nil {
+					t.Fatalf("read source after repair: %v", err)
+				}
+				if err := s.db.QueryRow(`SELECT payload FROM sync_mutations WHERE seq = ?`, mutation.Seq).Scan(&repairedPayload); err != nil {
+					t.Fatalf("read mutation after repair: %v", err)
+				}
+				if repairedTitle != title || repairedPayload != payload || repairedDeletedAt != deletedAt {
+					t.Fatalf("ineligible repair mutated source title=%q payload=%q deleted_at=%v; want title=%q payload=%q deleted_at=%v", repairedTitle, repairedPayload, repairedDeletedAt, title, payload, deletedAt)
+				}
+			})
+		}
+	})
+
+	t.Run("reports only actions from the successful retry attempt", func(t *testing.T) {
+		s, _, _, _ := seed(t, "Recovered title. More detail.", func(map[string]json.RawMessage) {})
+		oldBackoffs := sqliteWriteRetryBackoffs
+		sqliteWriteRetryBackoffs = []time.Duration{0}
+		t.Cleanup(func() { sqliteWriteRetryBackoffs = oldBackoffs })
+
+		originalCommit := s.hooks.commit
+		commitAttempts := 0
+		s.hooks.commit = func(tx *sql.Tx) error {
+			commitAttempts++
+			if commitAttempts == 1 {
+				return errors.New("database is locked")
+			}
+			return originalCommit(tx)
+		}
+		t.Cleanup(func() { s.hooks.commit = originalCommit })
+
+		report, err := s.RepairObservationMutationTitles("project-a", false)
+		if err != nil {
+			t.Fatalf("repair after retry: %v", err)
+		}
+		if commitAttempts != 2 || len(report.Actions) != 1 {
+			t.Fatalf("commit attempts=%d report=%+v", commitAttempts, report)
+		}
+	})
+
 	t.Run("applies a Unicode blank source title", func(t *testing.T) {
 		s, obs, _, _ := seed(t, "Recovered title. More detail.", func(map[string]json.RawMessage) {})
 		if _, err := s.db.Exec(`UPDATE observations SET title = ? WHERE id = ?`, "\u2003", obs.ID); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -10052,6 +10052,181 @@ func TestQuarantineIrreparableSyncMutationsRollsBackWhenLifecycleRefreshFails(t 
 	}
 }
 
+func TestRepairObservationMutationTitles(t *testing.T) {
+	seed := func(t *testing.T, content string, mutate func(map[string]json.RawMessage)) (*Store, Observation, SyncMutation, string) {
+		t.Helper()
+		s := newTestStore(t)
+		if err := s.CreateSession("title-repair", "project-a", "/work/project-a"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		id, err := s.AddObservation(AddObservationParams{SessionID: "title-repair", Type: "bugfix", Title: "original", Content: "original", Project: "project-a", Scope: "project"})
+		if err != nil {
+			t.Fatalf("add observation: %v", err)
+		}
+		obs, err := s.GetObservation(id)
+		if err != nil {
+			t.Fatalf("get observation: %v", err)
+		}
+		if _, err := s.db.Exec(`UPDATE observations SET title = '', content = ? WHERE id = ?`, content, id); err != nil {
+			t.Fatalf("seed titleless source: %v", err)
+		}
+		var mutation SyncMutation
+		if err := s.db.QueryRow(`SELECT seq, target_key, entity, entity_key, op, payload, source, project, occurred_at, acked_at FROM sync_mutations WHERE entity = ? AND entity_key = ?`, SyncEntityObservation, obs.SyncID).Scan(&mutation.Seq, &mutation.TargetKey, &mutation.Entity, &mutation.EntityKey, &mutation.Op, &mutation.Payload, &mutation.Source, &mutation.Project, &mutation.OccurredAt, &mutation.AckedAt); err != nil {
+			t.Fatalf("read mutation: %v", err)
+		}
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(mutation.Payload), &payload); err != nil {
+			t.Fatalf("decode mutation: %v", err)
+		}
+		payload["title"] = json.RawMessage(`"  "`)
+		payload["unknown"] = json.RawMessage(`{"kept":true}`)
+		mutate(payload)
+		body, _ := json.Marshal(payload)
+		if _, err := s.db.Exec(`UPDATE sync_mutations SET payload = ? WHERE seq = ?`, string(body), mutation.Seq); err != nil {
+			t.Fatalf("seed frozen payload: %v", err)
+		}
+		mutation.Payload = string(body)
+		return s, *obs, mutation, string(body)
+	}
+
+	t.Run("plans and applies an in-place repair", func(t *testing.T) {
+		s, obs, mutation, originalPayload := seed(t, "<private>secret</private> First sentence. Second sentence.", func(map[string]json.RawMessage) {})
+		var mutationCountBefore int
+		if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationCountBefore); err != nil {
+			t.Fatalf("count mutations before repair: %v", err)
+		}
+		plan, err := s.RepairObservationMutationTitles("project-a", false)
+		if err != nil || len(plan.Actions) != 1 || plan.Actions[0].Title != "[REDACTED] First sentence." {
+			t.Fatalf("plan=%+v err=%v", plan, err)
+		}
+		var title, payload, disposition string
+		var seq int64
+		var ackedAt sql.NullString
+		if err := s.db.QueryRow(`SELECT title FROM observations WHERE id = ?`, obs.ID).Scan(&title); err != nil || title != "" {
+			t.Fatalf("plan changed source title=%q err=%v", title, err)
+		}
+		if err := s.db.QueryRow(`SELECT seq, payload, acked_at, disposition FROM sync_mutations WHERE seq = ?`, mutation.Seq).Scan(&seq, &payload, &ackedAt, &disposition); err != nil || seq != mutation.Seq || payload != originalPayload || ackedAt.Valid || disposition != SyncMutationDispositionPending {
+			t.Fatalf("plan changed mutation seq=%d payload=%q acked=%v disposition=%q err=%v", seq, payload, ackedAt, disposition, err)
+		}
+
+		applied, err := s.RepairObservationMutationTitles("project-a", true)
+		if err != nil || len(applied.Actions) != 1 {
+			t.Fatalf("apply=%+v err=%v", applied, err)
+		}
+		if err := s.db.QueryRow(`SELECT title FROM observations WHERE id = ?`, obs.ID).Scan(&title); err != nil || title != applied.Actions[0].Title {
+			t.Fatalf("source title=%q err=%v", title, err)
+		}
+		if err := s.db.QueryRow(`SELECT payload, acked_at, disposition FROM sync_mutations WHERE seq = ?`, mutation.Seq).Scan(&payload, &ackedAt, &disposition); err != nil || ackedAt.Valid || disposition != SyncMutationDispositionPending {
+			t.Fatalf("mutation state payload=%q acked=%v disposition=%q err=%v", payload, ackedAt, disposition, err)
+		}
+		var mutationCountAfter int
+		if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationCountAfter); err != nil || mutationCountAfter != mutationCountBefore {
+			t.Fatalf("mutation count after repair=%d before=%d err=%v", mutationCountAfter, mutationCountBefore, err)
+		}
+		var repaired map[string]json.RawMessage
+		_ = json.Unmarshal([]byte(payload), &repaired)
+		if string(repaired["unknown"]) != `{"kept":true}` || ValidateSyncMutationPayload(mutation.Entity, mutation.Op, payload, mutation.EntityKey).ReasonCode != "" {
+			t.Fatalf("repaired payload=%s", payload)
+		}
+		var ftsCount int
+		if err := s.db.QueryRow(`SELECT count(*) FROM observations_fts WHERE observations_fts MATCH 'REDACTED'`).Scan(&ftsCount); err != nil || ftsCount != 1 {
+			t.Fatalf("fts count=%d err=%v", ftsCount, err)
+		}
+		if again, err := s.RepairObservationMutationTitles("project-a", true); err != nil || len(again.Actions) != 0 {
+			t.Fatalf("repeat=%+v err=%v", again, err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name, content string
+		mutate        func(map[string]json.RawMessage)
+		want          int
+	}{
+		{"additional missing field", "content", func(p map[string]json.RawMessage) { p["scope"] = json.RawMessage(`""`) }, 0},
+		{"empty content", "", func(map[string]json.RawMessage) {}, 0},
+		{"unicode sentence", "  日本語の文章です。 Second sentence.", func(map[string]json.RawMessage) {}, 1},
+		{"rune safe truncation", strings.Repeat("界", 301), func(map[string]json.RawMessage) {}, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _, _, _ := seed(t, tc.content, tc.mutate)
+			report, err := s.RepairObservationMutationTitles("project-a", false)
+			if err != nil || len(report.Actions) != tc.want {
+				t.Fatalf("report=%+v err=%v", report, err)
+			}
+			if tc.name == "unicode sentence" && report.Actions[0].Title != "日本語の文章です。" {
+				t.Fatalf("unicode title=%q", report.Actions[0].Title)
+			}
+			if tc.name == "rune safe truncation" && utf8.RuneCountInString(report.Actions[0].Title) != 303 {
+				t.Fatalf("truncated title=%q", report.Actions[0].Title)
+			}
+		})
+	}
+
+	t.Run("applies a Unicode blank source title", func(t *testing.T) {
+		s, obs, _, _ := seed(t, "Recovered title. More detail.", func(map[string]json.RawMessage) {})
+		if _, err := s.db.Exec(`UPDATE observations SET title = ? WHERE id = ?`, "\u2003", obs.ID); err != nil {
+			t.Fatalf("seed Unicode blank title: %v", err)
+		}
+		report, err := s.RepairObservationMutationTitles("project-a", true)
+		if err != nil || len(report.Actions) != 1 || report.Actions[0].Title != "Recovered title." {
+			t.Fatalf("report=%+v err=%v", report, err)
+		}
+	})
+
+	t.Run("repairs every pending upsert for one observation", func(t *testing.T) {
+		s, obs, mutation, _ := seed(t, "Recovered title. More detail.", func(map[string]json.RawMessage) {})
+		if err := s.EnrollProject("project-a"); err != nil {
+			t.Fatalf("enroll project: %v", err)
+		}
+		result, err := s.db.Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`, mutation.TargetKey, mutation.Entity, mutation.EntityKey, mutation.Op, mutation.Payload, mutation.Source, mutation.Project)
+		if err != nil {
+			t.Fatalf("insert second frozen payload: %v", err)
+		}
+		secondSeq, err := result.LastInsertId()
+		if err != nil {
+			t.Fatalf("read second sequence: %v", err)
+		}
+		plan, err := s.RepairObservationMutationTitles("project-a", false)
+		if err != nil || len(plan.Actions) != 2 || plan.Actions[0].Seq != mutation.Seq || plan.Actions[1].Seq != secondSeq {
+			t.Fatalf("plan=%+v err=%v", plan, err)
+		}
+		applied, err := s.RepairObservationMutationTitles("project-a", true)
+		if err != nil || !reflect.DeepEqual(applied.Actions, plan.Actions) {
+			t.Fatalf("apply=%+v plan=%+v err=%v", applied, plan, err)
+		}
+		pending, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
+		if err != nil {
+			t.Fatalf("list pending mutations: %v", err)
+		}
+		var repaired []SyncMutation
+		for _, pendingMutation := range pending {
+			if pendingMutation.EntityKey == obs.SyncID {
+				repaired = append(repaired, pendingMutation)
+			}
+		}
+		if len(repaired) != 2 || repaired[0].Seq != mutation.Seq || repaired[1].Seq != secondSeq || ValidateSyncMutationPayload(repaired[0].Entity, repaired[0].Op, repaired[0].Payload, repaired[0].EntityKey).ReasonCode != "" || ValidateSyncMutationPayload(repaired[1].Entity, repaired[1].Op, repaired[1].Payload, repaired[1].EntityKey).ReasonCode != "" {
+			t.Fatalf("repaired pending mutations=%+v", repaired)
+		}
+	})
+
+	t.Run("rolls back both writes", func(t *testing.T) {
+		s, obs, mutation, _ := seed(t, "Repair me.", func(map[string]json.RawMessage) {})
+		if _, err := s.db.Exec(`CREATE TRIGGER reject_title_repair BEFORE UPDATE OF payload ON sync_mutations BEGIN SELECT RAISE(ABORT, 'payload blocked'); END`); err != nil {
+			t.Fatalf("create trigger: %v", err)
+		}
+		if _, err := s.RepairObservationMutationTitles("project-a", true); err == nil {
+			t.Fatal("expected repair failure")
+		}
+		var title, payload string
+		if err := s.db.QueryRow(`SELECT title FROM observations WHERE id = ?`, obs.ID).Scan(&title); err != nil || title != "" {
+			t.Fatalf("source rollback title=%q err=%v", title, err)
+		}
+		if err := s.db.QueryRow(`SELECT payload FROM sync_mutations WHERE seq = ?`, mutation.Seq).Scan(&payload); err != nil || !strings.Contains(payload, `"title":"  "`) {
+			t.Fatalf("mutation rollback payload=%q err=%v", payload, err)
+		}
+	})
+}
+
 func TestDeleteSession_NotFound(t *testing.T) {
 	s := newTestStore(t)
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #814

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds a targeted doctor repair for pending observation upserts whose stored and payload titles are blank.
- Derives a Unicode-safe title from observation content and updates the observation plus every eligible pending payload atomically.
- Keeps ineligible mutations on the existing quarantine path and documents the repair behavior.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/diagnostic.go` | Adds planning and atomic application for observation mutation title repair. |
| `internal/store/store_test.go` | Covers repair, rollback, Unicode, FTS, and multiple pending upserts. |
| `cmd/engram/doctor.go` | Runs repair before residual invalid-mutation quarantine. |
| `cmd/engram/doctor_test.go` | Covers the doctor repair path. |
| `docs/DOCTOR.md` | Documents title recovery and quarantine behavior. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

Focused candidate tests passed:

- `go test ./internal/store ./cmd/engram -run="^(TestRepairObservationMutationTitles|TestCmdDoctorRepairRepairsTitleOnlyObservationMutation)$" -count=1 -timeout=2m`
- `git diff --check`

The full local unit command was attempted on Windows but did not complete green: `internal/setup` could not find `sh`, and two tests in the unchanged `plugin` package failed (`TestClaudeCodeWindowsPromptResolverRejectsMalformedCanonicalProject` and `TestCodexUnixUserPromptSubmitDetachesPromptPersistenceStdin`). CI remains authoritative for those checks.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #814`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

- The maintainer explicitly accepted `size:exception` for this cohesive 409-line candidate (406 additions, 3 deletions), which is 9 lines above the normal review budget.
- Native bounded review completed and approved the corrected candidate after validating the multi-upsert regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added targeted repair for observation sync records missing only a title.
  * Titles are derived from local content, with previews available before applying repairs.
  * Repair results are included in JSON output under `repairs`.

* **Bug Fixes**
  * Restores eligible observations while preserving existing sync state and metadata.
  * Keeps irreparable sync records quarantined for further review.

* **Documentation**
  * Clarified repair safety, local-only data changes, previews, and quarantined actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->