### PR TITLE
fix(pi): honest empty search - do not report HTTP 200 null body as unreachable (#672)

### DIFF
--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -181,6 +181,11 @@ function isTimeoutError(error: unknown): boolean {
 // treat a null registration response as unacknowledged and stop before writing;
 // other callers retain the existing null fallthrough contract.
 let lastFetchTimeoutMethod: string | undefined;
+// Whether the most recent engramFetch actually got an HTTP response. Distinguishes a
+// genuine unreachable server (no response) from a successful HTTP 200 whose body is the
+// JSON literal `null` -- which /search returns for zero results and must NOT be reported
+// as "could not reach".
+let lastFetchSawResponse = false;
 
 function takeLastFetchTimeoutMethod(): string | undefined {
   const method = lastFetchTimeoutMethod;
@@ -195,6 +200,7 @@ async function engramFetch<TResponse = unknown>(path: string, opts: FetchOptions
   // on the first leg would mislabel an unrelated failure on the second as "may already have
   // been applied", telling the agent not to retry a write that never left the machine.
   lastFetchTimeoutMethod = undefined;
+  lastFetchSawResponse = false;
   let res: Response | undefined;
   let timedOut = false;
   for (let attempt = 0; attempt < ENGRAM_FETCH_MAX_ATTEMPTS; attempt += 1) {
@@ -223,6 +229,7 @@ async function engramFetch<TResponse = unknown>(path: string, opts: FetchOptions
   // not reach" invites the caller to retry a write whose outcome is genuinely unknown. Record
   // which it was so the tool layer can say what we do and do not know.
   if (timedOut) lastFetchTimeoutMethod = method;
+  if (res) lastFetchSawResponse = true;
   if (!res) return null;
 
   let data: unknown = null;
@@ -1091,8 +1098,16 @@ async function executeMemoryTool(toolName: string, params: Record<string, unknow
     await refreshProjectDetection(ctx.cwd);
     ctx.ui?.setStatus?.("engram", `🧠 ${project} · ${action}…`);
     const data = await callMemoryTool(toolName, params, ctx);
-    if (data === null) {
+    if (data === null && !lastFetchSawResponse) {
       throw new Error(unreachableMessage(takeLastFetchTimeoutMethod()));
+    }
+    if (data === null) {
+      // HTTP succeeded with an empty body (e.g. /search with zero hits returns the JSON
+      // literal `null`): an honest empty result, not a connection failure.
+      const brain = String.fromCodePoint(0x1f9e0);
+      const emptyResult = { content: [{ type: "text" as const, text: "No memories found." }], details: { data: [] as never[] } };
+      ctx.ui?.setStatus?.("engram", `${brain} ${project} · ${humanToolName(toolName)} · no results`);
+      return emptyResult;
     }
     const result = { content: [{ type: "text" as const, text: textResult(data) }], details: { data } };
     if (toolName === "mem_doctor" && data && typeof data === "object" && "status" in data && data.status === "error") {


### PR DESCRIPTION
## Summary

Delivers the plugin-side half of the two-layer fix proposed in #672 (comment 2026-08-26). The server-side half is already merged (#862) — this PR closes the remaining gap.

## Problem recap

`engramFetch` returns `null` for three distinct outcomes:

1. No HTTP response at all (server unreachable / timed out) — genuine failure
2. HTTP 200 whose body fails to parse — server bug
3. HTTP 200 with body being the JSON literal `null` — what older `/search` servers legitimately return for zero hits

The caller (`executeMemoryTool`) treated **every** `null` as outcome 1, so a zero-hit search was reported to the agent as "could not reach Engram" — inviting pointless retries and hiding the honest "no memories found" answer.

## Fix (plugin/pi/index.ts only)

- Track whether the most recent `engramFetch` actually received an HTTP response (`lastFetchSawResponse`), reset per call.
- `data === null` **without** a seen response → unreachable error, unchanged semantics.
- `data === null` **with** a seen response → honest empty result: `No memories found.` with empty `details.data`, plus the standard status-bar update.

## Why still needed after #862

- #862 fixed the server for new builds, but installed servers already in the field still return `null` bodies.
- The client-side distinction is defense in depth: any current or future endpoint that legitimately responds with an empty body must not be misreported as a connection failure.

## Testing

- `esbuild` parse/type-stripping pass on `plugin/pi/index.ts` (no build infrastructure exists in-repo for the plugin; it is loaded directly by Pi).
- Behavior verified live on Windows since 2026-08-26 (local install running this patch): zero-hit `mem_search` queries return "No memories found." instead of the false "could not reach" error.

Closes #672 (together with the already-merged #862).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server connectivity failures versus successful responses with no results.
  * Requests returning no memories now display a clear “No memories found” status.
  * Connectivity errors are reported only when the server cannot be reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->