### PR TITLE
fix(cloud): extend bootstrap write timeout

### DIFF
--- a/internal/cloud/remote/transport.go
+++ b/internal/cloud/remote/transport.go
@@ -17,11 +17,17 @@ import (
 	engramsync "github.com/Gentleman-Programming/engram/v2/internal/sync"
 )
 
+const (
+	ordinaryOperationTimeout = 30 * time.Second
+	writeChunkTimeout        = 5 * time.Minute
+)
+
 type RemoteTransport struct {
-	baseURL    string
-	token      string
-	project    string
-	httpClient *http.Client
+	baseURL         string
+	token           string
+	project         string
+	httpClient      *http.Client
+	writeHTTPClient *http.Client
 }
 
 type HTTPStatusError struct {
@@ -92,7 +98,10 @@ func NewRemoteTransport(baseURL, token, project string) (*RemoteTransport, error
 		token:   strings.TrimSpace(token),
 		project: project,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: ordinaryOperationTimeout,
+		},
+		writeHTTPClient: &http.Client{
+			Timeout: writeChunkTimeout,
 		},
 	}, nil
 }
@@ -210,7 +219,7 @@ func (rt *RemoteTransport) WriteChunk(chunkID string, data []byte, entry engrams
 	req.Header.Set("Content-Type", "application/json")
 	rt.setAuthorization(req)
 
-	resp, err := rt.httpClient.Do(req)
+	resp, err := rt.writeHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("cloud: push chunk %s: %w", chunkID, err)
 	}
@@ -312,7 +321,7 @@ func NewMutationTransport(baseURL, token string) (*MutationTransport, error) {
 		baseURL: normalized,
 		token:   strings.TrimSpace(token),
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: ordinaryOperationTimeout,
 		},
 	}, nil
 }

--- a/internal/cloud/remote/transport_test.go
+++ b/internal/cloud/remote/transport_test.go
@@ -8,10 +8,89 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Gentleman-Programming/engram/v2/internal/cloud/chunkcodec"
 	engramsync "github.com/Gentleman-Programming/engram/v2/internal/sync"
 )
+
+type remoteRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f remoteRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestNewRemoteTransportUsesOperationSpecificTimeouts(t *testing.T) {
+	rt, err := NewRemoteTransport("https://cloud.example.test", "token", "proj-a")
+	if err != nil {
+		t.Fatalf("NewRemoteTransport: %v", err)
+	}
+
+	if ordinaryOperationTimeout != 30*time.Second {
+		t.Fatalf("ordinary operation timeout = %s, want 30s", ordinaryOperationTimeout)
+	}
+	if writeChunkTimeout != 5*time.Minute {
+		t.Fatalf("write chunk timeout = %s, want 5m", writeChunkTimeout)
+	}
+	if rt.httpClient.Timeout != ordinaryOperationTimeout {
+		t.Fatalf("ordinary client timeout = %s, want %s", rt.httpClient.Timeout, ordinaryOperationTimeout)
+	}
+	if rt.writeHTTPClient.Timeout != writeChunkTimeout {
+		t.Fatalf("write client timeout = %s, want %s", rt.writeHTTPClient.Timeout, writeChunkTimeout)
+	}
+	if rt.httpClient == rt.writeHTTPClient {
+		t.Fatal("ordinary and write operations must use distinct HTTP clients")
+	}
+}
+
+func TestRemoteTransportUsesDedicatedWriteClient(t *testing.T) {
+	var ordinaryRequests, writeRequests int
+	rt := &RemoteTransport{
+		baseURL: "https://cloud.example.test",
+		project: "proj-a",
+		httpClient: &http.Client{
+			Timeout: ordinaryOperationTimeout,
+			Transport: remoteRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				ordinaryRequests++
+				if req.Method != http.MethodGet {
+					return nil, errors.New("ordinary client used for write")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"version":1,"chunks":[]}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+		writeHTTPClient: &http.Client{
+			Timeout: writeChunkTimeout,
+			Transport: remoteRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				writeRequests++
+				if req.Method != http.MethodPost {
+					return nil, errors.New("write client used for read")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+
+	if _, err := rt.ReadManifest(); err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if err := rt.WriteChunk("chunk-1", []byte(`{"sessions":[]}`), engramsync.ChunkEntry{CreatedBy: "tester", CreatedAt: "2026-04-01T00:00:00Z"}); err != nil {
+		t.Fatalf("WriteChunk: %v", err)
+	}
+	if ordinaryRequests != 1 {
+		t.Fatalf("ordinary client requests = %d, want 1", ordinaryRequests)
+	}
+	if writeRequests != 1 {
+		t.Fatalf("write client requests = %d, want 1", writeRequests)
+	}
+}
 
 func TestReadManifestReturnsHTTPStatusErrorForAuthAndPolicyFailures(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #932

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Give cloud chunk writes a dedicated five-minute HTTP timeout for large bootstrap materialization.
- Preserve the existing 30-second timeout for reads and mutation transport operations.
- Cover timeout policy and client routing with deterministic focused tests.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/remote/transport.go` | Use a dedicated finite-timeout client for `WriteChunk`. |
| `internal/cloud/remote/transport_test.go` | Verify timeout values and operation-specific client routing. |

## 🧪 Test Plan

- [x] Focused timeout and routing tests: `go test ./internal/cloud/remote -run 'Test(NewRemoteTransportUsesOperationSpecificTimeouts|RemoteTransportUsesDedicatedWriteClient)$' -count=1`
- [x] Remote package tests: `go test ./internal/cloud/remote`
- [x] Sync transport contract: `go test ./internal/sync -run '^TestRemoteTransportImplementsTransportContract$' -count=1`
- [ ] Full sync package: did not finish within the bounded local runs.
- [ ] Full repository unit tests: deferred to CI.
- [ ] E2E tests: deferred to CI.
- [ ] Deployment smoke test with a large self-hosted bootstrap.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs are not required because this changes an internal timeout policy without changing the public interface.
- [x] Commits follow Conventional Commits format.
- [x] No `Co-Authored-By` trailers are present.

---

## 💬 Notes for Reviewers

This is intentionally a draft until CI and deployment-level verification complete. The change leaves payload admission, server deadlines, transaction rollback, and resume/progress semantics unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for large or slow chunk uploads by allowing them more time to complete.
  * Preserved shorter timeouts for standard remote read and mutation operations.
  * Reduced the likelihood of upload failures caused by long-running chunk transfers while maintaining responsive behavior for ordinary remote operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->