### PR TITLE
feat(store): enforce a deterministic maximum FTS query size

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -491,6 +491,10 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		MatchMode: matchMode,
 	})
 	if err != nil {
+		if errors.Is(err, store.ErrFTSQueryTooLarge) {
+			jsonError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -787,6 +791,10 @@ func (s *Server) handleSearchPrompts(w http.ResponseWriter, r *http.Request) {
 		queryInt(r, "limit", 10),
 	)
 	if err != nil {
+		if errors.Is(err, store.ErrFTSQueryTooLarge) {
+			jsonError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -862,6 +862,31 @@ func TestSearchEndpointsRejectOversizedFTSQueries(t *testing.T) {
 	}
 }
 
+func TestSearchEndpointsRejectTooManyShortFTSTerms(t *testing.T) {
+	srv := New(newServerTestStore(t), 0)
+	query := strings.TrimSpace(strings.Repeat("x ", 769))
+	want := "fts query too large: got 769 terms; maximum is 768 terms for short-term search; shorten the query and retry"
+
+	for _, path := range []string{"/search", "/prompts/search"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path+"?q="+url.QueryEscape(query), nil)
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+			}
+			var response map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if got := response["error"]; got != want {
+				t.Fatalf("error = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestHandleSearchAllowsEmptyMatchMode(t *testing.T) {
 	st := newServerTestStore(t)
 	srv := New(st, 0)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -837,6 +837,31 @@ func TestHandleSearchForwardsMatchModeAndAllProjects(t *testing.T) {
 	}
 }
 
+func TestSearchEndpointsRejectOversizedFTSQueries(t *testing.T) {
+	srv := New(newServerTestStore(t), 0)
+	query := strings.Repeat("a", 65_537)
+	want := "fts query too large: got 65537 bytes; maximum is 65536 bytes; shorten the query and retry"
+
+	for _, path := range []string{"/search", "/prompts/search"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path+"?q="+url.QueryEscape(query), nil)
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+			}
+			var response map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if got := response["error"]; got != want {
+				t.Fatalf("error = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestHandleSearchAllowsEmptyMatchMode(t *testing.T) {
 	st := newServerTestStore(t)
 	srv := New(st, 0)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -862,6 +862,32 @@ func TestSearchEndpointsRejectOversizedFTSQueries(t *testing.T) {
 	}
 }
 
+func TestSearchEndpointsReturnInternalErrorForStoreFailure(t *testing.T) {
+	st := newServerTestStore(t)
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	srv := New(st, 0)
+
+	for _, path := range []string{"/search?q=x", "/prompts/search?q=x"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
+			}
+			var response map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response["error"] == "" {
+				t.Fatalf("internal store error response missing error: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestSearchEndpointsRejectTooManyShortFTSTerms(t *testing.T) {
 	srv := New(newServerTestStore(t), 0)
 	query := strings.TrimSpace(strings.Repeat("x ", 769))

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -383,6 +383,9 @@ func (s *Store) FindCandidates(savedID int64, opts CandidateOptions) ([]Candidat
 	if strings.TrimSpace(queryText) == "" {
 		queryText = title
 	}
+	if err := validateFTSQueryLength(queryText); err != nil {
+		return nil, err
+	}
 	ftsQuery := sanitizeFTSCandidates(queryText)
 	if ftsQuery == "" {
 		return nil, nil

--- a/internal/store/relations_test.go
+++ b/internal/store/relations_test.go
@@ -110,6 +110,63 @@ func TestFindCandidates_HappyPath(t *testing.T) {
 	}
 }
 
+func TestFindCandidatesValidatesStoredTitleLength(t *testing.T) {
+	s := setupRelationsStore(t)
+	_, _ = addTestObs(t, s, "candidate title", "decision", "testproject", "project")
+
+	atLimitID, _ := addTestObs(t, s, strings.Repeat("é", 32_768), "decision", "testproject", "project")
+	if _, err := s.FindCandidates(atLimitID, CandidateOptions{
+		Project:    "testproject",
+		Scope:      "project",
+		Query:      "candidate",
+		SkipInsert: true,
+	}); err != nil {
+		t.Fatalf("FindCandidates with a 65536-byte stored title: %v", err)
+	}
+
+	title := strings.Repeat("a", 65_537)
+	savedID, _ := addTestObs(t, s, title, "decision", "testproject", "project")
+	_, err := s.FindCandidates(savedID, CandidateOptions{
+		Project:    "testproject",
+		Scope:      "project",
+		SkipInsert: true,
+	})
+	if err == nil {
+		t.Fatal("FindCandidates with a 65537-byte stored title returned nil error")
+	}
+	if !errors.Is(err, ErrFTSQueryTooLarge) {
+		t.Fatalf("FindCandidates error = %v, want ErrFTSQueryTooLarge", err)
+	}
+	if got, want := err.Error(), "fts query too large: got 65537 bytes; maximum is 65536 bytes; shorten the query and retry"; got != want {
+		t.Fatalf("FindCandidates error = %q, want %q", got, want)
+	}
+}
+
+func TestFindCandidatesUsesEffectiveQueryForLengthValidation(t *testing.T) {
+	s := setupRelationsStore(t)
+	_, _ = addTestObs(t, s, "candidate title", "decision", "testproject", "project")
+
+	oversizedTitleID, _ := addTestObs(t, s, strings.Repeat("a", 65_537), "decision", "testproject", "project")
+	if _, err := s.FindCandidates(oversizedTitleID, CandidateOptions{
+		Project:    "testproject",
+		Scope:      "project",
+		Query:      "candidate",
+		SkipInsert: true,
+	}); err != nil {
+		t.Fatalf("FindCandidates with valid override query: %v", err)
+	}
+
+	_, err := s.FindCandidates(oversizedTitleID, CandidateOptions{
+		Project:    "testproject",
+		Scope:      "project",
+		Query:      strings.Repeat("b", 65_537),
+		SkipInsert: true,
+	})
+	if !errors.Is(err, ErrFTSQueryTooLarge) {
+		t.Fatalf("FindCandidates error = %v, want ErrFTSQueryTooLarge", err)
+	}
+}
+
 func TestFindCandidates_EscapesInteriorQuotes(t *testing.T) {
 	s := setupRelationsStore(t)
 	_, _ = addTestObs(t, s, `hello"world candidate`, "decision", "testproject", "project")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,6 +37,8 @@ import (
 // See https://www.sqlite.org/rescode.html#constraint_foreignkey
 const sqliteConstraintForeignKey = 787
 
+const maxFTSQueryBytes = 65_536
+
 const (
 	sqlitePrimaryBusy   = 5
 	sqlitePrimaryLocked = 6
@@ -67,6 +69,7 @@ var (
 	ErrObservationTitleRequired    = errors.New("observation title is required")
 	ErrObservationContentRequired  = errors.New("observation content is required")
 	ErrPromptContentRequired       = errors.New("prompt content is required")
+	ErrFTSQueryTooLarge            = errors.New("fts query too large")
 )
 
 // Sentinel errors for relation sync apply path (Phase 2).
@@ -3252,6 +3255,9 @@ func (s *Store) compactionPrompts(sessionID, project string, limit int) ([]Promp
 }
 
 func (s *Store) SearchPrompts(query string, project string, limit int) ([]Prompt, error) {
+	if err := validateFTSQueryLength(query); err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 10
 	}
@@ -3712,6 +3718,10 @@ func (s *Store) SearchContext(ctx context.Context, query string, opts SearchOpti
 		// valid
 	default:
 		return nil, fmt.Errorf("invalid match_mode %q: must be \"all\" or \"any\"", opts.MatchMode)
+	}
+
+	if err := validateFTSQueryLength(query); err != nil {
+		return nil, err
 	}
 
 	// Normalize project filter so "Engram" finds records stored as "engram"
@@ -8857,6 +8867,13 @@ func stripPrivateTags(s string) string {
 	// Clean up multiple consecutive [REDACTED] and excessive whitespace
 	result = strings.TrimSpace(result)
 	return result
+}
+
+func validateFTSQueryLength(query string) error {
+	if len(query) > maxFTSQueryBytes {
+		return fmt.Errorf("%w: got %d bytes; maximum is %d bytes; shorten the query and retry", ErrFTSQueryTooLarge, len(query), maxFTSQueryBytes)
+	}
+	return nil
 }
 
 // sanitizeFTS wraps each word in quotes so FTS5 doesn't choke on special chars.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,7 +37,15 @@ import (
 // See https://www.sqlite.org/rescode.html#constraint_foreignkey
 const sqliteConstraintForeignKey = 787
 
-const maxFTSQueryBytes = 65_536
+const (
+	maxFTSQueryBytes = 65_536
+
+	// maxFTSShortTermQueryTerms keeps LIKE fallbacks below empirically observed
+	// SQLite failures. Filtered SearchContext first failed at 990 terms, while
+	// SearchPrompts first failed at 997 terms. The cap of 768 leaves at least
+	// 221 terms of headroom below the observed worst path.
+	maxFTSShortTermQueryTerms = 768
+)
 
 const (
 	sqlitePrimaryBusy   = 5
@@ -3265,6 +3273,9 @@ func (s *Store) SearchPrompts(query string, project string, limit int) ([]Prompt
 	var sql string
 	var args []any
 	if hasShortFTSTerm(query) {
+		if err := validateShortTermFTSQuery(query); err != nil {
+			return nil, err
+		}
 		sql, args = buildPromptLIKEQuery(query, project, limit)
 	} else {
 		ftsQuery := sanitizeFTS(query)
@@ -3795,6 +3806,9 @@ func (s *Store) SearchContext(ctx context.Context, query string, opts SearchOpti
 	var sqlQ string
 	var args []any
 	if hasShortFTSTerm(query) {
+		if err := validateShortTermFTSQuery(query); err != nil {
+			return nil, err
+		}
 		sqlQ, args = buildSearchLIKEQuery(query, opts, limit)
 	} else {
 		// Build FTS5 query: "all" (default) uses AND semantics; "any" uses OR for broader recall.
@@ -8872,6 +8886,13 @@ func stripPrivateTags(s string) string {
 func validateFTSQueryLength(query string) error {
 	if len(query) > maxFTSQueryBytes {
 		return fmt.Errorf("%w: got %d bytes; maximum is %d bytes; shorten the query and retry", ErrFTSQueryTooLarge, len(query), maxFTSQueryBytes)
+	}
+	return nil
+}
+
+func validateShortTermFTSQuery(query string) error {
+	if terms := len(searchTerms(query)); terms > maxFTSShortTermQueryTerms {
+		return fmt.Errorf("%w: got %d terms; maximum is %d terms for short-term search; shorten the query and retry", ErrFTSQueryTooLarge, terms, maxFTSShortTermQueryTerms)
 	}
 	return nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13187,6 +13187,13 @@ func TestFTSQueryLengthLimit(t *testing.T) {
 	if got := len(tooLarge); got != 65_537 {
 		t.Fatalf("oversized query length = %d, want 65537", got)
 	}
+	runeTooLarge := strings.Repeat("é", 32_769)
+	if got := utf8.RuneCountInString(runeTooLarge); got != 32_769 {
+		t.Fatalf("rune-oversized query rune count = %d, want 32769", got)
+	}
+	if got := len(runeTooLarge); got != 65_538 {
+		t.Fatalf("rune-oversized query byte length = %d, want 65538", got)
+	}
 
 	if err := validateFTSQueryLength(atLimit); err != nil {
 		t.Fatalf("query at 65536 bytes: %v", err)
@@ -13197,9 +13204,16 @@ func TestFTSQueryLengthLimit(t *testing.T) {
 		run  func(string) error
 	}{
 		{
-			name: "observations",
+			name: "search",
 			run: func(query string) error {
 				_, err := s.Search(query, SearchOptions{Project: "engram", Limit: 10})
+				return err
+			},
+		},
+		{
+			name: "search context",
+			run: func(query string) error {
+				_, err := s.SearchContext(context.Background(), query, SearchOptions{Project: "engram", Limit: 10})
 				return err
 			},
 		},
@@ -13211,15 +13225,32 @@ func TestFTSQueryLengthLimit(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.run(tooLarge); err == nil {
-				t.Fatal("query at 65537 bytes returned nil error")
-			} else if !errors.Is(err, ErrFTSQueryTooLarge) {
-				t.Fatalf("oversized query error = %v, want ErrFTSQueryTooLarge", err)
-			} else if got, want := err.Error(), "fts query too large: got 65537 bytes; maximum is 65536 bytes; shorten the query and retry"; got != want {
-				t.Fatalf("oversized query error = %q, want %q", got, want)
-			}
-		})
+		for _, query := range []struct {
+			name string
+			text string
+			want string
+		}{
+			{
+				name: "65537 bytes",
+				text: tooLarge,
+				want: "fts query too large: got 65537 bytes; maximum is 65536 bytes; shorten the query and retry",
+			},
+			{
+				name: "32769 runes and 65538 bytes",
+				text: runeTooLarge,
+				want: "fts query too large: got 65538 bytes; maximum is 65536 bytes; shorten the query and retry",
+			},
+		} {
+			t.Run(tc.name+"/"+query.name, func(t *testing.T) {
+				if err := tc.run(query.text); err == nil {
+					t.Fatalf("query at %s returned nil error", query.name)
+				} else if !errors.Is(err, ErrFTSQueryTooLarge) {
+					t.Fatalf("oversized query error = %v, want ErrFTSQueryTooLarge", err)
+				} else if got := err.Error(); got != query.want {
+					t.Fatalf("oversized query error = %q, want %q", got, query.want)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13177,6 +13177,52 @@ func TestSearchContext_AlreadyCanceled(t *testing.T) {
 	}
 }
 
+func TestFTSQueryLengthLimit(t *testing.T) {
+	s := newTestStore(t)
+	atLimit := strings.Repeat("é", 32_768)
+	if got := len(atLimit); got != 65_536 {
+		t.Fatalf("at-limit query length = %d, want 65536", got)
+	}
+	tooLarge := atLimit + "a"
+	if got := len(tooLarge); got != 65_537 {
+		t.Fatalf("oversized query length = %d, want 65537", got)
+	}
+
+	if err := validateFTSQueryLength(atLimit); err != nil {
+		t.Fatalf("query at 65536 bytes: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func(string) error
+	}{
+		{
+			name: "observations",
+			run: func(query string) error {
+				_, err := s.Search(query, SearchOptions{Project: "engram", Limit: 10})
+				return err
+			},
+		},
+		{
+			name: "prompts",
+			run: func(query string) error {
+				_, err := s.SearchPrompts(query, "engram", 10)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(tooLarge); err == nil {
+				t.Fatal("query at 65537 bytes returned nil error")
+			} else if !errors.Is(err, ErrFTSQueryTooLarge) {
+				t.Fatalf("oversized query error = %v, want ErrFTSQueryTooLarge", err)
+			} else if got, want := err.Error(), "fts query too large: got 65537 bytes; maximum is 65536 bytes; shorten the query and retry"; got != want {
+				t.Fatalf("oversized query error = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestFTSQueriesUseFTSFirstCrossJoin(t *testing.T) {
 	searchQuery, _ := buildSearchFTSQuery(`"memory"`, SearchOptions{}, 10)
 	for name, query := range map[string]string{

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13223,6 +13223,78 @@ func TestFTSQueryLengthLimit(t *testing.T) {
 	}
 }
 
+func TestShortTermFTSQueryTermLimit(t *testing.T) {
+	s := newTestStore(t)
+	queryWithTerms := func(count int) string {
+		return strings.TrimSpace(strings.Repeat("x ", count))
+	}
+
+	atLimit := queryWithTerms(768)
+	if got := len(atLimit); got >= maxFTSQueryBytes {
+		t.Fatalf("at-limit short-term query length = %d, want below %d bytes", got, maxFTSQueryBytes)
+	}
+	tooManyTerms := queryWithTerms(769)
+	longTerms := strings.TrimSpace(strings.Repeat("term ", 769))
+	want := "fts query too large: got 769 terms; maximum is 768 terms for short-term search; shorten the query and retry"
+
+	searches := []struct {
+		name string
+		run  func(string) error
+	}{
+		{
+			name: "observations",
+			run: func(query string) error {
+				_, err := s.SearchContext(context.Background(), query, SearchOptions{Project: "engram", Limit: 10})
+				return err
+			},
+		},
+		{
+			name: "prompts",
+			run: func(query string) error {
+				_, err := s.SearchPrompts(query, "engram", 10)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range searches {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(atLimit); err != nil {
+				t.Fatalf("query at 768 short terms: %v", err)
+			}
+			if err := tc.run(longTerms); err != nil {
+				t.Fatalf("query with 769 non-short FTS terms: %v", err)
+			}
+			if err := tc.run(tooManyTerms); err == nil {
+				t.Fatal("query at 769 short terms returned nil error")
+			} else if !errors.Is(err, ErrFTSQueryTooLarge) {
+				t.Fatalf("over-term query error = %v, want ErrFTSQueryTooLarge", err)
+			} else if got := err.Error(); got != want {
+				t.Fatalf("over-term query error = %q, want %q", got, want)
+			}
+		})
+	}
+
+	t.Run("mixed short and long terms", func(t *testing.T) {
+		mixedTerms := func(count int) string {
+			return "x " + strings.TrimSpace(strings.Repeat("term ", count-1))
+		}
+
+		for _, tc := range searches {
+			t.Run(tc.name, func(t *testing.T) {
+				if err := tc.run(mixedTerms(768)); err != nil {
+					t.Fatalf("query at 768 mixed terms: %v", err)
+				}
+				if err := tc.run(mixedTerms(769)); err == nil {
+					t.Fatal("query at 769 mixed terms returned nil error")
+				} else if !errors.Is(err, ErrFTSQueryTooLarge) {
+					t.Fatalf("over-term query error = %v, want ErrFTSQueryTooLarge", err)
+				}
+			})
+		}
+	})
+}
+
 func TestFTSQueriesUseFTSFirstCrossJoin(t *testing.T) {
 	searchQuery, _ := buildSearchFTSQuery(`"memory"`, SearchOptions{}, 10)
 	for name, query := range map[string]string{

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13179,7 +13179,7 @@ func TestSearchContext_AlreadyCanceled(t *testing.T) {
 
 func TestFTSQueryLengthLimit(t *testing.T) {
 	s := newTestStore(t)
-	atLimit := strings.Repeat("é", 32_768)
+	atLimit := strings.Repeat("abc", 21_845) + "a"
 	if got := len(atLimit); got != 65_536 {
 		t.Fatalf("at-limit query length = %d, want 65536", got)
 	}
@@ -13201,30 +13201,38 @@ func TestFTSQueryLengthLimit(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		run  func(string) error
+		run  func(context.Context, string) error
 	}{
 		{
 			name: "search",
-			run: func(query string) error {
+			run: func(_ context.Context, query string) error {
 				_, err := s.Search(query, SearchOptions{Project: "engram", Limit: 10})
 				return err
 			},
 		},
 		{
 			name: "search context",
-			run: func(query string) error {
-				_, err := s.SearchContext(context.Background(), query, SearchOptions{Project: "engram", Limit: 10})
+			run: func(ctx context.Context, query string) error {
+				_, err := s.SearchContext(ctx, query, SearchOptions{Project: "engram", Limit: 10})
 				return err
 			},
 		},
 		{
 			name: "prompts",
-			run: func(query string) error {
+			run: func(_ context.Context, query string) error {
 				_, err := s.SearchPrompts(query, "engram", 10)
 				return err
 			},
 		},
 	} {
+		t.Run(tc.name+"/65536 bytes", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			if err := tc.run(ctx, atLimit); err != nil {
+				t.Fatalf("query at 65536 bytes: %v", err)
+			}
+		})
+
 		for _, query := range []struct {
 			name string
 			text string
@@ -13242,7 +13250,7 @@ func TestFTSQueryLengthLimit(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name+"/"+query.name, func(t *testing.T) {
-				if err := tc.run(query.text); err == nil {
+				if err := tc.run(context.Background(), query.text); err == nil {
 					t.Fatalf("query at %s returned nil error", query.name)
 				} else if !errors.Is(err, ErrFTSQueryTooLarge) {
 					t.Fatalf("oversized query error = %v, want ErrFTSQueryTooLarge", err)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #718

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Enforce a deterministic 65,536-byte limit before FTS query sanitization and execution.
- Return an actionable `ErrFTSQueryTooLarge` error and map it to HTTP 400 for search endpoints.
- Cover exact boundaries, UTF-8 byte counting, effective relation-candidate queries, and HTTP behavior.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Add the shared FTS query-size policy and guard search entry points. |
| `internal/store/relations.go` | Validate only the effective candidate query before FTS processing. |
| `internal/server/server.go` | Map oversized FTS query errors to HTTP 400. |
| `internal/store/store_test.go` | Cover byte boundaries, UTF-8 input, and sentinel behavior. |
| `internal/store/relations_test.go` | Cover title and override-query boundaries. |
| `internal/server/server_test.go` | Cover HTTP 400 responses for both search endpoints. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] Focused package tests pass locally: `go test ./internal/store ./internal/server`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

The full local unit command is not marked as passing. On Darwin it fails in three tests that reproduce identically on a clean `upstream/main` snapshot:

- `TestCmdSaveUsesDetectionSeamAndPrintsNormalizationWarning`: `/var` resolves to `/private/var`.
- `TestDetectProjectFull_BareRepositoryUsesRepositoryName`: the same macOS path canonicalization mismatch.
- `TestUpdateInstructions`: production returns Homebrew instructions on Darwin while the test expects the GitHub Releases URL.

None of those packages or code paths are changed by this PR. GitHub CI remains the integration gate.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #718`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (baseline Darwin failures documented above)
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Documentation impact assessed; no route or payload shape changed
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The limit is measured with Go's raw string byte length before any FTS sanitization or SQLite `MATCH` construction. Exactly 65,536 bytes remain accepted; 65,537 bytes and above return a classified, actionable error. Valid-query ranking, cancellation, timeout, and result behavior are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search and prompt-search requests exceeding 65,536 bytes are now rejected with HTTP 400 instead of a generic server error.
  * Queries containing more than 768 short terms are rejected with HTTP 400.
  * Error messages explain the applicable query limit and provide guidance to shorten and retry.
  * Queries at the maximum supported length or term count continue to work correctly.
  * Unexpected search service failures continue to return an appropriate server error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Independent QA evidence

The exact candidate received three independent read-only review passes:

- **Adversarial review:** APPROVE after exercising 12 boundary, byte-counting, alternate-path, error-wrapping, and HTTP behavior vectors.
- **Requirements traceability:** APPROVE against every acceptance criterion in #718.
- **Evidence audit:** VERIFIED through fresh focused and package-level test execution.

Fresh independent verification included:

```bash
go test -count=1 ./internal/store ./internal/server
```

No blocking findings were reported. A later multi-perspective QA pass identified two mutation-surviving test gaps, both closed in `c222d8b`: multibyte input above the byte boundary and route-specific non-sentinel HTTP 500 behavior.

### Review correction evidence

The accepted-boundary concern raised during review was validated with executable probes before changing the candidate. Inputs containing many short terms could select the LIKE fallback and exceed SQLite's expression-depth limit while remaining below 65,536 bytes.

The correction keeps the raw byte limit and adds a 768-term cap only when `SearchContext` or `SearchPrompts` selects that fallback. Empirical probes found the first deterministic failure at 990 terms for filtered observation search and 997 terms for prompt search, leaving at least 221 terms of headroom. `FindCandidates` remains on its direct FTS path and is unaffected.

Additional verification:

```bash
go test ./internal/store -run 'Test(FTSQueryLengthLimit|ShortTermFTSQueryTermLimit)'
go test ./internal/store ./internal/server
go test -tags e2e ./internal/server/...
git diff --check
```

All commands passed. Tests cover 768 accepted, 769 rejected, non-short FTS terms, mixed short/long terms, sentinel classification, and HTTP 400 behavior for both affected routes.



### Final QA gap closure

The final test-only commit `c222d8b` adds two independent controls without changing production code:

- A 32,769-rune input containing `é` is 65,538 UTF-8 bytes and is rejected through `Search`, `SearchContext`, and `SearchPrompts`, proving byte-based rather than rune-based enforcement.
- Closed-store requests to `/search` and `/prompts/search` retain HTTP 500 with a stable error envelope, proving the new 400 mapping remains sentinel-specific.

Focused tests, complete store/server package tests, server E2E tests, and `git diff --check` all passed. An independent test-design audit confirmed both previously identified mutation gaps are closed.



### Accepted boundary execution evidence

The test-only commit `8c25835` executes a valid single-term query of exactly 65,536 bytes through `Search`, `SearchContext`, and `SearchPrompts`. All three methods complete successfully, while the existing 65,537-byte ASCII and 65,538-byte multibyte rejection assertions remain intact.

Focused boundary tests, complete store/server package tests, server E2E tests, and `git diff --check` passed. An independent test-design audit confirmed that the new assertions exercise the real FTS paths and pin the accepted side of the boundary without coupling to the production constant.
