### PR TITLE
fix(plugin): parse naive sqlite timestamps in utc and enable save-nudge for initial observations

### DIFF
--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -170,6 +171,7 @@ func DetectProjectFull(dir string) DetectionResult {
 			for i, c := range children {
 				names[i] = normalizeAvailableProject(filepath.Base(c))
 			}
+			sort.Strings(names)
 			absDir, _ := filepath.Abs(dir)
 			// REQ-304: Project is empty on ambiguous (spec is authoritative).
 			// DetectProject wrapper handles CLI compat by using filepath.Base on error.

--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -688,11 +688,12 @@ export const Engram: Plugin = async (ctx) => {
           return
         }
 
-        // No observations yet — nothing to nudge about
-        if (lastObsEpoch === 0) return
+        // No observations yet — use session start epoch as fallback
+        const effectiveLastEpoch = lastObsEpoch > 0 ? lastObsEpoch : sessionStartEpoch
+        if (effectiveLastEpoch === 0) return
 
         // Only nudge if last save was more than 15 minutes ago
-        if (nowSecs - lastObsEpoch < 900) return
+        if (nowSecs - effectiveLastEpoch < 900) return
 
         // Append the nudge to the last system message
         const nudge =

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -316,11 +316,20 @@ user_prompt_submit_without_jq() {
   encoded_project="$JSON_VALUE"
   last_save_json=$(curl -sf "${ENGRAM_URL}/observations?project=${encoded_project}&limit=1&sort=created_at:desc" --max-time "$ENGRAM_HOOK_MAX_TIME" 2>/dev/null)
   json_string_value_without_jq "created_at" "$last_save_json" && last_save_at="$JSON_VALUE" || last_save_at=""
-  [ -n "$last_save_at" ] || { printf '%s\n' '{}'; return 0; }
-  last_epoch=$(parse_epoch "$last_save_at")
-  [ -n "$last_epoch" ] || { printf '%s\n' '{}'; return 0; }
-  now_epoch=$(date "+%s")
-  elapsed=$(( now_epoch - last_epoch ))
+  if [ -n "$last_save_at" ]; then
+    last_epoch=$(parse_epoch "$last_save_at")
+    [ -n "$last_epoch" ] || { printf '%s\n' '{}'; return 0; }
+    now_epoch=$(date "+%s")
+    elapsed=$(( now_epoch - last_epoch ))
+  else
+    if [ -n "$session_age_secs" ]; then
+      now_epoch=$(date "+%s")
+      elapsed="$session_age_secs"
+    else
+      printf '%s\n' '{}'
+      return 0
+    fi
+  fi
 
   if [ "$elapsed" -gt 900 ]; then
     nudge_cooldown="${ENGRAM_NUDGE_COOLDOWN_SECS:-900}"
@@ -404,8 +413,9 @@ parse_epoch() {
     date -j -u -f "%Y-%m-%dT%H:%M:%S" "$Z_TS" "+%s" 2>/dev/null && return 0
   fi
 
-  date -j -f "%Y-%m-%dT%H:%M:%S" "$TS" "+%s" 2>/dev/null \
-    || date -j -f "%Y-%m-%d %H:%M:%S" "$TS" "+%s" 2>/dev/null \
+  date -j -u -f "%Y-%m-%dT%H:%M:%S" "$TS" "+%s" 2>/dev/null \
+    || date -j -u -f "%Y-%m-%d %H:%M:%S" "$TS" "+%s" 2>/dev/null \
+    || date -u -d "$TS" "+%s" 2>/dev/null \
     || date -d "$TS" "+%s" 2>/dev/null
 }
 
@@ -522,21 +532,24 @@ if [ -z "$LAST_SAVE_JSON" ]; then
 fi
 
 LAST_SAVE_AT=$(echo "$LAST_SAVE_JSON" | jq -r '.[0].created_at // empty' 2>/dev/null)
-
-if [ -z "$LAST_SAVE_AT" ]; then
-  # No observations yet — no nudge (session might just be starting)
-  echo "$OUTPUT"
-  exit 0
-fi
-
-# Parse last save timestamp and compare to now
-LAST_EPOCH=$(parse_epoch "$LAST_SAVE_AT")
-if [ -z "$LAST_EPOCH" ]; then
-  echo "$OUTPUT"
-  exit 0
-fi
 NOW_EPOCH=$(date "+%s")
-ELAPSED=$(( NOW_EPOCH - LAST_EPOCH ))
+
+if [ -n "$LAST_SAVE_AT" ]; then
+  LAST_EPOCH=$(parse_epoch "$LAST_SAVE_AT")
+  if [ -z "$LAST_EPOCH" ]; then
+    echo "$OUTPUT"
+    exit 0
+  fi
+  ELAPSED=$(( NOW_EPOCH - LAST_EPOCH ))
+else
+  # No observations yet — use session age as elapsed time so active sessions are nudged
+  if [ -n "$SESSION_AGE_SECS" ]; then
+    ELAPSED="$SESSION_AGE_SECS"
+  else
+    echo "$OUTPUT"
+    exit 0
+  fi
+fi
 
 # Nudge if last save was > 15 minutes ago (900 seconds), but debounce so we do
 # not repeat the reminder on every message while the agent has nothing to save.

--- a/plugin/claude_code_hook_behavior_test.go
+++ b/plugin/claude_code_hook_behavior_test.go
@@ -316,6 +316,78 @@ func TestNudgeBehavior(t *testing.T) {
 	}
 }
 
+func TestNudgeBehavior_NaiveSQLiteTimestampInNonUTCHost(t *testing.T) {
+	requireHookBinaries(t)
+	sessionID := newSessionID(t)
+	markSessionBootstrapped(t, sessionID)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/project/current" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"project":"engram","project_source":"config"}`)
+			return
+		}
+		if !strings.HasPrefix(r.URL.Path, "/observations") {
+			http.NotFound(w, r)
+			return
+		}
+		// Naive SQLite timestamp without timezone marker
+		createdAt := time.Now().Add(-20 * time.Minute).UTC().Format("2006-01-02 15:04:05")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[{"created_at":%q}]`, createdAt)
+	}))
+	defer srv.Close()
+
+	stdin := fmt.Sprintf(`{"session_id":%q,"cwd":%q}`, sessionID, t.TempDir())
+	env := map[string]string{
+		"ENGRAM_PORT": serverPort(t, srv),
+		"TZ":          "America/Bogota", // UTC-5
+	}
+
+	payload := decodeHookPayload(t, runHook(t, "user-prompt-submit.sh", stdin, env))
+	if !strings.Contains(payload.HookSpecificOutput.AdditionalContext, "MEMORY REMINDER") {
+		t.Fatalf("expected nudge in non-UTC timezone, got: %q", payload.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+func TestNudgeBehavior_ZeroObservationsWhenSessionAgePastThreshold(t *testing.T) {
+	requireHookBinaries(t)
+	sessionID := newSessionID(t)
+	markSessionBootstrapped(t, sessionID)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/project/current" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"project":"engram","project_source":"config"}`)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/sessions/") {
+			startedAt := time.Now().Add(-20 * time.Minute).UTC().Format("2006-01-02 15:04:05")
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"started_at":%q}`, startedAt)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/observations") {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[]`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	stdin := fmt.Sprintf(`{"session_id":%q,"cwd":%q}`, sessionID, t.TempDir())
+	env := map[string]string{
+		"ENGRAM_PORT": serverPort(t, srv),
+		"TZ":          "America/Bogota",
+	}
+
+	payload := decodeHookPayload(t, runHook(t, "user-prompt-submit.sh", stdin, env))
+	if !strings.Contains(payload.HookSpecificOutput.AdditionalContext, "MEMORY REMINDER") {
+		t.Fatalf("expected nudge for session with 0 observations past threshold, got: %q", payload.HookSpecificOutput.AdditionalContext)
+	}
+}
+
 // passiveCapture is the body subagent-stop.sh POSTs to /observations/passive.
 type passiveCapture struct {
 	SessionID string `json:"session_id"`

--- a/plugin/codex/scripts/user-prompt-submit.sh
+++ b/plugin/codex/scripts/user-prompt-submit.sh
@@ -81,8 +81,9 @@ parse_epoch() {
     date -j -u -f "%Y-%m-%dT%H:%M:%S" "$Z_TS" "+%s" 2>/dev/null && return 0
   fi
 
-  date -j -f "%Y-%m-%dT%H:%M:%S" "$TS" "+%s" 2>/dev/null \
-    || date -j -f "%Y-%m-%d %H:%M:%S" "$TS" "+%s" 2>/dev/null \
+  date -j -u -f "%Y-%m-%dT%H:%M:%S" "$TS" "+%s" 2>/dev/null \
+    || date -j -u -f "%Y-%m-%d %H:%M:%S" "$TS" "+%s" 2>/dev/null \
+    || date -u -d "$TS" "+%s" 2>/dev/null \
     || date -d "$TS" "+%s" 2>/dev/null
 }
 
@@ -167,21 +168,24 @@ if [ -z "$LAST_SAVE_JSON" ]; then
 fi
 
 LAST_SAVE_AT=$(echo "$LAST_SAVE_JSON" | jq -r '.[0].created_at // empty' 2>/dev/null)
-
-if [ -z "$LAST_SAVE_AT" ]; then
-  # No observations yet — no nudge (session might just be starting)
-  echo "$OUTPUT"
-  exit 0
-fi
-
-# Parse last save timestamp and compare to now
-LAST_EPOCH=$(parse_epoch "$LAST_SAVE_AT")
-if [ -z "$LAST_EPOCH" ]; then
-  echo "$OUTPUT"
-  exit 0
-fi
 NOW_EPOCH=$(date "+%s")
-ELAPSED=$(( NOW_EPOCH - LAST_EPOCH ))
+
+if [ -n "$LAST_SAVE_AT" ]; then
+  LAST_EPOCH=$(parse_epoch "$LAST_SAVE_AT")
+  if [ -z "$LAST_EPOCH" ]; then
+    echo "$OUTPUT"
+    exit 0
+  fi
+  ELAPSED=$(( NOW_EPOCH - LAST_EPOCH ))
+else
+  # No observations yet — use session age as elapsed time so active sessions are nudged
+  if [ -n "$SESSION_AGE_SECS" ]; then
+    ELAPSED="$SESSION_AGE_SECS"
+  else
+    echo "$OUTPUT"
+    exit 0
+  fi
+fi
 
 # Nudge if last save was > 15 minutes ago (900 seconds), but debounce so we do
 # not repeat the reminder on every message while the agent has nothing to save.

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -688,11 +688,12 @@ export const Engram: Plugin = async (ctx) => {
           return
         }
 
-        // No observations yet — nothing to nudge about
-        if (lastObsEpoch === 0) return
+        // No observations yet — use session start epoch as fallback
+        const effectiveLastEpoch = lastObsEpoch > 0 ? lastObsEpoch : sessionStartEpoch
+        if (effectiveLastEpoch === 0) return
 
         // Only nudge if last save was more than 15 minutes ago
-        if (nowSecs - lastObsEpoch < 900) return
+        if (nowSecs - effectiveLastEpoch < 900) return
 
         // Append the nudge to the last system message
         const nudge =


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #668

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Forces UTC (`-u`) parsing for naive SQLite timestamps in `parse_epoch` across `claude-code` and `codex` hooks, preventing host timezones (e.g. UTC-5, UTC+2) from skewing elapsed time and suppressing or spamming save nudges.
- Falls back to session age when a project has zero observations in `claude-code`, `codex`, and `opencode` hooks, ensuring active sessions receive the initial memory save reminder.
- Adds regression tests in `plugin/claude_code_hook_behavior_test.go` covering non-UTC host timezones and zero-observation sessions past the 15-minute threshold.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/claude-code/scripts/user-prompt-submit.sh` | Added `-u` to naive timestamp date parsing and added session age fallback for zero-observation projects |
| `plugin/codex/scripts/user-prompt-submit.sh` | Added `-u` to naive timestamp date parsing and added session age fallback for zero-observation projects |
| `plugin/opencode/engram.ts` | Added `sessionStartEpoch` fallback when `lastObsEpoch === 0` |
| `internal/setup/plugins/opencode/engram.ts` | Synced embedded OpenCode plugin copy |
| `plugin/claude_code_hook_behavior_test.go` | Added `TestNudgeBehavior_NaiveSQLiteTimestampInNonUTCHost` and `TestNudgeBehavior_ZeroObservationsWhenSessionAgePastThreshold` |
| `internal/project/detect.go` | Ensured deterministic sorting of `AvailableProjects` for ambiguous project scans |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test -v ./plugin/...`
- [x] Full repo test suite passes: `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Project detection results now list available projects alphabetically for more consistent selection.
  - Save reminders now appear for active sessions even when no observations have been saved yet.
  - Session timing is handled more reliably across UTC and non-UTC environments, improving reminder behavior.
  - Improved save-reminder consistency across Claude Code, Codex, and OpenCode integrations.
- **Tests**
  - Added coverage for timezone-specific timestamps and reminders in sessions without observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->