### PR TITLE
fix(server): return empty arrays for collection endpoints

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -128,6 +128,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 - `POST /sessions` — Create session. Body: `{id, project, directory}`
 - `POST /sessions/{id}/end` — End session. Body: `{summary}`
 - `GET /sessions/recent` — Recent sessions. Query: `?project=X&all_projects=true&limit=N`
+  - No-result responses return `200` with `[]` (never `null`)
 - `GET /sessions/{id}` — Get single session by ID
 - `DELETE /sessions/{id}` — Delete session
   - `200` when deleted
@@ -141,6 +142,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
   - `400` when `title` or `content` is missing, empty, or whitespace-only. The observation-create paths (`engram save`, `mem_save`, `POST /observations`) enforce the same title rule because cloud sync rejects observation upserts without a title, and one rejected mutation blocks every later mutation for the project
 - `GET /observations` — Recent observations compatibility endpoint. Query: `?project=X&all_projects=true&scope=project|personal|global&limit=N&sort=created_at:desc`
 - `GET /observations/recent` — Recent observations. Query: `?project=X&all_projects=true&scope=project|personal|global&limit=N`
+  - No-result responses from both observation collection endpoints return `200` with `[]` (never `null`)
 - `GET /observations/{id}` — Get single observation by ID
 - `PATCH /observations/{id}` — Update fields. Body: `{title?, content?, type?, project?, scope?, topic_key?}`
   - `400` when `title` or `content` is provided but empty or whitespace-only. Omitting a field leaves its current value unchanged
@@ -172,6 +174,7 @@ Engram is local-first: local SQLite is authoritative; cloud features are optiona
 - `POST /prompts` — Save user prompt. Body: `{session_id, content, project?}`
 - `GET /prompts/recent` — Recent prompts. Query: `?project=X&all_projects=true&limit=N`
 - `GET /prompts/search` — Search prompts. Query: `?q=QUERY&project=X&all_projects=true&limit=N`
+  - No-result responses from both prompt collection endpoints return `200` with `[]` (never `null`)
 - `DELETE /prompts/{id}` — Delete prompt
   - `200` when deleted
   - `400` for invalid prompt id

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -350,6 +350,9 @@ func (s *Server) handleRecentSessions(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if sessions == nil {
+		sessions = []store.SessionSummary{}
+	}
 
 	jsonResponse(w, http.StatusOK, sessions)
 }
@@ -458,6 +461,9 @@ func (s *Server) handleRecentObservations(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+	if obs == nil {
+		obs = []store.Observation{}
 	}
 
 	jsonResponse(w, http.StatusOK, obs)
@@ -765,6 +771,9 @@ func (s *Server) handleRecentPrompts(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if prompts == nil {
+		prompts = []store.Prompt{}
+	}
 
 	jsonResponse(w, http.StatusOK, prompts)
 }
@@ -789,6 +798,9 @@ func (s *Server) handleSearchPrompts(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+	if prompts == nil {
+		prompts = []store.Prompt{}
 	}
 
 	jsonResponse(w, http.StatusOK, prompts)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -886,6 +886,33 @@ func TestHandleSearchNoHitsReturnsEmptyArray(t *testing.T) {
 	}
 }
 
+func TestCollectionHandlersNoResultsReturnEmptyArrays(t *testing.T) {
+	srv := New(newServerTestStore(t), 0)
+
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: "recent sessions", path: "/sessions/recent"},
+		{name: "recent observations", path: "/observations/recent"},
+		{name: "observations alias", path: "/observations"},
+		{name: "recent prompts", path: "/prompts/recent"},
+		{name: "search prompts", path: "/prompts/search?q=no-hits"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200: %s", tt.path, rec.Code, rec.Body.String())
+			}
+			if body := strings.TrimSpace(rec.Body.String()); body != "[]" {
+				t.Fatalf("GET %s body = %q, want []", tt.path, body)
+			}
+		})
+	}
+}
+
 func TestHandleSearchRejectsInvalidMatchMode(t *testing.T) {
 	srv := New(newServerTestStore(t), 0)
 	req := httptest.NewRequest(http.MethodGet, "/search?q=aurora&match_mode=or", nil)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #956

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Return JSON empty arrays instead of `null` from successful collection endpoints with no results.
- Add regression coverage for all affected routes and document the collection response contract.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/server/server.go` | Normalize nil collection results to typed empty slices before JSON encoding. |
| `internal/server/server_test.go` | Cover empty-array responses for the affected collection routes. |
| `DOCS.md` | Document that empty collection responses use `[]`. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/... -count=1`
- [ ] Manually tested the affected functionality

- [x] Focused regression passed: `go test ./internal/server -run '^TestCollectionHandlersNoResultsReturnEmptyArrays$' -count=1`
- [x] Affected package passed: `go test ./internal/server -count=1`

`go test -json -count=1 ./...` was run but did not pass: six baseline Windows fixture failures in `internal/setup` treat POSIX fixture paths as non-absolute. They are confined to those fixtures and do not exercise this change.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

CI on Linux should arbitrate the six baseline Windows fixture failures in `internal/setup`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Collection endpoints now return an empty JSON array (`[]`) instead of `null` when no results are available.
  - No-result responses continue to use HTTP `200`.

- **Documentation**
  - Updated API documentation to clarify empty-result response behavior for sessions, observations, and prompts endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->