### PR TITLE
fix(store): fence replaced SQLite generations

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -72,6 +72,10 @@ var loadMCPStats = func(s *store.Store) (*store.Stats, error) {
 	return s.Stats()
 }
 
+var loadContextStats = func(s *store.Store) (*store.Stats, error) {
+	return s.Stats()
+}
+
 func truncationWarning(metadata store.TruncationMetadata) string {
 	if !metadata.Truncated {
 		return ""
@@ -1749,7 +1753,10 @@ func handleContext(s *store.Store, cfg MCPConfig, activity *SessionActivity) ser
 			return respondWithProject(detRes, "No previous session memories found.", nil), nil
 		}
 
-		stats, _ := s.Stats()
+		stats, err := loadContextStats(s)
+		if err != nil {
+			return mcp.NewToolResultError("Failed to get context stats: " + err.Error()), nil
+		}
 		var projects string
 		if len(stats.Projects) > 0 {
 			projects = strings.Join(stats.Projects, ", ")

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -2929,6 +2929,9 @@ func respondWithProject(res projectpkg.DetectionResult, text string, extra map[s
 // resolution fails. It handles ambiguous project errors and invalid configs.
 func writeProjectErrorResult(activity *SessionActivity, sessionID string, res projectpkg.DetectionResult, err error) *mcp.CallToolResult {
 	code := "ambiguous_project"
+	if errors.Is(err, store.ErrDatabaseGenerationChanged) {
+		return errorWithMeta("database_generation_changed", err.Error(), res.AvailableProjects)
+	}
 	if errors.Is(err, projectpkg.ErrInvalidConfig) {
 		code = "invalid_project_config"
 	}
@@ -3072,6 +3075,8 @@ func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolRe
 	switch code {
 	case "ambiguous_project":
 		envelope["hint"] = "Ask the user to choose one of available_projects, then retry the same write tool (mem_save, mem_save_prompt, or mem_session_summary) with project and project_choice_reason=user_selected_after_ambiguous_project; alternatively cd into the target repo or add repo .engram/config.json."
+	case "database_generation_changed":
+		envelope["hint"] = "Restart Engram and retry."
 	case "invalid_project_choice":
 		envelope["hint"] = "Use exactly one of available_projects after asking the user, or cd into the target repo, or add repo .engram/config.json."
 	case "missing_recovery_token":

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -2883,7 +2883,10 @@ func resolveMCPProjectWithPolicy(s *store.Store, explicit, defaultProject string
 	}
 	var unknown *projectpkg.UnknownProjectError
 	if errors.As(err, &unknown) {
-		stats, _ := s.Stats()
+		stats, err := loadMCPStats(s)
+		if err != nil {
+			return result, err
+		}
 		return result, &unknownProjectError{Name: unknown.Name, AvailableProjects: stats.Projects}
 	}
 	if errors.Is(err, projectpkg.ErrInvalidProjectName) {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1721,6 +1721,29 @@ func TestHandlePromptContextStatsTimelineAndSessionHandlers(t *testing.T) {
 	}
 }
 
+func TestHandleContextPropagatesStatsError(t *testing.T) {
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("context-stats", "engram", "/tmp/engram"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{SessionID: "context-stats", Type: "decision", Title: "Fence", Content: "Restart after replacement", Project: "engram"}); err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	original := loadContextStats
+	t.Cleanup(func() { loadContextStats = original })
+	loadContextStats = func(*store.Store) (*store.Stats, error) {
+		return nil, store.ErrDatabaseGenerationChanged
+	}
+
+	result, err := handleContext(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"project": "engram"}}})
+	if err != nil {
+		t.Fatalf("context handler error: %v", err)
+	}
+	if !result.IsError || !strings.Contains(callResultText(t, result), store.ErrDatabaseGenerationChanged.Error()) {
+		t.Fatalf("context result = %q, want generation error", callResultText(t, result))
+	}
+}
+
 func TestMemContextRemainsProjectScopedAcrossSessions(t *testing.T) {
 	s := newMCPTestStore(t)
 	for _, sessionID := range []string{"manual-a", "manual-b"} {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -6535,6 +6535,22 @@ func TestResolveReadProject_UnknownOverride(t *testing.T) {
 	}
 }
 
+func TestResolveReadProject_UnknownOverrideStatsGenerationChange(t *testing.T) {
+	previous := loadMCPStats
+	loadMCPStats = func(*store.Store) (*store.Stats, error) {
+		return nil, store.ErrDatabaseGenerationChanged
+	}
+	t.Cleanup(func() {
+		loadMCPStats = previous
+	})
+
+	s := newMCPTestStore(t)
+	_, err := resolveReadProject(s, "does-not-exist")
+	if !errors.Is(err, store.ErrDatabaseGenerationChanged) {
+		t.Fatalf("resolveReadProject error = %v; want ErrDatabaseGenerationChanged", err)
+	}
+}
+
 // TestRespondWithProject_MergesEnvelope: assert project, project_source, project_path in result
 func TestRespondWithProject_MergesEnvelope(t *testing.T) {
 	res := project.DetectionResult{

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -6545,9 +6545,25 @@ func TestResolveReadProject_UnknownOverrideStatsGenerationChange(t *testing.T) {
 	})
 
 	s := newMCPTestStore(t)
-	_, err := resolveReadProject(s, "does-not-exist")
+	res, err := resolveReadProject(s, "does-not-exist")
 	if !errors.Is(err, store.ErrDatabaseGenerationChanged) {
 		t.Fatalf("resolveReadProject error = %v; want ErrDatabaseGenerationChanged", err)
+	}
+
+	result := readProjectErrorResult(NewSessionActivity(time.Minute), res, err)
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(callResultText(t, result)), &envelope); err != nil {
+		t.Fatalf("unmarshal project error result: %v", err)
+	}
+	if got := envelope["error_code"]; got != "database_generation_changed" {
+		t.Errorf("error_code = %q; want database_generation_changed", got)
+	}
+	message, _ := envelope["message"].(string)
+	if !strings.Contains(message, "restart Engram") {
+		t.Errorf("message = %q; want restart guidance", message)
+	}
+	if _, ok := envelope["recovery_token"]; ok {
+		t.Error("project error result included recovery_token")
 	}
 }
 

--- a/internal/store/generation_fence.go
+++ b/internal/store/generation_fence.go
@@ -17,6 +17,8 @@ import (
 // this process was running. Restart Engram before accessing the store again.
 var ErrDatabaseGenerationChanged = errors.New("Engram database generation changed; restart Engram")
 
+var statFile = os.Stat
+
 type databaseGeneration struct {
 	paths    []string
 	files    []os.FileInfo
@@ -43,13 +45,17 @@ func (g *databaseGeneration) check() error {
 		return g.err
 	}
 	for i, path := range g.paths {
-		info, err := os.Stat(path)
+		info, err := statFile(path)
 		if err != nil {
-			if os.IsNotExist(err) && i > 0 && !g.observed[i] {
-				continue
+			if os.IsNotExist(err) {
+				if i > 0 {
+					g.files[i], g.observed[i] = nil, false
+					continue
+				}
+				g.err = ErrDatabaseGenerationChanged
+				return g.err
 			}
-			g.err = ErrDatabaseGenerationChanged
-			return g.err
+			return err
 		}
 		if !g.observed[i] {
 			// Resolve Windows' deferred file ID before this path can be replaced.

--- a/internal/store/generation_fence.go
+++ b/internal/store/generation_fence.go
@@ -1,0 +1,445 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// ErrDatabaseGenerationChanged means Engram's SQLite files were replaced while
+// this process was running. Restart Engram before accessing the store again.
+var ErrDatabaseGenerationChanged = errors.New("Engram database generation changed; restart Engram")
+
+type databaseGeneration struct {
+	paths    []string
+	files    []os.FileInfo
+	observed []bool
+	mu       sync.Mutex
+	err      error
+}
+
+func newDatabaseGeneration(dbPath string) (*databaseGeneration, error) {
+	generation := &databaseGeneration{
+		paths: []string{dbPath, dbPath + "-wal", dbPath + "-shm"},
+		files: make([]os.FileInfo, 3), observed: make([]bool, 3),
+	}
+	if err := generation.check(); err != nil {
+		return nil, err
+	}
+	return generation, nil
+}
+
+func (g *databaseGeneration) check() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.err != nil {
+		return g.err
+	}
+	for i, path := range g.paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) && i > 0 && !g.observed[i] {
+				continue
+			}
+			g.err = ErrDatabaseGenerationChanged
+			return g.err
+		}
+		if !g.observed[i] {
+			// Resolve Windows' deferred file ID before this path can be replaced.
+			_ = os.SameFile(info, info)
+			g.files[i], g.observed[i] = info, true
+			continue
+		}
+		if !os.SameFile(g.files[i], info) {
+			g.err = ErrDatabaseGenerationChanged
+			return g.err
+		}
+	}
+	return nil
+}
+
+func ensureDatabaseFile(path string) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+var openDB = func(dbPath string, generation *databaseGeneration) (*sql.DB, error) {
+	d := &generationDriver{Driver: &sqlite.Driver{}, generation: generation}
+	return sql.OpenDB(generationConnector{driver: d, name: dbPath}), nil
+}
+
+type generationConnector struct {
+	driver *generationDriver
+	name   string
+}
+
+func (c generationConnector) Connect(context.Context) (driver.Conn, error) {
+	return c.driver.Open(c.name)
+}
+func (c generationConnector) Driver() driver.Driver { return c.driver }
+
+type generationDriver struct {
+	driver.Driver
+	generation *databaseGeneration
+}
+
+func (d *generationDriver) Open(name string) (driver.Conn, error) {
+	if err := d.generation.check(); err != nil {
+		return nil, err
+	}
+	conn, err := d.Driver.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.generation.check(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return generationConn{Conn: conn, generation: d.generation}, nil
+}
+
+type generationConn struct {
+	driver.Conn
+	generation *databaseGeneration
+}
+
+func (c generationConn) Prepare(query string) (driver.Stmt, error) {
+	if err := c.generation.check(); err != nil {
+		return nil, err
+	}
+	stmt, err := c.Conn.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.generation.check(); err != nil {
+		_ = stmt.Close()
+		return nil, err
+	}
+	return generationStmt{Stmt: stmt, generation: c.generation}, nil
+}
+
+func (c generationConn) Close() error {
+	return c.Conn.Close()
+}
+
+func (c generationConn) Begin() (driver.Tx, error) {
+	if err := c.generation.check(); err != nil {
+		return nil, err
+	}
+	tx, err := c.Conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+	if err := c.generation.check(); err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	return generationTx{Tx: tx, generation: c.generation}, nil
+}
+
+func (c generationConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if prepared, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		if err := c.generation.check(); err != nil {
+			return nil, err
+		}
+		stmt, err := prepared.PrepareContext(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.generation.check(); err != nil {
+			_ = stmt.Close()
+			return nil, err
+		}
+		return generationStmt{Stmt: stmt, generation: c.generation}, nil
+	}
+	return c.Prepare(query)
+}
+
+func (c generationConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if err := c.generation.check(); err != nil {
+		return nil, err
+	}
+	execer, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	result, err := execer.ExecContext(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.generation.check(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c generationConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if err := c.generation.check(); err != nil {
+		return nil, err
+	}
+	queryer, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	rows, err := queryer.QueryContext(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.generation.check(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	return generationRows{Rows: rows, generation: c.generation}, nil
+}
+
+func (c generationConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if begin, ok := c.Conn.(driver.ConnBeginTx); ok {
+		if err := c.generation.check(); err != nil {
+			return nil, err
+		}
+		tx, err := begin.BeginTx(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.generation.check(); err != nil {
+			_ = tx.Rollback()
+			return nil, err
+		}
+		return generationTx{Tx: tx, generation: c.generation}, nil
+	}
+	return c.Begin()
+}
+
+func (c generationConn) Ping(ctx context.Context) error {
+	if err := c.generation.check(); err != nil {
+		return err
+	}
+	pinger, ok := c.Conn.(driver.Pinger)
+	if !ok {
+		return driver.ErrSkip
+	}
+	if err := pinger.Ping(ctx); err != nil {
+		return err
+	}
+	return c.generation.check()
+}
+
+func (c generationConn) ResetSession(ctx context.Context) error {
+	if err := c.generation.check(); err != nil {
+		return err
+	}
+	if resetter, ok := c.Conn.(driver.SessionResetter); ok {
+		if err := resetter.ResetSession(ctx); err != nil {
+			return err
+		}
+	}
+	return c.generation.check()
+}
+
+func (c generationConn) IsValid() bool {
+	if c.generation.check() != nil {
+		return false
+	}
+	validator, ok := c.Conn.(driver.Validator)
+	return !ok || validator.IsValid()
+}
+
+func (c generationConn) CheckNamedValue(value *driver.NamedValue) error {
+	if checker, ok := c.Conn.(driver.NamedValueChecker); ok {
+		return checker.CheckNamedValue(value)
+	}
+	return driver.ErrSkip
+}
+
+type generationStmt struct {
+	driver.Stmt
+	generation *databaseGeneration
+}
+
+func (s generationStmt) Close() error {
+	err := s.Stmt.Close()
+	if generationErr := s.generation.check(); generationErr != nil {
+		return generationErr
+	}
+	return err
+}
+
+func (s generationStmt) Exec(args []driver.Value) (driver.Result, error) {
+	if err := s.generation.check(); err != nil {
+		return nil, err
+	}
+	result, err := s.Stmt.Exec(args)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.generation.check(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s generationStmt) Query(args []driver.Value) (driver.Rows, error) {
+	if err := s.generation.check(); err != nil {
+		return nil, err
+	}
+	rows, err := s.Stmt.Query(args)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.generation.check(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	return generationRows{Rows: rows, generation: s.generation}, nil
+}
+
+func (s generationStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	if err := s.generation.check(); err != nil {
+		return nil, err
+	}
+	execer, ok := s.Stmt.(driver.StmtExecContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	result, err := execer.ExecContext(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.generation.check(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s generationStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	if err := s.generation.check(); err != nil {
+		return nil, err
+	}
+	queryer, ok := s.Stmt.(driver.StmtQueryContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	rows, err := queryer.QueryContext(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.generation.check(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	return generationRows{Rows: rows, generation: s.generation}, nil
+}
+
+type generationTx struct {
+	driver.Tx
+	generation *databaseGeneration
+}
+
+func (t generationTx) Commit() error {
+	if err := t.generation.check(); err != nil {
+		_ = t.Tx.Rollback()
+		return err
+	}
+	if err := t.Tx.Commit(); err != nil {
+		return err
+	}
+	return t.generation.check()
+}
+
+func (t generationTx) Rollback() error {
+	err := t.Tx.Rollback()
+	if generationErr := t.generation.check(); generationErr != nil {
+		return generationErr
+	}
+	return err
+}
+
+type generationRows struct {
+	driver.Rows
+	generation *databaseGeneration
+}
+
+func (r generationRows) Close() error {
+	err := r.Rows.Close()
+	if generationErr := r.generation.check(); generationErr != nil {
+		return generationErr
+	}
+	return err
+}
+
+func (r generationRows) Next(dest []driver.Value) error {
+	if err := r.generation.check(); err != nil {
+		return err
+	}
+	err := r.Rows.Next(dest)
+	if generationErr := r.generation.check(); generationErr != nil {
+		return generationErr
+	}
+	return err
+}
+
+func (r generationRows) HasNextResultSet() bool {
+	rows, ok := r.Rows.(driver.RowsNextResultSet)
+	return ok && rows.HasNextResultSet()
+}
+
+func (r generationRows) NextResultSet() error {
+	if err := r.generation.check(); err != nil {
+		return err
+	}
+	rows, ok := r.Rows.(driver.RowsNextResultSet)
+	if !ok {
+		return io.EOF
+	}
+	err := rows.NextResultSet()
+	if generationErr := r.generation.check(); generationErr != nil {
+		_ = r.Rows.Close()
+		return generationErr
+	}
+	return err
+}
+
+func (r generationRows) ColumnTypeDatabaseTypeName(index int) string {
+	if rows, ok := r.Rows.(driver.RowsColumnTypeDatabaseTypeName); ok {
+		return rows.ColumnTypeDatabaseTypeName(index)
+	}
+	return ""
+}
+
+func (r generationRows) ColumnTypeLength(index int) (int64, bool) {
+	if rows, ok := r.Rows.(driver.RowsColumnTypeLength); ok {
+		return rows.ColumnTypeLength(index)
+	}
+	return 0, false
+}
+
+func (r generationRows) ColumnTypeNullable(index int) (bool, bool) {
+	if rows, ok := r.Rows.(driver.RowsColumnTypeNullable); ok {
+		return rows.ColumnTypeNullable(index)
+	}
+	return false, false
+}
+
+func (r generationRows) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
+	if rows, ok := r.Rows.(driver.RowsColumnTypePrecisionScale); ok {
+		return rows.ColumnTypePrecisionScale(index)
+	}
+	return 0, 0, false
+}
+
+func (r generationRows) ColumnTypeScanType(index int) reflect.Type {
+	if rows, ok := r.Rows.(driver.RowsColumnTypeScanType); ok {
+		return rows.ColumnTypeScanType(index)
+	}
+	return nil
+}

--- a/internal/store/generation_fence_test.go
+++ b/internal/store/generation_fence_test.go
@@ -32,13 +32,44 @@ func TestDatabaseGeneration(t *testing.T) {
 			assertGenerationChanged(t, generation.check())
 		})
 
-		t.Run("detects disappearance "+sidecarName(sidecar), func(t *testing.T) {
+		t.Run("handles disappearance "+sidecarName(sidecar), func(t *testing.T) {
 			generation, dbPath := newTestDatabaseGeneration(t, sidecar == "-wal", sidecar == "-shm")
 			if err := os.Remove(dbPath + sidecar); err != nil {
 				t.Fatalf("remove generation file: %v", err)
 			}
-			assertGenerationChanged(t, generation.check())
+			if sidecar == "" {
+				assertGenerationChanged(t, generation.check())
+				return
+			}
+			if err := generation.check(); err != nil {
+				t.Fatalf("check after sidecar disappearance: %v", err)
+			}
+			writeTestFile(t, dbPath+sidecar)
+			if err := generation.check(); err != nil {
+				t.Fatalf("adopt replacement sidecar: %v", err)
+			}
 		})
+	}
+}
+
+func TestDatabaseGenerationRecoversFromStatError(t *testing.T) {
+	generation, dbPath := newTestDatabaseGeneration(t, false, false)
+	original := statFile
+	t.Cleanup(func() { statFile = original })
+	statErr := errors.New("transient stat error")
+	failed := false
+	statFile = func(path string) (os.FileInfo, error) {
+		if path == dbPath && !failed {
+			failed = true
+			return nil, statErr
+		}
+		return original(path)
+	}
+	if err := generation.check(); err != statErr {
+		t.Fatalf("check error = %v, want transient stat error", err)
+	}
+	if err := generation.check(); err != nil {
+		t.Fatalf("check after transient stat error: %v", err)
 	}
 }
 

--- a/internal/store/generation_fence_test.go
+++ b/internal/store/generation_fence_test.go
@@ -1,0 +1,230 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDatabaseGeneration(t *testing.T) {
+	t.Run("adopts sidecars when first observed", func(t *testing.T) {
+		generation, dbPath := newTestDatabaseGeneration(t, false, false)
+		if err := generation.check(); err != nil {
+			t.Fatalf("initial check: %v", err)
+		}
+		writeTestFile(t, dbPath+"-wal")
+		writeTestFile(t, dbPath+"-shm")
+		if err := generation.check(); err != nil {
+			t.Fatalf("adopt sidecars: %v", err)
+		}
+	})
+
+	for _, sidecar := range []string{"", "-wal", "-shm"} {
+		sidecar := sidecar
+		t.Run("detects replacement "+sidecarName(sidecar), func(t *testing.T) {
+			generation, dbPath := newTestDatabaseGeneration(t, sidecar == "-wal", sidecar == "-shm")
+			replaceTestFile(t, dbPath+sidecar)
+			assertGenerationChanged(t, generation.check())
+			assertGenerationChanged(t, generation.check())
+		})
+
+		t.Run("detects disappearance "+sidecarName(sidecar), func(t *testing.T) {
+			generation, dbPath := newTestDatabaseGeneration(t, sidecar == "-wal", sidecar == "-shm")
+			if err := os.Remove(dbPath + sidecar); err != nil {
+				t.Fatalf("remove generation file: %v", err)
+			}
+			assertGenerationChanged(t, generation.check())
+		})
+	}
+}
+
+func TestGenerationFenceRejectsUnsafeOperations(t *testing.T) {
+	t.Run("rejects before operation", func(t *testing.T) {
+		generation, dbPath := newTestDatabaseGeneration(t, false, false)
+		called := false
+		conn := generationConn{Conn: &testFenceConn{exec: func() { called = true }}, generation: generation}
+		replaceTestFile(t, dbPath)
+		_, err := conn.ExecContext(context.Background(), "UPDATE test", nil)
+		assertGenerationChanged(t, err)
+		if called {
+			t.Fatal("operation ran after generation change")
+		}
+	})
+
+	t.Run("rejects after write", func(t *testing.T) {
+		generation, dbPath := newTestDatabaseGeneration(t, false, false)
+		conn := generationConn{Conn: &testFenceConn{exec: func() { replaceTestFile(t, dbPath) }}, generation: generation}
+		_, err := conn.ExecContext(context.Background(), "UPDATE test", nil)
+		assertGenerationChanged(t, err)
+	})
+
+	t.Run("rejects after commit", func(t *testing.T) {
+		generation, dbPath := newTestDatabaseGeneration(t, false, false)
+		tx := generationTx{Tx: &testFenceTx{commit: func() { replaceTestFile(t, dbPath) }}, generation: generation}
+		assertGenerationChanged(t, tx.Commit())
+	})
+
+	t.Run("rejects while iterating rows", func(t *testing.T) {
+		generation, dbPath := newTestDatabaseGeneration(t, false, false)
+		conn := generationConn{Conn: &testFenceConn{rows: &testFenceRows{next: func() { replaceTestFile(t, dbPath) }}}, generation: generation}
+		rows, err := conn.QueryContext(context.Background(), "SELECT test", nil)
+		if err != nil {
+			t.Fatalf("query rows: %v", err)
+		}
+		assertGenerationChanged(t, rows.Next(make([]driver.Value, 1)))
+	})
+}
+
+func TestNewRejectsGenerationChangedBeforeSQLiteOpens(t *testing.T) {
+	original := openDB
+	t.Cleanup(func() { openDB = original })
+	openDB = func(dbPath string, generation *databaseGeneration) (*sql.DB, error) {
+		replaceTestFile(t, dbPath)
+		return original(dbPath, generation)
+	}
+	cfg := FallbackConfig(t.TempDir())
+	_, err := New(cfg)
+	assertGenerationChanged(t, err)
+}
+
+func TestStatsPropagatesGenerationChange(t *testing.T) {
+	s := newTestStore(t)
+	s.hooks.queryIt = func(queryer, string, ...any) (rowScanner, error) { return nil, ErrDatabaseGenerationChanged }
+	_, err := s.Stats()
+	assertGenerationChanged(t, err)
+}
+
+func TestGenerationRowsNextResultSetIsFenced(t *testing.T) {
+	generation, dbPath := newTestDatabaseGeneration(t, false, false)
+	base := &testFenceRows{hasNextResultSet: true, nextResultSet: func() { replaceTestFile(t, dbPath) }}
+	rows := generationRows{Rows: base, generation: generation}
+	if !rows.HasNextResultSet() {
+		t.Fatal("HasNextResultSet = false, want true")
+	}
+	assertGenerationChanged(t, rows.NextResultSet())
+	if !base.closed {
+		t.Fatal("rows were not closed after generation change")
+	}
+}
+
+func newTestDatabaseGeneration(t *testing.T, wal, shm bool) (*databaseGeneration, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "engram.db")
+	writeTestFile(t, dbPath)
+	if wal {
+		writeTestFile(t, dbPath+"-wal")
+	}
+	if shm {
+		writeTestFile(t, dbPath+"-shm")
+	}
+	generation, err := newDatabaseGeneration(dbPath)
+	if err != nil {
+		t.Fatalf("capture database generation: %v", err)
+	}
+	return generation, dbPath
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("database generation"), 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func replaceTestFile(t *testing.T, path string) {
+	t.Helper()
+	previous, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	_ = os.SameFile(previous, previous)
+	replacement := path + ".replacement"
+	writeTestFile(t, replacement)
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove %s: %v", path, err)
+	}
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatalf("replace %s: %v", path, err)
+	}
+	current, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat replacement %s: %v", path, err)
+	}
+	if os.SameFile(previous, current) {
+		t.Fatalf("replacement for %s retained its identity", path)
+	}
+}
+
+func sidecarName(sidecar string) string {
+	if sidecar == "" {
+		return "database"
+	}
+	return sidecar[1:]
+}
+
+func assertGenerationChanged(t *testing.T, err error) {
+	t.Helper()
+	if !errors.Is(err, ErrDatabaseGenerationChanged) {
+		t.Fatalf("error = %v, want ErrDatabaseGenerationChanged", err)
+	}
+}
+
+type testFenceConn struct {
+	exec func()
+	rows *testFenceRows
+}
+
+func (c *testFenceConn) Prepare(string) (driver.Stmt, error) { return testFenceStmt{}, nil }
+func (c *testFenceConn) Close() error                        { return nil }
+func (c *testFenceConn) Begin() (driver.Tx, error)           { return testFenceTx{}, nil }
+func (c *testFenceConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	if c.exec != nil {
+		c.exec()
+	}
+	return driver.RowsAffected(1), nil
+}
+func (c *testFenceConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return c.rows, nil
+}
+
+type testFenceStmt struct{}
+
+func (testFenceStmt) Close() error                               { return nil }
+func (testFenceStmt) NumInput() int                              { return -1 }
+func (testFenceStmt) Exec([]driver.Value) (driver.Result, error) { return driver.RowsAffected(1), nil }
+func (testFenceStmt) Query([]driver.Value) (driver.Rows, error)  { return &testFenceRows{}, nil }
+
+type testFenceTx struct{ commit func() }
+
+func (t testFenceTx) Commit() error {
+	if t.commit != nil {
+		t.commit()
+	}
+	return nil
+}
+func (testFenceTx) Rollback() error { return nil }
+
+type testFenceRows struct {
+	next, nextResultSet      func()
+	hasNextResultSet, closed bool
+}
+
+func (r *testFenceRows) Columns() []string { return []string{"value"} }
+func (r *testFenceRows) Close() error      { r.closed = true; return nil }
+func (r *testFenceRows) Next([]driver.Value) error {
+	if r.next != nil {
+		r.next()
+	}
+	return nil
+}
+func (r *testFenceRows) HasNextResultSet() bool { return r.hasNextResultSet }
+func (r *testFenceRows) NextResultSet() error {
+	if r.nextResultSet != nil {
+		r.nextResultSet()
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,8 +31,6 @@ import (
 	sqlite "modernc.org/sqlite"
 )
 
-var openDB = sql.Open
-
 // sqliteConstraintForeignKey is the extended SQLite result code for a foreign-key
 // constraint violation (SQLITE_CONSTRAINT_FOREIGNKEY = 787).
 // See https://www.sqlite.org/rescode.html#constraint_foreignkey
@@ -716,7 +714,14 @@ func New(cfg Config) (*Store, error) {
 	}
 
 	dbPath := filepath.Join(cfg.DataDir, "engram.db")
-	db, err := openDB("sqlite", dbPath)
+	if err := ensureDatabaseFile(dbPath); err != nil {
+		return nil, fmt.Errorf("engram: create database file: %w", err)
+	}
+	generation, err := newDatabaseGeneration(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("engram: capture database generation: %w", err)
+	}
+	db, err := openDB(dbPath, generation)
 	if err != nil {
 		return nil, fmt.Errorf("engram: open database: %w", err)
 	}
@@ -761,7 +766,14 @@ func newWithoutRepair(cfg Config) (*Store, error) {
 	}
 
 	dbPath := filepath.Join(cfg.DataDir, "engram.db")
-	db, err := openDB("sqlite", dbPath)
+	if err := ensureDatabaseFile(dbPath); err != nil {
+		return nil, fmt.Errorf("engram: create database file: %w", err)
+	}
+	generation, err := newDatabaseGeneration(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("engram: capture database generation: %w", err)
+	}
+	db, err := openDB(dbPath, generation)
 	if err != nil {
 		return nil, fmt.Errorf("engram: open database: %w", err)
 	}
@@ -3791,14 +3803,20 @@ func (s *Store) statsForProject(project string) (*Stats, error) {
 		where = " WHERE LOWER(project) = ?"
 		args = append(args, project)
 	}
-	s.db.QueryRow("SELECT COUNT(*) FROM sessions"+where, args...).Scan(&stats.TotalSessions)
-	s.db.QueryRow("SELECT COUNT(*) FROM observations WHERE deleted_at IS NULL"+func() string {
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM sessions"+where, args...).Scan(&stats.TotalSessions); errors.Is(err, ErrDatabaseGenerationChanged) {
+		return nil, err
+	}
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM observations WHERE deleted_at IS NULL"+func() string {
 		if project == "" {
 			return ""
 		}
 		return " AND LOWER(project) = ?"
-	}(), args...).Scan(&stats.TotalObservations)
-	s.db.QueryRow("SELECT COUNT(*) FROM user_prompts"+where, args...).Scan(&stats.TotalPrompts)
+	}(), args...).Scan(&stats.TotalObservations); errors.Is(err, ErrDatabaseGenerationChanged) {
+		return nil, err
+	}
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM user_prompts"+where, args...).Scan(&stats.TotalPrompts); errors.Is(err, ErrDatabaseGenerationChanged) {
+		return nil, err
+	}
 
 	projectsQuery := "SELECT project FROM observations WHERE project IS NOT NULL AND deleted_at IS NULL"
 	if project != "" {
@@ -3807,14 +3825,33 @@ func (s *Store) statsForProject(project string) (*Stats, error) {
 	projectsQuery += " GROUP BY project ORDER BY MAX(created_at) DESC"
 	rows, err := s.queryItHook(s.db, projectsQuery, args...)
 	if err != nil {
+		if errors.Is(err, ErrDatabaseGenerationChanged) {
+			return nil, err
+		}
 		return stats, nil
 	}
-	defer rows.Close()
 
 	for rows.Next() {
-		var p string
-		if err := rows.Scan(&p); err == nil {
-			stats.Projects = append(stats.Projects, p)
+		var projectName string
+		if err := rows.Scan(&projectName); err != nil {
+			_ = rows.Close()
+			if errors.Is(err, ErrDatabaseGenerationChanged) {
+				return nil, err
+			}
+			return stats, nil
+		}
+		stats.Projects = append(stats.Projects, projectName)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		if errors.Is(err, ErrDatabaseGenerationChanged) {
+			return nil, err
+		}
+		return stats, nil
+	}
+	if err := rows.Close(); err != nil {
+		if errors.Is(err, ErrDatabaseGenerationChanged) {
+			return nil, err
 		}
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5744,7 +5744,7 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 	t.Run("new open database hook error", func(t *testing.T) {
 		orig := openDB
 		t.Cleanup(func() { openDB = orig })
-		openDB = func(driverName, dataSourceName string) (*sql.DB, error) {
+		openDB = func(_ string, _ *databaseGeneration) (*sql.DB, error) {
 			return nil, errors.New("forced open error")
 		}
 


### PR DESCRIPTION
## Linked Issue

Closes #477

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Maintenance/tooling
- [ ] `type:breaking-change` - Breaking change

## Summary

- Capture the live identity of `engram.db`, `engram.db-wal`, and `engram.db-shm` before SQLite operations can diverge.
- Fence connections, statements, transactions, rows, and result sets at the `database/sql/driver` boundary.
- Fail loudly with restart guidance instead of acknowledging work against a replaced generation.

## Changes

| File | Change |
|------|--------|
| `internal/store/generation_fence.go` | Adds the sticky DB/WAL/SHM identity fence and preserves driver optional interfaces. |
| `internal/store/generation_fence_test.go` | Covers replacement, disappearance, pre/post operation checks, commit, rows, and result sets. |
| `internal/store/store.go` | Captures identity before opening SQLite and propagates generation errors from stats. |
| `internal/mcp/mcp.go` | Returns a tool error when context stats observe a replaced generation. |
| `internal/{store,mcp}/*_test.go` | Adds startup and MCP propagation regressions. |

## Test Plan

- [x] `go test ./internal/store -count=1`
- [x] `go test ./internal/mcp -count=1`
- [x] `go vet ./internal/store ./internal/mcp`
- [x] `go test -tags e2e ./internal/server/... -count=1`
- [x] Linux/amd64 and Darwin/arm64 Store test cross-compilation
- [ ] `go test ./...` exhausted local host memory/time; remote CI is required for complete unit-suite proof.

## Contributor Checklist

- [x] Linked approved issue #477.
- [x] Uses one conventional commit without co-author trailers.
- [x] Keeps transparent reopen, health checks, leases, and migration machinery out of scope.
- [x] No documentation change is required; restart guidance is included in the typed error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added protection against database file replacement or disappearance while the application is running.
  - Database operations now stop safely and report an error when the database changes unexpectedly.
  - Context statistics and project resolution now surface database errors instead of returning incomplete results.
  - Added clear restart guidance when the database generation changes.
  - Improved cleanup of affected database resources, including transactions and result rows.
- **Tests**
  - Added coverage for database replacement, missing files, interrupted operations, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->