### PR TITLE
docs(readme): link the site and the Gentle-AI sites from the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 </p>
 
 <p align="center">
+  <a href="https://engram.gentlemanprogramming.com/"><strong>Website</strong></a> &bull;
+  <a href="https://gentle-ai.gentlemanprogramming.com/"><strong>Gentle-AI</strong></a> &bull;
+  <a href="https://gentle-ai-wiki.gentlemanprogramming.com/"><strong>Gentle-AI Wiki</strong></a>
+</p>
+
+<p align="center">
   <a href="docs/INSTALLATION.md">Installation</a> &bull;
   <a href="docs/engram-cloud/README.md">Engram Cloud</a> &bull;
   <a href="docs/AGENT-SETUP.md">Agent Setup</a> &bull;


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #937

---

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

## 📝 Summary

- Adds a link row to the README header so a reader landing on the repository has a path to the project sites.
- All three URLs were requested live and returned `200` with no redirect.

## 📂 Changes

| File | Change |
|------|--------|
| `README.md` | Link row added to the header block |

## 🧪 Test Plan

Documentation-only change; no code, build inputs, or runtime behavior is touched.

- [x] Unit tests pass locally — not affected by this change
- [x] Manually tested the affected functionality — every added URL resolves `200`

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above
- [x] I added the appropriate `type:*` label to this PR
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

https://claude.ai/code/session_015hDNaNWqutTp8CMrBeFRge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered row of links to the Engram website, Gentle-AI, and Gentle-AI Wiki in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->