### PR TITLE
fix(setup): detect Claude slim plugin capability

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -87,6 +87,7 @@ var (
 	setupInstallAgent            = setup.Install
 	setupAddClaudeCodeAllowlist  = setup.AddClaudeCodeAllowlist
 	setupEnsureClaudeCodeUserMCP = setup.EnsureClaudeCodeUserMCP
+	setupVerifyClaudeCodeSlim    = setup.VerifyClaudeCodeSlimCapability
 	scanInputLine                = fmt.Scanln
 
 	storeSearch = func(s *store.Store, query string, opts store.SearchOptions) ([]store.SearchResult, error) {
@@ -2806,7 +2807,9 @@ func cmdSetup(cfg store.Config) {
 			fatal(err)
 		}
 		if protocolFlag {
-			applyProtocolMode(cfg, slug, resolveProtocolModeFlag(protocolRaw))
+			mode := resolveProtocolModeFlag(protocolRaw)
+			applyProtocolMode(cfg, slug, mode)
+			warnIfClaudeCodeSlimUnverified(slug, mode)
 		}
 		fmt.Printf("✓ Installed %s plugin (%d files)\n", result.Agent, result.Files)
 		fmt.Printf("  → %s\n", result.Destination)
@@ -2857,6 +2860,7 @@ func cmdSetupInteractive(cfg store.Config, mode string) {
 	}
 	if mode != "" {
 		applyProtocolMode(cfg, selected.Name, mode)
+		warnIfClaudeCodeSlimUnverified(selected.Name, mode)
 	}
 
 	fmt.Printf("✓ Installed %s plugin (%d files)\n", result.Agent, result.Files)
@@ -2879,6 +2883,8 @@ func printSetupUsage() {
 	fmt.Println("                          missing values fall back to full with a warning.")
 	fmt.Println("                          slim currently only takes effect for claude-code,")
 	fmt.Println("                          and only when the installed engram is >= 1.4.0.")
+	fmt.Println("                          Claude Code slim also requires Engram plugin >= 0.1.1;")
+	fmt.Println("                          setup warns, but continues, when it cannot verify it.")
 	fmt.Println("  --help, -h              Show this help and exit.")
 }
 
@@ -2905,6 +2911,17 @@ func resolveProtocolModeFlag(raw string) string {
 func applyProtocolMode(cfg store.Config, slug, mode string) {
 	if err := setup.WriteProtocolMode(cfg.DataDir, slug, mode); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not persist protocol mode: %v\n", err)
+	}
+}
+
+func warnIfClaudeCodeSlimUnverified(slug, mode string) {
+	if slug != "claude-code" || mode != setup.ProtocolModeSlim {
+		return
+	}
+	if err := setupVerifyClaudeCodeSlim(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: unable to verify the Claude Code Engram plugin supports --protocol=slim (requires plugin 0.1.1+): %v\n", err)
+		fmt.Fprintln(os.Stderr, "  Update the plugin through your normal Claude Code plugin update path, then restart Claude Code.")
+		fmt.Fprintln(os.Stderr, "  Session-only plugins loaded with `claude --plugin-dir ...` cannot be detected by this check.")
 	}
 }
 

--- a/cmd/engram/setup_protocol_test.go
+++ b/cmd/engram/setup_protocol_test.go
@@ -37,6 +37,9 @@ func TestCmdSetupHelpAnyPositionShowsProtocolFlagAndSkipsStdin(t *testing.T) {
 		if !strings.Contains(stdout, "--protocol") {
 			t.Fatalf("args=%v: usage output missing literal --protocol: %q", args, stdout)
 		}
+		if !strings.Contains(stdout, "plugin >= 0.1.1") {
+			t.Fatalf("args=%v: usage output missing Claude Code plugin floor: %q", args, stdout)
+		}
 	}
 }
 
@@ -124,6 +127,7 @@ func TestCmdSetupProtocolEqualsFormPersistsSlim(t *testing.T) {
 	setupInstallAgent = func(agent string) (*setup.Result, error) {
 		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
 	}
+	scanInputLine = func(...any) (int, error) { return 0, nil }
 
 	withArgs(t, "engram", "setup", "myagent", "--protocol=slim")
 	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSetup(cfg) })
@@ -133,6 +137,97 @@ func TestCmdSetupProtocolEqualsFormPersistsSlim(t *testing.T) {
 
 	if got := setup.ReadProtocolMode(cfg.DataDir, "myagent"); got != setup.ProtocolModeSlim {
 		t.Fatalf("ReadProtocolMode = %q, want slim", got)
+	}
+}
+
+func TestCmdSetupClaudeCodeSlimWarningPersistsMode(t *testing.T) {
+	stubRuntimeHooks(t)
+	stubExitWithPanic(t)
+	cfg := testConfig(t)
+
+	setupInstallAgent = func(agent string) (*setup.Result, error) {
+		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
+	}
+	scanInputLine = func(...any) (int, error) { return 0, nil }
+	oldVerify := setupVerifyClaudeCodeSlim
+	setupVerifyClaudeCodeSlim = func() error { return errors.New("plugin version 0.1.0 does not meet the required 0.1.1 floor") }
+	t.Cleanup(func() { setupVerifyClaudeCodeSlim = oldVerify })
+
+	withArgs(t, "engram", "setup", "claude-code", "--protocol=slim")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSetup(cfg) })
+	if recovered != nil {
+		t.Fatalf("slim capability warning must not fail setup, panic=%v", recovered)
+	}
+	if !strings.Contains(stdout, "Installed claude-code plugin") {
+		t.Fatalf("setup should still succeed: %q", stdout)
+	}
+	if !strings.Contains(stderr, "requires plugin 0.1.1+") || !strings.Contains(stderr, "--plugin-dir") {
+		t.Fatalf("expected actionable slim capability warning, got %q", stderr)
+	}
+	if got := setup.ReadProtocolMode(cfg.DataDir, "claude-code"); got != setup.ProtocolModeSlim {
+		t.Fatalf("ReadProtocolMode = %q, want slim despite warning", got)
+	}
+}
+
+func TestCmdSetupOnlyChecksClaudeCodeSlim(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		selected   string
+		wantMode   string
+		wantChecks int
+	}{
+		{name: "Claude Code full", args: []string{"engram", "setup", "claude-code", "--protocol=full"}, wantMode: setup.ProtocolModeFull},
+		{name: "Claude Code default", args: []string{"engram", "setup", "claude-code"}, wantMode: setup.ProtocolModeFull},
+		{name: "other agent slim", args: []string{"engram", "setup", "opencode", "--protocol=slim"}, wantMode: setup.ProtocolModeSlim},
+		{name: "interactive other agent slim", args: []string{"engram", "setup", "--protocol=slim"}, selected: "opencode", wantMode: setup.ProtocolModeSlim},
+		{name: "interactive Claude Code slim", args: []string{"engram", "setup", "--protocol=slim"}, selected: "claude-code", wantMode: setup.ProtocolModeSlim, wantChecks: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubRuntimeHooks(t)
+			stubExitWithPanic(t)
+			cfg := testConfig(t)
+			setupInstallAgent = func(agent string) (*setup.Result, error) {
+				return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
+			}
+			scanInputLine = func(...any) (int, error) { return 0, nil }
+			if tt.selected != "" {
+				setupSupportedAgents = func() []setup.Agent {
+					return []setup.Agent{{Name: tt.selected, Description: tt.selected, InstallDir: "/tmp/dest"}}
+				}
+				scanInputLine = func(a ...any) (int, error) {
+					*a[0].(*string) = "1"
+					return 1, nil
+				}
+			}
+			checks := 0
+			oldVerify := setupVerifyClaudeCodeSlim
+			setupVerifyClaudeCodeSlim = func() error {
+				checks++
+				return nil
+			}
+			t.Cleanup(func() { setupVerifyClaudeCodeSlim = oldVerify })
+
+			withArgs(t, tt.args...)
+			_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSetup(cfg) })
+			if recovered != nil || stderr != "" {
+				t.Fatalf("panic=%v stderr=%q", recovered, stderr)
+			}
+			if checks != tt.wantChecks {
+				t.Fatalf("capability checks = %d, want %d", checks, tt.wantChecks)
+			}
+			slug := "claude-code"
+			if tt.selected != "" {
+				slug = tt.selected
+			} else if strings.Contains(tt.args[2], "opencode") {
+				slug = "opencode"
+			}
+			if got := setup.ReadProtocolMode(cfg.DataDir, slug); got != tt.wantMode {
+				t.Fatalf("ReadProtocolMode(%q) = %q, want %q", slug, got, tt.wantMode)
+			}
+		})
 	}
 }
 

--- a/cmd/engram/setup_protocol_test.go
+++ b/cmd/engram/setup_protocol_test.go
@@ -145,6 +145,7 @@ func TestCmdSetupClaudeCodeSlimWarningPersistsMode(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)
 	cfg := testConfig(t)
+	setProtocolVersion(t, "1.4.0")
 
 	setupInstallAgent = func(agent string) (*setup.Result, error) {
 		return &setup.Result{Agent: agent, Destination: "/tmp/dest", Files: 2}, nil
@@ -164,6 +165,9 @@ func TestCmdSetupClaudeCodeSlimWarningPersistsMode(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "requires plugin 0.1.1+") || !strings.Contains(stderr, "--plugin-dir") {
 		t.Fatalf("expected actionable slim capability warning, got %q", stderr)
+	}
+	if strings.Contains(stderr, "slim will remain full") {
+		t.Fatalf("plugin capability warning must not include a binary-version warning: %q", stderr)
 	}
 	if got := setup.ReadProtocolMode(cfg.DataDir, "claude-code"); got != setup.ProtocolModeSlim {
 		t.Fatalf("ReadProtocolMode = %q, want slim despite warning", got)

--- a/cmd/engram/setup_protocol_test.go
+++ b/cmd/engram/setup_protocol_test.go
@@ -150,7 +150,7 @@ func TestCmdSetupClaudeCodeSlimWarningPersistsMode(t *testing.T) {
 	}
 	scanInputLine = func(...any) (int, error) { return 0, nil }
 	oldVerify := setupVerifyClaudeCodeSlim
-	setupVerifyClaudeCodeSlim = func() error { return errors.New("plugin version 0.1.0 does not meet the required 0.1.1 floor") }
+	setupVerifyClaudeCodeSlim = func() error { return errors.New("claude plugin list --json timed out") }
 	t.Cleanup(func() { setupVerifyClaudeCodeSlim = oldVerify })
 
 	withArgs(t, "engram", "setup", "claude-code", "--protocol=slim")

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -290,6 +290,8 @@ engram setup claude-code
 
 `engram setup claude-code` is the sole MCP registration owner. It writes the durable user-level config at `~/.claude/mcp/engram.json` with the absolute `engram` binary path. If that write is not possible, setup warns and completes the plugin installation; resolve the error and rerun setup before using plugin MCP tools. You'll be asked whether to add engram's agent-profile MCP tools to `~/.claude/settings.json` `permissions.allow`. The setup writes entries for both the durable user-level MCP server id (`mcp__engram__...`) and the plugin-scoped server id used by older Claude Code plugin installs, so re-running setup repairs stale or incomplete allowlists without adding startup delay. Existing marketplace plugin copies receive hooks, scripts, and skills updates through normal Claude Code plugin updates; do not edit the plugin cache manually.
 
+`engram setup claude-code --protocol=slim` requires Engram plugin version 0.1.1 or later. Setup checks `claude plugin list --json` after a successful install and warns, without failing or changing the selected slim mode, when it cannot verify the installed enabled marketplace plugin. Update through your normal Claude Code plugin update path and restart Claude Code. Session-only `claude --plugin-dir ...` plugins cannot be detected by this check.
+
 **Option C: Bare MCP** — all 22 tools by default, no session management:
 
 Add to your `.claude/settings.json` (project) or `~/.claude/settings.json` (global):

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -44,6 +44,9 @@ remain on `full`. For Claude Code, slim activates only when Engram is a clean
 tagged release at or above 1.4.0. Local `dev`, Go pseudo-version, dirty, and
 other non-release builds remain on `full`; setup persists the selection and
 warns so you can install a supported tagged release.
+Claude slim also requires plugin 0.1.1+. If setup cannot verify the enabled
+marketplace plugin, it warns without changing the selected mode; session-only
+`claude --plugin-dir ...` installs cannot be detected.
 
 ## Pi
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -93,6 +93,8 @@ claude --plugin-dir ./plugin/claude-code
 
 Existing marketplace-only copies create their durable MCP registration at the next SessionStart and require one more Claude Code restart before MCP tools return; do not edit the plugin cache manually.
 
+The `--protocol=slim` setup option requires Engram plugin 0.1.1 or later. After successful Claude Code setup, Engram checks `claude plugin list --json`; an unverifiable, disabled, or older plugin produces a warning but does not fail setup or replace the selected slim mode. Use your normal Claude Code plugin update path, then restart Claude Code. Plugins loaded with session-only `claude --plugin-dir ...` cannot be detected.
+
 ### What the Plugin Provides with Setup (vs bare MCP)
 
 | Feature | Bare MCP | Plugin + setup |

--- a/internal/command/command_usage_test.go
+++ b/internal/command/command_usage_test.go
@@ -23,7 +23,7 @@ func TestSubprocessesUseNewContext(t *testing.T) {
 	}{
 		{name: "project detection", path: filepath.Join(internalDir, "project", "detect.go"), wantCalls: 3},
 		{name: "Claude CLI", path: filepath.Join(internalDir, "llm", "claude.go"), wantCalls: 1},
-		{name: "setup commands", path: filepath.Join(internalDir, "setup", "setup.go"), wantCalls: 1},
+		{name: "setup commands", path: filepath.Join(internalDir, "setup", "setup.go"), wantCalls: 2},
 	}
 
 	for _, tt := range tests {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/Gentleman-Programming/engram/v2/internal/command"
@@ -85,6 +86,7 @@ type Result struct {
 
 const claudeCodeMarketplace = "Gentleman-Programming/engram"
 const codexMarketplace = "Gentleman-Programming/engram"
+const claudeCodeSlimPluginFloor = "0.1.1"
 
 const openCodeSubagentStatuslinePlugin = "opencode-subagent-statusline"
 
@@ -831,6 +833,168 @@ func stripJSONC(data []byte) []byte {
 }
 
 // ─── Claude Code ─────────────────────────────────────────────────────────────
+
+type claudeCodePlugin struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Enabled     *bool  `json:"enabled"`
+	Marketplace string `json:"marketplace"`
+}
+
+// VerifyClaudeCodeSlimCapability confirms that the installed marketplace plugin
+// has the hook guard required for the slim protocol. Claude Code does not promise
+// a complete JSON schema, so only known array and {"plugins": [...]} shapes are
+// accepted; an unfamiliar response remains unverified.
+func VerifyClaudeCodeSlimCapability() error {
+	claudeBin, err := lookPathFn("claude")
+	if err != nil {
+		return fmt.Errorf("locate claude: %w", err)
+	}
+
+	out, err := runCommand(claudeBin, "plugin", "list", "--json")
+	if err != nil {
+		return fmt.Errorf("claude plugin list --json: %w", err)
+	}
+
+	plugins, err := parseClaudeCodePluginList(out)
+	if err != nil {
+		return err
+	}
+
+	matches := make([]claudeCodePlugin, 0, 1)
+	for _, plugin := range plugins {
+		if isEngramClaudeCodePlugin(plugin) {
+			matches = append(matches, plugin)
+		}
+	}
+	if len(matches) == 0 {
+		return fmt.Errorf("no Engram plugin from the expected marketplace is listed")
+	}
+	if len(matches) != 1 {
+		return fmt.Errorf("multiple Engram plugins from the expected marketplace are listed")
+	}
+
+	plugin := matches[0]
+	if plugin.Enabled == nil || !*plugin.Enabled {
+		return fmt.Errorf("the listed Engram plugin is disabled")
+	}
+	if !meetsClaudeCodeSlimPluginFloor(plugin.Version) {
+		return fmt.Errorf("plugin version %q does not meet the required %s floor", plugin.Version, claudeCodeSlimPluginFloor)
+	}
+	return nil
+}
+
+func parseClaudeCodePluginList(raw []byte) ([]claudeCodePlugin, error) {
+	raw = []byte(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("Claude plugin list returned empty JSON")
+	}
+	if raw[0] == '[' {
+		var plugins []claudeCodePlugin
+		if err := json.Unmarshal(raw, &plugins); err != nil {
+			return nil, fmt.Errorf("parse Claude plugin list JSON: %w", err)
+		}
+		return plugins, nil
+	}
+	if raw[0] == '{' {
+		var response struct {
+			Plugins json.RawMessage `json:"plugins"`
+		}
+		if err := json.Unmarshal(raw, &response); err != nil {
+			return nil, fmt.Errorf("parse Claude plugin list JSON: %w", err)
+		}
+		if len(response.Plugins) == 0 {
+			return nil, fmt.Errorf("Claude plugin list JSON has no plugins array")
+		}
+		var plugins []claudeCodePlugin
+		if err := json.Unmarshal(response.Plugins, &plugins); err != nil {
+			return nil, fmt.Errorf("parse Claude plugin list plugins: %w", err)
+		}
+		return plugins, nil
+	}
+	return nil, fmt.Errorf("unrecognized Claude plugin list JSON shape")
+}
+
+func isEngramClaudeCodePlugin(plugin claudeCodePlugin) bool {
+	name := strings.ToLower(strings.TrimSpace(plugin.Name))
+	if name != "engram" && name != "engram@engram" {
+		return false
+	}
+	marketplace := strings.TrimSpace(plugin.Marketplace)
+	return strings.EqualFold(marketplace, "engram") || strings.EqualFold(marketplace, claudeCodeMarketplace)
+}
+
+func meetsClaudeCodeSlimPluginFloor(version string) bool {
+	values, prerelease, ok := parseClaudeCodePluginVersion(version)
+	if !ok {
+		return false
+	}
+	if values == [3]int{0, 1, 1} && prerelease {
+		return false
+	}
+	return values[0] > 0 || (values[0] == 0 && (values[1] > 1 || (values[1] == 1 && values[2] >= 1)))
+}
+
+// parseClaudeCodePluginVersion accepts only SemVer's three numeric components
+// and its well-formed optional prerelease/build identifiers.
+func parseClaudeCodePluginVersion(version string) ([3]int, bool, bool) {
+	var values [3]int
+	if version == "" || version != strings.TrimSpace(version) {
+		return values, false, false
+	}
+	version, build, hasBuild := strings.Cut(version, "+")
+	if hasBuild && !validSemverIdentifiers(build, false) {
+		return values, false, false
+	}
+	if strings.Contains(build, "+") {
+		return values, false, false
+	}
+	core, prerelease, hasPrerelease := strings.Cut(version, "-")
+	if hasPrerelease && !validSemverIdentifiers(prerelease, true) {
+		return values, false, false
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return values, false, false
+	}
+	for i, part := range parts {
+		if !validSemverNumber(part) {
+			return values, false, false
+		}
+		value, err := strconv.Atoi(part)
+		if err != nil || value < 0 {
+			return values, false, false
+		}
+		values[i] = value
+	}
+	return values, hasPrerelease, true
+}
+
+func validSemverNumber(value string) bool {
+	if value == "" || (len(value) > 1 && value[0] == '0') {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func validSemverIdentifiers(value string, rejectLeadingZeroNumbers bool) bool {
+	for _, identifier := range strings.Split(value, ".") {
+		if identifier == "" || (rejectLeadingZeroNumbers && len(identifier) > 1 && identifier[0] == '0' && validSemverNumber(identifier)) {
+			return false
+		}
+		for _, char := range identifier {
+			if !(char >= '0' && char <= '9' || char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char == '-') {
+				return false
+			}
+		}
+	}
+	return true
+}
 
 func installClaudeCode() (*Result, error) {
 	// Check that claude CLI is available

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Gentleman-Programming/engram/v2/internal/command"
 	"github.com/Gentleman-Programming/engram/v2/internal/mcp"
@@ -37,6 +38,9 @@ var (
 	osExecutable = os.Executable
 	runCommand   = func(name string, args ...string) ([]byte, error) {
 		return command.NewContext(context.Background(), name, args...).CombinedOutput()
+	}
+	runCommandWithContext = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return command.NewContext(ctx, name, args...).CombinedOutput()
 	}
 	openCodeReadFile = func(path string) ([]byte, error) {
 		return openCodeFS.ReadFile(path)
@@ -87,6 +91,7 @@ type Result struct {
 const claudeCodeMarketplace = "Gentleman-Programming/engram"
 const codexMarketplace = "Gentleman-Programming/engram"
 const claudeCodeSlimPluginFloor = "0.1.1"
+const claudeCodePluginListTimeout = 2 * time.Second // bounds only the read-only Claude plugin capability probe
 
 const openCodeSubagentStatuslinePlugin = "opencode-subagent-statusline"
 
@@ -851,8 +856,13 @@ func VerifyClaudeCodeSlimCapability() error {
 		return fmt.Errorf("locate claude: %w", err)
 	}
 
-	out, err := runCommand(claudeBin, "plugin", "list", "--json")
+	ctx, cancel := context.WithTimeout(context.Background(), claudeCodePluginListTimeout)
+	defer cancel()
+	out, err := runCommandWithContext(ctx, claudeBin, "plugin", "list", "--json")
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("claude plugin list --json timed out")
+		}
 		return fmt.Errorf("claude plugin list --json: %w", err)
 	}
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -40,6 +40,7 @@ func resetSetupSeams(t *testing.T) {
 	oldUserHomeDir := userHomeDir
 	oldLookPathFn := lookPathFn
 	oldRunCommand := runCommand
+	oldRunCommandWithContext := runCommandWithContext
 	oldStatFn := statFn
 	oldLstatFn := lstatFn
 	oldOpenCodeReadFile := openCodeReadFile
@@ -66,6 +67,7 @@ func resetSetupSeams(t *testing.T) {
 		userHomeDir = oldUserHomeDir
 		lookPathFn = oldLookPathFn
 		runCommand = oldRunCommand
+		runCommandWithContext = oldRunCommandWithContext
 		statFn = oldStatFn
 		lstatFn = oldLstatFn
 		openCodeReadFile = oldOpenCodeReadFile
@@ -1508,7 +1510,7 @@ func TestVerifyClaudeCodeSlimCapability(t *testing.T) {
 			resetSetupSeams(t)
 			lookPathFn = func(string) (string, error) { return "/test/claude", nil }
 			calls := 0
-			runCommand = func(name string, args ...string) ([]byte, error) {
+			runCommandWithContext = func(_ context.Context, name string, args ...string) ([]byte, error) {
 				calls++
 				if name != "/test/claude" || !reflect.DeepEqual(args, []string{"plugin", "list", "--json"}) {
 					t.Fatalf("command = %q %q, want claude plugin list --json", name, args)
@@ -1524,6 +1526,29 @@ func TestVerifyClaudeCodeSlimCapability(t *testing.T) {
 				t.Fatalf("claude plugin list invocations = %d, want 1", calls)
 			}
 		})
+	}
+}
+
+func TestVerifyClaudeCodeSlimCapabilityProbeBounds(t *testing.T) {
+	resetSetupSeams(t)
+	lookPathFn = func(string) (string, error) { return "", errors.New("not found") }
+	runCommandWithContext = func(context.Context, string, ...string) ([]byte, error) {
+		t.Fatal("probe must not run")
+		return nil, nil
+	}
+	if err := VerifyClaudeCodeSlimCapability(); err == nil {
+		t.Fatal("expected missing Claude error")
+	}
+	lookPathFn = func(string) (string, error) { return "/test/claude", nil }
+	runCommandWithContext = func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("probe context has no deadline")
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if err := VerifyClaudeCodeSlimCapability(); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want timeout", err)
 	}
 }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1476,6 +1476,83 @@ func TestInstallClaudeCodeBranches(t *testing.T) {
 	})
 }
 
+func TestVerifyClaudeCodeSlimCapability(t *testing.T) {
+	verified := `{"plugins":[{"name":"engram","version":"0.1.1","enabled":true,"marketplace":"engram"}]}`
+	current := `[{"name":"engram@engram","version":"0.1.2","enabled":true,"marketplace":"Gentleman-Programming/engram"}]`
+
+	tests := []struct {
+		name    string
+		output  string
+		runErr  error
+		wantErr bool
+	}{
+		{name: "supported floor", output: verified},
+		{name: "supported current array", output: current},
+		{name: "old version", output: `{"plugins":[{"name":"engram","version":"0.1.0","enabled":true,"marketplace":"engram"}]}`, wantErr: true},
+		{name: "command failure", runErr: errors.New("unknown flag: --json"), wantErr: true},
+		{name: "malformed JSON", output: `{`, wantErr: true},
+		{name: "missing plugin", output: `{"plugins":[]}`, wantErr: true},
+		{name: "unrelated plugin name", output: `{"plugins":[{"name":"other","version":"0.1.2","enabled":true,"marketplace":"engram"}]}`, wantErr: true},
+		{name: "wrong marketplace", output: `{"plugins":[{"name":"engram","version":"0.1.2","enabled":true,"marketplace":"other"}]}`, wantErr: true},
+		{name: "disabled plugin", output: `{"plugins":[{"name":"engram","version":"0.1.2","enabled":false,"marketplace":"engram"}]}`, wantErr: true},
+		{name: "missing enabled", output: `{"plugins":[{"name":"engram","version":"0.1.2","marketplace":"engram"}]}`, wantErr: true},
+		{name: "ambiguous plugins", output: `{"plugins":[{"name":"engram","version":"0.1.2","enabled":true,"marketplace":"engram"},{"name":"engram","version":"0.1.2","enabled":true,"marketplace":"engram"}]}`, wantErr: true},
+		{name: "invalid version", output: `{"plugins":[{"name":"engram","version":"current","enabled":true,"marketplace":"engram"}]}`, wantErr: true},
+		{name: "floor prerelease", output: `{"plugins":[{"name":"engram","version":"0.1.1-beta.1","enabled":true,"marketplace":"engram"}]}`, wantErr: true},
+		{name: "malformed suffix", output: `{"plugins":[{"name":"engram","version":"0.1.1+","enabled":true,"marketplace":"engram"}]}`, wantErr: true},
+		{name: "missing marketplace", output: `{"plugins":[{"name":"engram","version":"0.1.2","enabled":true}]}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetSetupSeams(t)
+			lookPathFn = func(string) (string, error) { return "/test/claude", nil }
+			calls := 0
+			runCommand = func(name string, args ...string) ([]byte, error) {
+				calls++
+				if name != "/test/claude" || !reflect.DeepEqual(args, []string{"plugin", "list", "--json"}) {
+					t.Fatalf("command = %q %q, want claude plugin list --json", name, args)
+				}
+				return []byte(tt.output), tt.runErr
+			}
+
+			err := VerifyClaudeCodeSlimCapability()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("VerifyClaudeCodeSlimCapability() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if calls != 1 {
+				t.Fatalf("claude plugin list invocations = %d, want 1", calls)
+			}
+		})
+	}
+}
+
+func TestParseClaudeCodePluginVersion(t *testing.T) {
+	tests := []struct {
+		version        string
+		wantPrerelease bool
+		wantValid      bool
+		wantFloor      bool
+	}{
+		{version: "0.1.1", wantValid: true, wantFloor: true},
+		{version: "0.1.1+build.7", wantValid: true, wantFloor: true},
+		{version: "0.1.2-rc.1", wantPrerelease: true, wantValid: true, wantFloor: true},
+		{version: "0.1.1-beta.1", wantPrerelease: true, wantValid: true},
+		{version: "0.1.1-"},
+		{version: "0.1.1+"},
+		{version: "0.1.1+bad+extra"},
+		{version: "0.1.1-beta..1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			_, prerelease, valid := parseClaudeCodePluginVersion(tt.version)
+			if prerelease != tt.wantPrerelease || valid != tt.wantValid || meetsClaudeCodeSlimPluginFloor(tt.version) != tt.wantFloor {
+				t.Fatalf("parseClaudeCodePluginVersion(%q) = prerelease %v, valid %v; floor %v", tt.version, prerelease, valid, meetsClaudeCodeSlimPluginFloor(tt.version))
+			}
+		})
+	}
+}
+
 // ─── Issue #100: Windows PATH fix ────────────────────────────────────────────
 
 func TestWriteClaudeCodeUserMCP(t *testing.T) {


### PR DESCRIPTION
<!-- 
  ⚠️ READ BEFORE SUBMITTING
  
  Every PR must:
  1. Link an approved issue (with status:approved label)
  2. Have exactly one type:* label
  3. Pass all 5 automated checks
  
  See CONTRIBUTING.md for the full workflow.
-->

## 🔗 Linked Issue

Closes #684

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Detect whether the installed Claude Code Engram plugin supports `--protocol=slim`.
- Warn without failing setup when plugin capability cannot be verified.
- Document the plugin floor and cover direct, interactive, error, and version-boundary behavior.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/setup/setup.go` | Query and conservatively validate installed Claude plugin capability. |
| `internal/setup/setup_test.go` | Cover plugin metadata, SemVer, ambiguity, and failure cases. |
| `cmd/engram/main.go` | Run the warning only for Claude Code slim setup and update help. |
| `cmd/engram/setup_protocol_test.go` | Cover direct and interactive setup behavior and mode persistence. |
| `docs/AGENT-SETUP.md` | Document the 0.1.1 plugin floor and detection limits. |
| `docs/PLUGINS.md` | Document warnings and session-only plugin limitations. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

Focused local verification completed:

- [x] `go test ./internal/setup ./cmd/engram -run '^(TestVerifyClaudeCodeSlimCapability|TestParseClaudeCodePluginVersion|TestCmdSetupHelpAnyPositionShowsProtocolFlagAndSkipsStdin|TestCmdSetupClaudeCodeSlimWarningPersistsMode|TestCmdSetupOnlyChecksClaudeCodeSlim)$'`
- [x] `go test ./cmd/engram -run '^TestCmdSetupClaudeCodeSlimWarningPersistsMode$' -count=10 -timeout=30s`
- [x] `go vet ./internal/setup ./cmd/engram`
- [x] `git diff --check`

The complete `cmd/engram` package run timed out locally. The complete `internal/setup` package run encounters unchanged POSIX-path fixtures that fail on Windows. No live Claude installation or update was performed; CI remains the authoritative full-suite result.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Gentle AI RDD approved the exact candidate before commit. The warning intentionally fails open: setup preserves the selected slim mode and never updates or reinstalls plugins implicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claude Code slim-protocol setup now verifies that the enabled Engram plugin meets the minimum required version.
  - Verification runs for both explicit-agent and interactive installations.

- **Bug Fixes**
  - Verification problems now produce non-blocking warnings while preserving the selected slim mode.

- **Documentation**
  - Added guidance on the Claude Code plugin version requirement, verification behavior, updates, and session-only plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->