### PR TITLE
fix(pi): restore passive capture for standard tools

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -184,7 +184,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 
 ### Passive Capture
 
-- `POST /observations/passive` — Extract structured learnings from text. Body: `{content, session_id, project?}`
+- `POST /observations/passive` — Scan submitted text and persist only structured learnings recognized by the parser. Body: `{content, session_id, project?, source?}`. General or raw text is not saved as an observation.
 
 ### Export / Import
 

--- a/plugin/pi/README.md
+++ b/plugin/pi/README.md
@@ -135,6 +135,8 @@ Full tool details remain available by expanding the tool output in Pi. If `gentl
 
 ## What Pi can remember
 
+Pi sends eligible non-Engram tool results to Engram for passive scanning after redaction. Only structured learnings recognized by Engram's parser are persisted; raw or general tool output is not saved as an observation.
+
 - Architecture decisions and tradeoffs
 - Bug fixes, root causes, and gotchas
 - User preferences and project conventions

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -1276,15 +1276,20 @@ export default function registerEngram(pi: ExtensionAPI) {
     await ensureSessionBestEffort(sessionId);
     toolCounts.set(sessionId, (toolCounts.get(sessionId) ?? 0) + 1);
 
-    if (toolName !== "Task" || event.result === undefined) return;
-    const content = typeof event.result === "string" ? event.result : JSON.stringify(event.result);
-    if (content.length <= 50) return;
+    if (event.result === undefined) return;
+    let content: string | undefined;
+    try {
+      content = typeof event.result === "string" ? event.result : JSON.stringify(event.result);
+    } catch {
+      return;
+    }
+    if (!content || content.length <= 50) return;
 
     const body: PassiveCaptureBody = {
       session_id: sessionId,
       content: stripPrivateTags(content),
       project,
-      source: "task-complete",
+      source: toolName,
     };
     await bestEffortEngramFetch("/observations/passive", { method: "POST", body });
   });

--- a/plugin/pi/test/passive-capture.test.mjs
+++ b/plugin/pi/test/passive-capture.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createPluginSandbox, importPluginFromSandbox } from "./plugin-sandbox.mjs";
+
+async function withPassiveCaptureFixture(run) {
+  const dir = await mkdtemp(join(tmpdir(), "engram-pi-passive-capture-"));
+  const originalUrl = process.env.ENGRAM_URL;
+  const originalBin = process.env.ENGRAM_BIN;
+  const captures = [];
+  const server = createServer(async (request, response) => {
+    if (request.url?.startsWith("/project/current")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ project: "fixture-project" }));
+      return;
+    }
+    if (request.url === "/observations/passive") {
+      let body = "";
+      for await (const chunk of request) body += chunk;
+      captures.push({ method: request.method, body: JSON.parse(body) });
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("{}");
+  });
+
+  try {
+    await new Promise((resolve, reject) => server.listen(0, "127.0.0.1", (error) => error ? reject(error) : resolve()));
+    const { port } = server.address();
+    process.env.ENGRAM_URL = `http://127.0.0.1:${port}`;
+    process.env.ENGRAM_BIN = join(dir, "not-used-when-engram-url-is-configured");
+
+    const registerEngram = await importPluginFromSandbox(await createPluginSandbox(dir));
+    const hooks = new Map();
+    registerEngram({ registerTool() {}, on(name, handler) { hooks.set(name, handler); } });
+    await run({ captures, toolExecutionEnd: hooks.get("tool_execution_end"), ctx: {
+      cwd: dir,
+      sessionManager: { getSessionId: () => "passive-capture-session" },
+    } });
+  } finally {
+    if (originalUrl === undefined) delete process.env.ENGRAM_URL; else process.env.ENGRAM_URL = originalUrl;
+    if (originalBin === undefined) delete process.env.ENGRAM_BIN; else process.env.ENGRAM_BIN = originalBin;
+    if (server.listening) await new Promise((resolve) => server.close(resolve));
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("an eligible standard tool result is redacted and submitted for passive scanning", async () => {
+  await withPassiveCaptureFixture(async ({ captures, toolExecutionEnd, ctx }) => {
+    const result = "General command output that is long enough to be scanned but is not an observation. <private>secret</private>";
+
+    await toolExecutionEnd({ toolName: "Bash", result }, ctx);
+
+    assert.deepEqual(captures, [{
+      method: "POST",
+      body: {
+        session_id: "passive-capture-session",
+        content: "General command output that is long enough to be scanned but is not an observation. [REDACTED]",
+        project: "fixture-project",
+        source: "Bash",
+      },
+    }]);
+  });
+});
+
+test("Engram-native tool results are excluded from passive scanning", async () => {
+  await withPassiveCaptureFixture(async ({ captures, toolExecutionEnd, ctx }) => {
+    await toolExecutionEnd({ toolName: "mem_search", result: "This long native-tool result must not reach passive capture at all." }, ctx);
+
+    assert.deepEqual(captures, []);
+  });
+});
+
+test("serializable object results are submitted for passive scanning", async () => {
+  await withPassiveCaptureFixture(async ({ captures, toolExecutionEnd, ctx }) => {
+    const result = { output: "A serializable object result that is long enough to be submitted for passive scanning." };
+
+    await toolExecutionEnd({ toolName: "Read", result }, ctx);
+
+    assert.equal(captures.length, 1);
+    assert.equal(captures[0].body.content, JSON.stringify(result));
+    assert.equal(captures[0].body.source, "Read");
+  });
+});
+
+test("undefined, short, and unserializable tool results do not reach passive capture", async () => {
+  await withPassiveCaptureFixture(async ({ captures, toolExecutionEnd, ctx }) => {
+    const cyclic = {};
+    cyclic.self = cyclic;
+
+    await assert.doesNotReject(toolExecutionEnd({ toolName: "Read" }, ctx));
+    await assert.doesNotReject(toolExecutionEnd({ toolName: "Read", result: "too short" }, ctx));
+    await assert.doesNotReject(toolExecutionEnd({ toolName: "Read", result: () => {} }, ctx));
+    await assert.doesNotReject(toolExecutionEnd({ toolName: "Read", result: cyclic }, ctx));
+    await assert.doesNotReject(toolExecutionEnd({ toolName: "Read", result: 1n }, ctx));
+
+    assert.deepEqual(captures, []);
+  });
+});


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #546

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Restores passive scanning for eligible standard Pi tool results while excluding Engram-native tools.
- Preserves structured server-side extraction as the only observation persistence boundary and records accurate tool provenance.
- Skips unserializable results safely without letting the Pi hook reject.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Submit eligible non-Engram results to passive capture with defensive serialization and tool provenance. |
| `plugin/pi/test/passive-capture.test.mjs` | Add behavioral coverage for standard, native, serializable, and unserializable results. |
| `plugin/pi/README.md` | Clarify passive scanning versus structured-learning persistence. |
| `DOCS.md` | Document the passive endpoint's structured persistence boundary and optional source. |

## 🧪 Test Plan

- [x] Focused Pi passive-capture coverage: `node --test --test-name-pattern="passive" test/passive-capture.test.mjs` (4/4 passed, exit 0).
- [ ] Full Pi package suite: an earlier `npm test -- --test-name-pattern="passive"` invocation also ran two unrelated pre-existing Windows startup lifecycle failures; it exited 1 and is not represented as passing.
- [ ] Shellcheck was not run because no shell scripts changed.
- [ ] Go unit and E2E suites were not run because this is a bounded Pi plugin change.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Pending |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Pending |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | Pending |
| **Unit Tests** | `go test ./...` passes | Pending |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Pending |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | Pending |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #546`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (not run; Pi-only change)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run; Pi-only change)
- [x] Docs updated for the behavior change
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Passive submission does not persist raw tool output. The existing server parser stores only recognized structured learnings; general results are scanned but produce no observation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passive memory capture now supports eligible results from all tools, not only task-related tools.
  * Captures identify their originating tool as the source.
  * Serializable results are redacted and scanned for structured learnings; raw or general tool output is not saved as an observation.

* **Documentation**
  * Updated API and Pi documentation to explain optional sources, scanning behavior, and persistence rules.

* **Bug Fixes**
  * Invalid, empty, short, or unserializable results are safely excluded from passive capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->