### PR TITLE
fix(setup): resolve tool symlinks before hardlinking isolated hook PATH

### DIFF
--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -2991,6 +2991,14 @@ func isolatedHookPath(t *testing.T) (string, []string) {
 		if err != nil {
 			t.Skipf("required hook tool %q is unavailable: %v", tool, err)
 		}
+		// Hardlink the resolved target, not the lookup path: link(2) does not follow
+		// symlinks, so a Homebrew-style relative symlink (curl -> ../Cellar/curl/x/bin/curl)
+		// would be hardlinked as-is and dangle once placed in the temp bin dir.
+		resolved, err := filepath.EvalSymlinks(toolPath)
+		if err != nil {
+			t.Fatalf("resolve hook tool %q at %q: %v", tool, toolPath, err)
+		}
+		toolPath = resolved
 		linkPath := filepath.Join(binDir, filepath.Base(toolPath))
 		if err := os.Link(toolPath, linkPath); err != nil {
 			if err := os.Symlink(toolPath, linkPath); err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #941

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Resolve tools found on `PATH` before hardlinking them into the isolated hook test directory.
- Keep no-`jq` hook tests portable when package managers expose tools through relative symlinks.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/setup/setup_test.go` | Resolve tool symlinks with `filepath.EvalSymlinks` before creating hardlinks. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Manually tested the affected functionality

Verification performed:

- Focused no-`jq` setup test passed locally.
- `go test ./...` timed out after 20 minutes while reporting the known unrelated Windows POSIX-path assertion failures in `TestWriteClaudeCodeUserMCP`.
- `go test -tags e2e ./internal/server/...` passed.
- `npm test` in `plugin/pi` completed with 96 passing and 2 unrelated `startup-lifecycle.test.mjs` failures.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The production hook logic is unchanged. This patch only removes an environment-dependent assumption from the setup test harness. Local Windows verification limitations are documented above; repository CI remains authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability when required tools are installed through relative symbolic links.
  * Prevented temporary tool links from becoming invalid during isolated test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->