### PR TITLE
fix(cloud): normalize encoded project names

### DIFF
--- a/cmd/engram/cloud.go
+++ b/cmd/engram/cloud.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -698,24 +699,36 @@ func cmdCloudEnroll(cfg store.Config) {
 		exitFunc(1)
 	}
 
+	projectName, warning, err := normalizeCloudCLIProjectInput(os.Args[3])
+	if err != nil {
+		fatal(err)
+		return
+	}
+	if warning != "" {
+		fmt.Fprintln(os.Stderr, warning)
+	}
+
 	s, err := storeNew(cfg)
 	if err != nil {
 		fatal(err)
 		return
 	}
 	defer s.Close()
-
-	projectName := strings.TrimSpace(os.Args[3])
-	projectName, warning := store.NormalizeProject(projectName)
-	if warning != "" {
-		fmt.Fprintln(os.Stderr, warning)
-	}
 	if err := s.EnrollProject(projectName); err != nil {
 		fatal(err)
 		return
 	}
 
 	fmt.Printf("✓ Project %q enrolled for cloud sync\n", projectName)
+}
+
+func normalizeCloudCLIProjectInput(input string) (string, string, error) {
+	decoded, err := url.PathUnescape(strings.TrimSpace(input))
+	if err != nil {
+		return "", "", fmt.Errorf("invalid cloud project URL encoding %q: %w", input, err)
+	}
+	projectName, warning := store.NormalizeProject(decoded)
+	return projectName, warning, nil
 }
 
 func cmdCloudConfig(cfg store.Config) {

--- a/cmd/engram/cloud_project_input_test.go
+++ b/cmd/engram/cloud_project_input_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gentleman-Programming/engram/v2/internal/store"
+	engramsync "github.com/Gentleman-Programming/engram/v2/internal/sync"
+)
+
+func TestCloudCLIProjectInputUsesSinglePathUnescape(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "literal space", input: "my project", want: "my project"},
+		{name: "encoded space", input: "my%20project", want: "my project"},
+		{name: "encoded percent sequence", input: "my%2520project", want: "my%20project"},
+		{name: "literal plus", input: "my+project", want: "my+project"},
+	}
+
+	for _, tt := range tests {
+		t.Run("enroll "+tt.name, func(t *testing.T) {
+			cfg := testConfig(t)
+			withArgs(t, "engram", "cloud", "enroll", tt.input)
+
+			stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdCloudEnroll(cfg) })
+			if recovered != nil || stderr != "" {
+				t.Fatalf("enrollment should succeed, panic=%v stderr=%q", recovered, stderr)
+			}
+			if !strings.Contains(stdout, `Project "`+tt.want+`" enrolled`) {
+				t.Fatalf("expected canonical enrollment output for %q, got %q", tt.want, stdout)
+			}
+
+			s, err := store.New(cfg)
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+			defer s.Close()
+			enrolled, err := s.IsProjectEnrolled(tt.want)
+			if err != nil {
+				t.Fatalf("IsProjectEnrolled(%q): %v", tt.want, err)
+			}
+			if !enrolled {
+				t.Fatalf("expected %q to be enrolled", tt.want)
+			}
+		})
+
+		t.Run("sync "+tt.name, func(t *testing.T) {
+			cfg := testConfig(t)
+			s, err := store.New(cfg)
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+			if err := s.EnrollProject(tt.want); err != nil {
+				_ = s.Close()
+				t.Fatalf("EnrollProject(%q): %v", tt.want, err)
+			}
+			if err := s.Close(); err != nil {
+				t.Fatalf("close store: %v", err)
+			}
+
+			t.Setenv("ENGRAM_CLOUD_SERVER", "https://cloud.example.test")
+			oldSyncStatus := syncStatus
+			syncStatus = func(_ *engramsync.Syncer) (int, int, int, error) {
+				return 0, 0, 0, nil
+			}
+			t.Cleanup(func() { syncStatus = oldSyncStatus })
+			withArgs(t, "engram", "sync", "--cloud", "--status", "--project", tt.input)
+
+			stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+			if recovered != nil || stderr != "" {
+				t.Fatalf("cloud sync status should succeed, panic=%v stderr=%q", recovered, stderr)
+			}
+			if !strings.Contains(stdout, `Cloud sync status (project="`+tt.want+`")`) {
+				t.Fatalf("expected canonical cloud sync project %q, got %q", tt.want, stdout)
+			}
+		})
+	}
+}
+
+func TestNormalizeCloudCLIProjectInputRejectsMalformedEscapes(t *testing.T) {
+	_, _, err := normalizeCloudCLIProjectInput("my%2project")
+	if err == nil || !strings.Contains(err.Error(), "invalid URL escape") {
+		t.Fatalf("expected malformed URL escape error, got %v", err)
+	}
+}
+
+func TestCloudCLICommandsRejectMalformedProjectEscapes(t *testing.T) {
+	stubExitWithPanic(t)
+	cfg := testConfig(t)
+
+	tests := []struct {
+		name   string
+		invoke func()
+	}{
+		{
+			name: "enroll",
+			invoke: func() {
+				withArgs(t, "engram", "cloud", "enroll", "my%2project")
+				cmdCloudEnroll(cfg)
+			},
+		},
+		{
+			name: "sync",
+			invoke: func() {
+				withArgs(t, "engram", "sync", "--cloud", "--project", "my%2project")
+				cmdSync(cfg)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, stderr, recovered := captureOutputAndRecover(t, tt.invoke)
+			if code, ok := recovered.(exitCode); !ok || int(code) != 1 {
+				t.Fatalf("expected exit code 1, got %v", recovered)
+			}
+			if !strings.Contains(stderr, "invalid cloud project URL encoding") {
+				t.Fatalf("expected malformed encoding error, got %q", stderr)
+			}
+		})
+	}
+}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1686,6 +1686,18 @@ func cmdSync(cfg store.Config) {
 		fatal(fmt.Errorf("--all and --project cannot be used together"))
 		return
 	}
+	cloudEnabled := doCloud || envBool("ENGRAM_CLOUD_SYNC")
+	if cloudEnabled && projectProvided {
+		decodedProject, warning, decodeErr := normalizeCloudCLIProjectInput(project)
+		if decodeErr != nil {
+			fatal(fmt.Errorf("cloud sync project: %w", decodeErr))
+			return
+		}
+		project = decodedProject
+		if warning != "" {
+			fmt.Fprintln(os.Stderr, warning)
+		}
+	}
 
 	syncDir := ".engram"
 
@@ -1705,7 +1717,6 @@ func cmdSync(cfg store.Config) {
 		project = resolved
 	}
 
-	cloudEnabled := doCloud || envBool("ENGRAM_CLOUD_SYNC")
 	if cloudEnabled {
 		if doAll {
 			fatal(fmt.Errorf("cloud sync requires a single explicit --project scope; --all is not supported"))


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #658

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Decodes one path-style percent-encoding layer only for explicit cloud CLI project input before canonical normalization.
- Keeps persisted and detected canonical project names unchanged, and preserves literal `+` characters.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/cloud.go` | Decode explicit cloud enrollment project input with path-style percent semantics before canonical normalization. |
| `cmd/engram/main.go` | Apply the same decoding only to an explicit cloud `sync --project` input. |
| `cmd/engram/cloud_project_input_test.go` | Cover command paths for spaces, one-layer encoding, literal `+`, and malformed escapes. |

## 🧪 Test Plan

- [x] Focused issue regression tests pass: `go test ./cmd/engram -run '^(TestCloudCLIProjectInputUsesSinglePathUnescape|TestNormalizeCloudCLIProjectInputRejectsMalformedEscapes|TestCloudCLICommandsRejectMalformedProjectEscapes)$' -count=1`
- [x] Adjacent cloud command tests pass: `go test ./cmd/engram -run '^(TestCloudCommandIsolationDoesNotMutateLocalState|TestCloudEnrollAndSyncHelpDoNotMutateLocalState|TestCloudEnrollReportsNormalizedProjectName)$' -count=1`
- [ ] Unit tests pass locally: `go test ./...` — Not completed locally because the pre-existing Windows suite infrastructure timed out; CI unit-test evidence is required before merge.
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — Not run because the unit prerequisite did not pass and no WSL distribution is available; CI E2E evidence is required before merge.
- [ ] Manually tested the affected functionality — Not claimed.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #658`)
- [x] I added exactly **one** `type:*` label to this PR (`type:bug`)
- [ ] I ran unit tests locally: `go test ./...` — Pre-existing Windows timeout; CI evidence is required before merge.
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` — Not run because the unit prerequisite failed and no WSL distribution is available; CI evidence is required before merge.
- [x] Docs are not required because this fixes the established contract rather than introducing a new workflow.
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Native four-lens RDD approved the exact candidate. One informational, non-blocking resilience warning was recorded; no correction was required. All CI checks must pass before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloud enrollment and synchronization now correctly handle URL-encoded project names, including spaces, plus signs, and percent sequences.
  - Invalid project encoding is rejected with a clear error instead of proceeding.
  - Cloud project input is normalized consistently across enrollment and synchronization commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->