### PR TITLE
fix(server): report release version from health endpoint

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -799,6 +799,7 @@ func cmdServe(cfg store.Config) {
 	defer s.Close()
 
 	srv := newHTTPServer(s, port)
+	srv.SetVersion(version)
 
 	// Wire the semantic runner factory and prompt builder for POST /conflicts/scan.
 	// Both live in cmd/engram so internal/server avoids a direct dependency on internal/llm.

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -247,6 +247,46 @@ func TestFatal(t *testing.T) {
 	}
 }
 
+func TestCmdServeWiresBuildVersionIntoHealth(t *testing.T) {
+	cfg := testConfig(t)
+	stubRuntimeHooks(t)
+	withArgs(t, "engram", "serve")
+	t.Setenv("ENGRAM_CLOUD_AUTOSYNC", "")
+
+	const buildVersion = "test-build-version"
+	oldVersion := version
+	version = buildVersion
+	t.Cleanup(func() { version = oldVersion })
+
+	var captured *engramsrv.Server
+	newHTTPServer = func(s *store.Store, port int) *engramsrv.Server {
+		captured = engramsrv.New(s, port)
+		return captured
+	}
+
+	cmdServe(cfg)
+	if captured == nil {
+		t.Fatal("cmdServe did not create an HTTP server")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	res := httptest.NewRecorder()
+	captured.Handler().ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("health status=%d want=%d", res.Code, http.StatusOK)
+	}
+	var health struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&health); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if health.Version != buildVersion {
+		t.Fatalf("health version=%q want=%q", health.Version, buildVersion)
+	}
+}
+
 func TestCmdServeParsesPortAndErrors(t *testing.T) {
 	cfg := testConfig(t)
 	stubRuntimeHooks(t)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,10 +77,12 @@ type Server struct {
 	// promptBuilder constructs LLM prompts for semantic scan pairs.
 	// When nil and semantic=true, a no-op builder is used (returns empty string).
 	promptBuilder SemanticPromptBuilder
+	// version is reported by GET /health and defaults to "dev" for local builds.
+	version string
 }
 
 func New(s *store.Store, port int) *Server {
-	srv := &Server{store: s, port: port, listen: net.Listen, serve: http.Serve}
+	srv := &Server{store: s, port: port, listen: net.Listen, serve: http.Serve, version: "dev"}
 	srv.mux = http.NewServeMux()
 	srv.routes()
 	return srv
@@ -90,6 +92,11 @@ func New(s *store.Store, port int) *Server {
 // This is used to notify autosync.Manager via NotifyDirty().
 func (s *Server) SetOnWrite(fn func()) {
 	s.onWrite = fn
+}
+
+// SetVersion sets the release version reported by GET /health.
+func (s *Server) SetVersion(v string) {
+	s.version = v
 }
 
 // SetSyncStatus configures the sync status provider for the /sync/status endpoint.
@@ -292,7 +299,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusOK, map[string]any{
 		"status":  "ok",
 		"service": "engram",
-		"version": "0.1.0",
+		"version": s.version,
 	})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -60,6 +60,42 @@ func TestStartUsesInjectedServe(t *testing.T) {
 	}
 }
 
+func TestHealthReportsVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		setVersion bool
+		version    string
+	}{
+		{name: "defaults to dev", version: "dev"},
+		{name: "reports configured version", setVersion: true, version: "1.16.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := New(nil, 0)
+			if tt.setVersion {
+				srv.SetVersion(tt.version)
+			}
+
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected /health 200, got %d", rec.Code)
+			}
+
+			var response struct {
+				Version string `json:"version"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode /health response: %v", err)
+			}
+			if response.Version != tt.version {
+				t.Fatalf("/health version = %q, want %q", response.Version, tt.version)
+			}
+		})
+	}
+}
+
 func newServerTestStore(t *testing.T) *store.Store {
 	t.Helper()
 	cfg, err := store.DefaultConfig()


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #946

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Report the configured Engram release version from `GET /health` instead of a stale hard-coded value.
- Preserve `dev` as the default version for local server construction and cover both defaults and configured releases.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Pass the CLI build version to the HTTP server when serving. |
| `internal/server/server.go` | Store a configurable health version, default it to `dev`, and return it from `GET /health`. |
| `internal/server/server_test.go` | Verify default and configured health-version responses. |

## 🧪 Test Plan

- [x] Focused health endpoint test passes locally: `go test ./internal/server -run '^TestHealthReportsVersion$' -count=1`
- [x] CLI package tests pass locally: `go test ./cmd/engram -count=1`
- [ ] Unit tests pass locally: `go test ./...` (not run; verification was scoped to the affected packages)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run)
- [ ] Manually tested the affected functionality (not run; focused handler coverage verifies the response)

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #946`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (not run; scoped tests are listed above)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run)
- [x] Docs assessed: no update is required because the `version` field already existed and this change only corrects its value.
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The implementation was transferred from prior work by @danielgap. No `Co-Authored-By` trailer was added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The health endpoint now reports the application’s configured build version.
  * Builds without a configured version identify themselves as `dev`.
  * Version information is displayed consistently across deployed and development environments.

* **Bug Fixes**
  * Health responses no longer report a fixed version value that may be outdated.

* **Tests**
  * Added coverage to verify default and configured version reporting through the health endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->