### PR TITLE
fix(setup): diagnose unsupported slim versions

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2865,7 +2865,7 @@ func printSetupUsage() {
 	fmt.Println("                          installed agent slug (default: full). Unknown or")
 	fmt.Println("                          missing values fall back to full with a warning.")
 	fmt.Println("                          slim currently only takes effect for claude-code,")
-	fmt.Println("                          and only when the installed engram is >= 1.4.0.")
+	fmt.Println("                          and only with a clean tagged engram release >= 1.4.0.")
 	fmt.Println("  --help, -h              Show this help and exit.")
 }
 
@@ -2893,6 +2893,17 @@ func applyProtocolMode(cfg store.Config, slug, mode string) {
 	if err := setup.WriteProtocolMode(cfg.DataDir, slug, mode); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not persist protocol mode: %v\n", err)
 	}
+
+	classification := classifyProtocolVersion(version)
+	if mode != setup.ProtocolModeSlim || classification == protocolVersionSupported {
+		return
+	}
+
+	if classification == protocolVersionBelowFloor {
+		fmt.Fprintf(os.Stderr, "warning: slim will remain full: engram %q is below 1.4.0; install a clean tagged release at or above 1.4.0.\n", strings.TrimSpace(version))
+		return
+	}
+	fmt.Fprintf(os.Stderr, "warning: slim will remain full: engram %q is not a clean tagged release; install a clean tagged release at or above 1.4.0.\n", strings.TrimSpace(version))
 }
 
 // cmdProtocolMode implements `engram protocol-mode <slug>`: prints "slim" to
@@ -2923,34 +2934,51 @@ func cmdProtocolMode(cfg store.Config) {
 // MCP serverInstructions duplication fix shipped in this release.
 var protocolVersionFloor = [3]int{1, 4, 0}
 
-// meetsProtocolVersionFloor reports whether v (e.g. "1.4.0", "v1.5.2", or the
-// build-time "dev" placeholder) is >= protocolVersionFloor. Any unparseable
-// or empty value returns false — the caller then falls back to "full".
-func meetsProtocolVersionFloor(v string) bool {
+type protocolVersionClassification uint8
+
+const (
+	protocolVersionUnsupported protocolVersionClassification = iota
+	protocolVersionBelowFloor
+	protocolVersionSupported
+)
+
+// classifyProtocolVersion distinguishes clean releases that can use slim from
+// releases below the floor and development, pseudo, dirty, or other non-release
+// build versions. Legacy numeric versions such as "1.4" remain supported.
+func classifyProtocolVersion(v string) protocolVersionClassification {
 	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
-	if v == "" || v == "dev" {
-		return false
+	segments := strings.Split(v, ".")
+	if len(segments) < 2 || len(segments) > 3 {
+		return protocolVersionUnsupported
 	}
 
-	segments := strings.SplitN(v, ".", 3)
 	var parts [3]int
-	for i, s := range segments {
-		if i >= 3 {
-			break
+	for i, segment := range segments {
+		if segment == "" {
+			return protocolVersionUnsupported
 		}
-		n, err := strconv.Atoi(strings.TrimSpace(s))
-		if err != nil {
-			return false
+		n, err := strconv.Atoi(segment)
+		if err != nil || n < 0 {
+			return protocolVersionUnsupported
 		}
 		parts[i] = n
 	}
 
 	for i := 0; i < 3; i++ {
 		if parts[i] != protocolVersionFloor[i] {
-			return parts[i] > protocolVersionFloor[i]
+			if parts[i] > protocolVersionFloor[i] {
+				return protocolVersionSupported
+			}
+			return protocolVersionBelowFloor
 		}
 	}
-	return true
+	return protocolVersionSupported
+}
+
+// meetsProtocolVersionFloor reports whether v is a clean release at or above
+// protocolVersionFloor. Unsupported versions fall back to "full".
+func meetsProtocolVersionFloor(v string) bool {
+	return classifyProtocolVersion(v) == protocolVersionSupported
 }
 
 func printPostInstall(result *setup.Result) {

--- a/cmd/engram/setup_protocol_test.go
+++ b/cmd/engram/setup_protocol_test.go
@@ -43,6 +43,7 @@ func TestCmdSetupProtocolEqualsFormPersistsSlim(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
 	cfg := testConfig(t)
+	setProtocolVersion(t, "1.4.0")
 
 	setupInstallAgent = func(agent string) (*setup.Result, error) {
 		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
@@ -63,6 +64,7 @@ func TestCmdSetupProtocolSpaceFormPersistsSlim(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
 	cfg := testConfig(t)
+	setProtocolVersion(t, "1.4.0")
 
 	setupInstallAgent = func(agent string) (*setup.Result, error) {
 		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
@@ -83,6 +85,7 @@ func TestCmdSetupProtocolFlagFirstThenSlug(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
 	cfg := testConfig(t)
+	setProtocolVersion(t, "1.4.0")
 
 	setupInstallAgent = func(agent string) (*setup.Result, error) {
 		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
@@ -106,6 +109,7 @@ func TestCmdSetupUnknownFlagFallbackForwardsParsedProtocolMode(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
 	cfg := testConfig(t)
+	setProtocolVersion(t, "1.4.0")
 
 	setupSupportedAgents = func() []setup.Agent {
 		return []setup.Agent{{Name: "opencode", Description: "OpenCode", InstallDir: "/tmp/opencode"}}
@@ -140,6 +144,7 @@ func TestCmdSetupUnknownFlagBeforeProtocolStillForwardsMode(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
 	cfg := testConfig(t)
+	setProtocolVersion(t, "1.4.0")
 
 	setupSupportedAgents = func() []setup.Agent {
 		return []setup.Agent{{Name: "opencode", Description: "OpenCode", InstallDir: "/tmp/opencode"}}
@@ -319,6 +324,7 @@ func TestCmdSetupNoSlugWithProtocolAppliesToSelectedAgent(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
 	cfg := testConfig(t)
+	setProtocolVersion(t, "1.4.0")
 
 	setupSupportedAgents = func() []setup.Agent {
 		return []setup.Agent{{Name: "opencode", Description: "OpenCode", InstallDir: "/tmp/opencode"}}
@@ -352,6 +358,7 @@ func TestCmdSetupNoSlugWithProtocolAppliesToSelectedAgent(t *testing.T) {
 func TestCmdSetupWriteReadPathParityUnderEnvDataDir(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
+	setProtocolVersion(t, "1.4.0")
 
 	dataDir := t.TempDir()
 	t.Setenv("ENGRAM_DATA_DIR", dataDir)
@@ -385,10 +392,10 @@ func TestCmdSetupWriteReadPathParityUnderEnvDataDir(t *testing.T) {
 	if recovered != nil || stderr != "" {
 		t.Fatalf("panic=%v stderr=%q", recovered, stderr)
 	}
-	// version == "dev" in the test binary, so the version floor is never
-	// met — this assertion targets read-path parity, not the floor check.
-	if strings.TrimSpace(stdout) != "full" {
-		t.Fatalf("stdout = %q, want %q (version=dev fails the floor check)", stdout, "full")
+	// A supported version makes slim output prove that the runtime read uses
+	// exactly the data directory setup wrote to.
+	if strings.TrimSpace(stdout) != "slim" {
+		t.Fatalf("stdout = %q, want %q (write/read path mismatch)", stdout, "slim")
 	}
 }
 
@@ -517,25 +524,109 @@ func TestCmdProtocolModeMissingSlugKeyDefaultsFull(t *testing.T) {
 
 func TestMeetsProtocolVersionFloor(t *testing.T) {
 	tests := []struct {
-		in   string
-		want bool
+		name           string
+		version        string
+		classification protocolVersionClassification
+		wantSlim       bool
 	}{
-		{"1.4.0", true},
-		{"1.4.1", true},
-		{"1.5.0", true},
-		{"2.0.0", true},
-		{"1.3.9", false},
-		{"1.0.0", false},
-		{"0.9.9", false},
-		{"dev", false},
-		{"", false},
-		{"not-a-version", false},
-		{"v1.4.0", true},
-		{"1.4", true},
+		{"supported release", "1.4.0", protocolVersionSupported, true},
+		{"supported tagged release", "v1.5.0", protocolVersionSupported, true},
+		{"legacy numeric release", "1.4", protocolVersionSupported, true},
+		{"below-floor release", "1.3.9", protocolVersionBelowFloor, false},
+		{"development build", "dev", protocolVersionUnsupported, false},
+		{"Go pseudo-version", "v1.4.0-0.20260102030405-abcdef012345", protocolVersionUnsupported, false},
+		{"dirty build", "1.4.0-dirty", protocolVersionUnsupported, false},
+		{"non-release input", "not-a-version", protocolVersionUnsupported, false},
 	}
 	for _, tt := range tests {
-		if got := meetsProtocolVersionFloor(tt.in); got != tt.want {
-			t.Errorf("meetsProtocolVersionFloor(%q) = %v, want %v", tt.in, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyProtocolVersion(tt.version); got != tt.classification {
+				t.Fatalf("classifyProtocolVersion(%q) = %v, want %v", tt.version, got, tt.classification)
+			}
+			if got := meetsProtocolVersionFloor(tt.version); got != tt.wantSlim {
+				t.Fatalf("meetsProtocolVersionFloor(%q) = %v, want %v", tt.version, got, tt.wantSlim)
+			}
+		})
 	}
+}
+
+func TestApplyProtocolModeWarnsOnlyWhenSlimCannotActivate(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		mode        string
+		wantWarning string
+	}{
+		{"supported release", "1.4.0", setup.ProtocolModeSlim, ""},
+		{"full mode", "dev", setup.ProtocolModeFull, ""},
+		{"below-floor release", "1.3.9", setup.ProtocolModeSlim, "below 1.4.0"},
+		{"development build", "dev", setup.ProtocolModeSlim, "not a clean tagged release"},
+		{"Go pseudo-version", "v1.4.0-0.20260102030405-abcdef012345", setup.ProtocolModeSlim, "not a clean tagged release"},
+		{"dirty build", "1.4.0-dirty", setup.ProtocolModeSlim, "not a clean tagged release"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig(t)
+			setProtocolVersion(t, tt.version)
+
+			stdout, stderr := captureOutput(t, func() {
+				applyProtocolMode(cfg, "claude-code", tt.mode)
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if tt.wantWarning == "" {
+				if stderr != "" {
+					t.Fatalf("stderr = %q, want no warning", stderr)
+				}
+			} else if !strings.Contains(stderr, tt.wantWarning) || !strings.Contains(stderr, "install a clean tagged release") {
+				t.Fatalf("stderr = %q, want actionable warning containing %q", stderr, tt.wantWarning)
+			}
+			if got := setup.ReadProtocolMode(cfg.DataDir, "claude-code"); got != tt.mode {
+				t.Fatalf("ReadProtocolMode = %q, want %q", got, tt.mode)
+			}
+		})
+	}
+}
+
+func TestCmdProtocolModeOutputsOnlyModeForUnsupportedVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"supported release", "1.4.0", setup.ProtocolModeSlim},
+		{"below-floor release", "1.3.9", setup.ProtocolModeFull},
+		{"development build", "dev", setup.ProtocolModeFull},
+		{"Go pseudo-version", "v1.4.0-0.20260102030405-abcdef012345", setup.ProtocolModeFull},
+		{"dirty build", "1.4.0-dirty", setup.ProtocolModeFull},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubExitWithPanic(t)
+			cfg := testConfig(t)
+			if err := setup.WriteProtocolMode(cfg.DataDir, "claude-code", setup.ProtocolModeSlim); err != nil {
+				t.Fatalf("seed WriteProtocolMode: %v", err)
+			}
+			setProtocolVersion(t, tt.version)
+
+			withArgs(t, "engram", "protocol-mode", "claude-code")
+			stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdProtocolMode(cfg) })
+			if recovered != nil || stderr != "" {
+				t.Fatalf("panic=%v stderr=%q", recovered, stderr)
+			}
+			if stdout != tt.want+"\n" {
+				t.Fatalf("stdout = %q, want exactly %q", stdout, tt.want+"\n")
+			}
+		})
+	}
+}
+
+func setProtocolVersion(t *testing.T, value string) {
+	t.Helper()
+	oldVersion := version
+	version = value
+	t.Cleanup(func() { version = oldVersion })
 }

--- a/cmd/engram/setup_protocol_test.go
+++ b/cmd/engram/setup_protocol_test.go
@@ -611,6 +611,7 @@ func TestMeetsProtocolVersionFloor(t *testing.T) {
 		{"legacy numeric release", "1.4", protocolVersionSupported, true},
 		{"below-floor release", "1.3.9", protocolVersionBelowFloor, false},
 		{"development build", "dev", protocolVersionUnsupported, false},
+		{"empty version", "", protocolVersionUnsupported, false},
 		{"Go pseudo-version", "v1.4.0-0.20260102030405-abcdef012345", protocolVersionUnsupported, false},
 		{"dirty build", "1.4.0-dirty", protocolVersionUnsupported, false},
 		{"non-release input", "not-a-version", protocolVersionUnsupported, false},

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -36,6 +36,14 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 > agent's instruction surface, idempotently. The per-agent sections below describe
 > the exact files each command touches and the manual equivalent.
 
+### Protocol verbosity
+
+`engram setup <agent> --protocol=slim` requests the slim session-start protocol.
+Slim activates only when Engram is a clean tagged release at or above 1.4.0.
+Local `dev`, Go pseudo-version, dirty, and other non-release builds remain on
+`full`; setup persists the selection and warns so you can install a supported
+tagged release.
+
 ## Pi
 
 Install Engram's Pi package, the MCP adapter, and Pi MCP config:

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -38,11 +38,12 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 
 ### Protocol verbosity
 
-`engram setup <agent> --protocol=slim` requests the slim session-start protocol.
-Slim activates only when Engram is a clean tagged release at or above 1.4.0.
-Local `dev`, Go pseudo-version, dirty, and other non-release builds remain on
-`full`; setup persists the selection and warns so you can install a supported
-tagged release.
+`engram setup claude-code --protocol=slim` requests the slim session-start
+protocol. Slim is honored only for the `claude-code` agent; all other agents
+remain on `full`. For Claude Code, slim activates only when Engram is a clean
+tagged release at or above 1.4.0. Local `dev`, Go pseudo-version, dirty, and
+other non-release builds remain on `full`; setup persists the selection and
+warns so you can install a supported tagged release.
 
 ## Pi
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #741

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Diagnose why `--protocol=slim` remains on full mode for unsupported build versions.
- Warn with actionable guidance while retaining the requested protocol selection.
- RDD review approved the unchanged candidate.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Classify clean tagged releases and emit actionable slim-mode fallback warnings. |
| `cmd/engram/setup_protocol_test.go` | Cover supported, below-floor, development, pseudo-version, and dirty-version behavior. |
| `docs/AGENT-SETUP.md` | Document slim activation requirements and fallback behavior. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

Focused protocol-version diagnostics tests passed. `go test ./cmd/engram` timed out after 600 seconds. Full unit, E2E, and manual checks remain unproven.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Slim activates only for clean tagged Engram releases at or above 1.4.0. Unsupported build versions retain full mode and receive an actionable warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slim protocol mode is now supported for clean tagged releases version 1.4.0 and newer.
  * Setup retains the selected slim preference and warns when it cannot activate, allowing it to take effect after upgrading to a supported release.

* **Bug Fixes**
  * Improved protocol version handling for development, pseudo-version, dirty, and older builds.

* **Documentation**
  * Updated setup help and documentation with slim mode activation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->