### PR TITLE
test(store): stop comparing exported_at in export payload diff

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1627,7 +1627,7 @@ func TestPinnedObservationsAndFormatContextPriority(t *testing.T) {
 		t.Fatalf("marshal export without timestamp: %v", err)
 	}
 	if string(exportedJSONNoTimestamp) != string(exportedBeforePinJSON) {
-		t.Fatalf("pinning must not change export payload:\nbefore: %s\nafter:  %s", exportedBeforePinJSON, exportedJSON)
+		t.Fatalf("pinning must not change export payload:\nbefore: %s\nafter:  %s", exportedBeforePinJSON, exportedJSONNoTimestamp)
 	}
 
 	if err := s.UnpinObservation(ids[0]); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1560,6 +1560,11 @@ func TestPinnedObservationsAndFormatContextPriority(t *testing.T) {
 	if err != nil {
 		t.Fatalf("export project before pin: %v", err)
 	}
+	// exported_at is wall-clock time at second resolution; zero it before
+	// comparing payloads so a second boundary crossed by the real DB work
+	// between the two exports below can't make an otherwise-identical
+	// payload look different.
+	exportedBeforePin.ExportedAt = ""
 	exportedBeforePinJSON, err := json.Marshal(exportedBeforePin)
 	if err != nil {
 		t.Fatalf("marshal export before pin: %v", err)
@@ -1616,7 +1621,12 @@ func TestPinnedObservationsAndFormatContextPriority(t *testing.T) {
 	if strings.Contains(string(exportedJSON), `"pinned"`) {
 		t.Fatalf("pinned state must stay out of sync/export JSON, got %s", exportedJSON)
 	}
-	if string(exportedJSON) != string(exportedBeforePinJSON) {
+	exported.ExportedAt = ""
+	exportedJSONNoTimestamp, err := json.Marshal(exported)
+	if err != nil {
+		t.Fatalf("marshal export without timestamp: %v", err)
+	}
+	if string(exportedJSONNoTimestamp) != string(exportedBeforePinJSON) {
 		t.Fatalf("pinning must not change export payload:\nbefore: %s\nafter:  %s", exportedBeforePinJSON, exportedJSON)
 	}
 


### PR DESCRIPTION
## Linked Issue

Closes #907

## PR Type

- [x] `type:bug`
- [ ] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

## Summary

`TestPinnedObservationsAndFormatContextPriority` exports a project twice around a pin operation and asserts the two JSON payloads are byte-for-byte identical, to prove pinning stays out of sync/export state. `ExportData.ExportedAt` comes from `store.Now()`, which has 1-second resolution — the real DB work between the two exports can cross a second boundary under load, failing an otherwise-identical payload comparison.

Observed on `main` CI ([run 33469945176](https://github.com/Gentleman-Programming/engram/actions/runs/33469945176)):

```
before: ...,"exported_at":"2026-09-01 04:29:15",...
after:  ...,"exported_at":"2026-09-01 04:29:16",...
```

with every other field identical.

Test-only change: zero `ExportedAt` on both payloads before comparing, since the assertion's intent is "pinning must not change the exported data," not "two exports issued seconds apart must share a wall-clock timestamp." No production code touched.

## Changes

| File | Change |
|------|--------|
| `internal/store/store_test.go` | Normalize `ExportedAt` to empty on both the before-pin and after-pin export payloads before the byte-for-byte JSON comparison. |

## Test Plan

- [x] `go test ./internal/store/... -run TestPinnedObservationsAndFormatContextPriority -count=5` (green)
- [x] `go test ./...` (all green except the pre-existing, unrelated `TestDetectProjectFull_ChildScanFindsLaterSecondRepository` flake in `internal/project`, reproducible on a clean `main` checkout)

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #907`)
- [x] I added exactly one `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally
- [x] Docs updated (if behavior changed) — N/A, test-only
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by normalizing variable export timestamps before comparisons.
  * Reduced intermittent failures caused by timing differences between export operations.
  * Ensured pinned-observation and context-priority checks focus on meaningful output rather than timestamp variation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->