### PR TITLE
fix(claude-code): extend user prompt submit timeout

### DIFF
--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -338,7 +338,7 @@ PowerShell fallback test and local override example:
           {
             "type": "command",
             "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File \"C:\\path\\to\\engram\\plugin\\claude-code\\scripts\\user-prompt-submit.ps1\"",
-            "timeout": 2
+            "timeout": 10
           }
         ]
       }

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -157,7 +157,7 @@ PowerShell local override/testing example for locked-down Windows endpoints:
           {
             "type": "command",
             "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File \"C:\\path\\to\\engram\\plugin\\claude-code\\scripts\\user-prompt-submit.ps1\"",
-            "timeout": 2
+            "timeout": 10
           }
         ]
       }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3307,8 +3307,8 @@ func TestClaudeCodeUserPromptSubmitHookTimeout(t *testing.T) {
 	if hook.Command != "\"${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh\"" {
 		t.Fatalf("unexpected UserPromptSubmit command %q", hook.Command)
 	}
-	if hook.Timeout != 2 {
-		t.Fatalf("UserPromptSubmit timeout = %d, want 2", hook.Timeout)
+	if hook.Timeout != 10 {
+		t.Fatalf("UserPromptSubmit timeout = %d, want 10", hook.Timeout)
 	}
 }
 

--- a/plugin/claude-code/hooks/hooks.json
+++ b/plugin/claude-code/hooks/hooks.json
@@ -31,7 +31,7 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh\"",
-            "timeout": 2
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #921

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Raise the Claude Code `UserPromptSubmit` outer timeout from 2 to 10 seconds for slower Windows/WSL startup paths.
- Keep the direct setup contract test and both PowerShell override examples aligned with the shipped hook configuration.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/claude-code/hooks/hooks.json` | Raise the outer `UserPromptSubmit` deadline to 10 seconds. |
| `internal/setup/setup_test.go` | Assert the updated timeout contract. |
| `docs/AGENT-SETUP.md` | Align the PowerShell fallback example. |
| `docs/PLUGINS.md` | Align the PowerShell local override example. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` (the bounded Windows run produced no result before the 20-minute timeout)
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

Focused verification completed before review:

- [x] `go test ./internal/setup -run '^TestClaudeCodeUserPromptSubmitHookTimeout$' -count=1`
- [x] `go test ./plugin -count=1`
- [x] Native four-lens RDD approved the exact committed tree without correction.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #921`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The change intentionally adjusts only the outer Claude Code hook deadline. Internal request timeouts and the hook routing remain unchanged. The full local Windows unit command did not finish within the bounded 20-minute run; focused contract and plugin package tests passed, and GitHub CI remains authoritative for the complete suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased the Claude Code `UserPromptSubmit` hook timeout from 2 seconds to 10 seconds, allowing more time for the hook to complete.

- **Documentation**
  - Updated setup and plugin documentation examples to reflect the 10-second timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->