### PR TITLE
test(pi): guard compaction against stale context

### DIFF
--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -1067,6 +1067,16 @@ test("session compaction strictly registers before forwarding its summary", () =
   assert.match(source, /async function archiveCompactionSummary[\s\S]*engramFetchResult\("\/observations"/);
 });
 
+test("session compaction never captures or reads stale Pi context", () => {
+  const compactStart = source.indexOf('pi.on("session_compact"');
+  const compactEnd = source.indexOf('\n  pi.on("before_agent_start"', compactStart);
+  assert.notEqual(compactStart, -1, "session_compact handler not found");
+  assert.notEqual(compactEnd, -1, "session_compact handler end not found");
+
+  const compactHandler = source.slice(compactStart, compactEnd);
+  assert.doesNotMatch(compactHandler, /\bctx\b/, "session_compact must not capture or access stale Pi context");
+});
+
 test("four session-attributed writes ignore model session_id and require the Pi runtime ID", () => {
   for (const tool of ["mem_save", "mem_save_prompt", "mem_session_summary", "mem_capture_passive"]) {
     const schema = source.match(new RegExp(`${tool}: Type\\.Object\\(\\{([\\s\\S]*?)\\n  \\}\\),`));


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #591

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add a source-level contract that prevents Pi's `session_compact` handler from capturing or reading stale `ctx` state.
- Complement the runtime compaction regression coverage delivered with the production fix in #989.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/test/index-source.test.mjs` | Assert that the complete `session_compact` handler contains no `ctx` identifier. |

## 🧪 Test Plan

- [x] Pi plugin suite passes locally: `npm --prefix plugin/pi test` (114/114 tests).
- [x] Focused source contracts pass: `node --test test/index-source.test.mjs` (62/62 tests).
- [x] Focused native tool contracts pass: `node --test test/native-tool-contract.test.mjs` (16/16 tests).
- [ ] `go test ./...` did not produce a result before the combined verification command reached its 600-second timeout.
- [ ] `go test -tags e2e ./internal/server/...` was not reached after that timeout; CI will determine both Go results.

---

## 🤖 Automated Checks

These run automatically and must pass before merge.

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #591`).
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran unit tests locally; the Go suite did not finish before the disclosed timeout.
- [ ] I ran E2E tests locally; the E2E suite was not reached after the disclosed timeout.
- [x] Docs are not required because this is a test-only regression guard.
- [x] Commits follow conventional commits format.
- [x] No `Co-Authored-By` trailers are present.

---

## 💬 Notes for Reviewers

Receipt-driven review approved and acknowledged the exact frozen candidate under lineage `review-36b932c309c36db5`. The reliability lens recorded no blocking findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify session compaction does not access stale context.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->