### PR TITLE
test(mcp): address tool contract review findings

### DIFF
--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -3052,13 +3052,102 @@ func compareMCPToolInventory(expected, actual map[string]*server.ServerTool) err
 	return nil
 }
 
+func mcpToolInventoryFromV1Fixture(t *testing.T) map[string]*server.ServerTool {
+	t.Helper()
+
+	raw, err := os.ReadFile("testdata/tool-contract-v1.json")
+	if err != nil {
+		t.Fatalf("read v1 tool contract fixture: %v", err)
+	}
+	fixture, err := readMCPToolContractFixture(raw)
+	if err != nil {
+		t.Fatalf("read v1 tool contract fixture: %v", err)
+	}
+	inventory := make(map[string]*server.ServerTool, len(fixture))
+	for name := range fixture {
+		inventory[name] = &server.ServerTool{}
+	}
+	return inventory
+}
+
+func TestCompareMCPToolInventory(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected map[string]*server.ServerTool
+		actual   map[string]*server.ServerTool
+		wantErr  bool
+	}{
+		{
+			name: "equal inventories",
+			expected: map[string]*server.ServerTool{
+				"mem_save":   &server.ServerTool{},
+				"mem_search": &server.ServerTool{},
+			},
+			actual: map[string]*server.ServerTool{
+				"mem_save":   &server.ServerTool{},
+				"mem_search": &server.ServerTool{},
+			},
+		},
+		{
+			name:     "both empty",
+			expected: map[string]*server.ServerTool{},
+			actual:   map[string]*server.ServerTool{},
+		},
+		{
+			name: "count mismatch",
+			expected: map[string]*server.ServerTool{
+				"mem_save":   &server.ServerTool{},
+				"mem_search": &server.ServerTool{},
+			},
+			actual: map[string]*server.ServerTool{
+				"mem_save": &server.ServerTool{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "actual extra tool with expected tools present",
+			expected: map[string]*server.ServerTool{
+				"mem_save":   &server.ServerTool{},
+				"mem_search": &server.ServerTool{},
+			},
+			actual: map[string]*server.ServerTool{
+				"mem_save":   &server.ServerTool{},
+				"mem_search": &server.ServerTool{},
+				"mem_stats":  &server.ServerTool{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing tool with equal count",
+			expected: map[string]*server.ServerTool{
+				"mem_save":   &server.ServerTool{},
+				"mem_search": &server.ServerTool{},
+			},
+			actual: map[string]*server.ServerTool{
+				"mem_save":  &server.ServerTool{},
+				"mem_stats": &server.ServerTool{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := compareMCPToolInventory(tt.expected, tt.actual)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("compareMCPToolInventory() error = %v, want error = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestNewServerWithToolsNilRegistersAll(t *testing.T) {
 	s := newMCPTestStore(t)
 	srv := NewServerWithTools(s, nil)
 	if srv == nil {
 		t.Fatal("expected MCP server instance")
 	}
-	if err := compareMCPToolInventory(NewServer(s).ListTools(), srv.ListTools()); err != nil {
+	if err := compareMCPToolInventory(mcpToolInventoryFromV1Fixture(t), srv.ListTools()); err != nil {
 		t.Fatalf("nil allowlist inventory: %v", err)
 	}
 }
@@ -3764,7 +3853,7 @@ func TestNewServerWithConfig(t *testing.T) {
 	if srv == nil {
 		t.Fatal("expected MCP server instance")
 	}
-	if err := compareMCPToolInventory(NewServer(s).ListTools(), srv.ListTools()); err != nil {
+	if err := compareMCPToolInventory(mcpToolInventoryFromV1Fixture(t), srv.ListTools()); err != nil {
 		t.Fatalf("default config inventory: %v", err)
 	}
 }

--- a/internal/mcp/tool_contract_test.go
+++ b/internal/mcp/tool_contract_test.go
@@ -426,6 +426,36 @@ func TestCompareMCPToolContract(t *testing.T) {
 	}
 }
 
+func TestCompareMCPToolContractNullableWidening(t *testing.T) {
+	for _, tc := range []struct {
+		name, want string
+		v1, live   map[string]mcpToolSchema
+	}{
+		{
+			name: "accepts primitive widening",
+			v1:   map[string]mcpToolSchema{"x": {Types: []string{"string"}}},
+			live: map[string]mcpToolSchema{"x": {Types: []string{"string", "null"}}},
+		},
+		{
+			name: "rejects complex object widening",
+			v1: map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{
+				"name": {Types: []string{"string"}},
+			}}},
+			live: map[string]mcpToolSchema{"x": {Types: []string{"object", "null"}, Properties: map[string]mcpToolSchema{
+				"name": {Types: []string{"string"}},
+			}}},
+			want: "unproven-type-drift",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := compareMCPToolContract(tc.v1, tc.live)
+			if tc.want == "" && err != nil || tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("nullable widening error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestCompareMCPToolContractDiagnostics(t *testing.T) {
 	base := map[string]mcpToolSchema{"a/b": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"x~y": {Types: []string{"string"}}}, Additional: true}, "z": {Types: []string{"string"}}}
 	live := map[string]mcpToolSchema{"a/b": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"x~y": {Types: []string{"number"}}}, Additional: false}}
@@ -789,7 +819,7 @@ func simplePrimitive(schema mcpToolSchema) bool {
 		return false
 	}
 	for _, typ := range schema.Types {
-		if !slices.Contains([]string{"string", "number", "integer", "boolean"}, typ) {
+		if !slices.Contains([]string{"string", "number", "integer", "boolean", "null"}, typ) {
 			return false
 		}
 	}

--- a/internal/mcp/tool_contract_update_test.go
+++ b/internal/mcp/tool_contract_update_test.go
@@ -3,6 +3,7 @@
 package mcp
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,12 +12,61 @@ import (
 )
 
 func TestWriteMCPToolContractFixture(t *testing.T) {
+	mode := os.Getenv("ENGRAM_MCP_CONTRACT_WRITE")
+	if mode == "" {
+		t.Skip("set ENGRAM_MCP_CONTRACT_WRITE to update the checked-in fixture")
+	}
 	live, err := observeMCPToolContract(NewServer(newMCPTestStore(t)).ListTools())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := writeMCPToolContractFixture(os.Getenv("ENGRAM_MCP_CONTRACT_WRITE"), filepath.Join("testdata", "tool-contract-v1.json"), live, os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != ""); err != nil {
+	if err := writeMCPToolContractFixture(mode, filepath.Join("testdata", "tool-contract-v1.json"), live, os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != ""); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMCPToolContractWriterSuccesses(t *testing.T) {
+	for _, tc := range []struct {
+		name, mode string
+		fixture    []byte
+		live       map[string]mcpToolSchema
+	}{
+		{
+			name: "initial v1 creates missing target",
+			mode: "initial-v1",
+			live: map[string]mcpToolSchema{
+				"x": {Types: []string{"string"}},
+			},
+		},
+		{
+			name:    "promote v1 replaces compatible fixture",
+			mode:    "promote-v1",
+			fixture: []byte(formatMCPToolContract(map[string]mcpToolSchema{"x": {Types: []string{"string"}}})),
+			live: map[string]mcpToolSchema{
+				"x": {Types: []string{"string", "null"}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "fixture.json")
+			if tc.fixture != nil {
+				if err := os.WriteFile(target, tc.fixture, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := writeMCPToolContractFixture(tc.mode, target, tc.live, false); err != nil {
+				t.Fatalf("writeMCPToolContractFixture: %v", err)
+			}
+			got, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []byte(formatMCPToolContract(tc.live))
+			if !bytes.Equal(got, want) {
+				t.Fatalf("written fixture = %q, want %q", got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- compare default MCP inventories against the committed contract fixture instead of a shared server-construction path
- add deterministic inventory cases for equal, empty, count-mismatch, missing-tool, and extra-tool behavior
- accept compatible `string` to `["string", "null"]` widening while keeping complex nullable schemas fail-closed
- add deterministic `initial-v1` and compatible `promote-v1` writer success tests using temporary directories and exact canonical-byte assertions

## Context

Follow-up to merged PR #910 and issue #717. This applies the valid review findings raised on #910 without reopening the completed feature scope.

## Safety

- test-only changes
- no production behavior changes
- no checked-in fixture changes
- manual fixture updates still require an explicit update mode
- CI refusal and incompatible-promotion paths remain covered

## Scope

Three MCP test files, 173 insertions and 4 deletions:

- `internal/mcp/mcp_test.go`
- `internal/mcp/tool_contract_test.go`
- `internal/mcp/tool_contract_update_test.go`

## Validation

- `git diff --check upstream/main...HEAD`
- focused inventory and contract comparison tests
- deterministic tagged writer success and refusal tests
- `go test ./internal/mcp -count=1`
- `go test -tags=mcp_contract_update ./internal/mcp -count=1`
- `go build ./...`
- `go test -tags=e2e ./internal/server/... -count=1`
- independent verification: PASS
- native high-risk review approved the exact candidate across risk, resilience, readability, and reliability lenses

Fixes #717


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation coverage for tool inventories, including missing, extra, empty, and mismatched tool scenarios.
  - Added checks for compatible nullable type changes and rejection of unsupported complex type changes.
  - Added coverage for creating and promoting compatible contract fixtures.
  - Updated inventory comparisons to use versioned reference fixtures for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->