### PR TITLE
fix(claude-code): preserve hook state without jq

### DIFF
--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -2465,19 +2466,49 @@ func TestClaudeCodeUserPromptHookHasWindowsGitBashSafePath(t *testing.T) {
 	}
 }
 
-func TestClaudeCodeUserPromptHookSanitizesWindowsSafeSessionKey(t *testing.T) {
+func TestClaudeCodeUserPromptHookUsesCollisionResistantWindowsSafeSessionKey(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "plugin", "claude-code", "scripts", "user-prompt-submit.sh"))
 	if err != nil {
 		t.Fatalf("read user prompt hook: %v", err)
 	}
 	text := string(data)
+	helperStart := strings.Index(text, "session_state_key_part()")
+	if helperStart < 0 {
+		t.Fatal("user prompt hook missing session state-key helper")
+	}
+	helperEnd := strings.Index(text[helperStart:], "print_toolsearch_message()")
+	if helperEnd < 0 {
+		t.Fatal("user prompt hook missing session state-key helper boundary")
+	}
+	helper := text[helperStart : helperStart+helperEnd]
 	for _, want := range []string{
-		"sanitize_session_key_part()",
-		"[[ \"$char\" =~ [a-zA-Z0-9_-] ]]",
-		"SESSION_KEY=\"engram-claude-${JSON_VALUE}-tools-loaded\"",
+		`local encoded="sid-"`,
+		`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`,
+		`printf -v byte '%02X' "'$char"`,
 	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("user prompt hook missing Windows session key sanitization fragment %q", want)
+		if !strings.Contains(helper, want) {
+			t.Fatalf("session state-key helper missing collision-resistant fragment %q", want)
+		}
+	}
+	if strings.Contains(text, "sanitize_session_key_part") {
+		t.Fatal("user prompt hook still references the removed lossy session-key sanitizer")
+	}
+
+	safePath := strings.Index(text, "if is_windows_bash &&")
+	if safePath < 0 {
+		t.Fatal("user prompt hook missing Windows Git Bash safe path")
+	}
+	blockEnd := strings.Index(text[safePath:], "# Load shared helpers after the Windows-safe fast path")
+	if blockEnd < 0 {
+		t.Fatal("user prompt hook missing Windows Git Bash safe path boundary")
+	}
+	windowsSafePath := text[safePath : safePath+blockEnd]
+	for _, want := range []string{
+		`session_state_key_part "$SESSION_ID"`,
+		`SESSION_KEY="engram-claude-${JSON_VALUE}-tools-loaded"`,
+	} {
+		if !strings.Contains(windowsSafePath, want) {
+			t.Fatalf("Windows-safe path does not build its state key through the collision-resistant helper: %q", want)
 		}
 	}
 }
@@ -2489,15 +2520,40 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 
 	bashPath, pathDirs := isolatedHookPath(t)
 
+	type promptPayload struct {
+		SessionID string `json:"session_id"`
+		Project   string `json:"project"`
+		Content   string `json:"content"`
+	}
+	type capturedPrompt struct {
+		payload promptPayload
+		err     error
+	}
+	projectCWDs := make(chan string, 16)
+	observationProjects := make(chan string, 16)
+	prompts := make(chan capturedPrompt, 8)
+	const cwd = "/workspace with space/mañana"
+	const project = "hook test/mañana"
+	const expectedPrompt = "quote \" slash \\ newline\nbmp Ω pair 😃 esc \x1b"
+	input := `{"cwd":"/workspace with space/mañana","session_id":"session-677","prompt":"quote \" slash \\ newline\nbmp \u03a9 pair \uD83D\uDE03 esc \u001b"}`
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/project/current":
-			_, _ = w.Write([]byte(`{"project":"hook-test","project_source":"config"}`))
+			projectCWDs <- r.URL.Query().Get("cwd")
+			_, _ = w.Write([]byte(`{"project":"hook test/mañana","project_source":"config"}`))
 		case "/sessions/session-677":
 			_, _ = w.Write([]byte(`{"started_at":"2000-01-01T00:00:00Z"}`))
 		case "/observations":
+			observationProjects <- r.URL.Query().Get("project")
 			_, _ = w.Write([]byte(`[{"created_at":"2000-01-01T00:00:00Z"}]`))
 		case "/prompts":
+			body, err := io.ReadAll(r.Body)
+			var payload promptPayload
+			if err == nil {
+				err = json.Unmarshal(body, &payload)
+			}
+			prompts <- capturedPrompt{payload: payload, err: err}
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			http.NotFound(w, r)
@@ -2514,18 +2570,18 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 		t.Fatalf("resolve user prompt hook path: %v", err)
 	}
 	stateDir := t.TempDir()
-	input := `{"cwd":"/workspace","session_id":"session-677","prompt":"remember this"}`
-	env := withoutEnv(os.Environ(), "PATH", "TMPDIR", "ENGRAM_PORT", "ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE")
+	env := withoutEnv(os.Environ(), "PATH", "TMPDIR", "ENGRAM_PORT", "ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE", "ENGRAM_HOOK_MAX_TIME")
 	env = append(env,
 		"PATH="+strings.Join(pathDirs, string(os.PathListSeparator)),
 		"TMPDIR="+stateDir,
 		"ENGRAM_PORT="+serverURL.Port(),
 		"ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE=0",
+		"ENGRAM_HOOK_MAX_TIME=1",
 	)
 
-	runHook := func() (string, string) {
+	runHook := func(input string, env []string) (string, string) {
 		t.Helper()
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, bashPath, scriptPath)
 		cmd.Env = env
@@ -2534,10 +2590,14 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
-			t.Fatalf("run user prompt hook without jq: %v\nstderr: %s", err, stderr.String())
-		}
-		if ctx.Err() != nil {
-			t.Fatalf("user prompt hook timed out: %v", ctx.Err())
+			stderrText := stderr.String()
+			if len(stderrText) > 4096 {
+				stderrText = stderrText[:4096] + "…"
+			}
+			if ctx.Err() != nil {
+				t.Fatalf("user prompt hook timed out: %v\nstderr: %s", ctx.Err(), stderrText)
+			}
+			t.Fatalf("run user prompt hook without jq: %v\nstderr: %s", err, stderrText)
 		}
 		if strings.Contains(stderr.String(), "jq:") {
 			t.Fatalf("user prompt hook invoked jq without jq on PATH: %s", stderr.String())
@@ -2549,17 +2609,17 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 		return stdout.String(), stderr.String()
 	}
 
-	firstOutput, _ := runHook()
+	firstOutput, _ := runHook(input, env)
 	if !strings.Contains(firstOutput, "CRITICAL FIRST ACTION") {
 		t.Fatalf("first hook invocation = %q, want bootstrap response", firstOutput)
 	}
 
-	secondOutput, secondStderr := runHook()
+	secondOutput, secondStderr := runHook(input, env)
 	if !strings.Contains(secondOutput, "MEMORY REMINDER") {
 		t.Fatalf("second hook invocation = %q, want save nudge; stderr: %s", secondOutput, secondStderr)
 	}
 
-	thirdOutput, _ := runHook()
+	thirdOutput, _ := runHook(input, env)
 	if strings.Contains(thirdOutput, "MEMORY REMINDER") || strings.Contains(thirdOutput, "CRITICAL FIRST ACTION") {
 		t.Fatalf("third hook invocation = %q, want cooldown response", thirdOutput)
 	}
@@ -2570,6 +2630,76 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 	}
 	if len(stateFiles) != 2 {
 		t.Fatalf("hook state files = %v, want one session and one cooldown file", stateFiles)
+	}
+
+	for range 3 {
+		select {
+		case captured := <-prompts:
+			if captured.err != nil {
+				t.Fatalf("decode prompt POST body: %v", captured.err)
+			}
+			if captured.payload != (promptPayload{SessionID: "session-677", Project: project, Content: expectedPrompt}) {
+				t.Fatalf("prompt POST payload = %#v, want %#v", captured.payload, promptPayload{SessionID: "session-677", Project: project, Content: expectedPrompt})
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for prompt POST")
+		}
+	}
+	for range 5 {
+		select {
+		case got := <-projectCWDs:
+			if got != cwd {
+				t.Fatalf("/project/current cwd = %q, want %q", got, cwd)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for /project/current request")
+		}
+	}
+	for range 2 {
+		select {
+		case got := <-observationProjects:
+			if got != project {
+				t.Fatalf("/observations project = %q, want %q", got, project)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for /observations request")
+		}
+	}
+
+	negativeStateDir := t.TempDir()
+	negativeEnv := withoutEnv(env, "TMPDIR")
+	negativeEnv = append(negativeEnv, "TMPDIR="+negativeStateDir)
+	for index, escapedPrompt := range []string{
+		`\u12G4`,
+		`\uD800`,
+		`\uDC00`,
+		`\u0000`,
+	} {
+		negativeInput := fmt.Sprintf(`{"cwd":"%s","session_id":"negative-%d","prompt":"invalid %s"}`, cwd, index, escapedPrompt)
+		runHook(negativeInput, negativeEnv)
+	}
+	select {
+	case captured := <-prompts:
+		t.Fatalf("invalid JSON escape unexpectedly posted prompt payload %#v (decode error: %v)", captured.payload, captured.err)
+	case <-time.After(time.Second):
+	}
+
+	collisionStateDir := t.TempDir()
+	collisionEnv := withoutEnv(env, "TMPDIR")
+	collisionEnv = append(collisionEnv, "TMPDIR="+collisionStateDir)
+	for _, sessionID := range []string{"a/b", "a?b"} {
+		collisionInput := fmt.Sprintf(`{"cwd":"%s","session_id":"%s","prompt":""}`, cwd, sessionID)
+		output, _ := runHook(collisionInput, collisionEnv)
+		if !strings.Contains(output, "CRITICAL FIRST ACTION") {
+			t.Fatalf("first hook invocation for unsafe session %q = %q, want bootstrap response", sessionID, output)
+		}
+	}
+	collisionStateFiles, err := filepath.Glob(filepath.Join(collisionStateDir, "engram-claude-*-tools-loaded"))
+	if err != nil {
+		t.Fatalf("list unsafe session state files: %v", err)
+	}
+	if len(collisionStateFiles) != 2 {
+		t.Fatalf("unsafe session state files = %v, want distinct state files", collisionStateFiles)
 	}
 }
 
@@ -2594,7 +2724,7 @@ func isolatedHookPath(t *testing.T) (string, []string) {
 	for _, tool := range []string{"cat", "curl", "date", "dirname", "touch"} {
 		toolPath, err := exec.LookPath(tool)
 		if err != nil {
-			t.Fatalf("find required hook tool %q: %v", tool, err)
+			t.Skipf("required hook tool %q is unavailable: %v", tool, err)
 		}
 		linkPath := filepath.Join(binDir, filepath.Base(toolPath))
 		if err := os.Link(toolPath, linkPath); err != nil {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2,15 +2,21 @@ package setup
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestEmbeddedOpenCodePluginMatchesSourceByteForByte(t *testing.T) {
@@ -2474,6 +2480,153 @@ func TestClaudeCodeUserPromptHookSanitizesWindowsSafeSessionKey(t *testing.T) {
 			t.Fatalf("user prompt hook missing Windows session key sanitization fragment %q", want)
 		}
 	}
+}
+
+func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs the Claude Code shell hook as a child process")
+	}
+
+	bashPath, pathDirs := isolatedHookPath(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/project/current":
+			_, _ = w.Write([]byte(`{"project":"hook-test","project_source":"config"}`))
+		case "/sessions/session-677":
+			_, _ = w.Write([]byte(`{"started_at":"2000-01-01T00:00:00Z"}`))
+		case "/observations":
+			_, _ = w.Write([]byte(`[{"created_at":"2000-01-01T00:00:00Z"}]`))
+		case "/prompts":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "plugin", "claude-code", "scripts", "user-prompt-submit.sh"))
+	if err != nil {
+		t.Fatalf("resolve user prompt hook path: %v", err)
+	}
+	stateDir := t.TempDir()
+	input := `{"cwd":"/workspace","session_id":"session-677","prompt":"remember this"}`
+	env := withoutEnv(os.Environ(), "PATH", "TMPDIR", "ENGRAM_PORT", "ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE")
+	env = append(env,
+		"PATH="+strings.Join(pathDirs, string(os.PathListSeparator)),
+		"TMPDIR="+stateDir,
+		"ENGRAM_PORT="+serverURL.Port(),
+		"ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE=0",
+	)
+
+	runHook := func() (string, string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, bashPath, scriptPath)
+		cmd.Env = env
+		cmd.Stdin = strings.NewReader(input)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("run user prompt hook without jq: %v\nstderr: %s", err, stderr.String())
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("user prompt hook timed out: %v", ctx.Err())
+		}
+		if strings.Contains(stderr.String(), "jq:") {
+			t.Fatalf("user prompt hook invoked jq without jq on PATH: %s", stderr.String())
+		}
+		var response map[string]any
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+			t.Fatalf("user prompt hook emitted invalid JSON %q: %v", stdout.String(), err)
+		}
+		return stdout.String(), stderr.String()
+	}
+
+	firstOutput, _ := runHook()
+	if !strings.Contains(firstOutput, "CRITICAL FIRST ACTION") {
+		t.Fatalf("first hook invocation = %q, want bootstrap response", firstOutput)
+	}
+
+	secondOutput, secondStderr := runHook()
+	if !strings.Contains(secondOutput, "MEMORY REMINDER") {
+		t.Fatalf("second hook invocation = %q, want save nudge; stderr: %s", secondOutput, secondStderr)
+	}
+
+	thirdOutput, _ := runHook()
+	if strings.Contains(thirdOutput, "MEMORY REMINDER") || strings.Contains(thirdOutput, "CRITICAL FIRST ACTION") {
+		t.Fatalf("third hook invocation = %q, want cooldown response", thirdOutput)
+	}
+
+	stateFiles, err := filepath.Glob(filepath.Join(stateDir, "engram-claude-*"))
+	if err != nil {
+		t.Fatalf("list hook state files: %v", err)
+	}
+	if len(stateFiles) != 2 {
+		t.Fatalf("hook state files = %v, want one session and one cooldown file", stateFiles)
+	}
+}
+
+func isolatedHookPath(t *testing.T) (string, []string) {
+	t.Helper()
+	if gitPath, err := exec.LookPath("git"); err == nil {
+		gitRoot := filepath.Dir(filepath.Dir(gitPath))
+		gitBash := filepath.Join(gitRoot, "bin", "bash.exe")
+		if _, err := os.Stat(gitBash); err == nil {
+			pathDirs := []string{filepath.Join(gitRoot, "usr", "bin"), filepath.Join(gitRoot, "bin"), os.Getenv("SystemRoot") + `\System32`}
+			assertJQAbsent(t, pathDirs)
+			return gitBash, pathDirs
+		}
+	}
+
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash is required for Claude Code hook regression: %v", err)
+	}
+
+	binDir := t.TempDir()
+	for _, tool := range []string{"cat", "curl", "date", "dirname", "touch"} {
+		toolPath, err := exec.LookPath(tool)
+		if err != nil {
+			t.Fatalf("find required hook tool %q: %v", tool, err)
+		}
+		linkPath := filepath.Join(binDir, filepath.Base(toolPath))
+		if err := os.Link(toolPath, linkPath); err != nil {
+			if err := os.Symlink(toolPath, linkPath); err != nil {
+				t.Fatalf("expose required hook tool %q without jq: %v", tool, err)
+			}
+		}
+	}
+	assertJQAbsent(t, []string{binDir})
+	return bashPath, []string{binDir}
+}
+
+func assertJQAbsent(t *testing.T, pathDirs []string) {
+	t.Helper()
+	for _, dir := range pathDirs {
+		for _, name := range []string{"jq", "jq.exe"} {
+			if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+				t.Fatalf("controlled hook PATH includes jq at %q", filepath.Join(dir, name))
+			}
+		}
+	}
+}
+
+func withoutEnv(env []string, names ...string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, item := range env {
+		name, _, _ := strings.Cut(item, "=")
+		if !slices.Contains(names, name) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
 }
 
 func TestClaudeCodeUserPromptHookIncludesPowerShellFallback(t *testing.T) {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2632,6 +2632,7 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 		t.Fatalf("hook state files = %v, want one session and one cooldown file", stateFiles)
 	}
 
+	const hookRequestWaitTimeout = 5 * time.Second
 	for range 3 {
 		select {
 		case captured := <-prompts:
@@ -2641,7 +2642,7 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 			if captured.payload != (promptPayload{SessionID: "session-677", Project: project, Content: expectedPrompt}) {
 				t.Fatalf("prompt POST payload = %#v, want %#v", captured.payload, promptPayload{SessionID: "session-677", Project: project, Content: expectedPrompt})
 			}
-		case <-time.After(time.Second):
+		case <-time.After(hookRequestWaitTimeout):
 			t.Fatal("timed out waiting for prompt POST")
 		}
 	}
@@ -2651,7 +2652,7 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 			if got != cwd {
 				t.Fatalf("/project/current cwd = %q, want %q", got, cwd)
 			}
-		case <-time.After(time.Second):
+		case <-time.After(hookRequestWaitTimeout):
 			t.Fatal("timed out waiting for /project/current request")
 		}
 	}
@@ -2661,7 +2662,7 @@ func TestClaudeCodeUserPromptHookWithoutJQPreservesSessionStateAndNudge(t *testi
 			if got != project {
 				t.Fatalf("/observations project = %q, want %q", got, project)
 			}
-		case <-time.After(time.Second):
+		case <-time.After(hookRequestWaitTimeout):
 			t.Fatal("timed out waiting for /observations request")
 		}
 	}

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -17,6 +17,7 @@
 
 ENGRAM_PORT="${ENGRAM_PORT:-7437}"
 ENGRAM_URL="http://127.0.0.1:${ENGRAM_PORT}"
+ENGRAM_HOOK_MAX_TIME="${ENGRAM_HOOK_MAX_TIME:-0.2}"
 
 # Windows Git Bash/MSYS2 can fail while forking helper processes under
 # enterprise Defender/EDR, which makes Claude Code wait on prompt submission.
@@ -40,19 +41,21 @@ set_json_string_value() {
   fi
 }
 
-sanitize_session_key_part() {
+session_state_key_part() {
   local raw="$1"
-  local safe=""
-  local i char
+  local encoded="sid-"
+  local i char byte
+  local LC_ALL=C
+  if [[ "$raw" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]]; then
+    JSON_VALUE="$raw"
+    return 0
+  fi
   for (( i=0; i<${#raw}; i++ )); do
     char="${raw:i:1}"
-    if [[ "$char" =~ [a-zA-Z0-9_-] ]]; then
-      safe+="$char"
-    else
-      safe+="_"
-    fi
+    printf -v byte '%02X' "'$char"
+    encoded+="$byte"
   done
-  JSON_VALUE="$safe"
+  JSON_VALUE="$encoded"
 }
 
 print_toolsearch_message() {
@@ -63,7 +66,8 @@ json_string_value_without_jq() {
   local key="$1"
   local json="$2"
   local pattern='"'"$key"'"[[:space:]]*:[[:space:]]*"(([^"\\]|\\.)*)"'
-  local raw i char escaped value=""
+  local raw i char escaped hex codepoint low_hex low_surrogate value=""
+  local LC_ALL=C
   JSON_VALUE=""
   [[ "$json" =~ $pattern ]] || return 1
   raw="${BASH_REMATCH[1]}"
@@ -83,15 +87,60 @@ json_string_value_without_jq() {
       n) value+=$'\n' ;;
       r) value+=$'\r' ;;
       t) value+=$'\t' ;;
+      u)
+        hex="${raw:i+1:4}"
+        [[ "$hex" =~ ^[0-9A-Fa-f]{4}$ ]] || return 1
+        codepoint=$(( 16#$hex ))
+        i=$(( i + 4 ))
+        if [ "$codepoint" -ge 55296 ] && [ "$codepoint" -le 56319 ]; then
+          [ "${raw:i+1:2}" = $'\\u' ] || return 1
+          low_hex="${raw:i+3:4}"
+          [[ "$low_hex" =~ ^[0-9A-Fa-f]{4}$ ]] || return 1
+          low_surrogate=$(( 16#$low_hex ))
+          [ "$low_surrogate" -ge 56320 ] && [ "$low_surrogate" -le 57343 ] || return 1
+          codepoint=$(( 65536 + (codepoint - 55296) * 1024 + low_surrogate - 56320 ))
+          i=$(( i + 6 ))
+        elif [ "$codepoint" -ge 56320 ] && [ "$codepoint" -le 57343 ]; then
+          return 1
+        fi
+        utf8_from_codepoint_without_jq "$codepoint" || return 1
+        value+="$JSON_VALUE"
+        ;;
       *) return 1 ;;
     esac
   done
   JSON_VALUE="$value"
 }
 
+utf8_from_codepoint_without_jq() {
+  local codepoint="$1"
+  local byte1 byte2 byte3 byte4
+  [ "$codepoint" -gt 0 ] && [ "$codepoint" -le 1114111 ] || return 1
+  if [ "$codepoint" -le 127 ]; then
+    printf -v byte1 '%03o' "$codepoint"
+    printf -v JSON_VALUE '%b' "\\0${byte1}"
+  elif [ "$codepoint" -le 2047 ]; then
+    printf -v byte1 '%03o' "$(( 192 | (codepoint >> 6) ))"
+    printf -v byte2 '%03o' "$(( 128 | (codepoint & 63) ))"
+    printf -v JSON_VALUE '%b' "\\0${byte1}\\0${byte2}"
+  elif [ "$codepoint" -le 65535 ]; then
+    printf -v byte1 '%03o' "$(( 224 | (codepoint >> 12) ))"
+    printf -v byte2 '%03o' "$(( 128 | ((codepoint >> 6) & 63) ))"
+    printf -v byte3 '%03o' "$(( 128 | (codepoint & 63) ))"
+    printf -v JSON_VALUE '%b' "\\0${byte1}\\0${byte2}\\0${byte3}"
+  else
+    printf -v byte1 '%03o' "$(( 240 | (codepoint >> 18) ))"
+    printf -v byte2 '%03o' "$(( 128 | ((codepoint >> 12) & 63) ))"
+    printf -v byte3 '%03o' "$(( 128 | ((codepoint >> 6) & 63) ))"
+    printf -v byte4 '%03o' "$(( 128 | (codepoint & 63) ))"
+    printf -v JSON_VALUE '%b' "\\0${byte1}\\0${byte2}\\0${byte3}\\0${byte4}"
+  fi
+}
+
 json_escape_without_jq() {
   local raw="$1"
-  local i char value=""
+  local i char byte byte2 byte3 byte4 codepoint escaped value=""
+  local LC_ALL=C
   for (( i=0; i<${#raw}; i++ )); do
     char="${raw:i:1}"
     case "$char" in
@@ -102,7 +151,58 @@ json_escape_without_jq() {
       $'\n') value+='\n' ;;
       $'\r') value+='\r' ;;
       $'\t') value+='\t' ;;
-      *) value+="$char" ;;
+      *)
+        printf -v byte '%d' "'$char"
+        if [ "$byte" -ge 1 ] && [ "$byte" -le 31 ]; then
+          printf -v escaped '\\u%04x' "$byte"
+          value+="$escaped"
+        elif [ "$byte" -ge 128 ]; then
+          codepoint=""
+          if [ "$byte" -ge 194 ] && [ "$byte" -le 223 ] && [ "$(( i + 1 ))" -lt "${#raw}" ]; then
+            printf -v byte2 '%d' "'${raw:i+1:1}"
+            if [ "$byte2" -ge 128 ] && [ "$byte2" -le 191 ]; then
+              codepoint=$(( ((byte & 31) << 6) | (byte2 & 63) ))
+              i=$(( i + 1 ))
+            fi
+          elif [ "$byte" -ge 224 ] && [ "$byte" -le 239 ] && [ "$(( i + 2 ))" -lt "${#raw}" ]; then
+            printf -v byte2 '%d' "'${raw:i+1:1}"
+            printf -v byte3 '%d' "'${raw:i+2:1}"
+            if [ "$byte2" -ge 128 ] && [ "$byte2" -le 191 ] && [ "$byte3" -ge 128 ] && [ "$byte3" -le 191 ]; then
+              codepoint=$(( ((byte & 15) << 12) | ((byte2 & 63) << 6) | (byte3 & 63) ))
+              if [ "$codepoint" -ge 2048 ] && { [ "$codepoint" -lt 55296 ] || [ "$codepoint" -gt 57343 ]; }; then
+                i=$(( i + 2 ))
+              else
+                codepoint=""
+              fi
+            fi
+          elif [ "$byte" -ge 240 ] && [ "$byte" -le 244 ] && [ "$(( i + 3 ))" -lt "${#raw}" ]; then
+            printf -v byte2 '%d' "'${raw:i+1:1}"
+            printf -v byte3 '%d' "'${raw:i+2:1}"
+            printf -v byte4 '%d' "'${raw:i+3:1}"
+            if [ "$byte2" -ge 128 ] && [ "$byte2" -le 191 ] && [ "$byte3" -ge 128 ] && [ "$byte3" -le 191 ] && [ "$byte4" -ge 128 ] && [ "$byte4" -le 191 ]; then
+              codepoint=$(( ((byte & 7) << 18) | ((byte2 & 63) << 12) | ((byte3 & 63) << 6) | (byte4 & 63) ))
+              if [ "$codepoint" -ge 65536 ] && [ "$codepoint" -le 1114111 ]; then
+                i=$(( i + 3 ))
+              else
+                codepoint=""
+              fi
+            fi
+          fi
+          if [ -n "$codepoint" ]; then
+            if [ "$codepoint" -le 65535 ]; then
+              printf -v escaped '\\u%04x' "$codepoint"
+            else
+              printf -v escaped '\\u%04x\\u%04x' "$(( 55296 + ((codepoint - 65536) >> 10) ))" "$(( 56320 + ((codepoint - 65536) & 1023) ))"
+            fi
+            value+="$escaped"
+          else
+            printf -v escaped '\\u00%02x' "$byte"
+            value+="$escaped"
+          fi
+        else
+          value+="$char"
+        fi
+        ;;
     esac
   done
   JSON_VALUE="$value"
@@ -169,7 +269,7 @@ user_prompt_submit_without_jq() {
   fi
 
   if [ -n "$session_id" ]; then
-    sanitize_session_key_part "$session_id"
+    session_state_key_part "$session_id"
     session_key="engram-claude-${JSON_VALUE}-tools-loaded"
   else
     session_key="engram-claude-unknown-$$-tools-loaded"
@@ -189,7 +289,7 @@ user_prompt_submit_without_jq() {
   }
 
   if [ -n "$session_id" ]; then
-    session_start=$(curl -sf "${ENGRAM_URL}/sessions/${session_id}" --max-time 0.2 2>/dev/null)
+    session_start=$(curl -sf "${ENGRAM_URL}/sessions/${session_id}" --max-time "$ENGRAM_HOOK_MAX_TIME" 2>/dev/null)
     json_string_value_without_jq "started_at" "$session_start" && session_start="$JSON_VALUE" || session_start=""
   fi
   if [ -n "$session_start" ]; then
@@ -202,7 +302,7 @@ user_prompt_submit_without_jq() {
 
   url_encode_without_jq "$project"
   encoded_project="$JSON_VALUE"
-  last_save_json=$(curl -sf "${ENGRAM_URL}/observations?project=${encoded_project}&limit=1&sort=created_at:desc" --max-time 0.2 2>/dev/null)
+  last_save_json=$(curl -sf "${ENGRAM_URL}/observations?project=${encoded_project}&limit=1&sort=created_at:desc" --max-time "$ENGRAM_HOOK_MAX_TIME" 2>/dev/null)
   json_string_value_without_jq "created_at" "$last_save_json" && last_save_at="$JSON_VALUE" || last_save_at=""
   [ -n "$last_save_at" ] || { printf '%s\n' '{}'; return 0; }
   last_epoch=$(parse_epoch "$last_save_at")
@@ -237,7 +337,7 @@ if is_windows_bash && [ "${ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE:-auto}" != "0" ]
   set_json_string_value "session_id" "$INPUT"
   SESSION_ID="$JSON_VALUE"
   if [ -n "$SESSION_ID" ]; then
-    sanitize_session_key_part "$SESSION_ID"
+    session_state_key_part "$SESSION_ID"
     SESSION_KEY="engram-claude-${JSON_VALUE}-tools-loaded"
   else
     SESSION_KEY="engram-claude-windows-$$-tools-loaded"
@@ -335,17 +435,18 @@ OUTPUT="{}"
 # FIRST-MESSAGE DETECTION
 #
 # Use a state file per session to determine if this is the first user message.
-# State file lives in /tmp and is keyed by session_id (falls back to project+pid).
+# State file lives in TMPDIR (or /tmp) and is keyed by session_id (falls back to project+pid).
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Build a stable session key — prefer SESSION_ID, then a process-local fallback.
 if [ -n "$SESSION_ID" ]; then
-  SESSION_KEY="engram-claude-${SESSION_ID}-tools-loaded"
+  session_state_key_part "$SESSION_ID"
+  SESSION_KEY="engram-claude-${JSON_VALUE}-tools-loaded"
 else
   SESSION_KEY="engram-claude-unknown-$$-tools-loaded"
 fi
 
-STATE_FILE="/tmp/${SESSION_KEY}"
+STATE_FILE="${TMPDIR:-/tmp}/${SESSION_KEY}"
 
 if [ ! -f "$STATE_FILE" ]; then
   # ── FIRST MESSAGE ────────────────────────────────────────────────────────────
@@ -375,7 +476,7 @@ fi
 # Get session start time to check if session is > 5 minutes old
 SESSION_START=""
 if [ -n "$SESSION_ID" ]; then
-  SESSION_START=$(curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}" --max-time 0.2 2>/dev/null \
+  SESSION_START=$(curl -sf "${ENGRAM_URL}/sessions/${SESSION_ID}" --max-time "$ENGRAM_HOOK_MAX_TIME" 2>/dev/null \
     | jq -r '.started_at // empty' 2>/dev/null)
 fi
 
@@ -400,7 +501,7 @@ fi
 ENCODED_PROJECT=$(printf '%s' "$PROJECT" | jq -sRr @uri)
 LAST_SAVE_JSON=$(curl -sf \
   "${ENGRAM_URL}/observations?project=${ENCODED_PROJECT}&limit=1&sort=created_at:desc" \
-  --max-time 0.2 2>/dev/null)
+  --max-time "$ENGRAM_HOOK_MAX_TIME" 2>/dev/null)
 
 if [ -z "$LAST_SAVE_JSON" ]; then
   # Server not responding or slow — fail silently, no nudge

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -59,6 +59,175 @@ print_toolsearch_message() {
   printf '%s\n' '{"systemMessage":"CRITICAL FIRST ACTION — Execute this ToolSearch NOW before responding to the user:\nselect:mcp__engram__mem_save,mcp__engram__mem_search,mcp__engram__mem_context,mcp__engram__mem_session_summary,mcp__engram__mem_session_start,mcp__engram__mem_session_end,mcp__engram__mem_get_observation,mcp__engram__mem_suggest_topic_key,mcp__engram__mem_capture_passive,mcp__engram__mem_save_prompt,mcp__engram__mem_update,mcp__engram__mem_current_project,mcp__engram__mem_judge\n\nAfter loading tools, call mem_context to check for prior session history before responding."}'
 }
 
+json_string_value_without_jq() {
+  local key="$1"
+  local json="$2"
+  local pattern='"'"$key"'"[[:space:]]*:[[:space:]]*"(([^"\\]|\\.)*)"'
+  local raw i char escaped value=""
+  JSON_VALUE=""
+  [[ "$json" =~ $pattern ]] || return 1
+  raw="${BASH_REMATCH[1]}"
+  for (( i=0; i<${#raw}; i++ )); do
+    char="${raw:i:1}"
+    if [ "$char" != $'\\' ]; then
+      value+="$char"
+      continue
+    fi
+    (( i++ ))
+    [ "$i" -lt "${#raw}" ] || return 1
+    escaped="${raw:i:1}"
+    case "$escaped" in
+      '"'|$'\\'|/) value+="$escaped" ;;
+      b) value+=$'\b' ;;
+      f) value+=$'\f' ;;
+      n) value+=$'\n' ;;
+      r) value+=$'\r' ;;
+      t) value+=$'\t' ;;
+      *) return 1 ;;
+    esac
+  done
+  JSON_VALUE="$value"
+}
+
+json_escape_without_jq() {
+  local raw="$1"
+  local i char value=""
+  for (( i=0; i<${#raw}; i++ )); do
+    char="${raw:i:1}"
+    case "$char" in
+      '"') value+='\"' ;;
+      $'\\') value+=$'\\\\' ;;
+      $'\b') value+='\b' ;;
+      $'\f') value+='\f' ;;
+      $'\n') value+='\n' ;;
+      $'\r') value+='\r' ;;
+      $'\t') value+='\t' ;;
+      *) value+="$char" ;;
+    esac
+  done
+  JSON_VALUE="$value"
+}
+
+url_encode_without_jq() {
+  local raw="$1"
+  local i char byte value=""
+  local LC_ALL=C
+  for (( i=0; i<${#raw}; i++ )); do
+    char="${raw:i:1}"
+    case "$char" in
+      [a-zA-Z0-9.~_-]) value+="$char" ;;
+      *)
+        printf -v byte '%02X' "'$char"
+        value+="%${byte}"
+        ;;
+    esac
+  done
+  JSON_VALUE="$value"
+}
+
+resolve_project_without_jq() {
+  local dir="$1"
+  local encoded response project source
+  [ -n "$dir" ] || return 1
+  url_encode_without_jq "$dir"
+  encoded="$JSON_VALUE"
+  response=$(curl -sf "${ENGRAM_URL}/project/current?cwd=${encoded}" --max-time 2 2>/dev/null) || return 1
+  json_string_value_without_jq "project" "$response" || return 1
+  project="$JSON_VALUE"
+  json_string_value_without_jq "project_source" "$response" || return 1
+  source="$JSON_VALUE"
+  json_string_value_without_jq "error_hint" "$response" && return 1
+  case "$source" in
+    config|git_remote|git_root|git_child|dir_basename|process_override) ;;
+    *) return 1 ;;
+  esac
+  [ -n "$project" ] || return 1
+  printf '%s\n' "$project"
+}
+
+user_prompt_submit_without_jq() {
+  local cwd="" session_id="" prompt="" project="" session_key state_dir state_file
+  local session_start="" session_start_epoch now_epoch session_age_secs encoded_project
+  local last_save_json="" last_save_at="" last_epoch elapsed nudge_cooldown nudge_state_file last_nudge_epoch=""
+
+  json_string_value_without_jq "cwd" "$INPUT" && cwd="$JSON_VALUE"
+  json_string_value_without_jq "session_id" "$INPUT" && session_id="$JSON_VALUE"
+  json_string_value_without_jq "prompt" "$INPUT" && prompt="$JSON_VALUE"
+
+  if [ -n "$prompt" ] && [ -n "$session_id" ]; then
+    (
+      project=$(resolve_project_without_jq "$cwd") || exit 0
+      json_escape_without_jq "$session_id"
+      local escaped_session="$JSON_VALUE"
+      json_escape_without_jq "$project"
+      local escaped_project="$JSON_VALUE"
+      json_escape_without_jq "$prompt"
+      curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
+        -H 'Content-Type: application/json' \
+        -d "{\"session_id\":\"${escaped_session}\",\"project\":\"${escaped_project}\",\"content\":\"${JSON_VALUE}\"}" >/dev/null 2>&1 || true
+    ) &
+  fi
+
+  if [ -n "$session_id" ]; then
+    sanitize_session_key_part "$session_id"
+    session_key="engram-claude-${JSON_VALUE}-tools-loaded"
+  else
+    session_key="engram-claude-unknown-$$-tools-loaded"
+  fi
+  state_dir="${TMPDIR:-/tmp}"
+  state_file="${state_dir}/${session_key}"
+
+  if [ ! -f "$state_file" ]; then
+    : > "$state_file" 2>/dev/null || true
+    print_toolsearch_message
+    return 0
+  fi
+
+  project=$(resolve_project_without_jq "$cwd") || {
+    printf '%s\n' '{}'
+    return 0
+  }
+
+  if [ -n "$session_id" ]; then
+    session_start=$(curl -sf "${ENGRAM_URL}/sessions/${session_id}" --max-time 0.2 2>/dev/null)
+    json_string_value_without_jq "started_at" "$session_start" && session_start="$JSON_VALUE" || session_start=""
+  fi
+  if [ -n "$session_start" ]; then
+    session_start_epoch=$(parse_epoch "$session_start")
+    [ -n "$session_start_epoch" ] || { printf '%s\n' '{}'; return 0; }
+    now_epoch=$(date "+%s")
+    session_age_secs=$(( now_epoch - session_start_epoch ))
+    [ "$session_age_secs" -ge 300 ] || { printf '%s\n' '{}'; return 0; }
+  fi
+
+  url_encode_without_jq "$project"
+  encoded_project="$JSON_VALUE"
+  last_save_json=$(curl -sf "${ENGRAM_URL}/observations?project=${encoded_project}&limit=1&sort=created_at:desc" --max-time 0.2 2>/dev/null)
+  json_string_value_without_jq "created_at" "$last_save_json" && last_save_at="$JSON_VALUE" || last_save_at=""
+  [ -n "$last_save_at" ] || { printf '%s\n' '{}'; return 0; }
+  last_epoch=$(parse_epoch "$last_save_at")
+  [ -n "$last_epoch" ] || { printf '%s\n' '{}'; return 0; }
+  now_epoch=$(date "+%s")
+  elapsed=$(( now_epoch - last_epoch ))
+
+  if [ "$elapsed" -gt 900 ]; then
+    nudge_cooldown="${ENGRAM_NUDGE_COOLDOWN_SECS:-900}"
+    nudge_state_file="${state_file%-tools-loaded}-last-nudge"
+    if [ -f "$nudge_state_file" ]; then
+      read -r last_nudge_epoch < "$nudge_state_file" 2>/dev/null || last_nudge_epoch=""
+    fi
+    case "$last_nudge_epoch" in
+      ''|*[!0-9]*) last_nudge_epoch="" ;;
+    esac
+    if [ -z "$last_nudge_epoch" ] || [ "$(( now_epoch - last_nudge_epoch ))" -ge "$nudge_cooldown" ]; then
+      printf '%s\n' "$now_epoch" > "$nudge_state_file" 2>/dev/null || true
+      printf '%s\n' '{"systemMessage":"MEMORY REMINDER: It'\''s been over 15 minutes since your last save. If you'\''ve made decisions, discoveries, or completed significant work, call mem_save now."}'
+      return 0
+    fi
+  fi
+  printf '%s\n' '{}'
+}
+
 if is_windows_bash && [ "${ENGRAM_CLAUDE_WINDOWS_BASH_SAFE_MODE:-auto}" != "0" ]; then
   INPUT=""
   while IFS= read -r LINE || [ -n "$LINE" ]; do
@@ -90,33 +259,6 @@ fi
 # for dirname/pwd before deciding whether the safe path applies.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/_helpers.sh"
-
-# Read hook input from stdin
-INPUT=$(cat)
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
-PROJECT=""
-
-# ──────────────────────────────────────────────────────────────────────────────
-# PROMPT PERSIST
-#
-# Every user message is captured to POST /prompts so mem_save can attach the
-# originating prompt via SessionActivity. The canonical project is resolved by
-# the server before this script writes. Fire-and-forget: never blocks and never
-# fails the hook.
-# ──────────────────────────────────────────────────────────────────────────────
-PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
-if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
-  # Detached subshell so the POST never stalls the hook. The server derives the
-  # prompt's project from the session and rejects any mismatch.
-  (
-    PROJECT=$(resolve_project "$CWD") || exit 0
-    curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
-      -H 'Content-Type: application/json' \
-      -d "$(jq -n --arg s "$SESSION_ID" --arg p "$PROJECT" --arg c "$PROMPT" \
-            '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
-  ) &
-fi
 
 parse_epoch() {
   TS="$1"
@@ -154,6 +296,37 @@ parse_epoch() {
     || date -j -f "%Y-%m-%d %H:%M:%S" "$TS" "+%s" 2>/dev/null \
     || date -d "$TS" "+%s" 2>/dev/null
 }
+
+# Read hook input from stdin
+INPUT=$(cat)
+if ! command -v jq >/dev/null 2>&1; then
+  user_prompt_submit_without_jq
+  exit 0
+fi
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+PROJECT=""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# PROMPT PERSIST
+#
+# Every user message is captured to POST /prompts so mem_save can attach the
+# originating prompt via SessionActivity. The canonical project is resolved by
+# the server before this script writes. Fire-and-forget: never blocks and never
+# fails the hook.
+# ──────────────────────────────────────────────────────────────────────────────
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+if [ -n "$PROMPT" ] && [ -n "$SESSION_ID" ]; then
+  # Detached subshell so the POST never stalls the hook. The server derives the
+  # prompt's project from the session and rejects any mismatch.
+  (
+    PROJECT=$(resolve_project "$CWD") || exit 0
+    curl -sf -X POST "${ENGRAM_URL}/prompts" --max-time 2 \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg s "$SESSION_ID" --arg p "$PROJECT" --arg c "$PROMPT" \
+            '{session_id:$s, project:$p, content:$c}')" >/dev/null 2>&1 || true
+  ) &
+fi
 
 # Default: no injection
 OUTPUT="{}"


### PR DESCRIPTION
## Type

- [x] **Bug fix** — fixes incorrect behavior
- [ ] **New feature** — adds functionality
- [ ] **Breaking change** — changes existing behavior
- [ ] **Documentation** — updates docs only
- [ ] **Refactor** — no functional changes

## Summary

- Add a jq-free Claude Code hook fallback that preserves session state, project resolution, prompt persistence, and save-nudge cooldowns.
- Keep the existing jq path unchanged when jq is available.
- Add a process-level regression test that runs the real shell hook with jq excluded from PATH.

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)

## Testing

- [x] Unit tests pass locally
- [x] E2E tests pass locally
- [ ] Tested on Linux / macOS / Windows
- [ ] Tested migration from previous version

## Documentation

- [x] No documentation needed
- [ ] Updated documentation
- [ ] Updated CLAUDE.md if structure changed

## Issue

Closes #677

## Notes

- `go test ./...` passed on Windows after exposing Git Bash `sh` in the process-local PATH.
- `go test -tags e2e ./internal/server/...` passed.
- Focused Claude hook regression and ShellCheck passed.
- Additional local `npm test` in `plugin/pi`: 84 passed and 2 unrelated startup/timing tests failed outside the candidate paths. CI must revalidate that automated check before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude Code prompt hook compatibility in environments without `jq`.
  * Preserved session state, first-message detection, save nudges, cooldown behavior, timeout handling, and project resolution in fallback mode.
  * Maintained valid JSON output and robust handling of escaped or invalid input.
  * Prevented session collisions by using safer, distinct state-file keys.
  * Added configurable hook request timeouts while retaining a short default for responsive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->