### PR TITLE
fix(store): reject session project ownership mismatches

### DIFF
--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -5559,6 +5559,65 @@ func TestMemSave_ExplicitProjectMustMatchExistingSessionProject(t *testing.T) {
 	}
 }
 
+func TestMemSave_RejectsStaleManualSessionProjectMismatchWithoutWrites(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("known-target-project", "target-project", "/work/target-project"); err != nil {
+		t.Fatalf("create target session: %v", err)
+	}
+	if _, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "known-target-project",
+		Type:      "manual",
+		Title:     "target project seed",
+		Content:   "makes the explicit project known",
+		Project:   "target-project",
+	}); err != nil {
+		t.Fatalf("seed target project: %v", err)
+	}
+	if err := s.CreateSession("manual-save-target-project", "other-project", "/work/other-project"); err != nil {
+		t.Fatalf("create stale manual session: %v", err)
+	}
+
+	var beforeObservations, beforeMutations int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM observations`).Scan(&beforeObservations); err != nil {
+		t.Fatalf("count observations before save: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations`).Scan(&beforeMutations); err != nil {
+		t.Fatalf("count sync mutations before save: %v", err)
+	}
+
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":   "stale manual session mismatch",
+		"content": "must not be stored",
+		"type":    "manual",
+		"project": "target-project",
+	}}})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected stale manual session mismatch to fail")
+	}
+	if got := callResultText(t, res); !strings.Contains(got, "session project does not match requested project") {
+		t.Fatalf("error = %q, want session project mismatch", got)
+	}
+
+	var afterObservations, afterMutations int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM observations`).Scan(&afterObservations); err != nil {
+		t.Fatalf("count observations after save: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations`).Scan(&afterMutations); err != nil {
+		t.Fatalf("count sync mutations after save: %v", err)
+	}
+	if afterObservations != beforeObservations || afterMutations != beforeMutations {
+		t.Fatalf("failed save changed observations/mutations from %d/%d to %d/%d", beforeObservations, beforeMutations, afterObservations, afterMutations)
+	}
+}
+
 func TestMemSave_NonAmbiguousExplicitProjectIgnoresStaleRecoveryReason(t *testing.T) {
 	dir := t.TempDir()
 	initTestGitRepo(t, dir)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -60,6 +60,7 @@ var (
 	ErrPromptNotFound              = errors.New("prompt not found")
 	ErrProjectNotFound             = errors.New("project not found")
 	ErrProjectRequired             = errors.New("project identity is required")
+	ErrSessionProjectMismatch      = errors.New("session project does not match requested project")
 	ErrProjectRescueInvalidRequest = errors.New("project rescue request is invalid")
 	// ErrProjectOwnershipAmbiguous is returned when an unowned session cannot
 	// adopt a write's project because it already parents records owned by a
@@ -2458,6 +2459,13 @@ func (s *Store) CreateSession(id, project, directory string) error {
 	}
 
 	return s.withTx(func(tx *sql.Tx) error {
+		existingProject, found, err := sessionOwnershipTx(tx, id)
+		if err != nil {
+			return err
+		}
+		if found && existingProject != "" && existingProject != project {
+			return fmt.Errorf("%w: session %q belongs to project %q, not %q", ErrSessionProjectMismatch, id, existingProject, project)
+		}
 		if err := s.createSessionTx(tx, id, project, directory); err != nil {
 			return err
 		}
@@ -7696,9 +7704,7 @@ func (s *Store) resolveWriteProjectTx(tx *sql.Tx, sessionID, requested string) (
 		return requested, nil
 	}
 	if sessionProject != "" {
-		// An owned session keeps its ownership; the caller decides whether a
-		// mismatch is an error. This preserves existing behavior.
-		return requested, nil
+		return "", fmt.Errorf("%w: session %q belongs to project %q, not %q", ErrSessionProjectMismatch, sessionID, sessionProject, requested)
 	}
 
 	kind, owner, err := foreignRecordOwnerTx(tx, sessionID, requested)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -119,6 +119,58 @@ func TestProjectIdentityAdmissionRejectsEmptyWritesWithoutJournalState(t *testin
 	assertCounts(0, 0, 0, 0)
 }
 
+func TestProjectIdentityAdmissionRejectsOwnedManualSessionMismatchWithoutWrites(t *testing.T) {
+	s := newTestStore(t)
+	const sessionID = "manual-save-target-project"
+
+	if err := s.CreateSession(sessionID, "other-project", "/tmp/other-project"); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	assertCounts := func(wantObservations, wantMutations int) {
+		t.Helper()
+		for table, want := range map[string]int{"observations": wantObservations, "sync_mutations": wantMutations} {
+			var got int
+			if err := s.DB().QueryRow("SELECT COUNT(*) FROM " + table).Scan(&got); err != nil {
+				t.Fatalf("count %s: %v", table, err)
+			}
+			if got != want {
+				t.Fatalf("%s count = %d, want %d", table, got, want)
+			}
+		}
+	}
+	assertCounts(0, 1)
+
+	if err := s.CreateSession(sessionID, "target-project", "/tmp/target-project"); !errors.Is(err, ErrSessionProjectMismatch) {
+		t.Fatalf("CreateSession error = %v, want ErrSessionProjectMismatch", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: sessionID,
+		Type:      "note",
+		Title:     "mismatched write",
+		Content:   "must not be stored",
+		Project:   "target-project",
+	}); !errors.Is(err, ErrSessionProjectMismatch) {
+		t.Fatalf("AddObservation error = %v, want ErrSessionProjectMismatch", err)
+	}
+	assertCounts(0, 1)
+
+	if got := sessionProjectOrNull(t, s, sessionID); got != "other-project" {
+		t.Fatalf("session project = %q, want other-project", got)
+	}
+}
+
+func TestCreateSessionAdoptsBlankProject(t *testing.T) {
+	type legacySession struct{ id, project string }
+	s := newTestStoreWithNullableLegacySessions(t, legacySession{"blank-session", ""})
+
+	if err := s.CreateSession("blank-session", "target-project", "/tmp/target-project"); err != nil {
+		t.Fatalf("CreateSession on blank session: %v", err)
+	}
+	if got := sessionProjectOrNull(t, s, "blank-session"); got != "target-project" {
+		t.Fatalf("session project = %q, want target-project", got)
+	}
+}
+
 func newTestStoreWithNullableLegacySessions(t *testing.T, sessions ...struct{ id, project string }) *Store {
 	t.Helper()
 	cfg := mustDefaultConfig(t)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #712

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Fail closed when a manually supplied session belongs to a different project than the requested project.
- Reject the stale-session ownership mismatch before any store writes occur.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Enforce project identity admission for sessions before persistence. |
| `internal/store/store_test.go` | Add regression coverage for rejecting mismatched owned sessions and adopting blank projects. |
| `internal/mcp/mcp_test.go` | Verify `MemSave` rejects stale manual session project mismatches without writes. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` (not run)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run)
- [ ] Manually tested the affected functionality
- [x] Focused regression command passed: `go test ./internal/store ./internal/mcp -run 'TestProjectIdentityAdmissionRejectsOwnedManualSessionMismatchWithoutWrites\|TestCreateSessionAdoptsBlankProject\|TestMemSave_RejectsStaleManualSessionProjectMismatchWithoutWrites' -count=1`
- [x] MCP package tests passed: `go test ./internal/mcp -count=1` (134.273s)
- [ ] Store package test had no verdict: `go test ./internal/store -count=1` reached the 180-second limit without output
- [x] Whitespace validation passed before commit: `git diff --check`

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs are not required because this change enforces an internal invariant; no documentation changed.
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The bounded `go test ./internal/store -count=1` run reached the 180-second limit without output or a verdict, so it is intentionally not reported as passing. Full unit and E2E suites were not run. The focused regression command and the full MCP package test passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented saves from being applied when a session belongs to a different project than the one requested.
  - Failed project-mismatch saves now leave existing observations and synchronization data unchanged.
  - Clearer error messaging is shown when session and project identities do not match.
  - Sessions created from legacy records without a project now correctly adopt the requested project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->