### PR TITLE
fix(cloud): name denied project in policy errors

### DIFF
--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -624,7 +624,7 @@ func (s *CloudServer) authorizeProjectScope(ctx context.Context, w http.Response
 		}
 		if usesManagedProjectGrants(principal) {
 			if err := s.principalProject.AuthorizeProjectForPrincipal(ctx, principal, project); err != nil {
-				writeActionableError(w, http.StatusForbidden, constants.UpgradeErrorClassPolicy, constants.ReasonPolicyForbidden, "forbidden: project is not allowed")
+				writeProjectPolicyDenied(w, project)
 				return false
 			}
 			return true
@@ -634,7 +634,7 @@ func (s *CloudServer) authorizeProjectScope(ctx context.Context, w http.Response
 		return true
 	}
 	if err := s.projectAuth.AuthorizeProject(project); err != nil {
-		writeActionableError(w, http.StatusForbidden, constants.UpgradeErrorClassPolicy, constants.ReasonPolicyForbidden, "forbidden: project is not allowed")
+		writeProjectPolicyDenied(w, project)
 		return false
 	}
 	return true
@@ -650,6 +650,10 @@ func writeActionableError(w http.ResponseWriter, status int, class, code, messag
 		"error_code":  strings.TrimSpace(code),
 		"error":       strings.TrimSpace(message),
 	})
+}
+
+func writeProjectPolicyDenied(w http.ResponseWriter, project string) {
+	writeActionableError(w, http.StatusForbidden, constants.UpgradeErrorClassPolicy, constants.ReasonPolicyForbidden, fmt.Sprintf("forbidden: project %q is not allowed", project))
 }
 
 func coerceChunkProject(payload []byte, project string) ([]byte, error) {

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -810,8 +810,15 @@ func TestHandlerEnforcesProjectAllowlistWithoutBearerAuth(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 with auth disabled but allowlist enforced, got %d body=%q", rec.Code, rec.Body.String())
 	}
-	if strings.Contains(rec.Body.String(), "proj-a") || strings.Contains(rec.Body.String(), "proj-b") {
-		t.Fatalf("forbidden response must not leak allowlist details, got body=%q", rec.Body.String())
+	payload := decodeActionableError(t, rec)
+	if payload.ErrorClass != "policy" || payload.ErrorCode != "policy_forbidden" {
+		t.Fatalf("expected policy_forbidden response, got class=%q code=%q", payload.ErrorClass, payload.ErrorCode)
+	}
+	if payload.Error != `forbidden: project "proj-a" is not allowed` {
+		t.Fatalf("expected denied project in error message, got %q", payload.Error)
+	}
+	if strings.Contains(rec.Body.String(), "proj-b") || strings.Contains(rec.Body.String(), "allowed:") || strings.Contains(rec.Body.String(), "for this token") {
+		t.Fatalf("forbidden response must not leak allowlist details or authorization internals, got body=%q", rec.Body.String())
 	}
 }
 

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -772,6 +772,9 @@ func TestHandlerProjectScopeForbiddenReturnsPolicyClassPayload(t *testing.T) {
 	if payload.ErrorCode != "policy_forbidden" {
 		t.Fatalf("expected policy_forbidden error code, got %q", payload.ErrorCode)
 	}
+	if payload.Error != `forbidden: project "proj-a" is not allowed` {
+		t.Fatalf("expected denied project in error message, got %q", payload.Error)
+	}
 }
 
 func TestHandlerPushRejectsOversizedPayload(t *testing.T) {

--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -92,13 +92,16 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 
 	// BR2-1: Reject any entry with an empty project before auth/pause checks.
 	// An empty project is always invalid: it bypasses per-project auth and would
-	// be inserted into cloud_mutations with a blank project column.
-	for _, entry := range req.Entries {
-		if strings.TrimSpace(entry.Project) == "" {
+	// be inserted into cloud_mutations with a blank project column. Normalize
+	// each validated entry at this boundary so every subsequent policy, audit,
+	// response, and storage use shares the same project identity.
+	for i := range req.Entries {
+		if strings.TrimSpace(req.Entries[i].Project) == "" {
 			writeActionableError(w, http.StatusBadRequest, "invalid_request", "empty_project",
 				"mutation entries must specify a project")
 			return
 		}
+		req.Entries[i].Project = project.CanonicalizeProjectName(req.Entries[i].Project)
 	}
 
 	// N4: Assert MutationStore once here; use ms throughout (pause gate + InsertMutationBatch).
@@ -116,12 +119,11 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 	// guarantees every entry has a non-empty project before this loop is reached.
 	seen := make(map[string]struct{})
 	for _, entry := range req.Entries {
-		project := project.CanonicalizeProjectName(entry.Project)
-		if _, ok := seen[project]; ok {
+		if _, ok := seen[entry.Project]; ok {
 			continue
 		}
-		seen[project] = struct{}{}
-		if !s.authorizeProjectScope(r.Context(), w, project) {
+		seen[entry.Project] = struct{}{}
+		if !s.authorizeProjectScope(r.Context(), w, entry.Project) {
 			// authorizeProjectScope already wrote the 403 response.
 			return
 		}
@@ -131,11 +133,11 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 	// Server-side has no filesystem cwd semantics; source is always "request_body".
 	// N3: The `if len(req.Entries) > 0` guard is removed — JC1 (above) guarantees
 	// at least one entry exists at this point.
-	primaryProject := strings.TrimSpace(req.Entries[0].Project)
+	primaryProject := req.Entries[0].Project
 
 	// Check sync pause per project (REQ-203 + BW9: use writeActionableError for 409).
 	for _, entry := range req.Entries {
-		proj := strings.TrimSpace(entry.Project)
+		proj := entry.Project
 		enabled, err := ms.IsProjectSyncEnabled(proj)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("check project sync: %v", err), http.StatusInternalServerError)

--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -116,7 +116,7 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 	// guarantees every entry has a non-empty project before this loop is reached.
 	seen := make(map[string]struct{})
 	for _, entry := range req.Entries {
-		project := strings.TrimSpace(entry.Project)
+		project := project.CanonicalizeProjectName(entry.Project)
 		if _, ok := seen[project]; ok {
 			continue
 		}

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -937,6 +937,16 @@ func TestMutationPushRejectsMixedProjectBatch(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for mixed batch with unauthorized project, got %d body=%q", rec.Code, rec.Body.String())
 	}
+	payload := decodeActionableError(t, rec)
+	if payload.ErrorClass != "policy" {
+		t.Fatalf("expected policy class, got %q", payload.ErrorClass)
+	}
+	if payload.ErrorCode != "policy_forbidden" {
+		t.Fatalf("expected policy_forbidden error code, got %q", payload.ErrorCode)
+	}
+	if payload.Error != `forbidden: project "proj-b" is not allowed` {
+		t.Fatalf("expected denied project in error message, got %q", payload.Error)
+	}
 
 	// Verify nothing was stored for proj-a either (all-or-nothing rejection)
 	if len(ms.mutations) != 0 {

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -812,6 +812,67 @@ func TestMutationPushSyncPaused409(t *testing.T) {
 	}
 }
 
+func TestMutationPushAliasCannotBypassCanonicalPause(t *testing.T) {
+	ms := newFakeMutationStore()
+	ms.syncEnabledMap["proj-b"] = false
+	srv := newMutationTestServer(ms, "secret", []string{"proj-b"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", marshalPushRequestWithCreatedBy(t, makeMutationEntries(2, "PROJ--B"), "alice"))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected paused canonical project alias to return 409, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(ms.mutations) != 0 {
+		t.Fatalf("expected paused alias rejection to store no mutations, got %+v", ms.mutations)
+	}
+	if len(ms.auditCalls) != 1 || ms.auditCalls[0].Project != "proj-b" || ms.auditCalls[0].EntryCount != 2 {
+		t.Fatalf("expected canonical project in pause audit, got %+v", ms.auditCalls)
+	}
+	var response mutationPushResponseEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode pause response: %v", err)
+	}
+	if response.Project != "proj-b" {
+		t.Fatalf("expected canonical project in pause response, got %q", response.Project)
+	}
+}
+
+func TestMutationPushAcceptedAliasUsesCanonicalProjectIdentity(t *testing.T) {
+	ms := newFakeMutationStore()
+	srv := newMutationTestServer(ms, "secret", []string{"proj-b"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", marshalPushRequest(t, makeMutationEntries(1, " PROJ--B ")))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected canonical project alias to return 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(ms.mutations) != 1 || ms.mutations[0].Project != "proj-b" {
+		t.Fatalf("expected canonical project in stored mutation, got %+v", ms.mutations)
+	}
+	var storedPayload map[string]any
+	if err := json.Unmarshal(ms.mutations[0].Payload, &storedPayload); err != nil {
+		t.Fatalf("decode stored mutation payload: %v", err)
+	}
+	if storedPayload["project"] != "proj-b" {
+		t.Fatalf("expected canonical project in stored mutation payload, got %#v", storedPayload["project"])
+	}
+	var response mutationPushResponseEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode success response: %v", err)
+	}
+	if response.Project != "proj-b" {
+		t.Fatalf("expected canonical project in success response, got %q", response.Project)
+	}
+}
+
 func TestMutationPushNonPausedAccepted(t *testing.T) {
 	// REQ-203: non-paused → 200
 	ms := newFakeMutationStore()

--- a/internal/cloud/cloudserver/mutations_test.go
+++ b/internal/cloud/cloudserver/mutations_test.go
@@ -921,10 +921,11 @@ func TestMutationPushRejectsMixedProjectBatch(t *testing.T) {
 	// Token authorized only for "proj-a"
 	srv := newMutationTestServer(ms, "secret", []string{"proj-a"})
 
-	// Batch contains both "proj-a" (authorized) and "proj-b" (unauthorized)
+	// Batch contains both "proj-a" (authorized) and "PROJ-B" (unauthorized).
+	// The denied project must be reported in its canonical form.
 	entries := []MutationEntry{
 		{Project: "proj-a", Entity: "obs", EntityKey: "k1", Op: "upsert", Payload: json.RawMessage(`{}`)},
-		{Project: "proj-b", Entity: "obs", EntityKey: "k2", Op: "upsert", Payload: json.RawMessage(`{}`)},
+		{Project: "PROJ-B", Entity: "obs", EntityKey: "k2", Op: "upsert", Payload: json.RawMessage(`{}`)},
 	}
 	body := marshalPushRequest(t, entries)
 

--- a/internal/cloud/cloudserver/principal_auth_test.go
+++ b/internal/cloud/cloudserver/principal_auth_test.go
@@ -219,6 +219,16 @@ func TestManagedPrincipalProjectGrantsAuthorizeChunkPullAndPush(t *testing.T) {
 	if pullDenied.Code != http.StatusForbidden {
 		t.Fatalf("expected ungranted manifest pull 403, got %d body=%q", pullDenied.Code, pullDenied.Body.String())
 	}
+	pullDeniedPayload := decodeActionableError(t, pullDenied)
+	if pullDeniedPayload.ErrorClass != "policy" {
+		t.Fatalf("expected policy class, got %q", pullDeniedPayload.ErrorClass)
+	}
+	if pullDeniedPayload.ErrorCode != "policy_forbidden" {
+		t.Fatalf("expected policy_forbidden error code, got %q", pullDeniedPayload.ErrorCode)
+	}
+	if pullDeniedPayload.Error != `forbidden: project "beta" is not allowed` {
+		t.Fatalf("expected denied project in error message, got %q", pullDeniedPayload.Error)
+	}
 
 	chunkDenied := httptest.NewRecorder()
 	chunkDeniedReq := httptest.NewRequest(http.MethodGet, "/sync/pull/chunk-alpha?project=beta", nil)

--- a/internal/cloud/cloudserver/principal_auth_test.go
+++ b/internal/cloud/cloudserver/principal_auth_test.go
@@ -237,6 +237,16 @@ func TestManagedPrincipalProjectGrantsAuthorizeChunkPullAndPush(t *testing.T) {
 	if chunkDenied.Code != http.StatusForbidden {
 		t.Fatalf("expected ungranted chunk pull 403, got %d body=%q", chunkDenied.Code, chunkDenied.Body.String())
 	}
+	chunkDeniedPayload := decodeActionableError(t, chunkDenied)
+	if chunkDeniedPayload.ErrorClass != "policy" {
+		t.Fatalf("expected policy class, got %q", chunkDeniedPayload.ErrorClass)
+	}
+	if chunkDeniedPayload.ErrorCode != "policy_forbidden" {
+		t.Fatalf("expected policy_forbidden error code, got %q", chunkDeniedPayload.ErrorCode)
+	}
+	if chunkDeniedPayload.Error != `forbidden: project "beta" is not allowed` {
+		t.Fatalf("expected denied project in error message, got %q", chunkDeniedPayload.Error)
+	}
 
 	pushGranted := httptest.NewRecorder()
 	pushGrantedBody := strings.NewReader(`{"project":"alpha","created_by":"tester","data":{"sessions":[{"id":"s-1","directory":"/tmp/s-1"}]}}`)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #968

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Include the normalized denied project in policy-forbidden cloud-server error messages.
- Preserve the existing 403 policy error class and code across project authorization paths.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudserver/cloudserver.go` | Centralize project-policy denial responses and include the denied project in the message. |
| `internal/cloud/cloudserver/cloudserver_test.go` | Assert the denied project in the project-scope policy error payload. |
| `internal/cloud/cloudserver/mutations_test.go` | Assert the denied project and existing policy contract for mixed-project push rejection. |
| `internal/cloud/cloudserver/principal_auth_test.go` | Assert the denied project and existing policy contract for managed-principal pull denial. |

## 🧪 Test Plan

- [x] Focused cloud-server tests passed locally (exit 0): `go test ./internal/cloud/cloudserver -run '^(TestHandlerProjectScopeForbiddenReturnsPolicyClassPayload|TestManagedPrincipalProjectGrantsAuthorizeChunkPullAndPush|TestMutationPushRejectsMixedProjectBatch)$'`
- [x] Focused cloud-server package tests passed locally (exit 0, 404 ms): `go test ./internal/cloud/cloudserver`
- [ ] Unit tests pass locally: `go test ./...` (nonterminal after bounded 2-minute and 10-minute attempts; broad validation is delegated to CI)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run)
- [ ] Manually tested the affected functionality (not run)

Local `go test ./...` attempts were nonterminal after bounded 2-minute and 10-minute attempts, with no failure evidence. Broad validation is delegated to CI. Runtime end-to-end validation, E2E tests, and plugin tests were intentionally not run. This is a server-only error-contract fix; documentation is intentionally out of scope.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has `type:*` Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #968`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (not run; focused test evidence is recorded above)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run)
- [x] Docs reviewed; intentionally out of scope for this server-only error-contract fix
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The candidate is the existing approved commit `c778f1f`. Broader-suite and runtime E2E limitations are recorded in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project access-denial responses by identifying the specific project that is not allowed.
  * Standardized denied project operations with structured policy error details, including policy classification and error code.
  * Project names are now consistently normalized across project operations, providing clearer and more consistent responses.
  * Maintained protections against exposing project allowlist or authorization details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->