### PR TITLE
fix(sync): export observations absent from history

### DIFF
--- a/docs/codebase/sync-and-cloud.md
+++ b/docs/codebase/sync-and-cloud.md
@@ -30,6 +30,8 @@ Local SQLite
 
 Project-scoped chunks carry sessions, observations, prompts, and the non-orphaned `memory_relations` graph for observations in that project. Relation rows travel as existing `relation` sync mutations inside the chunk so imports reuse the same idempotent relation apply path as cloud sync.
 
+During incremental local project exports, an observation absent from available chunk history bypasses the manifest watermark. A direct historical row or an observation mutation, including a tombstone, establishes historical presence; sessions and prompts otherwise retain timestamp-only filtering, while sessions needed by emitted observations are included for dependency closure.
+
 Cloud exports are size-bounded: `engram sync --cloud` splits the pending mutation replay into deterministic, dependency-complete chunks of at most 4 MiB each, so a large initial replay stays within the server's `ENGRAM_CLOUD_MAX_PUSH_BYTES` limit (default 8 MiB). Each chunk acknowledges only its own mutation sequences after a successful push, so an interrupted sync resumes from the first unacknowledged mutation instead of replaying acknowledged work.
 
 Guardrails:

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1615,14 +1615,48 @@ func (sy *Syncer) exportedChunkKeys(m *Manifest) (map[string]struct{}, map[strin
 				relationKeys[mutation.EntityKey] = struct{}{}
 			}
 			if mutation.Entity == store.SyncEntityObservation {
-				historicalObservationKeys[mutation.EntityKey] = struct{}{}
-				if mutation.Op == store.SyncOpUpsert && store.ValidateSyncMutationPayload(mutation.Entity, mutation.Op, mutation.Payload, mutation.EntityKey).ReasonCode == "" {
-					observationKeys[mutation.EntityKey] = struct{}{}
+				switch mutation.Op {
+				case store.SyncOpDelete:
+					if strings.TrimSpace(mutation.EntityKey) != "" {
+						historicalObservationKeys[mutation.EntityKey] = struct{}{}
+					}
+				case store.SyncOpUpsert:
+					if syncID, ok := observationUpsertIdentity(mutation); ok {
+						historicalObservationKeys[syncID] = struct{}{}
+						observationKeys[syncID] = struct{}{}
+					}
 				}
 			}
 		}
 	}
 	return relationKeys, observationKeys, historicalObservationKeys, nil
+}
+
+// observationUpsertIdentity returns the payload-owned identity of a replayable
+// observation upsert. It keeps the identity byte-exact: whitespace only proves
+// non-emptiness, never changes the key stored in the export indexes.
+func observationUpsertIdentity(mutation store.SyncMutation) (string, bool) {
+	if store.ValidateSyncMutationPayload(mutation.Entity, mutation.Op, mutation.Payload, mutation.EntityKey).ReasonCode != "" {
+		return "", false
+	}
+
+	payload := strings.TrimSpace(mutation.Payload)
+	if payload == "" {
+		return "", false
+	}
+	if payload[0] == '"' {
+		if err := json.Unmarshal([]byte(payload), &payload); err != nil {
+			return "", false
+		}
+		payload = strings.TrimSpace(payload)
+	}
+	var body struct {
+		SyncID string `json:"sync_id"`
+	}
+	if err := json.Unmarshal([]byte(payload), &body); err != nil || strings.TrimSpace(body.SyncID) == "" || body.SyncID != mutation.EntityKey {
+		return "", false
+	}
+	return body.SyncID, true
 }
 
 // filterRelationMutationsForExport returns the relation mutations that still

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -462,15 +462,15 @@ func (sy *Syncer) Export(createdBy string, project string) (*SyncResult, error) 
 	// Get the timestamp of the last chunk to filter "new" data
 	lastChunkTime := sy.lastChunkTime(manifest)
 
-	// Filter to only new data (created after last chunk)
-	chunk := sy.filterNewData(data, lastChunkTime)
-
 	// Relations are filtered by chunk presence, not timestamp; see the
 	// rationale on filterRelationMutationsForExport and issue #353.
-	exportedRelations, exportedObservations, err := sy.exportedChunkKeys(manifest)
+	exportedRelations, exportedObservations, historicalObservations, err := sy.exportedChunkKeys(manifest)
 	if err != nil {
 		return nil, fmt.Errorf("scan exported relations: %w", err)
 	}
+	chunk := sy.filterNewData(data, lastChunkTime)
+	chunk.Observations = filterObservationsForExport(data.Observations, historicalObservations, lastChunkTime)
+	includeObservationParentSessions(chunk, data.Sessions)
 	chunk.Mutations = filterRelationMutationsForExport(relationMutations, exportedRelations, lastChunkTime)
 	if err := filterRelationMutationsForEndpointAvailability(chunk, data, exportedObservations, strings.TrimSpace(project) != ""); err != nil {
 		return nil, fmt.Errorf("filter relation endpoints: %w", err)
@@ -1451,6 +1451,46 @@ func (sy *Syncer) filterNewData(data *store.ExportData, lastChunkTime string) *C
 	return chunk
 }
 
+func filterObservationsForExport(observations []store.Observation, historical map[string]struct{}, lastChunkTime string) []store.Observation {
+	if lastChunkTime == "" {
+		return observations
+	}
+
+	cutoff := normalizeTime(lastChunkTime)
+	filtered := make([]store.Observation, 0, len(observations))
+	for _, observation := range observations {
+		_, present := historical[observation.SyncID]
+		if !present || normalizeTime(observation.CreatedAt) > cutoff || normalizeTime(observation.UpdatedAt) > cutoff {
+			filtered = append(filtered, observation)
+		}
+	}
+	return filtered
+}
+
+func includeObservationParentSessions(chunk *ChunkData, sessions []store.Session) {
+	if len(chunk.Observations) == 0 {
+		return
+	}
+
+	byID := make(map[string]store.Session, len(sessions))
+	for _, session := range sessions {
+		byID[session.ID] = session
+	}
+	included := make(map[string]struct{}, len(chunk.Sessions))
+	for _, session := range chunk.Sessions {
+		included[session.ID] = struct{}{}
+	}
+	for _, observation := range chunk.Observations {
+		if _, ok := included[observation.SessionID]; ok {
+			continue
+		}
+		if session, ok := byID[observation.SessionID]; ok {
+			chunk.Sessions = append(chunk.Sessions, session)
+			included[session.ID] = struct{}{}
+		}
+	}
+}
+
 // filterExportDataToProjectScope excludes personal observations from a local
 // project export. Scope is a privacy boundary even when an observation has the
 // same project as the requested chunk.
@@ -1530,19 +1570,21 @@ func filterRelationMutationsForEndpointAvailability(chunk *ChunkData, data *stor
 	return nil
 }
 
-// exportedChunkKeys returns the relation and observation keys already present
-// in the chunks recorded by the manifest. The manifest itself does not track
-// those keys, so chunk contents are the source of truth for their availability.
+// exportedChunkKeys returns relation keys, direct observation row keys, and all
+// historical observation keys from the chunks recorded by the manifest. The
+// manifest itself does not track those keys, so chunk contents are the source
+// of truth for their availability and historical presence.
 //
 // Cost: this reads every chunk listed in the manifest on each export. A
 // relation may live in any chunk, so the scan cannot stop early. For very long
 // sync histories this is O(total chunks); tracking relation keys in the
 // manifest would remove the rescan if it ever becomes a bottleneck.
-func (sy *Syncer) exportedChunkKeys(m *Manifest) (map[string]struct{}, map[string]struct{}, error) {
+func (sy *Syncer) exportedChunkKeys(m *Manifest) (map[string]struct{}, map[string]struct{}, map[string]struct{}, error) {
 	relationKeys := make(map[string]struct{})
 	observationKeys := make(map[string]struct{})
+	historicalObservationKeys := make(map[string]struct{})
 	if m == nil {
-		return relationKeys, observationKeys, nil
+		return relationKeys, observationKeys, historicalObservationKeys, nil
 	}
 	for _, entry := range m.Chunks {
 		// Read through the transport (not the local filesystem directly) so the
@@ -1558,22 +1600,26 @@ func (sy *Syncer) exportedChunkKeys(m *Manifest) (map[string]struct{}, map[strin
 				// but cannot be read is a real fault and fails loudly below.
 				continue
 			}
-			return nil, nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
+			return nil, nil, nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
 		}
 		var chunk ChunkData
 		if err := json.Unmarshal(raw, &chunk); err != nil {
-			return nil, nil, fmt.Errorf("unmarshal chunk %s: %w", entry.ID, err)
+			return nil, nil, nil, fmt.Errorf("unmarshal chunk %s: %w", entry.ID, err)
 		}
 		for _, observation := range chunk.Observations {
 			observationKeys[observation.SyncID] = struct{}{}
+			historicalObservationKeys[observation.SyncID] = struct{}{}
 		}
 		for _, mutation := range chunk.Mutations {
 			if mutation.Entity == store.SyncEntityRelation {
 				relationKeys[mutation.EntityKey] = struct{}{}
 			}
+			if mutation.Entity == store.SyncEntityObservation {
+				historicalObservationKeys[mutation.EntityKey] = struct{}{}
+			}
 		}
 	}
-	return relationKeys, observationKeys, nil
+	return relationKeys, observationKeys, historicalObservationKeys, nil
 }
 
 // filterRelationMutationsForExport returns the relation mutations that still

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1616,6 +1616,9 @@ func (sy *Syncer) exportedChunkKeys(m *Manifest) (map[string]struct{}, map[strin
 			}
 			if mutation.Entity == store.SyncEntityObservation {
 				historicalObservationKeys[mutation.EntityKey] = struct{}{}
+				if mutation.Op == store.SyncOpUpsert && store.ValidateSyncMutationPayload(mutation.Entity, mutation.Op, mutation.Payload, mutation.EntityKey).ReasonCode == "" {
+					observationKeys[mutation.EntityKey] = struct{}{}
+				}
 			}
 		}
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1136,6 +1136,7 @@ func TestLocalChunkExportUsesObservationHistory(t *testing.T) {
 	tests := []struct {
 		name               string
 		history            func(store.Observation) ChunkData
+		observationCreated string
 		observationUpdated string
 		wantObservation    bool
 		wantEmpty          bool
@@ -1176,6 +1177,15 @@ func TestLocalChunkExportUsesObservationHistory(t *testing.T) {
 			observationUpdated: "2025-07-01 00:00:00",
 			wantObservation:    true,
 		},
+		{
+			name: "observation created after watermark still exports after historical presence",
+			history: func(observation store.Observation) ChunkData {
+				return ChunkData{Observations: []store.Observation{{SyncID: observation.SyncID}}}
+			},
+			observationCreated: "2025-07-01 00:00:00",
+			observationUpdated: "2025-07-01 00:00:00",
+			wantObservation:    true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1203,7 +1213,11 @@ func TestLocalChunkExportUsesObservationHistory(t *testing.T) {
 			if _, err := s.DB().Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, "2025-01-01 00:00:00", sessionID); err != nil {
 				t.Fatalf("backdate session: %v", err)
 			}
-			if _, err := s.DB().Exec(`UPDATE observations SET created_at = ?, updated_at = ? WHERE id = ?`, "2025-01-01 00:00:00", tc.observationUpdated, observationID); err != nil {
+			observationCreated := tc.observationCreated
+			if observationCreated == "" {
+				observationCreated = "2025-01-01 00:00:00"
+			}
+			if _, err := s.DB().Exec(`UPDATE observations SET created_at = ?, updated_at = ? WHERE id = ?`, observationCreated, tc.observationUpdated, observationID); err != nil {
 				t.Fatalf("backdate observation: %v", err)
 			}
 			if _, err := s.DB().Exec(`UPDATE user_prompts SET created_at = ? WHERE id = ?`, "2025-01-01 00:00:00", promptID); err != nil {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1127,6 +1127,139 @@ func TestLocalChunkExportFailsLoudlyOnCorruptPriorChunk(t *testing.T) {
 	}
 }
 
+func TestLocalChunkExportUsesObservationHistory(t *testing.T) {
+	tests := []struct {
+		name               string
+		history            func(store.Observation) ChunkData
+		observationUpdated string
+		wantObservation    bool
+		wantEmpty          bool
+	}{
+		{
+			name: "older observation absent from history bypasses global watermark",
+			history: func(_ store.Observation) ChunkData {
+				return ChunkData{}
+			},
+			observationUpdated: "2025-01-01 00:00:00",
+			wantObservation:    true,
+		},
+		{
+			name: "older observation in a direct historical row remains filtered",
+			history: func(observation store.Observation) ChunkData {
+				return ChunkData{Observations: []store.Observation{{SyncID: observation.SyncID}}}
+			},
+			observationUpdated: "2025-01-01 00:00:00",
+			wantEmpty:          true,
+		},
+		{
+			name: "observation tombstone mutation counts as historical presence",
+			history: func(observation store.Observation) ChunkData {
+				return ChunkData{Mutations: []store.SyncMutation{{
+					Entity:    store.SyncEntityObservation,
+					EntityKey: observation.SyncID,
+					Op:        store.SyncOpDelete,
+				}}}
+			},
+			observationUpdated: "2025-01-01 00:00:00",
+			wantEmpty:          true,
+		},
+		{
+			name: "newer observation still exports after historical presence",
+			history: func(observation store.Observation) ChunkData {
+				return ChunkData{Observations: []store.Observation{{SyncID: observation.SyncID}}}
+			},
+			observationUpdated: "2025-07-01 00:00:00",
+			wantObservation:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			const sessionID = "session-observation-history"
+			if err := s.CreateSession(sessionID, "proj-a", "/tmp/proj-a"); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			observationID, err := s.AddObservation(store.AddObservationParams{
+				SessionID: sessionID,
+				Type:      "decision",
+				Title:     "observation history",
+				Content:   "observation history",
+				Project:   "proj-a",
+				Scope:     "project",
+			})
+			if err != nil {
+				t.Fatalf("add observation: %v", err)
+			}
+			promptID, err := s.AddPrompt(store.AddPromptParams{SessionID: sessionID, Content: "prompt history", Project: "proj-a"})
+			if err != nil {
+				t.Fatalf("add prompt: %v", err)
+			}
+			if _, err := s.DB().Exec(`UPDATE sessions SET started_at = ? WHERE id = ?`, "2025-01-01 00:00:00", sessionID); err != nil {
+				t.Fatalf("backdate session: %v", err)
+			}
+			if _, err := s.DB().Exec(`UPDATE observations SET created_at = ?, updated_at = ? WHERE id = ?`, "2025-01-01 00:00:00", tc.observationUpdated, observationID); err != nil {
+				t.Fatalf("backdate observation: %v", err)
+			}
+			if _, err := s.DB().Exec(`UPDATE user_prompts SET created_at = ? WHERE id = ?`, "2025-01-01 00:00:00", promptID); err != nil {
+				t.Fatalf("backdate prompt: %v", err)
+			}
+
+			observation, err := s.GetObservation(observationID)
+			if err != nil {
+				t.Fatalf("get observation: %v", err)
+			}
+			syncDir := filepath.Join(t.TempDir(), ".engram")
+			writeLocalChunkFile(t, syncDir, "history", tc.history(*observation))
+			writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{
+				ID: "history", CreatedAt: "2025-06-01T00:00:00Z",
+			}}})
+
+			result, err := New(s, syncDir).Export("alice", "proj-a")
+			if err != nil {
+				t.Fatalf("export: %v", err)
+			}
+			if result.IsEmpty != tc.wantEmpty {
+				t.Fatalf("empty export = %t, want %t", result.IsEmpty, tc.wantEmpty)
+			}
+			if got := result.SessionsExported; got != boolToInt(tc.wantObservation) {
+				t.Fatalf("exported sessions = %d, want %d", got, boolToInt(tc.wantObservation))
+			}
+			if result.IsEmpty {
+				return
+			}
+
+			payload, err := readGzip(filepath.Join(syncDir, "chunks", result.ChunkID+".jsonl.gz"))
+			if err != nil {
+				t.Fatalf("read export chunk: %v", err)
+			}
+			var exported ChunkData
+			if err := json.Unmarshal(payload, &exported); err != nil {
+				t.Fatalf("unmarshal export chunk: %v", err)
+			}
+			if got := len(exported.Observations); got != boolToInt(tc.wantObservation) {
+				t.Fatalf("exported observations = %d, want %d; chunk=%+v", got, boolToInt(tc.wantObservation), exported)
+			}
+			if got := len(exported.Sessions); got != boolToInt(tc.wantObservation) {
+				t.Fatalf("exported sessions = %d, want %d; chunk=%+v", got, boolToInt(tc.wantObservation), exported)
+			}
+			if exported.Sessions[0].ID != sessionID {
+				t.Fatalf("exported session = %q, want parent %q", exported.Sessions[0].ID, sessionID)
+			}
+			if len(exported.Prompts) != 0 {
+				t.Fatalf("old prompts must retain timestamp filtering: %+v", exported)
+			}
+		})
+	}
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
 // TestLocalChunkExportReexportsRelationUpdatedAfterLastChunk covers the second
 // branch of the export filter: a relation already present in a prior chunk but
 // re-judged after the latest chunk must be exported again so the update

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1260,6 +1260,10 @@ func TestLocalChunkExportUsesObservationHistory(t *testing.T) {
 
 func TestExportedChunkKeysObservationMutationIdentity(t *testing.T) {
 	validPayload := `{"sync_id":" obs-mutation-only ","session_id":"session","type":"decision","title":"title","content":"content","scope":"project"}`
+	quotedPayload, err := json.Marshal(validPayload)
+	if err != nil {
+		t.Fatalf("marshal quoted payload: %v", err)
+	}
 	tests := []struct {
 		name           string
 		mutation       store.SyncMutation
@@ -1270,6 +1274,13 @@ func TestExportedChunkKeysObservationMutationIdentity(t *testing.T) {
 		{
 			name:           "valid mutation-only upsert preserves its endpoint identity",
 			mutation:       store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: " obs-mutation-only ", Op: store.SyncOpUpsert, Payload: validPayload},
+			wantHistorical: true,
+			wantAvailable:  true,
+			wantKey:        " obs-mutation-only ",
+		},
+		{
+			name:           "JSON-string payload preserves its endpoint identity",
+			mutation:       store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: " obs-mutation-only ", Op: store.SyncOpUpsert, Payload: string(quotedPayload)},
 			wantHistorical: true,
 			wantAvailable:  true,
 			wantKey:        " obs-mutation-only ",

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -508,7 +508,7 @@ func TestLocalChunkExportIncludesRelationsForObservationsInheritingSessionProjec
 	}
 }
 
-func TestLocalChunkExportIncludesRelationWithPriorChunkEndpoints(t *testing.T) {
+func TestLocalChunkExportIncludesRelationWithMutationOnlyPriorEndpoint(t *testing.T) {
 	s := newTestStore(t)
 	const (
 		project   = "proj-a"
@@ -555,17 +555,6 @@ func TestLocalChunkExportIncludesRelationWithPriorChunkEndpoints(t *testing.T) {
 	if _, err := s.DB().Exec(`UPDATE observations SET created_at = ?, updated_at = ? WHERE sync_id IN (?, ?)`, oldTime, oldTime, source.SyncID, target.SyncID); err != nil {
 		t.Fatalf("backdate endpoints: %v", err)
 	}
-	if _, err := s.AddObservation(store.AddObservationParams{
-		SessionID: sessionID,
-		Type:      "decision",
-		Title:     "new project observation",
-		Content:   "new project observation content",
-		Project:   project,
-		Scope:     "project",
-	}); err != nil {
-		t.Fatalf("add new project observation: %v", err)
-	}
-
 	const relationID = "rel-watermark-closure"
 	if _, err := s.SaveRelation(store.SaveRelationParams{SyncID: relationID, SourceID: source.SyncID, TargetID: target.SyncID}); err != nil {
 		t.Fatalf("save relation: %v", err)
@@ -580,12 +569,25 @@ func TestLocalChunkExportIncludesRelationWithPriorChunkEndpoints(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("judge relation: %v", err)
 	}
+	if _, err := s.DB().Exec(`UPDATE memory_relations SET created_at = ?, updated_at = ? WHERE sync_id = ?`, oldTime, oldTime, relationID); err != nil {
+		t.Fatalf("backdate relation: %v", err)
+	}
+	targetPayload, err := json.Marshal(target)
+	if err != nil {
+		t.Fatalf("marshal target endpoint: %v", err)
+	}
 
 	syncDir := filepath.Join(t.TempDir(), ".engram")
-	writeLocalChunkFile(t, syncDir, "previous-chunk", ChunkData{Observations: []store.Observation{
-		{SyncID: source.SyncID},
-		{SyncID: target.SyncID},
-	}})
+	writeLocalChunkFile(t, syncDir, "previous-chunk", ChunkData{
+		Sessions:     []store.Session{{ID: sessionID, Project: project, Directory: "/tmp/proj-a", StartedAt: oldTime}},
+		Observations: []store.Observation{*source},
+		Mutations: []store.SyncMutation{{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: target.SyncID,
+			Op:        store.SyncOpUpsert,
+			Payload:   string(targetPayload),
+		}},
+	})
 	writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{
 		ID: "previous-chunk", CreatedAt: "2025-06-01T00:00:00Z",
 	}}})
@@ -593,6 +595,9 @@ func TestLocalChunkExportIncludesRelationWithPriorChunkEndpoints(t *testing.T) {
 	result, err := New(s, syncDir).Export("alice", project)
 	if err != nil {
 		t.Fatalf("export: %v", err)
+	}
+	if result.IsEmpty {
+		t.Fatal("expected pre-watermark relation with historical mutation endpoint to export")
 	}
 	chunkJSON, err := readGzip(filepath.Join(syncDir, "chunks", result.ChunkID+".jsonl.gz"))
 	if err != nil {
@@ -609,7 +614,7 @@ func TestLocalChunkExportIncludesRelationWithPriorChunkEndpoints(t *testing.T) {
 		}
 	}
 	if !foundRelation {
-		t.Fatalf("relation with prior-chunk endpoints was not exported: %+v", chunk.Mutations)
+		t.Fatalf("relation with prior mutation endpoint was not exported: %+v", chunk.Mutations)
 	}
 	for _, observation := range chunk.Observations {
 		if observation.SyncID == source.SyncID || observation.SyncID == target.SyncID {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1258,6 +1258,86 @@ func TestLocalChunkExportUsesObservationHistory(t *testing.T) {
 	}
 }
 
+func TestExportedChunkKeysObservationMutationIdentity(t *testing.T) {
+	validPayload := `{"sync_id":" obs-mutation-only ","session_id":"session","type":"decision","title":"title","content":"content","scope":"project"}`
+	tests := []struct {
+		name           string
+		mutation       store.SyncMutation
+		wantHistorical bool
+		wantAvailable  bool
+		wantKey        string
+	}{
+		{
+			name:           "valid mutation-only upsert preserves its endpoint identity",
+			mutation:       store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: " obs-mutation-only ", Op: store.SyncOpUpsert, Payload: validPayload},
+			wantHistorical: true,
+			wantAvailable:  true,
+			wantKey:        " obs-mutation-only ",
+		},
+		{
+			name:     "empty payload identity is rejected",
+			mutation: store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: "obs-empty", Op: store.SyncOpUpsert, Payload: `{"sync_id":"","session_id":"session","type":"decision","title":"title","content":"content","scope":"project"}`},
+		},
+		{
+			name:     "whitespace payload identity is rejected",
+			mutation: store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: " \t", Op: store.SyncOpUpsert, Payload: `{"sync_id":" \t","session_id":"session","type":"decision","title":"title","content":"content","scope":"project"}`},
+		},
+		{
+			name:     "malformed payload identity is rejected",
+			mutation: store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: "1", Op: store.SyncOpUpsert, Payload: `{"sync_id":1,"session_id":"session","type":"decision","title":"title","content":"content","scope":"project"}`},
+		},
+		{
+			name:     "malformed payload is rejected",
+			mutation: store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: "obs-malformed", Op: store.SyncOpUpsert, Payload: `{"sync_id"`},
+		},
+		{
+			name:     "missing payload identity is rejected",
+			mutation: store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: "obs-missing", Op: store.SyncOpUpsert, Payload: `{"session_id":"session","type":"decision","title":"title","content":"content","scope":"project"}`},
+		},
+		{
+			name:     "mismatched identity is rejected",
+			mutation: store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: "obs-entity-key", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-payload","session_id":"session","type":"decision","title":"title","content":"content","scope":"project"}`},
+		},
+		{
+			name:           "tombstone preserves history but not endpoint availability",
+			mutation:       store.SyncMutation{Entity: store.SyncEntityObservation, EntityKey: "obs-tombstone", Op: store.SyncOpDelete},
+			wantHistorical: true,
+			wantKey:        "obs-tombstone",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(ChunkData{Mutations: []store.SyncMutation{tc.mutation}})
+			if err != nil {
+				t.Fatalf("marshal chunk: %v", err)
+			}
+			transport := newFakeCloudTransport()
+			transport.chunks["history"] = raw
+			sy := NewWithTransport(nil, transport)
+			_, available, historical, err := sy.exportedChunkKeys(&Manifest{Version: 1, Chunks: []ChunkEntry{{ID: "history"}}})
+			if err != nil {
+				t.Fatalf("exportedChunkKeys: %v", err)
+			}
+			if got := len(historical); got != boolToInt(tc.wantHistorical) {
+				t.Fatalf("historical keys = %v, want historical=%t", historical, tc.wantHistorical)
+			}
+			if got := len(available); got != boolToInt(tc.wantAvailable) {
+				t.Fatalf("available keys = %v, want available=%t", available, tc.wantAvailable)
+			}
+			if tc.wantKey == "" {
+				return
+			}
+			if _, ok := historical[tc.wantKey]; ok != tc.wantHistorical {
+				t.Fatalf("historical key %q present=%t, want %t", tc.wantKey, ok, tc.wantHistorical)
+			}
+			if _, ok := available[tc.wantKey]; ok != tc.wantAvailable {
+				t.Fatalf("available key %q present=%t, want %t", tc.wantKey, ok, tc.wantAvailable)
+			}
+		})
+	}
+}
+
 func boolToInt(value bool) int {
 	if value {
 		return 1


### PR DESCRIPTION
## Linked Issue

Closes #615

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Reconciles incremental local observation exports against available chunk history before applying the global manifest watermark.
- Treats direct observation rows and observation mutations, including tombstones, as historical presence.
- Includes parent sessions for emitted observations and accepts mutation-only relation endpoints only when their upsert payload is replayable and identity-matched, rejecting empty, malformed, or conflicting observation identities.

## Changes

| File | Change |
|------|--------|
| `internal/sync/sync.go` | Adds observation-history filtering, parent-session dependency closure, and validated mutation-only relation endpoint availability. |
| `internal/sync/sync_test.go` | Covers absent, direct-row, tombstone, created/updated-after-watermark, quoted-payload, and replayable mutation-only endpoint paths. |
| `docs/codebase/sync-and-cloud.md` | Documents incremental observation reconciliation and dependency closure. |

## Test Plan

- [x] Focused sync tests pass locally: `go test ./internal/sync -run '^(TestLocalChunkExportUsesObservationHistory|TestLocalChunkExportIncludesRelationWithMutationOnlyPriorEndpoint|TestExportedChunkKeysObservationMutationIdentity)$' -count=1`
- [x] Sync package tests pass locally: `go test ./internal/sync -count=1`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] `git diff --check` passes (only the existing Windows LF-to-CRLF warning is emitted).
- [x] GitHub Unit Tests, E2E Tests, Plugin Tests, and PR Validation checks pass for `7939426`.
- [x] CodeRabbit completed with no unresolved actionable threads.
- [ ] Manually tested the affected functionality

### Native review evidence

- [x] Root candidate approved and acknowledged after one bounded correction (`review-0012cdd7e697bd39`).
- [x] Relation-endpoint follow-up approved and acknowledged (`review-0d3d986e85cff1fd`).
- [x] Observation-identity follow-up approved and acknowledged (`review-9cf7a0d9e938e833`).
- [x] Quoted-payload coverage follow-up approved and acknowledged (`review-0cf814371d34f9d8`).
- [x] Created-after-watermark coverage follow-up approved and acknowledged (`review-f5cfaad82179c7d2`).

---

## Automated Checks

| Check | Status |
|-------|--------|
| Check Issue Reference | PASS |
| Check Issue Has status:approved | PASS |
| Check PR Has exactly one `type:*` label | PASS |
| Unit Tests | PASS |
| E2E Tests | PASS |
| Plugin Tests | PASS |
| CodeRabbit | PASS |

---

## Contributor Checklist

- [x] Linked approved issue #615
- [x] Added exactly one `type:*` label
- [x] Relevant local tests pass
- [x] Full automated test suite passes in GitHub CI
- [x] Documentation updated for the behavior change
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## Notes for Reviewers

This is the minimal root-focused replacement for the issue #615 portion of #780. It intentionally excludes general session/prompt identity reconciliation, incomplete-history policy, historical lifecycle replay, codec identity changes, and cloud materialization. PR #780 remains frozen until replacement work is accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incremental local exports now use per-observation history to determine chunk contents.
  * Exported chunks include the sessions needed to interpret their observations.
  * New or updated observations appear in later exports, while previously exported or deleted observations are filtered appropriately.
  * Improved handling of historical and mutation-based observation changes during export.

* **Documentation**
  * Updated sync documentation to explain observation history, filtering, and session inclusion during incremental exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->