### PR TITLE
fix(pi): recover local server after mid-session loss

### DIFF
--- a/plugin/pi/README.md
+++ b/plugin/pi/README.md
@@ -182,6 +182,8 @@ Cloud is opt-in and project-scoped. Local SQLite remains the source of truth; cl
 
 If you only want HTTP session capture against an already running Engram server, set `ENGRAM_URL` and the extension will not auto-start a local `engram serve` process.
 
+When `ENGRAM_URL` is unset, a confirmed local server that later refuses connections gets one bounded restart attempt per initialized runtime. Pi replays only safe reads and idempotent session registration after health returns `2xx`; other writes report the transport failure instead of risking a duplicate mutation.
+
 ## Configuration
 
 ### Existing Engram server

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -111,6 +111,12 @@ interface EngramFetchResult<TResponse> {
 
 type EngramFetcher = <TResponse = unknown>(path: string, opts?: FetchOptions) => Promise<TResponse | null>;
 
+function isSafeToReplay(path: string, method: string): boolean {
+  // Session creation is explicitly idempotent on the server (INSERT OR IGNORE). Other writes
+  // have no idempotency key, so only reads and this registration request can be replayed.
+  return method === "GET" || (method === "POST" && path === "/sessions");
+}
+
 interface SessionBody {
   id: string;
   project: string;
@@ -190,6 +196,7 @@ async function engramFetchResult<TResponse = unknown>(path: string, opts: FetchO
   const method = opts.method ?? "GET";
   let res: Response | undefined;
   let timedOut = false;
+  let refused = false;
   for (let attempt = 0; attempt < ENGRAM_FETCH_MAX_ATTEMPTS; attempt += 1) {
     try {
       res = await fetch(`${ENGRAM_URL}${redactUrlPath(path)}`, {
@@ -208,12 +215,20 @@ async function engramFetchResult<TResponse = unknown>(path: string, opts: FetchO
         timedOut = true;
         break;
       }
-      if (attempt < ENGRAM_FETCH_MAX_ATTEMPTS - 1) await wait(ENGRAM_FETCH_BACKOFF_BASE_MS * 2 ** attempt);
+      refused = isConnectionRefusedError(error);
+      if (!isSafeToReplay(path, method) || attempt === ENGRAM_FETCH_MAX_ATTEMPTS - 1) break;
+      await wait(ENGRAM_FETCH_BACKOFF_BASE_MS * 2 ** attempt);
     }
   }
 
   if (!res) {
     if (timedOut) return { data: null, timedOutMethod: method };
+    // A confirmed local refusal after successful initialization means the implicitly owned
+    // server may have died. One generation-scoped recovery is shared by every caller. Only
+    // operations whose idempotence is established above are replayed after it is healthy.
+    if (refused && await recoverImplicitEngramServer() && isSafeToReplay(path, method)) {
+      return engramFetchResult<TResponse>(path, opts);
+    }
     throw new Error(unreachableMessage(undefined));
   }
 
@@ -339,6 +354,10 @@ function hasConnectionRefusedCode(value: unknown, depth = 0): boolean {
   return hasConnectionRefusedCode(record.cause, depth + 1);
 }
 
+function isConnectionRefusedError(error: unknown): boolean {
+  return (error instanceof Error && error.message === "connection refused") || hasConnectionRefusedCode(error);
+}
+
 async function probeEngramHealth(): Promise<EngramHealth> {
   try {
     const res = await fetch(`${ENGRAM_URL}/health`, {
@@ -347,7 +366,7 @@ async function probeEngramHealth(): Promise<EngramHealth> {
     return res.ok ? "ready" : "indeterminate";
   } catch (error) {
     if (isTimeoutError(error)) return "indeterminate";
-    if ((error instanceof Error && error.message === "connection refused") || hasConnectionRefusedCode(error)) {
+    if (isConnectionRefusedError(error)) {
       return "refused";
     }
     return "indeterminate";
@@ -588,6 +607,9 @@ let initialization: Promise<void> | undefined;
 let startupFailures = 0;
 let startupRetryAt = 0;
 let startupFailure: Error | undefined;
+let initializationGeneration = 0;
+let recoveredInitializationGeneration = 0;
+let recoveryFlight: { generation: number; promise: Promise<boolean> } | undefined;
 
 function startupBackoffMs(failures: number): number {
   return Math.min(ENGRAM_STARTUP_RETRY_MAX_MS, ENGRAM_STARTUP_RETRY_BASE_MS * 2 ** (failures - 1));
@@ -607,6 +629,7 @@ function sharedInitialization(start: () => Promise<void>): Promise<void> {
       startupFailures = 0;
       startupRetryAt = 0;
       startupFailure = undefined;
+      initializationGeneration += 1;
     },
     (error: unknown) => {
       initialization = undefined;
@@ -617,6 +640,27 @@ function sharedInitialization(start: () => Promise<void>): Promise<void> {
     },
   );
   return initialization;
+}
+
+// Initialization remains fulfilled for the session, so a later refusal needs a separate,
+// bounded recovery path. Marking a generation before starting prevents a failed restart from
+// becoming a spawn storm; tagging the flight prevents callers from joining an older generation.
+function recoverImplicitEngramServer(): Promise<boolean> {
+  const generation = initializationGeneration;
+  if (CONFIGURED_ENGRAM_URL !== undefined || generation === 0) return Promise.resolve(false);
+  const activeFlight = recoveryFlight;
+  if (activeFlight?.generation === generation) return activeFlight.promise;
+  if (recoveredInitializationGeneration === generation) return Promise.resolve(false);
+
+  recoveredInitializationGeneration = generation;
+  const promise = initializeEngramServer().then(
+    () => true,
+    () => false,
+  ).finally(() => {
+    if (recoveryFlight?.generation === generation) recoveryFlight = undefined;
+  });
+  recoveryFlight = { generation, promise };
+  return promise;
 }
 
 let project = "unknown";

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -31,10 +31,12 @@ function buildEngramFetchForTest({
   timeoutMs = 3000,
   maxAttempts = 3,
   backoffBaseMs = 150,
+  recover = async () => false,
 } = {}) {
   const body = extractFunctionBody("engramFetchResult", "{\n  const method")
     .replace("let res: Response | undefined;", "let res;")
     .replace("let data: unknown = null;", "let data = null;")
+    .replace("return engramFetchResult<TResponse>(path, opts);", "return engramFetchResult(path, opts);")
     .replace("return { data: data as TResponse };", "return { data };");
   const factory = new Function(
     "fetch",
@@ -45,6 +47,7 @@ function buildEngramFetchForTest({
     "ENGRAM_FETCH_TIMEOUT_MS",
     "ENGRAM_FETCH_MAX_ATTEMPTS",
     "ENGRAM_FETCH_BACKOFF_BASE_MS",
+    "recoverImplicitEngramServer",
     `
     class EngramHttpError extends Error {
       constructor(message, status, data) {
@@ -56,6 +59,12 @@ function buildEngramFetchForTest({
     }
     function isTimeoutError(error) {
       ${extractFunctionBody("isTimeoutError", "{\n  return error instanceof Error")}
+    }
+    function isSafeToReplay(path, method) {
+      return method === "GET" || (method === "POST" && path === "/sessions");
+    }
+    function isConnectionRefusedError(error) {
+      return error instanceof Error && error.message === "connection refused";
     }
     function unreachableMessage() {
       return "gentle-engram could not reach the Engram HTTP server";
@@ -76,6 +85,7 @@ function buildEngramFetchForTest({
     timeoutMs,
     maxAttempts,
     backoffBaseMs,
+    recover,
   );
 }
 
@@ -142,6 +152,7 @@ function buildProbeEngramHealthForTest({ fetch, isTimeoutError }) {
   const body = extractFunctionBody("probeEngramHealth", "{\n  try");
   const refusedBody = extractFunctionBody("hasConnectionRefusedCode", "{\n  if (depth")
     .replace("value as Record<string, unknown>", "value");
+  const refusalBody = extractFunctionBody("isConnectionRefusedError", "{\n  return");
   const factory = new Function(
     "fetch",
     "isTimeoutError",
@@ -150,6 +161,9 @@ function buildProbeEngramHealthForTest({ fetch, isTimeoutError }) {
     `
     function hasConnectionRefusedCode(value, depth = 0) {
       ${refusedBody}
+    }
+    function isConnectionRefusedError(error) {
+      ${refusalBody}
     }
     async function probeEngramHealth() {
       ${body}
@@ -176,6 +190,7 @@ function buildSharedInitializationForTest({ retryBaseMs = 1000, retryMaxMs = 600
     let startupFailures = 0;
     let startupRetryAt = 0;
     let startupFailure;
+    let initializationGeneration = 0;
     function startupBackoffMs(failures) {
       ${backoffBody}
     }
@@ -187,6 +202,23 @@ function buildSharedInitializationForTest({ retryBaseMs = 1000, retryMaxMs = 600
   );
   const sharedInitialization = factory({ now: () => clock.now }, retryBaseMs, retryMaxMs);
   return { sharedInitialization, clock };
+}
+
+function buildRecoveryForTest({ configuredUrl = false, initializeEngramServer }) {
+  const body = extractFunctionBody("recoverImplicitEngramServer", "{\n  const generation");
+  const factory = new Function("CONFIGURED_ENGRAM_URL", "initializeEngramServer", `
+    let initializationGeneration = 1;
+    let recoveredInitializationGeneration = 0;
+    let recoveryFlight;
+    function recoverImplicitEngramServer() {
+      ${body}
+    }
+    return {
+      recoverImplicitEngramServer,
+      setGeneration: (generation) => { initializationGeneration = generation; },
+    };
+  `);
+  return factory(configuredUrl ? "http://configured" : undefined, initializeEngramServer);
 }
 
 // A fake child process: an EventEmitter with the ChildProcess members the startup path
@@ -595,6 +627,41 @@ test("ENGRAM_URL bypasses Pi readiness and automatic spawn", async () => {
   assert.equal(readinessWaits, 0);
 });
 
+test("mid-session recovery shares one flight per initialization generation", async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  let restarts = 0;
+  const recovery = buildRecoveryForTest({
+    initializeEngramServer: async () => {
+      restarts += 1;
+      await gate;
+    },
+  });
+
+  const first = recovery.recoverImplicitEngramServer();
+  const second = recovery.recoverImplicitEngramServer();
+  assert.strictEqual(first, second, "concurrent callers share the recovery flight");
+  assert.equal(restarts, 1);
+  release();
+  assert.equal(await first, true);
+  assert.equal(await recovery.recoverImplicitEngramServer(), false, "a generation gets one bounded recovery");
+
+  recovery.setGeneration(2);
+  assert.equal(await recovery.recoverImplicitEngramServer(), true, "a newer initialization does not reuse a stale flight");
+  assert.equal(restarts, 2);
+});
+
+test("mid-session recovery never manages an explicit ENGRAM_URL", async () => {
+  let restarts = 0;
+  const recovery = buildRecoveryForTest({
+    configuredUrl: true,
+    initializeEngramServer: async () => { restarts += 1; },
+  });
+
+  assert.equal(await recovery.recoverImplicitEngramServer(), false);
+  assert.equal(restarts, 0);
+});
+
 test("a child that reaches readiness is released to keep running, never killed", async () => {
   const child = createFakeChild();
   let probes = 0;
@@ -926,7 +993,7 @@ test("a timeout resolves to null like any other failure, so callers keep their f
   }
 });
 
-test("a connection failure reports the generic unavailable error", async () => {
+test("an unsafe write connection failure reports the generic unavailable error", async () => {
   const originalFetch = globalThis.fetch;
   let calls = 0;
   globalThis.fetch = async () => {
@@ -936,7 +1003,7 @@ test("a connection failure reports the generic unavailable error", async () => {
   try {
     const { engramFetch } = buildEngramFetchForTest();
     await assert.rejects(() => engramFetch("/observations", { method: "POST", body: { title: "t" } }), /could not reach/);
-    assert.equal(calls, 3, "every retry attempt is spent before giving up");
+    assert.equal(calls, 1, "an unsafe write is sent once before reporting the failure");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1064,7 +1131,7 @@ test("isTimeoutError matches what Node actually rejects with on a real AbortSign
   }
 });
 
-test("connection failures still retry, because they never reached the server", async () => {
+test("unsafe writes do not retry after a connection failure", async () => {
   const originalFetch = globalThis.fetch;
   let calls = 0;
   globalThis.fetch = async () => {
@@ -1079,8 +1146,30 @@ test("connection failures still retry, because they never reached the server", a
   };
   try {
     const { engramFetch } = buildEngramFetchForTest();
-    assert.deepEqual(await engramFetch("/observations", { method: "POST", body: { title: "t" } }), { status: "ok" });
-    assert.equal(calls, 3);
+    await assert.rejects(() => engramFetch("/observations", { method: "POST", body: { title: "t" } }), /could not reach/);
+    assert.equal(calls, 1, "a write without an idempotency contract is never replayed");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a mid-session local refusal restarts once and replays a safe read", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetches = 0;
+  let recoveries = 0;
+  globalThis.fetch = async () => {
+    fetches += 1;
+    if (fetches <= 3) throw new Error("connection refused");
+    return { ok: true, async json() { return { observations: [] }; } };
+  };
+  try {
+    const { engramFetch } = buildEngramFetchForTest({
+      wait: () => Promise.resolve(),
+      recover: async () => { recoveries += 1; return true; },
+    });
+    assert.deepEqual(await engramFetch("/search?q=recovered"), { observations: [] });
+    assert.equal(recoveries, 1, "the failed initialized generation gets one recovery attempt");
+    assert.equal(fetches, 4, "the safe read is replayed only after recovery reports readiness");
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Linked Issue

Closes #458

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Recover the implicitly managed local Engram HTTP server once after a confirmed mid-session connection refusal.
- Share recovery across concurrent callers and replay only safe reads or idempotent session registration after healthy readiness.
- Document endpoint ownership and cover recovery, concurrency, explicit URL, and unsafe-write behavior.

## Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Add bounded generation-scoped local recovery and safe replay policy. |
| `plugin/pi/test/index-source.test.mjs` | Add behavior-focused recovery and negative-control coverage. |
| `plugin/pi/README.md` | Document mid-session recovery and explicit endpoint ownership. |

## Test Plan

- [x] Focused Pi tests: `node --test test/index-source.test.mjs` - 61/61 passed.
- [ ] Full Pi suite: `npm test` - 99/101 on Windows; two known fake-`.mjs` startup fixture tests fail before exercising this candidate.
- [ ] Unit tests: `go test ./...` - no output before the 300-second bound.
- [x] E2E tests: `go test -tags e2e ./internal/server/...` - passed.
- [ ] Manual runtime kill/restart was not repeated; the issue contains the deterministic runtime reproduction.

---

## Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Pending |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Pending |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | Pending |
| **Unit Tests** | `go test ./...` passes | Pending |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Pending |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | Pending |

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #458`).
- [x] I added exactly **one** `type:*` label to this PR.
- [ ] Local `go test ./...` did not finish inside its 300-second bound; CI is required for the repository-wide result.
- [x] I ran E2E tests locally.
- [x] Docs updated for the behavior change.
- [x] Commits follow conventional commit format.
- [x] No `Co-Authored-By` trailers in commits.

---

## Notes for Reviewers

The exact three-file candidate completed receipt-driven review with no blocking findings. Reliability review left one informational follow-up about direct session-registration replay coverage; no correction was required. The three changed file blobs remain byte-identical to the reviewed candidate. The remote branch also contains a post-review merge from current `main`; that merge did not alter any reviewed file blob.

The two local Pi package failures are the existing Windows fake-executable fixture cases. CI should provide the authoritative Linux package result.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for locally managed Engram servers after connection refusal.
  * Safe reads and session registration requests are replayed once after successful recovery.
  * Recovery attempts are shared within each runtime initialization.

* **Bug Fixes**
  * Prevented unsafe write requests from being retried, avoiding duplicate operations.
  * Improved handling of connection-refusal errors across supported environments.

* **Documentation**
  * Documented local server recovery behavior and request replay limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->