### PR TITLE
fix(mcp): make tool contract baseline portable and compatible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 plugin/claude-code/scripts/*.sh text eol=lf
 plugin/codex/scripts/*.sh text eol=lf
+internal/mcp/testdata/tool-contract-v1.json text eol=lf

--- a/internal/mcp/tool_contract_test.go
+++ b/internal/mcp/tool_contract_test.go
@@ -404,11 +404,28 @@ func TestCompareMCPToolContract(t *testing.T) {
 		{"new required property", map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"optional": {Types: []string{"integer"}}, "required": base["x"].Properties["required"], "new": {Types: []string{"string"}}}, Required: []string{"required", "new"}, Additional: false}}, "new-required-property"},
 		{"type narrowed", map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"optional": {Types: []string{"integer"}}, "required": {Types: []string{"array"}, Items: &mcpToolSchema{Types: []string{"number"}}}}, Required: []string{"required"}, Additional: false}}, "type-narrowed"},
 		{"enum narrowed", map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"optional": {Types: []string{"integer"}}, "required": {Types: []string{"array"}, Items: &mcpToolSchema{Types: []string{"string"}, Enum: []string{`"b"`}}}}, Required: []string{"required"}, Additional: false}}, "enum-narrowed"},
-		{"unproven optional addition", map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"optional": {Types: []string{"integer"}}, "required": base["x"].Properties["required"], "new": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"nested": {Types: []string{"string"}}}}}, Required: []string{"required"}, Additional: false}}, "unproven-optional-addition"},
+		{"optional complex addition to closed object", map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"optional": {Types: []string{"integer"}}, "required": base["x"].Properties["required"], "new": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"nested": {Types: []string{"string"}}}}}, Required: []string{"required"}, Additional: false}}, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := compareMCPToolContract(base, tc.live)
+			if tc.want == "" && err != nil || tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name, want string
+		v1, live   mcpToolSchema
+	}{
+		{"object plus null", "", mcpToolSchema{Types: []string{"object"}, Properties: map[string]mcpToolSchema{"nested": {Types: []string{"string"}}}}, mcpToolSchema{Types: []string{"object", "null"}, Properties: map[string]mcpToolSchema{"nested": {Types: []string{"string"}}}}},
+		{"array with items plus null", "", mcpToolSchema{Types: []string{"array"}, Items: &mcpToolSchema{Types: []string{"string"}}}, mcpToolSchema{Types: []string{"array", "null"}, Items: &mcpToolSchema{Types: []string{"string"}}}},
+		{"new array branch with items", "", mcpToolSchema{Types: []string{"object"}, Properties: map[string]mcpToolSchema{"nested": {Types: []string{"string"}}}}, mcpToolSchema{Types: []string{"object", "array"}, Properties: map[string]mcpToolSchema{"nested": {Types: []string{"string"}}}, Items: &mcpToolSchema{Types: []string{"string"}}}},
+		{"existing array branch gains items", "shape-drift", mcpToolSchema{Types: []string{"array"}}, mcpToolSchema{Types: []string{"array"}, Items: &mcpToolSchema{Types: []string{"string"}}}},
+		{"typeless schema gains items", "shape-drift", mcpToolSchema{}, mcpToolSchema{Items: &mcpToolSchema{Types: []string{"string"}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := compareMCPToolContract(map[string]mcpToolSchema{"x": tc.v1}, map[string]mcpToolSchema{"x": tc.live})
 			if tc.want == "" && err != nil || tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
@@ -420,7 +437,7 @@ func TestCompareMCPToolContract(t *testing.T) {
 		t.Fatalf("additionalProperties narrowing error = %v", err)
 	}
 	permissiveBase := map[string]mcpToolSchema{"x": {Types: []string{"object"}, Additional: true}}
-	permissiveLive := map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"new": {Types: []string{"boolean"}}}, Additional: true}}
+	permissiveLive := map[string]mcpToolSchema{"x": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"new": {Types: []string{"object"}, Properties: map[string]mcpToolSchema{"nested": {Types: []string{"string"}}}}}, Additional: true}}
 	if err := compareMCPToolContract(permissiveBase, permissiveLive); err == nil || !strings.Contains(err.Error(), "/tools/x/properties/new: additional-properties-narrowed") {
 		t.Fatalf("permissive additionalProperties optional addition error = %v", err)
 	}
@@ -650,7 +667,7 @@ func compareMCPToolSchema(drifts *[]mcpToolContractDrift, path string, v1, live 
 			break
 		}
 	}
-	if hasExtraType(v1.Types, live.Types) && (!simplePrimitive(v1) || !simplePrimitive(live)) {
+	if hasExtraType(v1.Types, live.Types) && !compatibleExtraMCPToolTypes(v1, live) && (!simplePrimitive(v1) || !simplePrimitive(live)) {
 		drift("unproven-type-drift")
 	}
 	if v1.Additional && !live.Additional {
@@ -666,7 +683,7 @@ func compareMCPToolSchema(drifts *[]mcpToolContractDrift, path string, v1, live 
 			}
 		}
 	}
-	if v1.Items == nil && live.Items != nil {
+	if v1.Items == nil && live.Items != nil && (len(v1.Types) == 0 || slices.Contains(v1.Types, "array")) {
 		drift("shape-drift")
 	} else if v1.Items != nil && live.Items != nil {
 		compareMCPToolSchema(drifts, jsonPointer(path, "items"), *v1.Items, *live.Items)
@@ -692,8 +709,6 @@ func compareMCPToolSchema(drifts *[]mcpToolContractDrift, path string, v1, live 
 		if _, exists := v1.Properties[name]; !exists && !slices.Contains(live.Required, name) {
 			if v1.Additional {
 				driftAt(drifts, jsonPointer(jsonPointer(path, "properties"), name), "additional-properties-narrowed", mcpToolSchema{}, live.Properties[name])
-			} else if !simplePrimitive(live.Properties[name]) {
-				driftAt(drifts, jsonPointer(jsonPointer(path, "properties"), name), "unproven-optional-addition", mcpToolSchema{}, live.Properties[name])
 			}
 		}
 	}
@@ -783,6 +798,26 @@ func hasExtraType(v1, live []string) bool {
 		}
 	}
 	return false
+}
+func compatibleExtraMCPToolTypes(v1, live mcpToolSchema) bool {
+	for _, typ := range live.Types {
+		if slices.Contains(v1.Types, typ) || typ == "number" && slices.Contains(v1.Types, "integer") {
+			continue
+		}
+		switch typ {
+		case "null":
+			if !slices.Contains(v1.Types, "object") && !slices.Contains(v1.Types, "array") {
+				return false
+			}
+		case "array":
+			if slices.Contains(v1.Types, "array") || live.Items == nil {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 func simplePrimitive(schema mcpToolSchema) bool {
 	if len(schema.Types) == 0 || len(schema.Properties) > 0 || schema.Items != nil || len(schema.Enum) > 0 {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #931

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Makes the versioned MCP tool-contract fixture baseline LF-portable across checkouts.
- Allows directional compatibility for safe null, new-array, and closed-object additions.
- Preserves diagnostics for genuine schema narrowing and shape drift.

## 📂 Changes

| File | Change |
|------|--------|
| `.gitattributes` | Enforce LF checkout behavior for the tool-contract fixture baseline. |
| `internal/mcp/tool_contract_test.go` | Cover safe directional additions and retain narrowing/shape-drift diagnostics. |

## 🧪 Test Plan

- [x] Focused comparator test passes locally: `go test ./internal/mcp -run TestCompareMCPToolContract -count=1`
- [x] Complete MCP package tests pass locally: `go test ./internal/mcp -count=1`
- [ ] Unit tests pass locally: `go test ./...` (timed out after 600 seconds; CI will supply full-unit proof)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run; CI will supply E2E proof)
- [ ] Manually tested the affected functionality (not applicable; this is a test-only contract-baseline change)

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #931`)
- [x] I added exactly **one** `type:*` label to this PR (`type:bug`)
- [ ] I ran unit tests locally: `go test ./...` (timed out after 600 seconds; CI will supply this proof)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run; CI will supply this proof)
- [x] Docs updated (not applicable; test-only behavior)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This is a test-only MCP tool-contract baseline change. The RDD correction was completed and approved. The local full suite timed out after 600 seconds without a candidate failure; required full-unit and E2E CI checks remain pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP tool contract validation to accept compatible schema additions, including nullable values and supported array definitions.
  * Reduced false-positive compatibility warnings for optional nested object fields and schemas that gain array item definitions.

* **Tests**
  * Expanded coverage for compatible schema changes and shape-drift scenarios.

* **Chores**
  * Standardized line endings for MCP contract test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->