### PR TITLE
fix(store): keep prompt FTS as the driving table

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3346,22 +3346,7 @@ func (s *Store) SearchPrompts(query string, project string, limit int) ([]Prompt
 	if hasShortFTSTerm(query) {
 		sql, args = buildPromptLIKEQuery(query, project, limit)
 	} else {
-		ftsQuery := sanitizeFTS(query)
-		sql = `
-			SELECT p.id, ifnull(p.sync_id, '') as sync_id, p.session_id, p.content, ifnull(p.project, '') as project, p.created_at
-			FROM prompts_fts fts
-			JOIN user_prompts p ON p.id = fts.rowid
-			WHERE prompts_fts MATCH ?
-		`
-		args = []any{ftsQuery}
-
-		if project != "" {
-			sql += " AND p.project = ?"
-			args = append(args, project)
-		}
-
-		sql += " ORDER BY fts.rank LIMIT ?"
-		args = append(args, limit)
+		sql, args = buildSearchPromptsFTSQuery(sanitizeFTS(query), project, limit)
 	}
 
 	rows, err := s.queryItHook(s.db, sql, args...)
@@ -3934,6 +3919,24 @@ func (s *Store) SearchContext(ctx context.Context, query string, opts SearchOpti
 		results = results[:limit]
 	}
 	return results, nil
+}
+
+func buildSearchPromptsFTSQuery(ftsQuery, project string, limit int) (string, []any) {
+	sqlQ := `
+		SELECT p.id, ifnull(p.sync_id, '') as sync_id, p.session_id, p.content, ifnull(p.project, '') as project, p.created_at
+		FROM prompts_fts fts
+		CROSS JOIN user_prompts p ON p.id = fts.rowid
+		WHERE prompts_fts MATCH ?
+	`
+	args := []any{ftsQuery}
+
+	if project != "" {
+		sqlQ += " AND p.project = ?"
+		args = append(args, project)
+	}
+
+	sqlQ += " ORDER BY fts.rank LIMIT ?"
+	return sqlQ, append(args, limit)
 }
 
 func buildSearchFTSQuery(ftsQuery string, opts SearchOptions, limit int) (string, []any) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13189,13 +13189,19 @@ func TestSearchContext_AlreadyCanceled(t *testing.T) {
 
 func TestFTSQueriesUseFTSFirstCrossJoin(t *testing.T) {
 	searchQuery, _ := buildSearchFTSQuery(`"memory"`, SearchOptions{}, 10)
-	for name, query := range map[string]string{
-		"search":          searchQuery,
-		"find candidates": findCandidatesFTSQuery,
+	promptQuery, _ := buildSearchPromptsFTSQuery(`"memory"`, "", 10)
+	for _, tc := range []struct {
+		name      string
+		query     string
+		crossJoin string
+	}{
+		{"search", searchQuery, "CROSS JOIN observations o ON o.id = fts.rowid"},
+		{"find candidates", findCandidatesFTSQuery, "CROSS JOIN observations o ON o.id = fts.rowid"},
+		{"prompts", promptQuery, "CROSS JOIN user_prompts p ON p.id = fts.rowid"},
 	} {
-		t.Run(name, func(t *testing.T) {
-			if !strings.Contains(query, "CROSS JOIN observations o ON o.id = fts.rowid") {
-				t.Fatalf("expected FTS-first CROSS JOIN, got query:\n%s", query)
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tc.query, tc.crossJoin) {
+				t.Fatalf("expected FTS-first CROSS JOIN, got query:\n%s", tc.query)
 			}
 		})
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13189,7 +13189,6 @@ func TestSearchContext_AlreadyCanceled(t *testing.T) {
 
 func TestFTSQueriesUseFTSFirstCrossJoin(t *testing.T) {
 	searchQuery, _ := buildSearchFTSQuery(`"memory"`, SearchOptions{}, 10)
-	promptQuery, _ := buildSearchPromptsFTSQuery(`"memory"`, "", 10)
 	for _, tc := range []struct {
 		name      string
 		query     string
@@ -13197,13 +13196,97 @@ func TestFTSQueriesUseFTSFirstCrossJoin(t *testing.T) {
 	}{
 		{"search", searchQuery, "CROSS JOIN observations o ON o.id = fts.rowid"},
 		{"find candidates", findCandidatesFTSQuery, "CROSS JOIN observations o ON o.id = fts.rowid"},
-		{"prompts", promptQuery, "CROSS JOIN user_prompts p ON p.id = fts.rowid"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if !strings.Contains(tc.query, tc.crossJoin) {
 				t.Fatalf("expected FTS-first CROSS JOIN, got query:\n%s", tc.query)
 			}
 		})
+	}
+
+	s := newTestStore(t)
+	for _, session := range []struct {
+		id      string
+		project string
+	}{
+		{"fts-plan-alpha", "alpha"},
+		{"fts-plan-beta", "beta"},
+	} {
+		if err := s.CreateSession(session.id, session.project, "/tmp/"+session.project); err != nil {
+			t.Fatalf("create %s session: %v", session.project, err)
+		}
+	}
+	for _, prompt := range []AddPromptParams{
+		{SessionID: "fts-plan-alpha", Content: "orbit alpha first", Project: "alpha"},
+		{SessionID: "fts-plan-alpha", Content: "orbit alpha second", Project: "alpha"},
+		{SessionID: "fts-plan-beta", Content: "orbit beta", Project: "beta"},
+	} {
+		if _, err := s.AddPrompt(prompt); err != nil {
+			t.Fatalf("add %s prompt: %v", prompt.Project, err)
+		}
+	}
+
+	var executedSQL string
+	var executedArgs []any
+	originalQueryIt := s.hooks.queryIt
+	s.hooks.queryIt = func(db queryer, query string, args ...any) (rowScanner, error) {
+		executedSQL = query
+		executedArgs = append([]any(nil), args...)
+		rows, err := db.Query(query, args...)
+		if err != nil {
+			return nil, err
+		}
+		return sqlRowScanner{rows: rows}, nil
+	}
+	t.Cleanup(func() { s.hooks.queryIt = originalQueryIt })
+
+	prompts, err := s.SearchPrompts("orbit", "alpha", 1)
+	if err != nil {
+		t.Fatalf("SearchPrompts: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0].Project != "alpha" {
+		t.Fatalf("SearchPrompts project/limit result = %+v, want one alpha prompt", prompts)
+	}
+	if !strings.Contains(executedSQL, "FROM prompts_fts fts") {
+		t.Fatalf("SearchPrompts did not execute the prompts FTS query:\n%s", executedSQL)
+	}
+	if !reflect.DeepEqual(executedArgs, []any{`"orbit"`, "alpha", 1}) {
+		t.Fatalf("SearchPrompts arguments = %#v, want %#v", executedArgs, []any{`"orbit"`, "alpha", 1})
+	}
+
+	rows, err := s.DB().Query("EXPLAIN QUERY PLAN "+executedSQL, executedArgs...)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN: %v", err)
+	}
+	defer rows.Close()
+
+	var plan []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan plan row: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("plan rows: %v", err)
+	}
+
+	ftsScan, rowIDLookup := -1, -1
+	for i, detail := range plan {
+		if strings.Contains(detail, "idx_prompts_project") {
+			t.Fatalf("project index drives prompt FTS search: %v", plan)
+		}
+		if strings.Contains(detail, "fts VIRTUAL TABLE") {
+			ftsScan = i
+		}
+		if strings.Contains(detail, "p USING INTEGER PRIMARY KEY") {
+			rowIDLookup = i
+		}
+	}
+	if ftsScan == -1 || rowIDLookup == -1 || ftsScan >= rowIDLookup {
+		t.Fatalf("expected prompts_fts scan before user_prompts rowid lookup, got %v", plan)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13250,6 +13250,9 @@ func TestFTSQueriesUseFTSFirstCrossJoin(t *testing.T) {
 	if !strings.Contains(executedSQL, "FROM prompts_fts fts") {
 		t.Fatalf("SearchPrompts did not execute the prompts FTS query:\n%s", executedSQL)
 	}
+	if !strings.Contains(executedSQL, "CROSS JOIN user_prompts p ON p.id = fts.rowid") {
+		t.Fatalf("SearchPrompts did not execute an FTS-first CROSS JOIN:\n%s", executedSQL)
+	}
 	if !reflect.DeepEqual(executedArgs, []any{`"orbit"`, "alpha", 1}) {
 		t.Fatalf("SearchPrompts arguments = %#v, want %#v", executedArgs, []any{`"orbit"`, "alpha", 1})
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #947

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Keep `prompts_fts` as the driving table by using an FTS-first `CROSS JOIN` when searching prompts.
- Add regression coverage that verifies prompt search uses the FTS-first query shape.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Build the prompt FTS query with `prompts_fts` followed by `CROSS JOIN user_prompts`. |
| `internal/store/store_test.go` | Cover the prompt FTS query in the FTS-first `CROSS JOIN` regression test. |

## 🧪 Test Plan

- [x] `go test ./internal/store -run '^TestFTSQueriesUseFTSFirstCrossJoin$' -count=1`
- [x] `go test ./internal/store -count=1`
- [ ] Unit tests pass locally: `go test ./...` (not run for this delivery)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run for this delivery)
- [ ] Manually tested the affected functionality (not applicable; query construction is covered by the regression and package tests)

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #947`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (not run for this delivery)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run for this delivery)
- [x] Docs updated (not required; this is an internal query-plan correction)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The FTS-first `CROSS JOIN` preserves the intended SQLite query order while retaining project filtering, rank ordering, and the result limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized prompt search query construction while preserving existing search behavior, filtering, result ordering, and limits.
  * No user-facing changes to prompt search functionality.

* **Tests**
  * Expanded validation of prompt search results and filtering.
  * Added coverage to verify full-text search query execution and prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->