### PR TITLE
feat(mcp): structured unknown_session recovery metadata

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -341,7 +341,7 @@ Examples:
 					mcp.Description("Category: decision, architecture, bugfix, pattern, config, discovery, learning (default: manual)"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("scope",
 					mcp.Description("Scope for this observation: project (default) or personal"),
@@ -485,7 +485,7 @@ Examples:
 					mcp.Description("The user's prompt text"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("project",
 					mcp.Description("Optional recovery target only after ambiguous_project. Ignored unless project_choice_reason is user_selected_after_ambiguous_project."),
@@ -669,7 +669,7 @@ GUIDELINES:
 					mcp.Description("Full session summary using the Goal/Instructions/Discoveries/Accomplished/Next Steps/Relevant Files format"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("project",
 					mcp.Description("Optional explicit project for this memory. Accepted only when backed by known context (existing project, matching session, repo config, or ambiguous-project recovery); invalid or unbacked names fail loudly."),
@@ -751,7 +751,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 					mcp.Description("The text output containing a '## Key Learnings:' section with numbered or bulleted items"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. When omitted, attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("source",
 					mcp.Description("Source identifier (e.g. 'subagent-stop', 'session-end')"),
@@ -2968,10 +2968,19 @@ func writeProjectErrorResult(activity *SessionActivity, sessionID string, res pr
 	}
 	var unknownSessionErr *unknownSessionError
 	if errors.As(err, &unknownSessionErr) {
-		return errorWithMeta("unknown_session",
+		result := errorWithMeta("unknown_session",
 			fmt.Sprintf("Session %q was provided but does not exist", unknownSessionErr.SessionID),
 			res.AvailableProjects,
 		)
+		// Structured recovery fields let a caller retry deterministically
+		// instead of re-parsing the hint string: drop session_id and retry
+		// the same call unchanged (#683). Never auto-retry on the caller's
+		// behalf here — that would hide typos and fragment session history.
+		addErrorMetadata(result, map[string]any{
+			"invalid_session_id":       unknownSessionErr.SessionID,
+			"retry_without_session_id": true,
+		})
+		return result
 	}
 	var unknownProjectErr *unknownProjectError
 	if errors.As(err, &unknownProjectErr) {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -341,7 +341,7 @@ Examples:
 					mcp.Description("Category: decision, architecture, bugfix, pattern, config, discovery, learning (default: manual)"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass an ID you supplied to a successful mem_session_start registration, or the ID from an authoritative already-registered runtime binding; mem_session_start does not generate or return a new ID. Never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("scope",
 					mcp.Description("Scope for this observation: project (default) or personal"),
@@ -485,7 +485,7 @@ Examples:
 					mcp.Description("The user's prompt text"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass an ID you supplied to a successful mem_session_start registration, or the ID from an authoritative already-registered runtime binding; mem_session_start does not generate or return a new ID. Never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("project",
 					mcp.Description("Optional recovery target only after ambiguous_project. Ignored unless project_choice_reason is user_selected_after_ambiguous_project."),
@@ -669,7 +669,7 @@ GUIDELINES:
 					mcp.Description("Full session summary using the Goal/Instructions/Discoveries/Accomplished/Next Steps/Relevant Files format"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass an ID you supplied to a successful mem_session_start registration, or the ID from an authoritative already-registered runtime binding; mem_session_start does not generate or return a new ID. Never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("project",
 					mcp.Description("Optional explicit project for this memory. Accepted only when backed by known context (existing project, matching session, repo config, or ambiguous-project recovery); invalid or unbacked names fail loudly."),
@@ -751,7 +751,7 @@ Duplicates are automatically detected and skipped — safe to call multiple time
 					mcp.Description("The text output containing a '## Key Learnings:' section with numbered or bulleted items"),
 				),
 				mcp.WithString("session_id",
-					mcp.Description("Session ID to associate with. Only pass a value returned by a prior successful mem_session_start call in this session — never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
+					mcp.Description("Session ID to associate with. Only pass an ID you supplied to a successful mem_session_start registration, or the ID from an authoritative already-registered runtime binding; mem_session_start does not generate or return a new ID. Never invent one from a task name, issue number, or date. An unregistered ID is rejected with error_code=unknown_session; retry the same call with session_id omitted rather than guessing another value. When omitted (the common case), attempts unique active runtime-session selection using current worktree evidence; falls back to manual-save-{project} when no candidate remains, and rejects ambiguity rather than selecting by recency."),
 				),
 				mcp.WithString("source",
 					mcp.Description("Source identifier (e.g. 'subagent-stop', 'session-end')"),
@@ -1679,7 +1679,13 @@ func handleSavePrompt(s *store.Store, cfg MCPConfig, activity *SessionActivity) 
 			return true, activity.ValidateAmbiguousProjectRecoveryToken(recoverySessionID, recoveryToken, strings.TrimSpace(choice), res.AvailableProjects, res.Path)
 		}
 
-		detRes, err := resolveWriteProjectWithChoiceAndProcessOverride(s, projectChoice, projectChoiceReason, validateRecoveryToken, cfg.DefaultProject)
+		var detRes projectpkg.DetectionResult
+		var err error
+		if strings.TrimSpace(sessionID) != "" {
+			detRes, err = resolveSaveWriteProjectWithProcessOverride(s, "", false, "", sessionID, nil, cfg.DefaultProject)
+		} else {
+			detRes, err = resolveWriteProjectWithChoiceAndProcessOverride(s, projectChoice, projectChoiceReason, validateRecoveryToken, cfg.DefaultProject)
+		}
 		if err != nil {
 			return writeProjectErrorResult(activity, recoverySessionID, detRes, err), nil
 		}
@@ -2108,9 +2114,9 @@ func handleCapturePassive(s *store.Store, cfg MCPConfig, activity *SessionActivi
 		source, _ := req.GetArguments()["source"].(string)
 		// project field intentionally not read — auto-detect only (REQ-308)
 
-		detRes, err := resolveWriteProjectWithProcessOverride(s, cfg.DefaultProject, false)
+		detRes, err := resolveSaveWriteProjectWithProcessOverride(s, "", false, "", sessionID, nil, cfg.DefaultProject)
 		if err != nil {
-			return writeProjectErrorResult(nil, "", detRes, err), nil
+			return writeProjectErrorResult(activity, sessionID, detRes, err), nil
 		}
 		project, _ := store.NormalizeProject(detRes.Project)
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -4954,6 +4954,70 @@ func TestMemSave_MissingSessionIDFailsLoudly(t *testing.T) {
 	}
 }
 
+// TestMemSessionSummary_UnregisteredTaskLikeSessionIDRejectedWithRecoveryMetadata
+// covers the #683 lifecycle failure: an agent invents a session_id from a task
+// or issue label (e.g. "issue-1096-update-20260813") instead of one returned by
+// mem_session_start. The unknown_session error must carry structured recovery
+// fields an agent can act on deterministically, the summary must not be
+// persisted under the guessed ID, and the documented recovery — retrying with
+// session_id omitted — must actually succeed.
+func TestMemSessionSummary_UnregisteredTaskLikeSessionIDRejectedWithRecoveryMetadata(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		"git@github.com:user/unregistered-session-summary.git")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	h := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+	invented := "issue-1096-update-20260813"
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content":    "## Goal\nfix the thing",
+		"session_id": invented,
+	}}})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected model-invented session_id to fail")
+	}
+	body := callResultJSON(t, res)
+	if body["error_code"] != "unknown_session" {
+		t.Fatalf("expected unknown_session error, got %v", body)
+	}
+	if body["invalid_session_id"] != invented {
+		t.Fatalf("expected invalid_session_id=%q, got %v", invented, body["invalid_session_id"])
+	}
+	if body["retry_without_session_id"] != true {
+		t.Fatalf("expected retry_without_session_id=true, got %v", body["retry_without_session_id"])
+	}
+
+	// The rejected call must never reach the write path under the guessed ID.
+	if _, err := s.GetSession(invented); err == nil {
+		t.Fatal("unregistered session_id must not be implicitly created")
+	}
+	wrongResults, _ := s.Search("fix the thing", store.SearchOptions{Project: "unregistered-session-summary", Limit: 5})
+	if len(wrongResults) != 0 {
+		t.Fatal("summary must not persist under an unregistered session_id")
+	}
+
+	// The documented recovery — omit session_id and retry unchanged — must succeed.
+	retryRes, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"content": "## Goal\nfix the thing",
+	}}})
+	if err != nil || retryRes.IsError {
+		t.Fatalf("retry without session_id: err=%v isError=%v text=%s", err, retryRes.IsError, callResultText(t, retryRes))
+	}
+	recoveredResults, _ := s.Search("fix the thing", store.SearchOptions{Project: "unregistered-session-summary", Limit: 5})
+	if len(recoveredResults) != 1 {
+		t.Fatalf("expected summary persisted after omitted-session_id retry, got %d", len(recoveredResults))
+	}
+}
+
 func TestMemSave_ExplicitProjectMustMatchExistingSessionProject(t *testing.T) {
 	dir := t.TempDir()
 	initTestGitRepo(t, dir)

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -4964,6 +4964,7 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 		name    string
 		handler func(*store.Store) server.ToolHandlerFunc
 		args    map[string]any
+		assert  func(*testing.T, *store.Store)
 	}{
 		{
 			name: "mem_save",
@@ -4971,6 +4972,13 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 				return handleSave(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
 			},
 			args: map[string]any{"title": "invented session", "content": "must not persist"},
+			assert: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				observations, err := s.RecentObservations(project, "project", 10)
+				if err != nil || len(observations) != 1 || observations[0].SessionID != defaultSessionID(project) || observations[0].Type != "manual" || observations[0].Title != "invented session" || observations[0].Content != "must not persist" {
+					t.Fatalf("recovered mem_save observation = %#v, err=%v", observations, err)
+				}
+			},
 		},
 		{
 			name: "mem_save_prompt",
@@ -4978,6 +4986,13 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 				return handleSavePrompt(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
 			},
 			args: map[string]any{"content": "must not persist"},
+			assert: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				prompts, err := s.RecentPrompts(project, 10)
+				if err != nil || len(prompts) != 1 || prompts[0].SessionID != defaultSessionID(project) || prompts[0].Content != "must not persist" {
+					t.Fatalf("recovered mem_save_prompt prompts = %#v, err=%v", prompts, err)
+				}
+			},
 		},
 		{
 			name: "mem_session_summary",
@@ -4985,13 +5000,27 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 				return handleSessionSummary(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
 			},
 			args: map[string]any{"content": "## Goal\nMust not persist"},
+			assert: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				observations, err := s.RecentObservations(project, "project", 10)
+				if err != nil || len(observations) != 1 || observations[0].SessionID != defaultSessionID(project) || observations[0].Type != "session_summary" || observations[0].Title != "Session summary: "+project || observations[0].Content != "## Goal\nMust not persist" {
+					t.Fatalf("recovered mem_session_summary observation = %#v, err=%v", observations, err)
+				}
+			},
 		},
 		{
 			name: "mem_capture_passive",
 			handler: func(s *store.Store) server.ToolHandlerFunc {
 				return handleCapturePassive(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
 			},
-			args: map[string]any{"content": "## Key Learnings:\n- Must not persist"},
+			args: map[string]any{"content": "## Key Learnings:\n- Retried passive learning is persisted as an observation"},
+			assert: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				observations, err := s.RecentObservations(project, "project", 10)
+				if err != nil || len(observations) != 1 || observations[0].SessionID != defaultSessionID(project) || observations[0].Type != "passive" || observations[0].Content != "Retried passive learning is persisted as an observation" || observations[0].ToolName == nil || *observations[0].ToolName != "mcp-passive" {
+					t.Fatalf("recovered mem_capture_passive observation = %#v, err=%v", observations, err)
+				}
+			},
 		},
 	}
 
@@ -5026,6 +5055,13 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 			if err != nil || len(prompts) != 0 {
 				t.Fatalf("prompts after rejected request = %d, err=%v", len(prompts), err)
 			}
+
+			delete(args, "session_id")
+			retryRes, err := tt.handler(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
+			if err != nil || retryRes.IsError {
+				t.Fatalf("retry without session_id: err=%v isError=%v text=%q", err, retryRes.IsError, callResultText(t, retryRes))
+			}
+			tt.assert(t, s)
 		})
 	}
 }

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -4961,17 +4961,19 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 	)
 
 	tests := []struct {
-		name    string
-		handler func(*store.Store) server.ToolHandlerFunc
-		args    map[string]any
-		assert  func(*testing.T, *store.Store)
+		name                    string
+		handler                 func(*store.Store) server.ToolHandlerFunc
+		args                    map[string]any
+		assert                  func(*testing.T, *store.Store)
+		testWithExplicitProject bool
 	}{
 		{
 			name: "mem_save",
 			handler: func(s *store.Store) server.ToolHandlerFunc {
 				return handleSave(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
 			},
-			args: map[string]any{"title": "invented session", "content": "must not persist"},
+			args:                    map[string]any{"title": "invented session", "content": "must not persist"},
+			testWithExplicitProject: true,
 			assert: func(t *testing.T, s *store.Store) {
 				t.Helper()
 				observations, err := s.RecentObservations(project, "project", 10)
@@ -4999,7 +5001,8 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 			handler: func(s *store.Store) server.ToolHandlerFunc {
 				return handleSessionSummary(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
 			},
-			args: map[string]any{"content": "## Goal\nMust not persist"},
+			args:                    map[string]any{"content": "## Goal\nMust not persist"},
+			testWithExplicitProject: true,
 			assert: func(t *testing.T, s *store.Store) {
 				t.Helper()
 				observations, err := s.RecentObservations(project, "project", 10)
@@ -5025,44 +5028,69 @@ func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := newMCPTestStore(t)
-			args := make(map[string]any, len(tt.args)+1)
-			for key, value := range tt.args {
-				args[key] = value
-			}
-			args["session_id"] = invented
+		requestVariants := []struct {
+			name            string
+			explicitProject bool
+		}{{name: "project omitted"}}
+		if tt.testWithExplicitProject {
+			requestVariants = append(requestVariants, struct {
+				name            string
+				explicitProject bool
+			}{name: "explicit project", explicitProject: true})
+		}
 
-			res, err := tt.handler(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
-			if err != nil {
-				t.Fatalf("handler error: %v", err)
-			}
-			if !res.IsError {
-				t.Fatal("expected unregistered session_id to fail")
-			}
-			body := callResultJSON(t, res)
-			if body["error_code"] != "unknown_session" || body["invalid_session_id"] != invented || body["retry_without_session_id"] != true {
-				t.Fatalf("unexpected unknown-session envelope: %v", body)
-			}
-			if _, err := s.GetSession(invented); !errors.Is(err, sql.ErrNoRows) {
-				t.Fatalf("invented session was created: %v", err)
-			}
-			observations, err := s.RecentObservations(project, "project", 10)
-			if err != nil || len(observations) != 0 {
-				t.Fatalf("observations after rejected request = %d, err=%v", len(observations), err)
-			}
-			prompts, err := s.RecentPrompts(project, 10)
-			if err != nil || len(prompts) != 0 {
-				t.Fatalf("prompts after rejected request = %d, err=%v", len(prompts), err)
-			}
+		for _, variant := range requestVariants {
+			t.Run(tt.name+"/"+variant.name, func(t *testing.T) {
+				s := newMCPTestStore(t)
+				if variant.explicitProject {
+					// Establish a known explicit project without seeding observations or prompts.
+					if err := s.CreateSession("known-explicit-project", project, t.TempDir()); err != nil {
+						t.Fatalf("create explicit-project setup session: %v", err)
+					}
+					if err := s.EndSession("known-explicit-project", ""); err != nil {
+						t.Fatalf("end explicit-project setup session: %v", err)
+					}
+				}
+				args := make(map[string]any, len(tt.args)+1)
+				for key, value := range tt.args {
+					args[key] = value
+				}
+				if variant.explicitProject {
+					args["project"] = project
+				}
+				args["session_id"] = invented
 
-			delete(args, "session_id")
-			retryRes, err := tt.handler(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
-			if err != nil || retryRes.IsError {
-				t.Fatalf("retry without session_id: err=%v isError=%v text=%q", err, retryRes.IsError, callResultText(t, retryRes))
-			}
-			tt.assert(t, s)
-		})
+				res, err := tt.handler(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
+				if err != nil {
+					t.Fatalf("handler error: %v", err)
+				}
+				if !res.IsError {
+					t.Fatal("expected unregistered session_id to fail")
+				}
+				body := callResultJSON(t, res)
+				if body["error_code"] != "unknown_session" || body["invalid_session_id"] != invented || body["retry_without_session_id"] != true {
+					t.Fatalf("unexpected unknown-session envelope: %v", body)
+				}
+				if _, err := s.GetSession(invented); !errors.Is(err, sql.ErrNoRows) {
+					t.Fatalf("invented session was created: %v", err)
+				}
+				observations, err := s.RecentObservations(project, "project", 10)
+				if err != nil || len(observations) != 0 {
+					t.Fatalf("observations after rejected request = %d, err=%v", len(observations), err)
+				}
+				prompts, err := s.RecentPrompts(project, 10)
+				if err != nil || len(prompts) != 0 {
+					t.Fatalf("prompts after rejected request = %d, err=%v", len(prompts), err)
+				}
+
+				delete(args, "session_id")
+				retryRes, err := tt.handler(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
+				if err != nil || retryRes.IsError {
+					t.Fatalf("retry without session_id: err=%v isError=%v text=%q", err, retryRes.IsError, callResultText(t, retryRes))
+				}
+				tt.assert(t, s)
+			})
+		}
 	}
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -4954,67 +4954,148 @@ func TestMemSave_MissingSessionIDFailsLoudly(t *testing.T) {
 	}
 }
 
-// TestMemSessionSummary_UnregisteredTaskLikeSessionIDRejectedWithRecoveryMetadata
-// covers the #683 lifecycle failure: an agent invents a session_id from a task
-// or issue label (e.g. "issue-1096-update-20260813") instead of one returned by
-// mem_session_start. The unknown_session error must carry structured recovery
-// fields an agent can act on deterministically, the summary must not be
-// persisted under the guessed ID, and the documented recovery — retrying with
-// session_id omitted — must actually succeed.
-func TestMemSessionSummary_UnregisteredTaskLikeSessionIDRejectedWithRecoveryMetadata(t *testing.T) {
-	dir := t.TempDir()
-	initTestGitRepo(t, dir)
-	cmd := exec.Command("git", "-C", dir, "remote", "add", "origin",
-		"git@github.com:user/unregistered-session-summary.git")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git remote add: %v\n%s", err, out)
-	}
-	t.Chdir(dir)
+func TestWriteToolsRejectUnregisteredSessionID(t *testing.T) {
+	const (
+		project  = "unknown-session-project"
+		invented = "issue-1096-update-20260813"
+	)
 
-	s := newMCPTestStore(t)
-	h := handleSessionSummary(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
-
-	invented := "issue-1096-update-20260813"
-	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
-		"content":    "## Goal\nfix the thing",
-		"session_id": invented,
-	}}})
-	if err != nil {
-		t.Fatalf("handler error: %v", err)
-	}
-	if !res.IsError {
-		t.Fatal("expected model-invented session_id to fail")
-	}
-	body := callResultJSON(t, res)
-	if body["error_code"] != "unknown_session" {
-		t.Fatalf("expected unknown_session error, got %v", body)
-	}
-	if body["invalid_session_id"] != invented {
-		t.Fatalf("expected invalid_session_id=%q, got %v", invented, body["invalid_session_id"])
-	}
-	if body["retry_without_session_id"] != true {
-		t.Fatalf("expected retry_without_session_id=true, got %v", body["retry_without_session_id"])
-	}
-
-	// The rejected call must never reach the write path under the guessed ID.
-	if _, err := s.GetSession(invented); err == nil {
-		t.Fatal("unregistered session_id must not be implicitly created")
-	}
-	wrongResults, _ := s.Search("fix the thing", store.SearchOptions{Project: "unregistered-session-summary", Limit: 5})
-	if len(wrongResults) != 0 {
-		t.Fatal("summary must not persist under an unregistered session_id")
+	tests := []struct {
+		name    string
+		handler func(*store.Store) server.ToolHandlerFunc
+		args    map[string]any
+	}{
+		{
+			name: "mem_save",
+			handler: func(s *store.Store) server.ToolHandlerFunc {
+				return handleSave(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
+			},
+			args: map[string]any{"title": "invented session", "content": "must not persist"},
+		},
+		{
+			name: "mem_save_prompt",
+			handler: func(s *store.Store) server.ToolHandlerFunc {
+				return handleSavePrompt(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
+			},
+			args: map[string]any{"content": "must not persist"},
+		},
+		{
+			name: "mem_session_summary",
+			handler: func(s *store.Store) server.ToolHandlerFunc {
+				return handleSessionSummary(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
+			},
+			args: map[string]any{"content": "## Goal\nMust not persist"},
+		},
+		{
+			name: "mem_capture_passive",
+			handler: func(s *store.Store) server.ToolHandlerFunc {
+				return handleCapturePassive(s, MCPConfig{DefaultProject: project}, NewSessionActivity(10*time.Minute))
+			},
+			args: map[string]any{"content": "## Key Learnings:\n- Must not persist"},
+		},
 	}
 
-	// The documented recovery — omit session_id and retry unchanged — must succeed.
-	retryRes, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
-		"content": "## Goal\nfix the thing",
-	}}})
-	if err != nil || retryRes.IsError {
-		t.Fatalf("retry without session_id: err=%v isError=%v text=%s", err, retryRes.IsError, callResultText(t, retryRes))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newMCPTestStore(t)
+			args := make(map[string]any, len(tt.args)+1)
+			for key, value := range tt.args {
+				args[key] = value
+			}
+			args["session_id"] = invented
+
+			res, err := tt.handler(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatal("expected unregistered session_id to fail")
+			}
+			body := callResultJSON(t, res)
+			if body["error_code"] != "unknown_session" || body["invalid_session_id"] != invented || body["retry_without_session_id"] != true {
+				t.Fatalf("unexpected unknown-session envelope: %v", body)
+			}
+			if _, err := s.GetSession(invented); !errors.Is(err, sql.ErrNoRows) {
+				t.Fatalf("invented session was created: %v", err)
+			}
+			observations, err := s.RecentObservations(project, "project", 10)
+			if err != nil || len(observations) != 0 {
+				t.Fatalf("observations after rejected request = %d, err=%v", len(observations), err)
+			}
+			prompts, err := s.RecentPrompts(project, 10)
+			if err != nil || len(prompts) != 0 {
+				t.Fatalf("prompts after rejected request = %d, err=%v", len(prompts), err)
+			}
+		})
 	}
-	recoveredResults, _ := s.Search("fix the thing", store.SearchOptions{Project: "unregistered-session-summary", Limit: 5})
-	if len(recoveredResults) != 1 {
-		t.Fatalf("expected summary persisted after omitted-session_id retry, got %d", len(recoveredResults))
+}
+
+func TestExplicitSessionIDUsesRegisteredProject(t *testing.T) {
+	const (
+		defaultProject    = "default-project"
+		registeredProject = "registered-project"
+		sessionID         = "registered-session"
+		sessionPath       = "/work/registered-project"
+	)
+
+	tests := []struct {
+		name    string
+		handler func(*store.Store) server.ToolHandlerFunc
+		args    map[string]any
+		assert  func(*testing.T, *store.Store)
+	}{
+		{
+			name: "mem_save_prompt",
+			handler: func(s *store.Store) server.ToolHandlerFunc {
+				return handleSavePrompt(s, MCPConfig{DefaultProject: defaultProject}, NewSessionActivity(10*time.Minute))
+			},
+			args: map[string]any{"content": "retain the registered project"},
+			assert: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				prompts, err := s.RecentPrompts(registeredProject, 10)
+				if err != nil || len(prompts) != 1 || prompts[0].SessionID != sessionID {
+					t.Fatalf("registered-project prompts = %#v, err=%v", prompts, err)
+				}
+			},
+		},
+		{
+			name: "mem_capture_passive",
+			handler: func(s *store.Store) server.ToolHandlerFunc {
+				return handleCapturePassive(s, MCPConfig{DefaultProject: defaultProject}, NewSessionActivity(10*time.Minute))
+			},
+			args: map[string]any{"content": "## Key Learnings:\n- Retain the registered project."},
+			assert: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				observations, err := s.RecentObservations(registeredProject, "project", 10)
+				if err != nil || len(observations) != 1 || observations[0].SessionID != sessionID {
+					t.Fatalf("registered-project observations = %#v, err=%v", observations, err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newMCPTestStore(t)
+			if err := s.CreateSession(sessionID, registeredProject, sessionPath); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			args := make(map[string]any, len(tt.args)+1)
+			for key, value := range tt.args {
+				args[key] = value
+			}
+			args["session_id"] = sessionID
+
+			res, err := tt.handler(s)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: args}})
+			if err != nil || res.IsError {
+				t.Fatalf("write with registered session: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+			}
+			body := callResultJSON(t, res)
+			if body["project"] != registeredProject || body["project_source"] != project.SourceSessionProject || body["project_path"] != sessionPath {
+				t.Fatalf("registered session envelope = %v", body)
+			}
+			tt.assert(t, s)
+		})
 	}
 }
 
@@ -8265,8 +8346,8 @@ func TestLifecycleHandlersHonorDefaultProject(t *testing.T) {
 	if err != nil || captureRes.IsError {
 		t.Fatalf("passive capture: err=%v result=%q", err, callResultText(t, captureRes))
 	}
-	if got := callResultJSON(t, captureRes)["project_source"]; got != sourceProcessOverride {
-		t.Fatalf("capture source = %v; want %s", got, sourceProcessOverride)
+	if got := callResultJSON(t, captureRes)["project_source"]; got != project.SourceSessionProject {
+		t.Fatalf("capture source = %v; want %s from the registered session", got, project.SourceSessionProject)
 	}
 
 	end := handleSessionEnd(s, cfg, activity)


### PR DESCRIPTION
## Linked Issue

Closes #683

## PR Type

- [ ] `type:bug`
- [x] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

## Summary

Agents frequently invent `session_id` from a task name, issue number, or date label instead of using one previously registered with `mem_session_start`, hit `unknown_session`, and burn an extra model turn re-parsing prose before retrying. This implements the direction approved on the issue: "structured unknown-session retry guidance, preserve strict explicit-ID validation, direct callers to an existing binding or safe omitted-ID path."

- Strengthened the `session_id` schema description on every write tool that can hit `unknown_session` (`mem_save`, `mem_save_prompt`, `mem_session_summary`, `mem_capture_passive`): only pass a value previously registered with `mem_session_start`, never invent one, and expect `unknown_session` plus a safe omitted-ID retry.
- `unknown_session` errors carry structured recovery fields (`invalid_session_id`, `retry_without_session_id: true`) alongside the existing prose `hint`, so a caller can act deterministically.
- Rejection stays strict: no auto-created sessions and no silent server-side retry; the caller must retry explicitly.

## Changes

| File | Change |
|------|--------|
| `internal/mcp/mcp.go` | Added a shared registered-session resolver; all four write tools now reject unknown explicit IDs before persistence, return structured recovery metadata, and preserve registered project authority. |
| `internal/mcp/mcp_test.go` | Added table-driven regressions for all four write tools, no-persistence guarantees, omitted-ID recovery, and registered project/path authority for prompt and passive capture. |

## Test Plan

- [x] `go test ./internal/mcp -count=1`
- [x] `go test ./... -count=1` (local PowerShell required Git for Windows `bin` on `PATH` for `internal/setup`)
- [x] Remote Unit Tests, E2E Tests, Plugin Tests, PR validation, and CodeRabbit

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #683`)
- [x] I added exactly one `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally
- [x] Docs updated (if behavior changed) - schema descriptions are the caller-facing docs here
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved session ID validation across memory tools.
* Unrecognized session IDs are rejected without creating sessions or storing data.
* Errors now include structured recovery details and support retrying without a session ID.
* Memory saves and passive captures now use the project associated with a registered session.
* Retrying without a session ID continues to use the configured default project.
* Passive-capture errors now include relevant activity and session context.
* Session-based lifecycle reporting now identifies when project information comes from the session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
