### PR TITLE
fix(cloud): stamp image release version

### DIFF
--- a/.github/workflows/cloud-image.yml
+++ b/.github/workflows/cloud-image.yml
@@ -74,3 +74,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}

--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -2,13 +2,14 @@ FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
 
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -o /out/engram ./cmd/engram
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -ldflags="-X main.version=${VERSION}" -o /out/engram ./cmd/engram
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #557

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Pass the release version from cloud-image metadata into the Docker build.
- Stamp the cloud binary with that version while retaining `dev` as the default for local builds.

## 📂 Changes

| File | Change |
|------|--------|
| `.github/workflows/cloud-image.yml` | Pass the image metadata version as the Docker build `VERSION` argument. |
| `docker/cloud/Dockerfile` | Accept `VERSION` (defaulting to `dev`) and inject it into `main.version` during the Go build. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

- Focused version-injected and default-`dev` `go run` commands passed.
- `git diff --check` passed.
- `go test ./cmd/engram` exceeded the 600-second timeout.
- Docker was unavailable, so no Docker image test was run.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The cloud image build now uses release metadata to set the binary version. Local Docker builds retain the `dev` default. Docker was unavailable during local verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Cloud container images now embed their release version during the build process.
  * Development builds continue to use a default development version when no release version is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->