### PR TITLE
fix(cloud): normalize mutation pushes before storage (#503)

### DIFF
--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -177,30 +177,41 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	// REQ-006 / REQ-008: Validate each entry's payload before storage.
-	// Relation entries are strictly validated (all required fields).
-	// Legacy entities (session, observation, prompt) use the lenient floor only.
-	// Any failure rejects the ENTIRE batch (atomic — no partial inserts).
+	// Canonicalize every entry before storage so accepted legacy sparse payloads
+	// materialize the same way as later chunk replay. Any failure rejects the
+	// ENTIRE batch before InsertMutationBatch is called.
 	var invalid []map[string]any
+	normalizedEntries := make([]MutationEntry, 0, len(req.Entries))
 	for i, entry := range req.Entries {
-		if field, ok := validateMutationEntry(entry); !ok {
+		if strings.TrimSpace(entry.Entity) == "relation" {
+			if field, ok := validateRelationPayload(entry.Payload); !ok {
+				invalid = append(invalid, map[string]any{"index": i, "field": field, "entity": strings.TrimSpace(entry.Entity)})
+				continue
+			}
+		}
+		normalized, err := canonicalMutationEntry(entry)
+		if err != nil {
 			invalid = append(invalid, map[string]any{
 				"index":  i,
-				"field":  field,
-				"entity": entry.Entity,
+				"field":  "payload",
+				"entity": strings.TrimSpace(entry.Entity),
 			})
+			continue
 		}
+		normalizedEntries = append(normalizedEntries, normalized)
 	}
 	if len(invalid) > 0 {
 		jsonResponse(w, http.StatusBadRequest, map[string]any{
-			"error":       "invalid relation payload",
+			"error_class": constants.UpgradeErrorClassRepairable,
+			"error_code":  constants.UpgradeErrorCodePayloadInvalid,
+			"error":       "invalid mutation payload",
 			"reason_code": "validation_error",
 			"invalid":     invalid,
 		})
 		return
 	}
 
-	acceptedSeqs, err := ms.InsertMutationBatch(r.Context(), req.Entries)
+	acceptedSeqs, err := ms.InsertMutationBatch(r.Context(), normalizedEntries)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("insert mutations: %v", err), http.StatusInternalServerError)
 		return
@@ -213,6 +224,107 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 		"project_source": project.SourceRequestBody,
 		"project_path":   "",
 	})
+}
+
+// canonicalMutationEntry reuses the production chunk canonicalizer instead of
+// storing a payload form that would later fail during chunk materialization.
+func canonicalMutationEntry(entry MutationEntry) (MutationEntry, error) {
+	project := strings.TrimSpace(entry.Project)
+	payload, err := normalizeLegacyMutationPayload(entry, project)
+	if err != nil {
+		return MutationEntry{}, err
+	}
+	encoded, err := json.Marshal(map[string]any{"mutations": []map[string]string{{
+		"project": project, "entity": entry.Entity, "entity_key": entry.EntityKey,
+		"op": entry.Op, "payload": payload,
+	}}})
+	if err != nil {
+		return MutationEntry{}, err
+	}
+	canonical, err := chunkcodec.CanonicalizeForProject(encoded, project)
+	if err != nil {
+		return MutationEntry{}, err
+	}
+	var chunk struct {
+		Mutations []struct {
+			Project   string `json:"project"`
+			Entity    string `json:"entity"`
+			EntityKey string `json:"entity_key"`
+			Op        string `json:"op"`
+			Payload   string `json:"payload"`
+		} `json:"mutations"`
+	}
+	if err := json.Unmarshal(canonical, &chunk); err != nil || len(chunk.Mutations) != 1 {
+		if err == nil {
+			err = fmt.Errorf("expected one canonical mutation")
+		}
+		return MutationEntry{}, err
+	}
+	mutation := chunk.Mutations[0]
+	return MutationEntry{Project: mutation.Project, Entity: mutation.Entity, EntityKey: mutation.EntityKey, Op: mutation.Op, Payload: json.RawMessage(mutation.Payload)}, nil
+}
+
+// normalizeLegacyMutationPayload supplies deterministic placeholders only for
+// absent legacy upsert fields; supplied malformed values remain invalid.
+func normalizeLegacyMutationPayload(entry MutationEntry, project string) (string, error) {
+	entity, op := strings.TrimSpace(entry.Entity), strings.TrimSpace(entry.Op)
+	payload := strings.TrimSpace(string(entry.Payload))
+	if entity != "session" && entity != "observation" && entity != "prompt" {
+		return payload, nil
+	}
+	if strings.HasPrefix(payload, `"`) {
+		if err := json.Unmarshal([]byte(payload), &payload); err != nil {
+			return "", err
+		}
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(payload), &fields); err != nil || fields == nil {
+		if err == nil {
+			err = fmt.Errorf("payload must be an object")
+		}
+		return "", err
+	}
+	key := strings.TrimSpace(entry.EntityKey)
+	if op == "upsert" {
+		switch entity {
+		case "session":
+			if _, ok := fields["id"]; !ok {
+				fields["id"] = firstLegacyID(fields, key)
+			}
+			if _, ok := fields["directory"]; !ok {
+				fields["directory"] = "."
+			}
+		case "observation":
+			if _, ok := fields["sync_id"]; !ok {
+				fields["sync_id"] = key
+			}
+			id := firstLegacyID(fields, key)
+			for field, value := range map[string]string{"session_id": "legacy-" + id, "type": "legacy", "title": id, "content": id, "scope": "project"} {
+				if _, ok := fields[field]; !ok {
+					fields[field] = value
+				}
+			}
+		case "prompt":
+			if _, ok := fields["sync_id"]; !ok {
+				fields["sync_id"] = key
+			}
+			id := firstLegacyID(fields, key)
+			for field, value := range map[string]string{"session_id": "legacy-" + id, "content": id, "project": project} {
+				if _, ok := fields[field]; !ok {
+					fields[field] = value
+				}
+			}
+		}
+	}
+	encoded, err := json.Marshal(fields)
+	return string(encoded), err
+}
+
+func firstLegacyID(fields map[string]any, fallback string) string {
+	if id, ok := fields["sync_id"].(string); ok && strings.TrimSpace(id) != "" {
+		return strings.TrimSpace(id)
+	}
+	return fallback
 }
 
 // handleMutationPull handles GET /sync/mutations/pull.

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -219,6 +219,124 @@ func TestMutationPushStoresCanonicalEncodedPayload(t *testing.T) {
 	}
 }
 
+func TestMutationPushAcceptsSparseLegacyPayloads(t *testing.T) {
+	tests := []struct {
+		name           string
+		entry          MutationEntry
+		requiredFields []string
+	}{
+		{
+			name: "session",
+			entry: MutationEntry{
+				Project: "proj-a", Entity: store.SyncEntitySession, EntityKey: "sess-legacy", Op: store.SyncOpUpsert,
+				Payload: json.RawMessage(`{"sync_id":"sess-legacy"}`),
+			},
+			requiredFields: []string{"id", "directory"},
+		},
+		{
+			name: "observation",
+			entry: MutationEntry{
+				Project: "proj-a", Entity: store.SyncEntityObservation, EntityKey: "obs-legacy", Op: store.SyncOpUpsert,
+				Payload: json.RawMessage(`{"sync_id":"obs-legacy","title":"Legacy observation"}`),
+			},
+			requiredFields: []string{"sync_id", "session_id", "type", "title", "content", "scope", "project"},
+		},
+		{
+			name: "prompt",
+			entry: MutationEntry{
+				Project: "proj-a", Entity: store.SyncEntityPrompt, EntityKey: "prompt-legacy", Op: store.SyncOpUpsert,
+				Payload: json.RawMessage(`{"sync_id":"prompt-legacy"}`),
+			},
+			requiredFields: []string{"sync_id", "session_id", "content", "project"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms := newFakeMutationStore()
+			srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", marshalPushRequest(t, []MutationEntry{tt.entry}))
+			req.Header.Set("Authorization", "Bearer secret")
+			req.Header.Set("Content-Type", "application/json")
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected sparse legacy %s payload to return 200, got %d body=%q", tt.name, rec.Code, rec.Body.String())
+			}
+			if len(ms.mutations) != 1 {
+				t.Fatalf("expected one stored %s mutation, got %+v", tt.name, ms.mutations)
+			}
+			stored := ms.mutations[0]
+			if stored.Project != "proj-a" || stored.Entity != tt.entry.Entity || stored.EntityKey != tt.entry.EntityKey || stored.Op != store.SyncOpUpsert {
+				t.Fatalf("expected canonical stored %s metadata, got %+v", tt.name, stored)
+			}
+			if len(stored.Payload) == 0 || stored.Payload[0] != '{' {
+				t.Fatalf("expected native JSON payload, got %s", stored.Payload)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(stored.Payload, &payload); err != nil {
+				t.Fatalf("decode stored %s payload: %v", tt.name, err)
+			}
+			for _, field := range tt.requiredFields {
+				value, ok := payload[field]
+				if !ok || strings.TrimSpace(fmt.Sprint(value)) == "" {
+					t.Errorf("expected non-empty canonical %s field %q, got %#v", tt.name, field, value)
+				}
+			}
+		})
+	}
+}
+
+func TestMutationPushRejectsMalformedMixedBatchWithoutAcknowledgement(t *testing.T) {
+	ms := newFakeMutationStore()
+	srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
+	entries := []MutationEntry{
+		{
+			Project: "proj-a", Entity: store.SyncEntitySession, EntityKey: "sess-valid", Op: store.SyncOpUpsert,
+			Payload: json.RawMessage(`{"sync_id":"sess-valid"}`),
+		},
+		{
+			Project: "proj-a", Entity: store.SyncEntityObservation, EntityKey: "obs-invalid", Op: store.SyncOpUpsert,
+			Payload: json.RawMessage(`{"sync_id":"obs-invalid","session_id":"sess-valid","type":"note","title":"Invalid","content":"","scope":"project"}`),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", marshalPushRequest(t, entries))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected malformed mixed batch to return 400, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode rejection response: %v", err)
+	}
+	if string(response["error_class"]) != `"repairable"` || string(response["error_code"]) != `"upgrade_repairable_payload_invalid"` {
+		t.Fatalf("expected repairable payload error, got %s", rec.Body.String())
+	}
+	var invalid []struct {
+		Index  int    `json:"index"`
+		Field  string `json:"field"`
+		Entity string `json:"entity"`
+	}
+	if err := json.Unmarshal(response["invalid"], &invalid); err != nil {
+		t.Fatalf("decode invalid entries: %v", err)
+	}
+	if len(invalid) != 1 || invalid[0].Index != 1 || invalid[0].Field != "payload" || invalid[0].Entity != store.SyncEntityObservation {
+		t.Fatalf("expected invalid observation at index 1, got %+v", invalid)
+	}
+	if _, acknowledged := response["accepted_seqs"]; acknowledged {
+		t.Fatalf("expected no accepted sequences for rejected batch, got %s", rec.Body.String())
+	}
+	if len(ms.mutations) != 0 {
+		t.Fatalf("expected atomic rejection with no stored mutations, got %+v", ms.mutations)
+	}
+}
+
 func (s *fakeMutationStore) ListMutationsSince(ctx context.Context, sinceSeq int64, limit int, allowedProjects []string) ([]StoredMutation, bool, int64, error) {
 	if s.errList != nil {
 		return nil, false, 0, s.errList

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -184,6 +184,41 @@ func (s *fakeMutationStore) InsertMutationBatch(ctx context.Context, batch []Mut
 	return seqs, nil
 }
 
+func TestMutationPushStoresCanonicalEncodedPayload(t *testing.T) {
+	ms := newFakeMutationStore()
+	srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
+	entries := []MutationEntry{{
+		Project: " proj-a ", Entity: " observation ", Op: " upsert ", Payload: json.RawMessage(`"{\"sync_id\":\"obs-encoded\",\"session_id\":\"sess-1\",\"type\":\"note\",\"title\":\"Encoded\",\"content\":\"stored natively\",\"scope\":\"project\",\"project\":\"wrong\"}"`),
+	}}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", marshalPushRequest(t, entries))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(ms.mutations) != 1 {
+		t.Fatalf("expected one stored mutation, got %+v", ms.mutations)
+	}
+	stored := ms.mutations[0]
+	if stored.Project != "proj-a" || stored.Entity != store.SyncEntityObservation || stored.Op != store.SyncOpUpsert || stored.EntityKey != "obs-encoded" {
+		t.Fatalf("expected canonical stored entry, got %+v", stored)
+	}
+	if len(stored.Payload) == 0 || stored.Payload[0] != '{' {
+		t.Fatalf("expected native JSON payload, got %s", stored.Payload)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stored.Payload, &payload); err != nil {
+		t.Fatalf("decode stored payload: %v", err)
+	}
+	if payload["project"] != "proj-a" {
+		t.Fatalf("expected authorized project in payload, got %#v", payload["project"])
+	}
+}
+
 func (s *fakeMutationStore) ListMutationsSince(ctx context.Context, sinceSeq int64, limit int, allowedProjects []string) ([]StoredMutation, bool, int64, error) {
 	if s.errList != nil {
 		return nil, false, 0, s.errList

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -221,9 +221,10 @@ func TestMutationPushStoresCanonicalEncodedPayload(t *testing.T) {
 
 func TestMutationPushAcceptsSparseLegacyPayloads(t *testing.T) {
 	tests := []struct {
-		name           string
-		entry          MutationEntry
-		requiredFields []string
+		name              string
+		entry             MutationEntry
+		requiredFields    []string
+		expectedCanonical map[string]string
 	}{
 		{
 			name: "session",
@@ -232,6 +233,9 @@ func TestMutationPushAcceptsSparseLegacyPayloads(t *testing.T) {
 				Payload: json.RawMessage(`{"sync_id":"sess-legacy"}`),
 			},
 			requiredFields: []string{"id", "directory"},
+			expectedCanonical: map[string]string{
+				"id": "sess-legacy", "directory": ".", "project": "proj-a",
+			},
 		},
 		{
 			name: "observation",
@@ -240,6 +244,9 @@ func TestMutationPushAcceptsSparseLegacyPayloads(t *testing.T) {
 				Payload: json.RawMessage(`{"sync_id":"obs-legacy","title":"Legacy observation"}`),
 			},
 			requiredFields: []string{"sync_id", "session_id", "type", "title", "content", "scope", "project"},
+			expectedCanonical: map[string]string{
+				"sync_id": "obs-legacy", "session_id": "legacy-obs-legacy", "type": "legacy", "title": "Legacy observation", "content": "obs-legacy", "scope": "project", "project": "proj-a",
+			},
 		},
 		{
 			name: "prompt",
@@ -248,6 +255,9 @@ func TestMutationPushAcceptsSparseLegacyPayloads(t *testing.T) {
 				Payload: json.RawMessage(`{"sync_id":"prompt-legacy"}`),
 			},
 			requiredFields: []string{"sync_id", "session_id", "content", "project"},
+			expectedCanonical: map[string]string{
+				"sync_id": "prompt-legacy", "session_id": "legacy-prompt-legacy", "content": "prompt-legacy", "project": "proj-a",
+			},
 		},
 	}
 
@@ -283,6 +293,11 @@ func TestMutationPushAcceptsSparseLegacyPayloads(t *testing.T) {
 				text, isString := value.(string)
 				if !exists || !isString || strings.TrimSpace(text) == "" {
 					t.Errorf("expected non-empty canonical %s field %q, got %#v", tt.name, field, value)
+				}
+			}
+			for field, want := range tt.expectedCanonical {
+				if got := payload[field]; got != want {
+					t.Errorf("expected canonical %s field %q to be %q, got %#v", tt.name, field, want, got)
 				}
 			}
 		})

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -279,8 +279,9 @@ func TestMutationPushAcceptsSparseLegacyPayloads(t *testing.T) {
 				t.Fatalf("decode stored %s payload: %v", tt.name, err)
 			}
 			for _, field := range tt.requiredFields {
-				value, ok := payload[field]
-				if !ok || strings.TrimSpace(fmt.Sprint(value)) == "" {
+				value, exists := payload[field]
+				text, isString := value.(string)
+				if !exists || !isString || strings.TrimSpace(text) == "" {
 					t.Errorf("expected non-empty canonical %s field %q, got %#v", tt.name, field, value)
 				}
 			}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #503

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Canonicalize every accepted mutation through the production chunk codec before storage, preventing payloads accepted by the push gate from failing later as opaque HTTP 500 errors.
- Preserve sparse legacy session, observation, and prompt compatibility by filling only absent required fields while rejecting supplied malformed values with a repairable HTTP 400.
- Keep batch rejection atomic: invalid entries produce no inserts or acknowledgements.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudserver/mutations.go` | Canonicalize mutation entries before insertion and provide deterministic defaults for absent legacy fields. |
| `internal/cloud/cloudserver/mutations_test.go` | Prove encoded payloads are stored as native canonical JSON while retaining legacy compatibility coverage. |

## 🧪 Test Plan

- [x] Focused unit tests pass: `go test ./internal/cloud/cloudserver -count=1`
- [x] Focused mutation tests pass: `go test ./internal/cloud/cloudserver -run 'Test(MutationPushStoresCanonicalEncodedPayload|HandleMutationPush_LegacyObsMissingOptional_Returns200|RelationSync_BackwardsCompat_LegacyClient|HandleMutationPush_PartialBatch_Atomic)$' -count=1`
- [x] E2E tests pass: `go test -tags e2e ./internal/server/...`
- [ ] Full suite: `go test ./...` exceeded the 600-second local limit; CI remains authoritative.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #503`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran the complete unit suite locally; the bounded run exceeded 600 seconds and CI will complete it
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Documentation impact reviewed; no public workflow or configuration changed
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This is the focused replacement for #891. It contains only the issue #503 root-cause fix and its behavior-first coverage; unrelated changes from #891 are intentionally excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mutation submissions are now consistently normalized before storage, including whitespace cleanup and encoded payload handling.
  * Sparse legacy mutation payloads are accepted and stored with canonical metadata.
  * Invalid mutation entries now return clearer validation details, including error classifications and codes.
  * Mixed valid and invalid batches are rejected without acknowledging or storing any entries.
  * Stored mutations now use the authorized project context and correctly derive entity identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->