### PR TITLE
fix(autosync): prevent invalid project pushes

### DIFF
--- a/cmd/engram/doctor.go
+++ b/cmd/engram/doctor.go
@@ -167,7 +167,7 @@ func cmdDoctorRepair(cfg store.Config) {
 			failDoctorRepair(err.Error())
 			return
 		}
-		report, err := s.QuarantineIrreparableSyncMutations(project, mode == diagnostic.RepairModeApply)
+		report, err := s.QuarantineIrreparableSyncMutations(store.DefaultSyncTargetKey, project, mode == diagnostic.RepairModeApply)
 		if err != nil {
 			failDoctorRepair(err.Error())
 			return

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -502,7 +502,7 @@ func TestCmdDoctorSyncMutationRequiredFieldsBlockedEnvelope(t *testing.T) {
 	}
 }
 
-func TestCmdDoctorRepairQuarantinesOnlyIrreparableMutations(t *testing.T) {
+func TestCmdDoctorRepairQuarantinesInvalidEmptyProjectMutations(t *testing.T) {
 	cfg := testConfig(t)
 	s, err := store.New(cfg)
 	if err != nil {
@@ -520,7 +520,7 @@ func TestCmdDoctorRepairQuarantinesOnlyIrreparableMutations(t *testing.T) {
 		t.Fatalf("dry-run stderr=%q", dryErr)
 	}
 	dry := decodeRepairPlan(t, dryOut)
-	if dry["applied"] != false || len(dry["actions"].([]any)) != 1 {
+	if dry["applied"] != false || len(dry["actions"].([]any)) != 2 {
 		t.Fatalf("dry-run=%v", dry)
 	}
 
@@ -530,7 +530,7 @@ func TestCmdDoctorRepairQuarantinesOnlyIrreparableMutations(t *testing.T) {
 		t.Fatalf("apply stderr=%q", applyErr)
 	}
 	applied := decodeRepairPlan(t, applyOut)
-	if applied["applied"] != true || len(applied["actions"].([]any)) != 1 {
+	if applied["applied"] != true || len(applied["actions"].([]any)) != 2 {
 		t.Fatalf("apply=%v", applied)
 	}
 	db, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
@@ -545,7 +545,7 @@ func TestCmdDoctorRepairQuarantinesOnlyIrreparableMutations(t *testing.T) {
 	if err := db.QueryRow(`SELECT disposition FROM sync_mutations WHERE entity_key = 'later'`).Scan(&later); err != nil {
 		t.Fatalf("read later: %v", err)
 	}
-	if poison != store.SyncMutationDispositionQuarantined || later != store.SyncMutationDispositionPending {
+	if poison != store.SyncMutationDispositionQuarantined || later != store.SyncMutationDispositionQuarantined {
 		t.Fatalf("dispositions poison=%q later=%q", poison, later)
 	}
 }

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -101,7 +101,7 @@ type enrolledProjectRepairEnsurer interface {
 // irreparableSyncMutationQuarantiner prevents malformed legacy rows from
 // repeatedly reaching transport while preserving their local audit evidence.
 type irreparableSyncMutationQuarantiner interface {
-	QuarantineIrreparableSyncMutations(project string, apply bool) (store.SyncMutationQuarantineReport, error)
+	QuarantineIrreparableSyncMutations(targetKey, project string, apply bool) (store.SyncMutationQuarantineReport, error)
 }
 
 type nonEnrolledPendingError struct {
@@ -505,7 +505,7 @@ func (m *Manager) push(ctx context.Context) error {
 		}
 	}
 	if quarantiner, ok := m.store.(irreparableSyncMutationQuarantiner); ok {
-		report, err := quarantiner.QuarantineIrreparableSyncMutations("", true)
+		report, err := quarantiner.QuarantineIrreparableSyncMutations(m.cfg.TargetKey, "", true)
 		if err != nil {
 			return fmt.Errorf("quarantine irreparable pending mutations: %w", err)
 		}

--- a/internal/cloud/autosync/manager.go
+++ b/internal/cloud/autosync/manager.go
@@ -98,6 +98,12 @@ type enrolledProjectRepairEnsurer interface {
 	EnsureEnrolledProjectSyncMutations(ctx context.Context) error
 }
 
+// irreparableSyncMutationQuarantiner prevents malformed legacy rows from
+// repeatedly reaching transport while preserving their local audit evidence.
+type irreparableSyncMutationQuarantiner interface {
+	QuarantineIrreparableSyncMutations(project string, apply bool) (store.SyncMutationQuarantineReport, error)
+}
+
 type nonEnrolledPendingError struct {
 	counts []store.PendingSyncMutationProjectCount
 }
@@ -498,6 +504,15 @@ func (m *Manager) push(ctx context.Context) error {
 			return fmt.Errorf("repair enrolled sync journal: %w", err)
 		}
 	}
+	if quarantiner, ok := m.store.(irreparableSyncMutationQuarantiner); ok {
+		report, err := quarantiner.QuarantineIrreparableSyncMutations("", true)
+		if err != nil {
+			return fmt.Errorf("quarantine irreparable pending mutations: %w", err)
+		}
+		if len(report.Actions) > 0 {
+			log.Printf("[autosync] quarantined %d irreparable pending mutation(s); inspect with `engram doctor --check sync_mutation_required_fields`", len(report.Actions))
+		}
+	}
 
 	pending, err := m.store.ListPendingSyncMutations(m.cfg.TargetKey, m.cfg.PushBatchSize)
 	if err != nil {
@@ -514,18 +529,23 @@ func (m *Manager) push(ctx context.Context) error {
 		return nil
 	}
 
-	// Group by project (preserve order).
+	// Group by project (preserve order). Empty or padded project values are invalid
+	// for cloud transport: never send them, but continue with healthy project groups.
 	groups := make(map[string][]store.SyncMutation)
 	order := make([]string, 0)
+	var failures []error
 	for _, mut := range pending {
 		project := mut.Project
+		if strings.TrimSpace(project) != project || project == "" {
+			failures = append(failures, fmt.Errorf("pending mutation seq %d (%s/%s) has an empty or padded project and was not sent; repair local project metadata or inspect `engram doctor --check sync_mutation_required_fields`", mut.Seq, mut.Entity, mut.EntityKey))
+			continue
+		}
 		if _, ok := groups[project]; !ok {
 			order = append(order, project)
 		}
 		groups[project] = append(groups[project], mut)
 	}
 
-	var failures []error
 	for _, project := range order {
 		if err := ctx.Err(); err != nil {
 			failures = append(failures, err)

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -428,6 +428,98 @@ func TestManagerPushIsolatesProjectLocalFailures(t *testing.T) {
 	}
 }
 
+func TestManagerPushSkipsEmptyProjectAndSyncsValidGroups(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.mutations = []store.SyncMutation{
+		{Seq: 1, Entity: "relation", EntityKey: "legacy", Op: "upsert", Project: ""},
+		{Seq: 2, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+	}
+	tr := newFakeTransport()
+	tr.pushResultByProject = map[string]*PushMutationsResult{
+		"alpha": {AcceptedSeqs: []int64{2}},
+	}
+
+	err := New(ls, tr, DefaultConfig()).push(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "has an empty or padded project and was not sent") {
+		t.Fatalf("expected actionable empty-project error, got %v", err)
+	}
+	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha]" {
+		t.Fatalf("expected only alpha to reach transport, got %v", got)
+	}
+	if fmt.Sprint(ls.ackedSeqs) != "[2]" {
+		t.Fatalf("expected only the valid mutation to be acked, got %v", ls.ackedSeqs)
+	}
+}
+
+func TestManagerPushSkipsPaddedProjectAndSyncsValidGroups(t *testing.T) {
+	ls := newFakeLocalStore()
+	ls.mutations = []store.SyncMutation{
+		{Seq: 1, Entity: "relation", EntityKey: "legacy", Op: "upsert", Project: " alpha "},
+		{Seq: 2, Entity: "obs", EntityKey: "alpha", Op: "upsert", Project: "alpha"},
+	}
+	tr := newFakeTransport()
+	tr.pushResultByProject = map[string]*PushMutationsResult{
+		"alpha": {AcceptedSeqs: []int64{2}},
+	}
+
+	err := New(ls, tr, DefaultConfig()).push(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "has an empty or padded project and was not sent") {
+		t.Fatalf("expected actionable padded-project error, got %v", err)
+	}
+	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha]" {
+		t.Fatalf("expected only alpha to reach transport, got %v", got)
+	}
+	if fmt.Sprint(ls.ackedSeqs) != "[2]" {
+		t.Fatalf("expected only the valid mutation to be acked, got %v", ls.ackedSeqs)
+	}
+}
+
+func TestManagerPushQuarantinesLegacyPaddedProjectBeforeSendingValidGroups(t *testing.T) {
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatalf("store default config: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	local, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer local.Close() //nolint:errcheck
+	if err := local.EnrollProject("alpha"); err != nil {
+		t.Fatalf("enroll alpha: %v", err)
+	}
+	if _, err := local.DB().Exec(`
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project)
+		VALUES
+			('cloud', 'session', 'legacy', 'upsert', '{"id":"legacy","directory":"/tmp/legacy"}', 'local', ' alpha '),
+			('cloud', 'session', 'alpha', 'upsert', '{"id":"alpha","directory":"/tmp/alpha","project":"alpha"}', 'local', 'alpha')
+	`); err != nil {
+		t.Fatalf("seed legacy and valid mutations: %v", err)
+	}
+	var alphaSeq int64
+	if err := local.DB().QueryRow(`SELECT seq FROM sync_mutations WHERE entity_key = 'alpha'`).Scan(&alphaSeq); err != nil {
+		t.Fatalf("read alpha sequence: %v", err)
+	}
+	tr := newFakeTransport()
+	tr.pushResultByProject = map[string]*PushMutationsResult{
+		"alpha": {AcceptedSeqs: []int64{alphaSeq}},
+	}
+
+	if err := New(local, tr, DefaultConfig()).push(context.Background()); err != nil {
+		t.Fatalf("push valid group alongside quarantined legacy row: %v", err)
+	}
+	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha]" {
+		t.Fatalf("expected only alpha to reach transport, got %v", got)
+	}
+	var disposition string
+	if err := local.DB().QueryRow(`SELECT disposition FROM sync_mutations WHERE entity_key = 'legacy'`).Scan(&disposition); err != nil {
+		t.Fatalf("read legacy mutation disposition: %v", err)
+	}
+	if disposition != store.SyncMutationDispositionQuarantined {
+		t.Fatalf("expected legacy row to be quarantined, got %q", disposition)
+	}
+}
+
 func TestManagerPushReportsAllProjectLocalFailures(t *testing.T) {
 	ls := newFakeLocalStore()
 	ls.mutations = []store.SyncMutation{

--- a/internal/cloud/autosync/manager_test.go
+++ b/internal/cloud/autosync/manager_test.go
@@ -520,6 +520,85 @@ func TestManagerPushQuarantinesLegacyPaddedProjectBeforeSendingValidGroups(t *te
 	}
 }
 
+func TestManagerPushQuarantinesOnlyConfiguredTarget(t *testing.T) {
+	const targetKey = "replica"
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatalf("store default config: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	local, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer local.Close() //nolint:errcheck
+	if err := local.EnrollProject("alpha"); err != nil {
+		t.Fatalf("enroll alpha: %v", err)
+	}
+	if _, err := local.GetSyncState(targetKey); err != nil {
+		t.Fatalf("initialize configured target state: %v", err)
+	}
+	if _, err := local.DB().Exec(`
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project)
+		VALUES
+			(?, 'session', 'replica-legacy', 'upsert', '{"id":"replica-legacy","directory":"/tmp/legacy"}', 'local', ' alpha '),
+			(?, 'session', 'replica-valid', 'upsert', '{"id":"replica-valid","directory":"/tmp/alpha","project":"alpha"}', 'local', 'alpha'),
+			(?, 'session', 'default-legacy', 'upsert', '{"id":"default-legacy","directory":"/tmp/default"}', 'local', ' beta ')
+	`, targetKey, targetKey, store.DefaultSyncTargetKey); err != nil {
+		t.Fatalf("seed target-scoped mutations: %v", err)
+	}
+	if err := local.MarkSyncPending(store.DefaultSyncTargetKey); err != nil {
+		t.Fatalf("mark default target pending: %v", err)
+	}
+	var validSeq int64
+	if err := local.DB().QueryRow(`SELECT seq FROM sync_mutations WHERE entity_key = 'replica-valid'`).Scan(&validSeq); err != nil {
+		t.Fatalf("read valid mutation sequence: %v", err)
+	}
+	tr := newFakeTransport()
+	tr.pushResultByProject = map[string]*PushMutationsResult{
+		"alpha": {AcceptedSeqs: []int64{validSeq}},
+	}
+	autosyncCfg := DefaultConfig()
+	autosyncCfg.TargetKey = targetKey
+	mgr := New(local, tr, autosyncCfg)
+
+	if err := mgr.push(context.Background()); err != nil {
+		t.Fatalf("push configured target: %v", err)
+	}
+	if got := attemptedProjects(tr); fmt.Sprint(got) != "[alpha]" {
+		t.Fatalf("expected configured target valid group to reach transport, got %v", got)
+	}
+	if err := mgr.push(context.Background()); err != nil {
+		t.Fatalf("repeat push configured target: %v", err)
+	}
+	if got := atomic.LoadInt32(&tr.pushCalls); got != 1 {
+		t.Fatalf("expected no repeated transport attempt for quarantined row, got %d", got)
+	}
+
+	for _, check := range []struct {
+		key  string
+		want string
+	}{
+		{key: "replica-legacy", want: store.SyncMutationDispositionQuarantined},
+		{key: "default-legacy", want: store.SyncMutationDispositionPending},
+	} {
+		var disposition string
+		if err := local.DB().QueryRow(`SELECT disposition FROM sync_mutations WHERE entity_key = ?`, check.key).Scan(&disposition); err != nil {
+			t.Fatalf("read %s disposition: %v", check.key, err)
+		}
+		if disposition != check.want {
+			t.Fatalf("%s disposition = %q, want %q", check.key, disposition, check.want)
+		}
+	}
+	state, err := local.GetSyncState(store.DefaultSyncTargetKey)
+	if err != nil {
+		t.Fatalf("read default target lifecycle: %v", err)
+	}
+	if state.Lifecycle != store.SyncLifecyclePending {
+		t.Fatalf("default target lifecycle = %q, want %q", state.Lifecycle, store.SyncLifecyclePending)
+	}
+}
+
 func TestManagerPushReportsAllProjectLocalFailures(t *testing.T) {
 	ls := newFakeLocalStore()
 	ls.mutations = []store.SyncMutation{

--- a/internal/diagnostic/diagnostic_test.go
+++ b/internal/diagnostic/diagnostic_test.go
@@ -632,7 +632,7 @@ func TestSyncMutationRequiredFieldsSeparatesQuarantinedEvidenceFromBlockingWork(
 		t.Fatalf("expected blocked report before quarantine, got %+v", report)
 	}
 
-	quarantine, err := s.QuarantineIrreparableSyncMutations("engram", true)
+	quarantine, err := s.QuarantineIrreparableSyncMutations(store.DefaultSyncTargetKey, "engram", true)
 	if err != nil || len(quarantine.Actions) != 1 {
 		t.Fatalf("quarantine report=%+v err=%v", quarantine, err)
 	}
@@ -692,7 +692,7 @@ func TestSyncMutationRequiredFieldsReportsQuarantinedEvidenceWithoutCloudEnrollm
 	s, cfg := newDiagnosticTestStoreWithConfig(t)
 	seedDiagnosticPendingMutation(t, cfg.DataDir, "engram", store.SyncEntitySession, "poison", store.SyncOpUpsert, `{"id":"poison"}`)
 
-	quarantine, err := s.QuarantineIrreparableSyncMutations("engram", true)
+	quarantine, err := s.QuarantineIrreparableSyncMutations(store.DefaultSyncTargetKey, "engram", true)
 	if err != nil || len(quarantine.Actions) != 1 {
 		t.Fatalf("quarantine report=%+v err=%v", quarantine, err)
 	}

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -598,24 +598,16 @@ func (s *Store) JudgeRelation(p JudgeRelationParams) (*Relation, error) {
 
 	if err := s.withTx(func(tx *sql.Tx) error {
 		// ── Cross-project guard (Phase 2, REQ-003) ─────────────────────────
-		// Derive source and target project for enrollment checks and the guard.
-		// Use the same session-fallback form as JudgeBySemantic so that enrolled
-		// projects whose observations have a blank project column (but whose session
-		// carries the project) are resolved correctly. Missing observation → empty
-		// string (REQ-011 edge) because the LEFT JOIN returns no row.
-		var srcProject, tgtProject string
+		// Derive the source project using the same session fallback as
+		// JudgeBySemantic. A relation's cloud ownership follows its source; a
+		// missing source therefore has no authoritative project for replication.
+		var srcProject string
 		_ = tx.QueryRow(
 			`SELECT coalesce(nullif(o.project,''), s.project, '')
-			   FROM observations o
-			   LEFT JOIN sessions s ON s.id = o.session_id
-			  WHERE o.sync_id = ?`, sourceID,
+				   FROM observations o
+				   LEFT JOIN sessions s ON s.id = o.session_id
+				  WHERE o.sync_id = ?`, sourceID,
 		).Scan(&srcProject)
-		_ = tx.QueryRow(
-			`SELECT coalesce(nullif(o.project,''), s.project, '')
-			   FROM observations o
-			   LEFT JOIN sessions s ON s.id = o.session_id
-			  WHERE o.sync_id = ?`, targetID,
-		).Scan(&tgtProject)
 
 		// Delegate to shared helper; reject cross-project pairs.
 		if err := validateCrossProjectGuard(tx, sourceID, targetID); err != nil {
@@ -651,31 +643,21 @@ func (s *Store) JudgeRelation(p JudgeRelationParams) (*Relation, error) {
 		}
 
 		// ── Enqueue sync mutation when project is enrolled (REQ-001) ───────
-		// Derive project from source observation; empty string if source missing.
-		// (REQ-011: loud failure is the server's job; we enqueue project='' and log.)
-		//
-		// Enrollment check: prefer srcProject; fall back to tgtProject when source
-		// is missing locally (race condition). This ensures enqueue happens with
-		// project='' when source is absent but target's project IS enrolled.
-		enrollCheckProject := srcProject
-		if enrollCheckProject == "" {
-			enrollCheckProject = tgtProject
+		// Never invent cloud ownership from the target: source ownership is the
+		// relation's authoritative project. Preserve the local judgment, but leave
+		// it local-only until the source can provide a project.
+		if srcProject == "" {
+			log.Printf("[store] WARNING: JudgeRelation kept relation %s local-only; source observation project is unavailable, so no cloud mutation was enqueued", p.JudgmentID)
+			return nil
 		}
 		var enrolled int
 		if err := tx.QueryRow(
-			`SELECT 1 FROM sync_enrolled_projects WHERE project = ? LIMIT 1`, enrollCheckProject,
+			`SELECT 1 FROM sync_enrolled_projects WHERE project = ? LIMIT 1`, srcProject,
 		).Scan(&enrolled); err != nil && err != sql.ErrNoRows {
 			return fmt.Errorf("JudgeRelation: check enrollment: %w", err)
 		}
 		if enrolled == 0 {
 			return nil // not enrolled — no mutation enqueued
-		}
-
-		// REQ-011: log at WARNING level when source observation is missing locally
-		// (project='' race condition). The server will reject with 400; this log
-		// is the local breadcrumb so the gap is not silently swallowed.
-		if srcProject == "" {
-			log.Printf("[store] WARNING: JudgeRelation enqueueing relation %s with project='' (source observation missing locally); server will reject", p.JudgmentID)
 		}
 
 		// Read the full updated row to build the payload.

--- a/internal/store/relations_test.go
+++ b/internal/store/relations_test.go
@@ -1135,9 +1135,9 @@ func TestJudgeRelation_RejectsCrossProject(t *testing.T) {
 	}
 }
 
-// C.1e — When the source observation is missing, JudgeRelation must enqueue a
-// mutation with project=” (empty string, not an error).
-func TestJudgeRelation_MissingSource_EnqueuesEmptyProject(t *testing.T) {
+// C.1e — When the source observation is missing, JudgeRelation preserves the
+// local judgment but must not enqueue a cloud mutation without a project.
+func TestJudgeRelation_MissingSource_KeepsJudgmentLocalOnly(t *testing.T) {
 	s := setupEnrolledStore(t)
 
 	// Use a non-existent source sync_id and a real target.
@@ -1167,13 +1167,20 @@ func TestJudgeRelation_MissingSource_EnqueuesEmptyProject(t *testing.T) {
 	}
 
 	after := countRelationMutations(t, s, SyncEntityRelation, "")
-	if after <= before {
-		t.Errorf("expected mutation with project='' when source is missing; before=%d after=%d", before, after)
+	if after != before {
+		t.Errorf("source-missing relation must not enqueue an empty-project mutation; before=%d after=%d", before, after)
+	}
+	rel, err := s.GetRelation(relSyncID)
+	if err != nil {
+		t.Fatalf("GetRelation: %v", err)
+	}
+	if rel.JudgmentStatus != JudgmentStatusJudged {
+		t.Errorf("local relation judgment was not preserved: got %q", rel.JudgmentStatus)
 	}
 }
 
-// REQ-011 verify-followup: JudgeRelation with missing source MUST emit a
-// WARNING-level log mentioning the relation sync_id and the empty project.
+// REQ-011 verify-followup: JudgeRelation with missing source MUST emit an
+// actionable warning that the local judgment was not replicated.
 func TestJudgeRelation_MissingSource_EmitsWarningLog(t *testing.T) {
 	s := setupEnrolledStore(t)
 
@@ -1212,8 +1219,8 @@ func TestJudgeRelation_MissingSource_EmitsWarningLog(t *testing.T) {
 	if !strings.Contains(logged, relSyncID) {
 		t.Errorf("expected relation sync_id %q in log output; got: %q", relSyncID, logged)
 	}
-	if !strings.Contains(logged, "project=''") {
-		t.Errorf("expected \"project=''\" hint in log output; got: %q", logged)
+	if !strings.Contains(logged, "local-only") || !strings.Contains(logged, "no cloud mutation was enqueued") {
+		t.Errorf("expected actionable local-only replication warning; got: %q", logged)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4444,7 +4444,8 @@ func (s *Store) ListPendingSyncMutationsAfterSeq(targetKey string, afterSeq int6
 // QuarantineIrreparableSyncMutations explicitly disposes of pending mutations
 // the existing legacy validator proves cannot be repaired from local state.
 // It never acknowledges, rewrites, or deletes a mutation.
-func (s *Store) QuarantineIrreparableSyncMutations(project string, apply bool) (SyncMutationQuarantineReport, error) {
+func (s *Store) QuarantineIrreparableSyncMutations(targetKey, project string, apply bool) (SyncMutationQuarantineReport, error) {
+	targetKey = normalizeSyncTargetKey(targetKey)
 	project, _ = NormalizeProject(project)
 	project = strings.TrimSpace(project)
 	report := SyncMutationQuarantineReport{Project: project, Applied: apply, Actions: []SyncMutationQuarantineAction{}}
@@ -4453,7 +4454,7 @@ func (s *Store) QuarantineIrreparableSyncMutations(project string, apply bool) (
 		quarantinedAny := false
 		query := `SELECT seq, target_key, entity, entity_key, op, payload, source, project, occurred_at, acked_at
 			FROM sync_mutations WHERE target_key = ? AND acked_at IS NULL AND disposition = 'pending'`
-		args := []any{DefaultSyncTargetKey}
+		args := []any{targetKey}
 		if project != "" {
 			query += ` AND project = ?`
 			args = append(args, project)
@@ -4485,7 +4486,7 @@ func (s *Store) QuarantineIrreparableSyncMutations(project string, apply bool) (
 			if !apply {
 				continue
 			}
-			result, err := s.execHook(tx, `UPDATE sync_mutations SET disposition = 'quarantined', disposition_reason = ?, disposition_evidence = ?, disposition_at = datetime('now') WHERE target_key = ? AND seq = ? AND acked_at IS NULL AND disposition = 'pending'`, action.ReasonCode, action.Evidence, DefaultSyncTargetKey, action.Seq)
+			result, err := s.execHook(tx, `UPDATE sync_mutations SET disposition = 'quarantined', disposition_reason = ?, disposition_evidence = ?, disposition_at = datetime('now') WHERE target_key = ? AND seq = ? AND acked_at IS NULL AND disposition = 'pending'`, action.ReasonCode, action.Evidence, targetKey, action.Seq)
 			if err != nil {
 				return err
 			}
@@ -4511,12 +4512,14 @@ func (s *Store) QuarantineIrreparableSyncMutations(project string, apply bool) (
 		if !apply || !quarantinedAny {
 			return nil
 		}
-		if err := s.refreshSyncLifecycleTx(tx, DefaultSyncTargetKey); err != nil {
+		if err := s.refreshSyncLifecycleTx(tx, targetKey); err != nil {
 			return err
 		}
-		for affectedProject := range affectedProjects {
-			if err := s.refreshProjectSyncLifecycleTx(tx, affectedProject); err != nil {
-				return err
+		if targetKey == DefaultSyncTargetKey {
+			for affectedProject := range affectedProjects {
+				if err := s.refreshProjectSyncLifecycleTx(tx, affectedProject); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1771,6 +1771,9 @@ func (s *Store) evaluateCloudUpgradeLegacyMutationTx(tx *sql.Tx, mutation SyncMu
 		finding.Message = msg
 		return cloudUpgradeLegacyMutationEvaluation{finding: finding, hasIssue: true, canRepair: false}
 	}
+	if base.Project == "" || base.Project != mutation.Project {
+		return blocked(UpgradeReasonBlockedLegacyMutationManual, "mutation project must be non-empty and canonical for cloud transport and cannot be inferred from authoritative local state"), nil
+	}
 
 	if payload == "" {
 		return blocked(UpgradeReasonBlockedLegacyMutationManual, "legacy mutation payload is empty"), nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9897,13 +9897,8 @@ func TestQuarantineIrreparableSyncMutationsPreservesJournalAndUnblocksTransport(
 			t.Fatalf("seed mutation %s: %v", mutation.key, err)
 		}
 	}
-	var laterSeq int64
-	if err := s.db.QueryRow(`SELECT seq FROM sync_mutations WHERE entity_key = 'later'`).Scan(&laterSeq); err != nil {
-		t.Fatalf("read later sequence: %v", err)
-	}
-
 	dryRun, err := s.QuarantineIrreparableSyncMutations("", false)
-	if err != nil || len(dryRun.Actions) != 1 {
+	if err != nil || len(dryRun.Actions) != 2 {
 		t.Fatalf("dry-run report=%+v err=%v", dryRun, err)
 	}
 	var disposition string
@@ -9912,7 +9907,7 @@ func TestQuarantineIrreparableSyncMutationsPreservesJournalAndUnblocksTransport(
 	}
 
 	report, err := s.QuarantineIrreparableSyncMutations("", true)
-	if err != nil || len(report.Actions) != 1 {
+	if err != nil || len(report.Actions) != 2 {
 		t.Fatalf("apply report=%+v err=%v", report, err)
 	}
 	var payload, reason, evidence string
@@ -9924,7 +9919,7 @@ func TestQuarantineIrreparableSyncMutationsPreservesJournalAndUnblocksTransport(
 		t.Fatalf("quarantine did not preserve audit state: payload=%q disposition=%q reason=%q evidence=%q at=%v acked=%v", payload, disposition, reason, evidence, dispositionAt, ackedAt)
 	}
 	pending, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
-	if err != nil || len(pending) != 1 || pending[0].EntityKey != "later" || pending[0].Seq != laterSeq {
+	if err != nil || len(pending) != 0 {
 		t.Fatalf("transport pending=%+v err=%v", pending, err)
 	}
 	state, err := s.GetSyncState(DefaultSyncTargetKey)
@@ -9938,6 +9933,31 @@ func TestQuarantineIrreparableSyncMutationsPreservesJournalAndUnblocksTransport(
 	var repeatedEvidence string
 	if err := s.db.QueryRow(`SELECT disposition_evidence FROM sync_mutations WHERE entity_key = 'poison'`).Scan(&repeatedEvidence); err != nil || repeatedEvidence != evidence {
 		t.Fatalf("repeat changed evidence=%q err=%v", repeatedEvidence, err)
+	}
+}
+
+func TestQuarantineIrreparableSyncMutationsQuarantinesEmptyProject(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.db.Exec(`
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project)
+		VALUES ('cloud', 'session', 'legacy-empty-project', 'upsert', '{"id":"legacy-empty-project","directory":"/tmp/legacy"}', 'local', '')
+	`); err != nil {
+		t.Fatalf("seed empty-project mutation: %v", err)
+	}
+
+	report, err := s.QuarantineIrreparableSyncMutations("", true)
+	if err != nil || len(report.Actions) != 1 {
+		t.Fatalf("quarantine report=%+v err=%v", report, err)
+	}
+	if !strings.Contains(report.Actions[0].Message, "project must be non-empty and canonical for cloud transport") {
+		t.Fatalf("expected actionable project reason, got %+v", report.Actions[0])
+	}
+	var disposition string
+	if err := s.db.QueryRow(`SELECT disposition FROM sync_mutations WHERE entity_key = 'legacy-empty-project'`).Scan(&disposition); err != nil {
+		t.Fatalf("read empty-project disposition: %v", err)
+	}
+	if disposition != SyncMutationDispositionQuarantined {
+		t.Fatalf("expected empty-project mutation to be quarantined, got %q", disposition)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9897,7 +9897,7 @@ func TestQuarantineIrreparableSyncMutationsPreservesJournalAndUnblocksTransport(
 			t.Fatalf("seed mutation %s: %v", mutation.key, err)
 		}
 	}
-	dryRun, err := s.QuarantineIrreparableSyncMutations("", false)
+	dryRun, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "", false)
 	if err != nil || len(dryRun.Actions) != 2 {
 		t.Fatalf("dry-run report=%+v err=%v", dryRun, err)
 	}
@@ -9906,7 +9906,7 @@ func TestQuarantineIrreparableSyncMutationsPreservesJournalAndUnblocksTransport(
 		t.Fatalf("dry-run disposition=%q err=%v", disposition, err)
 	}
 
-	report, err := s.QuarantineIrreparableSyncMutations("", true)
+	report, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "", true)
 	if err != nil || len(report.Actions) != 2 {
 		t.Fatalf("apply report=%+v err=%v", report, err)
 	}
@@ -9926,7 +9926,7 @@ func TestQuarantineIrreparableSyncMutationsPreservesJournalAndUnblocksTransport(
 	if err != nil || state.LastAckedSeq != 0 {
 		t.Fatalf("state=%+v err=%v", state, err)
 	}
-	again, err := s.QuarantineIrreparableSyncMutations("", true)
+	again, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "", true)
 	if err != nil || len(again.Actions) != 0 {
 		t.Fatalf("repeat report=%+v err=%v", again, err)
 	}
@@ -9945,7 +9945,7 @@ func TestQuarantineIrreparableSyncMutationsQuarantinesEmptyProject(t *testing.T)
 		t.Fatalf("seed empty-project mutation: %v", err)
 	}
 
-	report, err := s.QuarantineIrreparableSyncMutations("", true)
+	report, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "", true)
 	if err != nil || len(report.Actions) != 1 {
 		t.Fatalf("quarantine report=%+v err=%v", report, err)
 	}
@@ -9979,7 +9979,7 @@ func TestQuarantineIrreparableSyncMutationsRefreshesAffectedLifecycles(t *testin
 			t.Fatalf("mark project pending: %v", err)
 		}
 
-		report, err := s.QuarantineIrreparableSyncMutations("project-a", true)
+		report, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "project-a", true)
 		if err != nil || len(report.Actions) != 1 {
 			t.Fatalf("apply report=%+v err=%v", report, err)
 		}
@@ -9999,7 +9999,7 @@ func TestQuarantineIrreparableSyncMutationsRefreshesAffectedLifecycles(t *testin
 			}
 		}
 
-		again, err := s.QuarantineIrreparableSyncMutations("project-a", true)
+		again, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "project-a", true)
 		if err != nil || len(again.Actions) != 0 {
 			t.Fatalf("repeat report=%+v err=%v", again, err)
 		}
@@ -10025,7 +10025,7 @@ func TestQuarantineIrreparableSyncMutationsRefreshesAffectedLifecycles(t *testin
 			}
 		}
 
-		if _, err := s.QuarantineIrreparableSyncMutations("project-a", true); err != nil {
+		if _, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "project-a", true); err != nil {
 			t.Fatalf("quarantine project-a: %v", err)
 		}
 		for _, targetKey := range []string{DefaultSyncTargetKey, syncTargetKeyForProject("project-b")} {
@@ -10060,7 +10060,7 @@ func TestQuarantineIrreparableSyncMutationsKeepsProjectPendingWhenWorkRemains(t 
 		}
 	}
 
-	report, err := s.QuarantineIrreparableSyncMutations("project-a", true)
+	report, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "project-a", true)
 	if err != nil || len(report.Actions) != 1 || report.Actions[0].EntityKey != "poison" {
 		t.Fatalf("apply report=%+v err=%v", report, err)
 	}
@@ -10090,7 +10090,7 @@ func TestQuarantineIrreparableSyncMutationsKeepsProjectPendingWhenWorkRemains(t 
 	if _, err := s.db.Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, 'session', 'poison-2', 'upsert', '{"id":"poison-2"}', 'local', 'project-a')`, DefaultSyncTargetKey); err != nil {
 		t.Fatalf("seed second poison mutation: %v", err)
 	}
-	second, err := s.QuarantineIrreparableSyncMutations("project-a", true)
+	second, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "project-a", true)
 	if err != nil || len(second.Actions) != 1 || second.Actions[0].EntityKey != "poison-2" {
 		t.Fatalf("second quarantine report=%+v err=%v", second, err)
 	}
@@ -10111,7 +10111,7 @@ func TestQuarantineIrreparableSyncMutationsClearsCloudUpgradeBlockers(t *testing
 		t.Fatalf("legacy report before quarantine=%+v err=%v", before, err)
 	}
 
-	if _, err := s.QuarantineIrreparableSyncMutations("project-a", true); err != nil {
+	if _, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "project-a", true); err != nil {
 		t.Fatalf("quarantine: %v", err)
 	}
 
@@ -10141,7 +10141,7 @@ func TestQuarantineIrreparableSyncMutationsFailsClosed(t *testing.T) {
 	if _, err := s.db.Exec(`CREATE TRIGGER reject_quarantine BEFORE UPDATE OF disposition ON sync_mutations BEGIN SELECT RAISE(ABORT, 'quarantine blocked'); END`); err != nil {
 		t.Fatalf("create reject trigger: %v", err)
 	}
-	if _, err := s.QuarantineIrreparableSyncMutations("", true); err == nil {
+	if _, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "", true); err == nil {
 		t.Fatal("expected quarantine persistence error")
 	}
 	var disposition string
@@ -10169,7 +10169,7 @@ func TestQuarantineIrreparableSyncMutationsRollsBackWhenLifecycleRefreshFails(t 
 		t.Fatalf("create lifecycle refresh trigger: %v", err)
 	}
 
-	if _, err := s.QuarantineIrreparableSyncMutations("project-a", true); err == nil {
+	if _, err := s.QuarantineIrreparableSyncMutations(DefaultSyncTargetKey, "project-a", true); err == nil {
 		t.Fatal("expected lifecycle refresh error")
 	}
 	var disposition string


### PR DESCRIPTION
## Linked Issue

Closes #742

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Prevent source-missing relation judgments from enqueueing cloud mutations without an authoritative project.
- Quarantine legacy mutations with empty or non-canonical project identities before transport.
- Continue syncing healthy project groups while preserving actionable audit evidence for rejected rows.
- Scope quarantine to the exact configured sync target so non-default queues cannot poison repeated push cycles.

## Changes

| File | Change |
|------|--------|
| `internal/store/relations.go` | Keep source-missing judgments local-only instead of enqueueing empty-project mutations. |
| `internal/cloud/autosync/manager.go` | Quarantine invalid mutations in the configured target while preserving healthy project progress. |
| `internal/store/store.go` | Classify invalid project identities and scope quarantine and lifecycle refresh to the exact target. |
| `*_test.go` | Add store, autosync, relation, diagnostic, and doctor regressions. |

## Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/... -count=1`
- [ ] Manually tested the affected functionality

Additional verification:

- [x] `go test ./cmd/engram ./internal/store ./internal/cloud/autosync -count=1`
- [x] `go test ./cmd/engram ./internal/store ./internal/cloud/autosync ./internal/diagnostic -count=1` after target-scoping correction
- [x] Focused empty-project, padded-project, and non-default-target regression tests
- [x] `git diff --check`
- [x] Initial RDD review approved and acknowledged for candidate `sha256:349a39a8523c8e528896886eb85fadd9eddf705224e854e701698707264759b5`
- [x] Follow-up target-scoping correction reviewed and acknowledged for candidate `sha256:08d9c3b42bf5e865ace15559d2140b82f8e6aadf20cbe92d8534a9f857e11539`

The full repository suite is not marked as locally passing because the Windows environment lacks the Unix `sh` dependency used by unrelated setup tests. CI remains authoritative for the full suite.

---

## Automated Checks

| Check | What it verifies | Status |
|-------|------------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | PASS |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | PASS |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | PASS |
| **Unit Tests** | `go test ./...` passes | PASS |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | PASS |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | PASS |
| **CodeRabbit** | Automated review has no unresolved actionable finding | PASS |

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (no public interface or configuration change required)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## Notes for Reviewers

Autosync remains intentionally global and groups transport batches by the exact project identity carried by each mutation. The fix does not bind the daemon to its working directory, an environment variable, or a single project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Prevented invalid or whitespace-only project records from being sent to cloud synchronization.
* Automatically quarantined irreparable pending sync records while allowing valid project changes to continue syncing.
* Scoped quarantine actions to the intended synchronization target.
* Preserved local relationship judgments when the source project is unavailable.
* Added actionable error reporting for records requiring manual attention.

## Tests

* Expanded coverage for invalid project identifiers, target-scoped quarantine behavior, and continued synchronization of valid records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
