### PR TITLE
fix(store): enforce project-owned session binding

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -93,7 +93,7 @@ var currentWorkingDirectory = func() string {
 }
 
 func ensureImplicitSessionWithCWD(s *store.Store, sessionID, project string) error {
-	return s.CreateSessionWithOwnershipMode(sessionID, project, currentWorkingDirectory(), store.SessionOwnershipProjectOwned)
+	return s.CreateSession(sessionID, project, currentWorkingDirectory())
 }
 
 // runtimeSessionDirectory derives the worktree-specific key for omitted
@@ -2600,6 +2600,7 @@ func resolveSaveWriteProject(s *store.Store, projectChoice string, explicitProje
 	trimmedProjectChoice := strings.TrimSpace(projectChoice)
 	trimmedReason := strings.TrimSpace(reason)
 	var sessionProject string
+	var sessionMode string
 	var sessionPath string
 	if trimmedSessionID != "" {
 		sess, err := s.GetSession(trimmedSessionID)
@@ -2610,6 +2611,7 @@ func resolveSaveWriteProject(s *store.Store, projectChoice string, explicitProje
 		if err != nil {
 			return projectpkg.DetectionResult{}, err
 		}
+		sessionMode = strings.TrimSpace(sess.OwnershipMode)
 		sessionPath = strings.TrimSpace(sess.Directory)
 	}
 
@@ -2643,7 +2645,7 @@ func resolveSaveWriteProject(s *store.Store, projectChoice string, explicitProje
 		if collisionErr := explicitWriteProjectCollision(trimmedProjectChoice, project, sessionProject, cwdRes); collisionErr != nil {
 			return cwdRes, collisionErr
 		}
-		if sessionProject != "" && project != sessionProject {
+		if sessionMode == store.SessionOwnershipProjectOwned && sessionProject != "" && project != sessionProject {
 			return projectpkg.DetectionResult{}, &sessionProjectMismatchError{
 				SessionID:       trimmedSessionID,
 				SessionProject:  sessionProject,
@@ -2716,7 +2718,7 @@ func resolveSaveWriteProject(s *store.Store, projectChoice string, explicitProje
 		if err != nil {
 			return res, err
 		}
-		if sessionProject != "" {
+		if sessionMode == store.SessionOwnershipProjectOwned && sessionProject != "" {
 			resolvedProject, err := normalizeExplicitWriteProject(res.Project)
 			if err != nil {
 				return projectpkg.DetectionResult{}, err

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -2482,6 +2482,20 @@ func (e *sessionProjectMismatchError) Error() string {
 	return fmt.Sprintf("session %q belongs to project %q, not %q", e.SessionID, e.SessionProject, e.ExplicitProject)
 }
 
+func sessionProjectResolutionError(sessionID, sessionProject, sessionMode, requestedProject string) error {
+	if sessionProject == "" || sessionProject == requestedProject || sessionMode == store.SessionOwnershipShared {
+		return nil
+	}
+	if sessionMode == store.SessionOwnershipProjectOwned {
+		return &sessionProjectMismatchError{
+			SessionID:       sessionID,
+			SessionProject:  sessionProject,
+			ExplicitProject: requestedProject,
+		}
+	}
+	return fmt.Errorf("%w: session %q has unclassified ownership for %q and cannot accept %q", store.ErrProjectOwnershipAmbiguous, sessionID, sessionProject, requestedProject)
+}
+
 // resolveWriteProject detects the current project from the process working
 // directory. Returns ErrAmbiguousProject if cwd is a parent of multiple repos.
 func resolveWriteProject() (projectpkg.DetectionResult, error) {
@@ -2645,12 +2659,8 @@ func resolveSaveWriteProject(s *store.Store, projectChoice string, explicitProje
 		if collisionErr := explicitWriteProjectCollision(trimmedProjectChoice, project, sessionProject, cwdRes); collisionErr != nil {
 			return cwdRes, collisionErr
 		}
-		if sessionMode == store.SessionOwnershipProjectOwned && sessionProject != "" && project != sessionProject {
-			return projectpkg.DetectionResult{}, &sessionProjectMismatchError{
-				SessionID:       trimmedSessionID,
-				SessionProject:  sessionProject,
-				ExplicitProject: project,
-			}
+		if err := sessionProjectResolutionError(trimmedSessionID, sessionProject, sessionMode, project); err != nil {
+			return projectpkg.DetectionResult{}, err
 		}
 
 		exists, err := s.ProjectExists(project)
@@ -2718,17 +2728,13 @@ func resolveSaveWriteProject(s *store.Store, projectChoice string, explicitProje
 		if err != nil {
 			return res, err
 		}
-		if sessionMode == store.SessionOwnershipProjectOwned && sessionProject != "" {
+		if sessionProject != "" {
 			resolvedProject, err := normalizeExplicitWriteProject(res.Project)
 			if err != nil {
 				return projectpkg.DetectionResult{}, err
 			}
-			if resolvedProject != sessionProject {
-				return projectpkg.DetectionResult{}, &sessionProjectMismatchError{
-					SessionID:       trimmedSessionID,
-					SessionProject:  sessionProject,
-					ExplicitProject: resolvedProject,
-				}
+			if err := sessionProjectResolutionError(trimmedSessionID, sessionProject, sessionMode, resolvedProject); err != nil {
+				return projectpkg.DetectionResult{}, err
 			}
 		}
 		return res, nil
@@ -3002,6 +3008,9 @@ func writeProjectErrorResult(activity *SessionActivity, sessionID string, res pr
 	if errors.Is(err, store.ErrDatabaseGenerationChanged) {
 		return errorWithMeta("database_generation_changed", err.Error(), res.AvailableProjects)
 	}
+	if errors.Is(err, store.ErrProjectOwnershipAmbiguous) {
+		return errorWithMeta("session_project_ownership_ambiguous", err.Error(), res.AvailableProjects)
+	}
 	if errors.Is(err, projectpkg.ErrRepositoryBinding) {
 		return errorWithMeta(
 			"repository_binding_unavailable",
@@ -3183,6 +3192,8 @@ func errorWithMeta(code, msg string, availableProjects []string) *mcp.CallToolRe
 		envelope["hint"] = "Choose a new session ID and retry mem_session_start; ended sessions cannot be reopened."
 	case "session_project_mismatch":
 		envelope["hint"] = "Use a project that matches the existing session, or omit session_id and write to a different project."
+	case "session_project_ownership_ambiguous":
+		envelope["hint"] = "Use ownership rescue to classify the historical session before writing to a different project."
 	case "project_required":
 		envelope["hint"] = "Use ownership rescue before updating this historical record, then retry the field update."
 	case "project_mismatch":

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -5584,8 +5584,12 @@ func TestMemSave_ExplicitProjectMustMatchExistingSessionProject(t *testing.T) {
 	t.Chdir(dir)
 
 	s := newMCPTestStore(t)
-	if err := s.CreateSession("cross-project-session", "session-owned-project", "/work/session-owned-project"); err != nil {
+	if err := s.CreateSessionWithOwnershipMode("cross-project-session", "session-owned-project", "/work/session-owned-project", store.SessionOwnershipProjectOwned); err != nil {
 		t.Fatalf("create session: %v", err)
+	}
+	var mutationsBefore int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM sync_mutations").Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count initial mutations: %v", err)
 	}
 	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
 
@@ -5609,6 +5613,55 @@ func TestMemSave_ExplicitProjectMustMatchExistingSessionProject(t *testing.T) {
 	obs, searchErr := s.Search("cross-project mismatch should fail", store.SearchOptions{Project: "other-project", Limit: 5})
 	if searchErr != nil || len(obs) != 0 {
 		t.Fatalf("mismatched explicit project must not receive write, obs=%d err=%v", len(obs), searchErr)
+	}
+	session, sessionErr := s.GetSession("cross-project-session")
+	if sessionErr != nil || session.Project != "session-owned-project" || session.OwnershipMode != store.SessionOwnershipProjectOwned {
+		t.Fatalf("session ownership after mismatch = %#v, err=%v", session, sessionErr)
+	}
+	var prompts int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM user_prompts").Scan(&prompts); err != nil {
+		t.Fatalf("count prompts after mismatch: %v", err)
+	}
+	if prompts != 0 {
+		t.Fatalf("mismatch created prompts=%d, want 0", prompts)
+	}
+	var mutationsAfter int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM sync_mutations").Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count mutations after mismatch: %v", err)
+	}
+	if mutationsAfter != mutationsBefore {
+		t.Fatalf("mismatch created mutations=%d, want %d", mutationsAfter, mutationsBefore)
+	}
+}
+
+func TestMemSave_ExplicitProjectAllowsExistingSharedSession(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	t.Chdir(dir)
+
+	s := newMCPTestStore(t)
+	if err := s.CreateSession("shared-session", "session-project", "/work/session-project"); err != nil {
+		t.Fatalf("create shared session: %v", err)
+	}
+	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))
+
+	res, err := h(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":      "shared sessions accept explicit projects",
+		"content":    "must write",
+		"type":       "manual",
+		"project":    "other-project",
+		"session_id": "shared-session",
+	}}})
+	if err != nil || res.IsError {
+		t.Fatalf("shared-session write: err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+	session, sessionErr := s.GetSession("shared-session")
+	if sessionErr != nil || session.Project != "session-project" || session.OwnershipMode != store.SessionOwnershipShared {
+		t.Fatalf("shared session after explicit write = %#v, err=%v", session, sessionErr)
+	}
+	obs, searchErr := s.Search("shared sessions accept explicit projects", store.SearchOptions{Project: "other-project", Limit: 5})
+	if searchErr != nil || len(obs) != 1 {
+		t.Fatalf("shared-session explicit write observations=%d err=%v, want 1", len(obs), searchErr)
 	}
 }
 
@@ -5662,7 +5715,7 @@ func TestMemSave_NonAmbiguousExplicitProjectStillFailsSessionMismatchWithStaleRe
 	t.Chdir(dir)
 
 	s := newMCPTestStore(t)
-	if err := s.CreateSession("stale-recovery-mismatch", "session-owned-project", "/work/session-owned-project"); err != nil {
+	if err := s.CreateSessionWithOwnershipMode("stale-recovery-mismatch", "session-owned-project", "/work/session-owned-project", store.SessionOwnershipProjectOwned); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
 	h := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -5665,6 +5665,114 @@ func TestMemSave_ExplicitProjectAllowsExistingSharedSession(t *testing.T) {
 	}
 }
 
+func TestMemSave_ExplicitProjectRejectsUnclassifiedSessionMismatchWithoutMutation(t *testing.T) {
+	dir := t.TempDir()
+	initTestGitRepo(t, dir)
+	t.Chdir(dir)
+
+	for _, tc := range []struct {
+		name string
+		mode any
+	}{
+		{name: "null mode", mode: nil},
+		{name: "blank mode", mode: " \t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newMCPTestStore(t)
+			const sessionID = "unclassified-explicit-session"
+			if _, err := s.DB().Exec(`INSERT INTO sessions (id, project, directory, ownership_mode) VALUES (?, ?, ?, ?)`, sessionID, "session-project", "/work/session-project", tc.mode); err != nil {
+				t.Fatalf("seed unclassified session: %v", err)
+			}
+			var observationsBefore, promptsBefore, mutationsBefore int
+			for table, target := range map[string]*int{
+				"observations":   &observationsBefore,
+				"user_prompts":   &promptsBefore,
+				"sync_mutations": &mutationsBefore,
+			} {
+				if err := s.DB().QueryRow(`SELECT count(*) FROM ` + table).Scan(target); err != nil {
+					t.Fatalf("count %s before mismatch: %v", table, err)
+				}
+			}
+
+			res, err := handleSave(s, MCPConfig{}, NewSessionActivity(10*time.Minute))(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+				"title":      "unclassified explicit mismatch",
+				"content":    "must not write",
+				"type":       "manual",
+				"project":    "other-project",
+				"session_id": sessionID,
+			}}})
+			if err != nil || !res.IsError {
+				t.Fatalf("explicit mismatch = err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+			}
+			if body := callResultJSON(t, res); body["error_code"] != "session_project_ownership_ambiguous" {
+				t.Fatalf("explicit mismatch envelope = %v", body)
+			}
+			var observationsAfter, promptsAfter, mutationsAfter int
+			for table, target := range map[string]*int{
+				"observations":   &observationsAfter,
+				"user_prompts":   &promptsAfter,
+				"sync_mutations": &mutationsAfter,
+			} {
+				if err := s.DB().QueryRow(`SELECT count(*) FROM ` + table).Scan(target); err != nil {
+					t.Fatalf("count %s after mismatch: %v", table, err)
+				}
+			}
+			if observationsAfter != observationsBefore || promptsAfter != promptsBefore || mutationsAfter != mutationsBefore {
+				t.Fatalf("explicit mismatch changed observations=%d prompts=%d mutations=%d; want %d %d %d", observationsAfter, promptsAfter, mutationsAfter, observationsBefore, promptsBefore, mutationsBefore)
+			}
+		})
+	}
+}
+
+func TestMemSave_AmbiguousRecoveryRejectsUnclassifiedSessionMismatch(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"recovery-project-a", "recovery-project-b"} {
+		child := filepath.Join(parent, name)
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initTestGitRepo(t, child)
+	}
+	t.Chdir(parent)
+
+	s := newMCPTestStore(t)
+	const sessionID = "unclassified-recovery-session"
+	if _, err := s.DB().Exec(`INSERT INTO sessions (id, project, directory, ownership_mode) VALUES (?, ?, ?, NULL)`, sessionID, "recovery-project-a", "/work/recovery-project-a"); err != nil {
+		t.Fatalf("seed unclassified session: %v", err)
+	}
+	activity := NewSessionActivity(10 * time.Minute)
+	token := activity.IssueAmbiguousProjectRecoveryToken(sessionID, []string{"recovery-project-a", "recovery-project-b"}, parent)
+
+	res, err := handleSave(s, MCPConfig{}, activity)(context.Background(), mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{
+		"title":                 "unclassified recovery mismatch",
+		"content":               "must not write",
+		"type":                  "manual",
+		"project":               "recovery-project-b",
+		"project_choice_reason": project.SourceUserSelectedAfterAmbiguousProject,
+		"recovery_token":        token,
+		"session_id":            sessionID,
+	}}})
+	if err != nil || !res.IsError {
+		t.Fatalf("ambiguous recovery mismatch = err=%v isError=%v text=%q", err, res.IsError, callResultText(t, res))
+	}
+	if body := callResultJSON(t, res); body["error_code"] != "session_project_ownership_ambiguous" {
+		t.Fatalf("ambiguous recovery mismatch envelope = %v", body)
+	}
+	var observations, prompts, mutations int
+	for table, target := range map[string]*int{
+		"observations":   &observations,
+		"user_prompts":   &prompts,
+		"sync_mutations": &mutations,
+	} {
+		if err := s.DB().QueryRow(`SELECT count(*) FROM ` + table).Scan(target); err != nil {
+			t.Fatalf("count %s after recovery mismatch: %v", table, err)
+		}
+	}
+	if observations != 0 || prompts != 0 || mutations != 0 {
+		t.Fatalf("ambiguous recovery mismatch wrote observations=%d prompts=%d mutations=%d", observations, prompts, mutations)
+	}
+}
+
 func TestMemSave_NonAmbiguousExplicitProjectIgnoresStaleRecoveryReason(t *testing.T) {
 	dir := t.TempDir()
 	initTestGitRepo(t, dir)

--- a/internal/store/session_ownership_test.go
+++ b/internal/store/session_ownership_test.go
@@ -134,6 +134,117 @@ func TestProjectOwnedSessionRejectsMismatchedPromptWithoutMutation(t *testing.T)
 	}
 }
 
+func TestUnclassifiedSessionRejectsMismatchedWritesWithoutMutation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode any
+	}{
+		{name: "null mode", mode: nil},
+		{name: "blank mode", mode: " \t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			const sessionID = "legacy-unclassified"
+			if _, err := s.DB().Exec(`INSERT INTO sessions (id, project, directory, ownership_mode) VALUES (?, ?, ?, ?)`, sessionID, "project-a", "/tmp/a", tc.mode); err != nil {
+				t.Fatalf("seed unclassified session: %v", err)
+			}
+
+			counts := func() (sessions, observations, prompts, mutations int) {
+				t.Helper()
+				for table, target := range map[string]*int{
+					"sessions":       &sessions,
+					"observations":   &observations,
+					"user_prompts":   &prompts,
+					"sync_mutations": &mutations,
+				} {
+					if err := s.DB().QueryRow(`SELECT count(*) FROM ` + table).Scan(target); err != nil {
+						t.Fatalf("count %s: %v", table, err)
+					}
+				}
+				return
+			}
+			sessionsBefore, observationsBefore, promptsBefore, mutationsBefore := counts()
+
+			if err := s.CreateSessionWithOwnershipMode(sessionID, "project-b", "/tmp/b", SessionOwnershipProjectOwned); !errors.Is(err, ErrProjectOwnershipAmbiguous) {
+				t.Fatalf("mismatched CreateSessionWithOwnershipMode error = %v, want ErrProjectOwnershipAmbiguous", err)
+			}
+			if _, err := s.AddObservation(AddObservationParams{SessionID: sessionID, Type: "manual", Title: "blocked", Content: "blocked", Project: "project-b", Scope: "project"}); !errors.Is(err, ErrProjectOwnershipAmbiguous) {
+				t.Fatalf("mismatched observation error = %v, want ErrProjectOwnershipAmbiguous", err)
+			}
+			if _, err := s.AddPrompt(AddPromptParams{SessionID: sessionID, Content: "blocked", Project: "project-b"}); !errors.Is(err, ErrProjectOwnershipAmbiguous) {
+				t.Fatalf("mismatched prompt error = %v, want ErrProjectOwnershipAmbiguous", err)
+			}
+			sessionsAfter, observationsAfter, promptsAfter, mutationsAfter := counts()
+			if sessionsAfter != sessionsBefore || observationsAfter != observationsBefore || promptsAfter != promptsBefore || mutationsAfter != mutationsBefore {
+				t.Fatalf("rejected mismatches changed sessions=%d observations=%d prompts=%d mutations=%d; want %d %d %d %d", sessionsAfter, observationsAfter, promptsAfter, mutationsAfter, sessionsBefore, observationsBefore, promptsBefore, mutationsBefore)
+			}
+
+			if _, err := s.AddObservation(AddObservationParams{SessionID: sessionID, Type: "manual", Title: "allowed", Content: "allowed", Project: "project-a", Scope: "project"}); err != nil {
+				t.Fatalf("same-project observation through unclassified session: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateSessionWithOwnershipModeClassifiesBlankLegacyMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode any
+	}{
+		{name: "null mode", mode: nil},
+		{name: "blank mode", mode: " \t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			const sessionID = "legacy-blank-mode"
+			if _, err := s.DB().Exec(`INSERT INTO sessions (id, project, directory, ownership_mode) VALUES (?, ?, ?, ?)`, sessionID, "project-a", "/tmp/a", tc.mode); err != nil {
+				t.Fatalf("seed blank-mode session: %v", err)
+			}
+
+			if err := s.CreateSessionWithOwnershipMode(sessionID, "project-a", "/tmp/a", SessionOwnershipProjectOwned); err != nil {
+				t.Fatalf("classify blank legacy mode: %v", err)
+			}
+			session, err := s.GetSession(sessionID)
+			if err != nil || session.OwnershipMode != SessionOwnershipProjectOwned {
+				t.Fatalf("classified session = %#v, %v; want project-owned", session, err)
+			}
+		})
+	}
+}
+
+func TestStartSessionRejectsUnclassifiedProjectMismatchWithoutMutation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode any
+	}{
+		{name: "null mode", mode: nil},
+		{name: "blank mode", mode: " \t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			const sessionID = "legacy-start-unclassified"
+			if _, err := s.DB().Exec(`INSERT INTO sessions (id, project, directory, ownership_mode) VALUES (?, ?, ?, ?)`, sessionID, "project-a", "/tmp/a", tc.mode); err != nil {
+				t.Fatalf("seed unclassified session: %v", err)
+			}
+			var mutationsBefore int
+			if err := s.DB().QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+				t.Fatalf("count mutations before mismatch: %v", err)
+			}
+
+			if err := s.StartSession(sessionID, "project-b", "/tmp/b"); !errors.Is(err, ErrProjectOwnershipAmbiguous) {
+				t.Fatalf("mismatched StartSession error = %v, want ErrProjectOwnershipAmbiguous", err)
+			}
+			var mutationsAfter int
+			if err := s.DB().QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+				t.Fatalf("count mutations after mismatch: %v", err)
+			}
+			if mutationsAfter != mutationsBefore {
+				t.Fatalf("mismatched StartSession changed mutations from %d to %d", mutationsBefore, mutationsAfter)
+			}
+		})
+	}
+}
+
 func TestSharedSessionAllowsCrossProjectWrites(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.CreateSession("runtime-session", "project-a", "/tmp/a"); err != nil {

--- a/internal/store/session_ownership_test.go
+++ b/internal/store/session_ownership_test.go
@@ -95,6 +95,59 @@ func TestProjectOwnedSessionRejectsMismatchedWriteWithoutMutation(t *testing.T) 
 	}
 }
 
+func TestProjectOwnedSessionRejectsMismatchedPromptWithoutMutation(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSessionWithOwnershipMode("manual-save-project-a", "project-a", "/tmp/a", SessionOwnershipProjectOwned); err != nil {
+		t.Fatalf("create project-owned session: %v", err)
+	}
+
+	var observationsBefore, promptsBefore, mutationsBefore int
+	if err := s.DB().QueryRow(`SELECT count(*) FROM observations`).Scan(&observationsBefore); err != nil {
+		t.Fatalf("count observations before mismatch: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT count(*) FROM user_prompts`).Scan(&promptsBefore); err != nil {
+		t.Fatalf("count prompts before mismatch: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count mutations before mismatch: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "manual-save-project-a", Content: "blocked", Project: "project-b"}); !errors.Is(err, ErrSessionOwnershipMismatch) {
+		t.Fatalf("mismatched prompt error = %v, want ErrSessionOwnershipMismatch", err)
+	}
+
+	var observationsAfter, promptsAfter, mutationsAfter int
+	if err := s.DB().QueryRow(`SELECT count(*) FROM observations`).Scan(&observationsAfter); err != nil {
+		t.Fatalf("count observations after mismatch: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT count(*) FROM user_prompts`).Scan(&promptsAfter); err != nil {
+		t.Fatalf("count prompts after mismatch: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT count(*) FROM sync_mutations`).Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count mutations after mismatch: %v", err)
+	}
+	if observationsAfter != observationsBefore || promptsAfter != promptsBefore || mutationsAfter != mutationsBefore {
+		t.Fatalf("mismatched prompt wrote observations=%d prompts=%d mutations=%d, want observations=%d prompts=%d mutations=%d", observationsAfter, promptsAfter, mutationsAfter, observationsBefore, promptsBefore, mutationsBefore)
+	}
+	session, err := s.GetSession("manual-save-project-a")
+	if err != nil || session.Project != "project-a" || session.OwnershipMode != SessionOwnershipProjectOwned {
+		t.Fatalf("session after mismatched prompt = %#v, %v", session, err)
+	}
+}
+
+func TestSharedSessionAllowsCrossProjectWrites(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("runtime-session", "project-a", "/tmp/a"); err != nil {
+		t.Fatalf("create shared session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{SessionID: "runtime-session", Type: "manual", Title: "Cross-project write", Content: "content", Project: "project-b", Scope: "project"}); err != nil {
+		t.Fatalf("cross-project write through shared session: %v", err)
+	}
+	session, err := s.GetSession("runtime-session")
+	if err != nil || session.Project != "project-a" || session.OwnershipMode != SessionOwnershipShared {
+		t.Fatalf("shared session after cross-project write = %#v, %v", session, err)
+	}
+}
+
 func TestImportedLegacyModeDoesNotDowngradeProjectOwnedSession(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.CreateSessionWithOwnershipMode("manual-save-project-a", "project-a", "/tmp/a", SessionOwnershipProjectOwned); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2497,8 +2497,10 @@ func (s *Store) CreateSessionWithOwnershipMode(id, project, directory, mode stri
 		if err != nil {
 			return err
 		}
-		if found && existingMode == SessionOwnershipProjectOwned && existingProject != "" && existingProject != project {
-			return fmt.Errorf("%w: session %q belongs to %q, not %q", ErrSessionOwnershipMismatch, id, existingProject, project)
+		if found {
+			if err := sessionProjectWriteError(id, existingProject, existingMode, project); err != nil {
+				return err
+			}
 		}
 		if err := s.createSessionTx(tx, id, project, directory, mode); err != nil {
 			return err
@@ -2537,6 +2539,22 @@ func (s *Store) StartSession(id, project, directory string) error {
 	}
 
 	return s.withTx(func(tx *sql.Tx) error {
+		ended, err := sessionEndedTx(tx, id)
+		if err != nil {
+			return err
+		}
+		if ended {
+			return ErrSessionAlreadyEnded
+		}
+		existingProject, existingMode, found, err := sessionOwnershipTx(tx, id)
+		if err != nil {
+			return err
+		}
+		if found {
+			if err := sessionProjectWriteError(id, existingProject, existingMode, project); err != nil {
+				return err
+			}
+		}
 		if err := s.startSessionTx(tx, id, project, directory, SessionOwnershipShared); err != nil {
 			return err
 		}
@@ -6914,10 +6932,10 @@ func (s *Store) createSessionTx(tx *sql.Tx, id, project, directory, mode string)
 	_, err := s.execHook(tx,
 		`INSERT INTO sessions (id, project, ownership_mode, directory) VALUES (?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
-			   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
-		   ownership_mode = CASE WHEN sessions.ownership_mode IS NULL THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
+		   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
+		   ownership_mode = CASE WHEN ifnull(trim(sessions.ownership_mode, ?), '') = '' THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
 		   directory = CASE WHEN sessions.directory = '' THEN excluded.directory ELSE sessions.directory END`,
-		id, project, mode, directory, sqlWhitespaceTrimSet,
+		id, project, mode, directory, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet,
 	)
 	return err
 }
@@ -6926,11 +6944,11 @@ func (s *Store) startSessionTx(tx *sql.Tx, id, project, directory, mode string) 
 	result, err := s.execHook(tx,
 		`INSERT INTO sessions (id, project, ownership_mode, directory) VALUES (?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
-			   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
-		   ownership_mode = CASE WHEN sessions.ownership_mode IS NULL THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
+		   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
+		   ownership_mode = CASE WHEN ifnull(trim(sessions.ownership_mode, ?), '') = '' THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
 		   directory = CASE WHEN sessions.directory = '' THEN excluded.directory ELSE sessions.directory END
 		 WHERE sessions.ended_at IS NULL`,
-		id, project, mode, directory, sqlWhitespaceTrimSet,
+		id, project, mode, directory, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet,
 	)
 	if err != nil {
 		return err
@@ -7842,6 +7860,28 @@ func sessionOwnershipTx(tx *sql.Tx, sessionID string) (project, mode string, fou
 	return normalized, strings.TrimSpace(rawMode.String), true, nil
 }
 
+func sessionEndedTx(tx *sql.Tx, sessionID string) (bool, error) {
+	var endedAt sql.NullString
+	err := tx.QueryRow(`SELECT ended_at FROM sessions WHERE id = ?`, sessionID).Scan(&endedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return endedAt.Valid, nil
+}
+
+func sessionProjectWriteError(sessionID, sessionProject, mode, requested string) error {
+	if sessionProject == "" || sessionProject == requested || mode == SessionOwnershipShared {
+		return nil
+	}
+	if mode == SessionOwnershipProjectOwned {
+		return fmt.Errorf("%w: session %q belongs to %q, not %q", ErrSessionOwnershipMismatch, sessionID, sessionProject, requested)
+	}
+	return fmt.Errorf("%w: session %q has unclassified ownership for %q and cannot accept %q", ErrProjectOwnershipAmbiguous, sessionID, sessionProject, requested)
+}
+
 // foreignRecordOwnerTx returns the first project, other than exclude, that owns
 // a record parented by this session. It is how a would-be adoption discovers it
 // would split an existing record away from its session. kind reads as a noun
@@ -7914,8 +7954,8 @@ func (s *Store) resolveWriteProjectTx(tx *sql.Tx, sessionID, requested string) (
 		}
 		return sessionProject, nil
 	}
-	if mode == SessionOwnershipProjectOwned && sessionProject != "" && sessionProject != requested {
-		return "", fmt.Errorf("%w: session %q belongs to %q, not %q", ErrSessionOwnershipMismatch, sessionID, sessionProject, requested)
+	if err := sessionProjectWriteError(sessionID, sessionProject, mode, requested); err != nil {
+		return "", err
 	}
 
 	// The session already agrees, or does not exist yet (callers create it

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2493,6 +2493,13 @@ func (s *Store) CreateSessionWithOwnershipMode(id, project, directory, mode stri
 	}
 
 	return s.withTx(func(tx *sql.Tx) error {
+		existingProject, existingMode, found, err := sessionOwnershipTx(tx, id)
+		if err != nil {
+			return err
+		}
+		if found && existingMode == SessionOwnershipProjectOwned && existingProject != "" && existingProject != project {
+			return fmt.Errorf("%w: session %q belongs to %q, not %q", ErrSessionOwnershipMismatch, id, existingProject, project)
+		}
 		if err := s.createSessionTx(tx, id, project, directory, mode); err != nil {
 			return err
 		}
@@ -6907,10 +6914,10 @@ func (s *Store) createSessionTx(tx *sql.Tx, id, project, directory, mode string)
 	_, err := s.execHook(tx,
 		`INSERT INTO sessions (id, project, ownership_mode, directory) VALUES (?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
-		   project   = CASE WHEN sessions.project = '' THEN excluded.project ELSE sessions.project END,
+			   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
 		   ownership_mode = CASE WHEN sessions.ownership_mode IS NULL THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
 		   directory = CASE WHEN sessions.directory = '' THEN excluded.directory ELSE sessions.directory END`,
-		id, project, mode, directory,
+		id, project, mode, directory, sqlWhitespaceTrimSet,
 	)
 	return err
 }
@@ -6919,11 +6926,11 @@ func (s *Store) startSessionTx(tx *sql.Tx, id, project, directory, mode string) 
 	result, err := s.execHook(tx,
 		`INSERT INTO sessions (id, project, ownership_mode, directory) VALUES (?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
-		   project   = CASE WHEN sessions.project = '' THEN excluded.project ELSE sessions.project END,
+			   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
 		   ownership_mode = CASE WHEN sessions.ownership_mode IS NULL THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
 		   directory = CASE WHEN sessions.directory = '' THEN excluded.directory ELSE sessions.directory END
 		 WHERE sessions.ended_at IS NULL`,
-		id, project, mode, directory,
+		id, project, mode, directory, sqlWhitespaceTrimSet,
 	)
 	if err != nil {
 		return err
@@ -7907,7 +7914,7 @@ func (s *Store) resolveWriteProjectTx(tx *sql.Tx, sessionID, requested string) (
 		}
 		return sessionProject, nil
 	}
-	if mode == SessionOwnershipProjectOwned && sessionProject != requested {
+	if mode == SessionOwnershipProjectOwned && sessionProject != "" && sessionProject != requested {
 		return "", fmt.Errorf("%w: session %q belongs to %q, not %q", ErrSessionOwnershipMismatch, sessionID, sessionProject, requested)
 	}
 
@@ -7917,8 +7924,7 @@ func (s *Store) resolveWriteProjectTx(tx *sql.Tx, sessionID, requested string) (
 		return requested, nil
 	}
 	if sessionProject != "" {
-		// An owned session keeps its ownership; the caller decides whether a
-		// mismatch is an error. This preserves existing behavior.
+		// Shared sessions deliberately accept writes for multiple projects.
 		return requested, nil
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -163,7 +163,7 @@ func TestProjectIdentityAdmissionRejectsNullableLegacySessionProjects(t *testing
 	type legacySession struct{ id, project string }
 	s := newTestStoreWithNullableLegacySessions(t,
 		legacySession{"null-session", "<NULL>"},
-		legacySession{"blank-session", " "},
+		legacySession{"blank-session", " \t"},
 	)
 
 	tests := []struct {
@@ -278,6 +278,106 @@ func TestProjectIdentityAdmissionAllowsOwnedWritesAndRejectsReassignment(t *test
 	}
 	if mutations != 2 {
 		t.Fatalf("sync mutations = %d, want 2", mutations)
+	}
+}
+
+func TestCreateProjectOwnedSessionRejectsMismatchWithoutMutation(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSessionWithOwnershipMode("owned-session", "alpha", "/tmp/alpha", SessionOwnershipProjectOwned); err != nil {
+		t.Fatalf("create owned session: %v", err)
+	}
+
+	var mutationsBefore int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM sync_mutations").Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count initial mutations: %v", err)
+	}
+	if err := s.CreateSessionWithOwnershipMode("owned-session", "beta", "/tmp/beta", SessionOwnershipProjectOwned); !errors.Is(err, ErrSessionOwnershipMismatch) {
+		t.Fatalf("CreateSessionWithOwnershipMode error = %v, want ErrSessionOwnershipMismatch", err)
+	}
+
+	session, err := s.GetSession("owned-session")
+	if err != nil {
+		t.Fatalf("get owned session: %v", err)
+	}
+	if session.Project != "alpha" || session.OwnershipMode != SessionOwnershipProjectOwned {
+		t.Fatalf("session = %#v, want project alpha and project-owned mode", session)
+	}
+	var observations, prompts, mutationsAfter int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM observations").Scan(&observations); err != nil {
+		t.Fatalf("count observations: %v", err)
+	}
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM user_prompts").Scan(&prompts); err != nil {
+		t.Fatalf("count prompts: %v", err)
+	}
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM sync_mutations").Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count mutations: %v", err)
+	}
+	if observations != 0 || prompts != 0 || mutationsAfter != mutationsBefore {
+		t.Fatalf("mismatch persisted observations=%d prompts=%d mutations=%d, want observations=0 prompts=0 mutations=%d", observations, prompts, mutationsAfter, mutationsBefore)
+	}
+
+	if err := s.CreateSessionWithOwnershipMode("owned-session", "ALPHA", "/tmp/alpha", SessionOwnershipProjectOwned); err != nil {
+		t.Fatalf("matching normalized project should succeed: %v", err)
+	}
+}
+
+func TestCreateProjectOwnedSessionAdoptsLegacyUnownedProject(t *testing.T) {
+	type legacySession struct{ id, project string }
+	s := newTestStoreWithNullableLegacySessions(t,
+		legacySession{"null-session", "<NULL>"},
+		legacySession{"empty-session", ""},
+		legacySession{"blank-session", " "},
+	)
+
+	for _, sessionID := range []string{"null-session", "empty-session", "blank-session"} {
+		t.Run(sessionID, func(t *testing.T) {
+			if err := s.CreateSessionWithOwnershipMode(sessionID, "target", "/tmp/target", SessionOwnershipProjectOwned); err != nil {
+				t.Fatalf("CreateSessionWithOwnershipMode: %v", err)
+			}
+			session, err := s.GetSession(sessionID)
+			if err != nil {
+				t.Fatalf("get adopted session: %v", err)
+			}
+			if session.Project != "target" || session.OwnershipMode != SessionOwnershipProjectOwned {
+				t.Fatalf("session = %#v, want project target and project-owned mode", session)
+			}
+		})
+	}
+}
+
+func TestAddObservationRejectsProjectOwnedSessionMismatchWithoutMutation(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSessionWithOwnershipMode("owned-session", "alpha", "/tmp/alpha", SessionOwnershipProjectOwned); err != nil {
+		t.Fatalf("create owned session: %v", err)
+	}
+
+	var mutationsBefore int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM sync_mutations").Scan(&mutationsBefore); err != nil {
+		t.Fatalf("count initial mutations: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{SessionID: "owned-session", Type: "note", Title: "mismatch", Content: "must not persist", Project: "beta"}); !errors.Is(err, ErrSessionOwnershipMismatch) {
+		t.Fatalf("AddObservation error = %v, want ErrSessionOwnershipMismatch", err)
+	}
+
+	session, err := s.GetSession("owned-session")
+	if err != nil {
+		t.Fatalf("get owned session: %v", err)
+	}
+	if session.Project != "alpha" || session.OwnershipMode != SessionOwnershipProjectOwned {
+		t.Fatalf("session = %#v, want project alpha and project-owned mode", session)
+	}
+	var observations, prompts, mutationsAfter int
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM observations").Scan(&observations); err != nil {
+		t.Fatalf("count observations: %v", err)
+	}
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM user_prompts").Scan(&prompts); err != nil {
+		t.Fatalf("count prompts: %v", err)
+	}
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM sync_mutations").Scan(&mutationsAfter); err != nil {
+		t.Fatalf("count mutations: %v", err)
+	}
+	if observations != 0 || prompts != 0 || mutationsAfter != mutationsBefore {
+		t.Fatalf("mismatch persisted observations=%d prompts=%d mutations=%d, want observations=0 prompts=0 mutations=%d", observations, prompts, mutationsAfter, mutationsBefore)
 	}
 }
 
@@ -1687,29 +1787,18 @@ func TestFormatCompactionContextIsSessionScoped(t *testing.T) {
 	addObservation("session-a", "recent-a", "recent-content-a", false)
 	addObservation("session-b", "pinned-b", "pinned-content-b", true)
 	addObservation("session-b", "recent-b", "recent-content-b", false)
-	if _, err := s.AddObservation(AddObservationParams{
-		SessionID: "session-a",
-		Type:      "decision",
-		Title:     "foreign-project-observation",
-		Content:   "must-not-appear",
-		Project:   "foreign",
-		Scope:     "project",
-	}); err != nil {
-		t.Fatalf("add foreign-project observation: %v", err)
-	}
+	seedForeignOwnedObservation(t, s, "session-a", "foreign", "foreign-project-observation")
 
 	for _, prompt := range []struct{ sessionID, content string }{
 		{"session-a", "prompt-a"},
 		{"session-b", "prompt-b"},
-		{"session-a", "foreign-project-prompt"},
 	} {
-		project := "engram"
-		if prompt.content == "foreign-project-prompt" {
-			project = "foreign"
-		}
-		if _, err := s.AddPrompt(AddPromptParams{SessionID: prompt.sessionID, Content: prompt.content, Project: project}); err != nil {
+		if _, err := s.AddPrompt(AddPromptParams{SessionID: prompt.sessionID, Content: prompt.content, Project: "engram"}); err != nil {
 			t.Fatalf("add %s: %v", prompt.content, err)
 		}
+	}
+	if _, err := s.db.Exec(`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES (?, ?, ?, ?)`, newSyncID("prompt"), "session-a", "foreign-project-prompt", "foreign"); err != nil {
+		t.Fatalf("seed foreign-project prompt: %v", err)
 	}
 
 	for _, tc := range []struct {
@@ -2124,6 +2213,9 @@ func TestTopicKeyUpsertIsScopedByProjectAndScope(t *testing.T) {
 	if err := s.CreateSession("s1", "engram", "/tmp/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
+	if err := s.CreateSession("s2", "another-project", "/tmp/another-project"); err != nil {
+		t.Fatalf("create other-project session: %v", err)
+	}
 
 	baseID, err := s.AddObservation(AddObservationParams{
 		SessionID: "s1",
@@ -2152,7 +2244,7 @@ func TestTopicKeyUpsertIsScopedByProjectAndScope(t *testing.T) {
 	}
 
 	otherProjectID, err := s.AddObservation(AddObservationParams{
-		SessionID: "s1",
+		SessionID: "s2",
 		Type:      "architecture",
 		Title:     "Auth model",
 		Content:   "Other project",
@@ -2266,23 +2358,9 @@ func TestExportProjectPreservesSessionReferentialClosure(t *testing.T) {
 		t.Fatalf("create session proj-b: %v", err)
 	}
 
-	if _, err := s.AddObservation(AddObservationParams{
-		SessionID: "sess-owned-by-proj-b",
-		Type:      "note",
-		Title:     "cross-project obs",
-		Content:   "observation references proj-b session",
-		Project:   "proj-a",
-		Scope:     "project",
-	}); err != nil {
-		t.Fatalf("add cross-project observation: %v", err)
-	}
-
-	if _, err := s.AddPrompt(AddPromptParams{
-		SessionID: "sess-owned-by-proj-b",
-		Content:   "cross-project prompt",
-		Project:   "proj-a",
-	}); err != nil {
-		t.Fatalf("add cross-project prompt: %v", err)
+	seedForeignOwnedObservation(t, s, "sess-owned-by-proj-b", "proj-a", "cross-project obs")
+	if _, err := s.db.Exec(`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES (?, ?, ?, ?)`, newSyncID("prompt"), "sess-owned-by-proj-b", "cross-project prompt", "proj-a"); err != nil {
+		t.Fatalf("seed cross-project prompt: %v", err)
 	}
 
 	exported, err := s.ExportProject("proj-a")
@@ -2325,23 +2403,9 @@ func TestExportProjectDoesNotLeakRowsOwnedByOtherProjectsViaSessionMembership(t 
 		t.Fatalf("create session proj-a: %v", err)
 	}
 
-	if _, err := s.AddObservation(AddObservationParams{
-		SessionID: "sess-proj-a",
-		Type:      "note",
-		Title:     "owned-by-proj-b",
-		Content:   "should not leak in proj-a export",
-		Project:   "proj-b",
-		Scope:     "project",
-	}); err != nil {
-		t.Fatalf("add cross-owned observation: %v", err)
-	}
-
-	if _, err := s.AddPrompt(AddPromptParams{
-		SessionID: "sess-proj-a",
-		Content:   "prompt owned by proj-b",
-		Project:   "proj-b",
-	}); err != nil {
-		t.Fatalf("add cross-owned prompt: %v", err)
+	seedForeignOwnedObservation(t, s, "sess-proj-a", "proj-b", "owned-by-proj-b")
+	if _, err := s.db.Exec(`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES (?, ?, ?, ?)`, newSyncID("prompt"), "sess-proj-a", "prompt owned by proj-b", "proj-b"); err != nil {
+		t.Fatalf("seed cross-owned prompt: %v", err)
 	}
 
 	if _, err := s.AddObservation(AddObservationParams{
@@ -4805,6 +4869,12 @@ func TestStoreAdditionalQueryAndMutationBranches(t *testing.T) {
 	if err := s.CreateSession("s-q", "engram", "/tmp/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
+	if err := s.CreateSession("s-q-alpha", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("create alpha session: %v", err)
+	}
+	if err := s.CreateSession("s-q-beta", "beta", "/tmp/beta"); err != nil {
+		t.Fatalf("create beta session: %v", err)
+	}
 
 	longContent := strings.Repeat("x", s.cfg.MaxObservationLength+100)
 	obsID, err := s.AddObservation(AddObservationParams{
@@ -4845,10 +4915,10 @@ func TestStoreAdditionalQueryAndMutationBranches(t *testing.T) {
 		t.Fatalf("expected nil topic key after empty update")
 	}
 
-	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-q", Content: "alpha prompt", Project: "alpha"}); err != nil {
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-q-alpha", Content: "alpha prompt", Project: "alpha"}); err != nil {
 		t.Fatalf("add alpha prompt: %v", err)
 	}
-	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-q", Content: "beta prompt", Project: "beta"}); err != nil {
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-q-beta", Content: "beta prompt", Project: "beta"}); err != nil {
 		t.Fatalf("add beta prompt: %v", err)
 	}
 
@@ -6697,7 +6767,7 @@ func TestCreateSessionMutationUsesPersistedCanonicalData(t *testing.T) {
 	if err := s.CreateSession("canonical-session", "engram", "/canonical"); err != nil {
 		t.Fatalf("initial CreateSession: %v", err)
 	}
-	if err := s.CreateSession("canonical-session", "other", "/stale"); err != nil {
+	if err := s.CreateSession("canonical-session", "ENGRAM", "/stale"); err != nil {
 		t.Fatalf("idempotent CreateSession: %v", err)
 	}
 	var raw string
@@ -6736,6 +6806,30 @@ func TestStartSessionCreatesAndIdempotentlyStartsActiveSession(t *testing.T) {
 	}
 	if mutations != 2 {
 		t.Fatalf("session mutations = %d, want 2 for two valid starts", mutations)
+	}
+}
+
+func TestStartSessionAdoptsLegacyUnownedProject(t *testing.T) {
+	type legacySession struct{ id, project string }
+	s := newTestStoreWithNullableLegacySessions(t,
+		legacySession{"null-start-session", "<NULL>"},
+		legacySession{"empty-start-session", ""},
+		legacySession{"blank-start-session", " \t"},
+	)
+
+	for _, sessionID := range []string{"null-start-session", "empty-start-session", "blank-start-session"} {
+		t.Run(sessionID, func(t *testing.T) {
+			if err := s.StartSession(sessionID, "target", "/tmp/target"); err != nil {
+				t.Fatalf("StartSession: %v", err)
+			}
+			session, err := s.GetSession(sessionID)
+			if err != nil {
+				t.Fatalf("get adopted session: %v", err)
+			}
+			if session.Project != "target" || session.OwnershipMode != SessionOwnershipShared {
+				t.Fatalf("session = %#v, want project target and shared mode", session)
+			}
+		})
 	}
 }
 
@@ -7379,8 +7473,8 @@ func TestCreateSessionDoesNotOverwriteExistingProject(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 
-	// Second call with project B should NOT overwrite
-	if err := s.CreateSession("sess-preserve", "projectB", "/tmp/b"); err != nil {
+	// A matching normalized project must not overwrite persisted session data.
+	if err := s.CreateSession("sess-preserve", "PROJECTA", "/tmp/b"); err != nil {
 		t.Fatalf("upsert session: %v", err)
 	}
 
@@ -7404,8 +7498,8 @@ func TestCreateSessionPartialUpsert(t *testing.T) {
 		if err := s.CreateSession("sess-partial-1", "myproject", ""); err != nil {
 			t.Fatalf("create: %v", err)
 		}
-		// Second call fills directory but project stays
-		if err := s.CreateSession("sess-partial-1", "other", "/new/dir"); err != nil {
+		// A matching project fills the missing directory.
+		if err := s.CreateSession("sess-partial-1", "MYPROJECT", "/new/dir"); err != nil {
 			t.Fatalf("upsert: %v", err)
 		}
 		sess, err := s.GetSession("sess-partial-1")
@@ -9056,10 +9150,20 @@ func TestListProjectNames(t *testing.T) {
 	if err := s.CreateSession("s2", "beta", "/tmp"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
+	if err := s.CreateSession("s3", "gamma", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
 
 	for _, project := range []string{"alpha", "alpha", "beta", "gamma"} {
+		sessionID := "s1"
+		if project == "beta" {
+			sessionID = "s2"
+		}
+		if project == "gamma" {
+			sessionID = "s3"
+		}
 		if _, err := s.AddObservation(AddObservationParams{
-			SessionID: "s1",
+			SessionID: sessionID,
 			Type:      "decision",
 			Title:     "test " + project,
 			Content:   "content for " + project,
@@ -12106,6 +12210,9 @@ func TestObservationsNeedingReview(t *testing.T) {
 	if err := s.CreateSession("review-sess", "review-proj", "/tmp/review"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
+	if err := s.CreateSession("other-review-sess", "other-proj", "/tmp/other"); err != nil {
+		t.Fatalf("CreateSession other project: %v", err)
+	}
 
 	staleID, err := s.AddObservation(AddObservationParams{SessionID: "review-sess", Type: "decision", Title: "stale", Content: "stale content", Project: "review-proj"})
 	if err != nil {
@@ -12115,7 +12222,7 @@ func TestObservationsNeedingReview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("add future: %v", err)
 	}
-	otherID, err := s.AddObservation(AddObservationParams{SessionID: "review-sess", Type: "decision", Title: "other", Content: "other content", Project: "other-proj"})
+	otherID, err := s.AddObservation(AddObservationParams{SessionID: "other-review-sess", Type: "decision", Title: "other", Content: "other content", Project: "other-proj"})
 	if err != nil {
 		t.Fatalf("add other: %v", err)
 	}
@@ -12669,19 +12776,17 @@ func TestDeleteProjectPreservesCrossProjectObservationSession(t *testing.T) {
 	if err := s.CreateSession("s-del-proj-cross-obs", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	for _, project := range []string{"alpha", "beta"} {
-		_, err := s.AddObservation(AddObservationParams{
-			SessionID: "s-del-proj-cross-obs",
-			Type:      "decision",
-			Title:     project + " observation",
-			Content:   project + " content",
-			Project:   project,
-			Scope:     "project",
-		})
-		if err != nil {
-			t.Fatalf("add %s observation: %v", project, err)
-		}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-del-proj-cross-obs",
+		Type:      "decision",
+		Title:     "alpha observation",
+		Content:   "alpha content",
+		Project:   "alpha",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add alpha observation: %v", err)
 	}
+	seedForeignOwnedObservation(t, s, "s-del-proj-cross-obs", "beta", "beta observation")
 
 	if _, err := s.DeleteProject("alpha", true); err != nil {
 		t.Fatalf("DeleteProject: %v", err)
@@ -12708,14 +12813,15 @@ func TestDeleteProjectPreservesCrossProjectPromptSession(t *testing.T) {
 	if err := s.CreateSession("s-del-proj-cross-prompt", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	for _, project := range []string{"alpha", "beta"} {
-		if _, err := s.AddPrompt(AddPromptParams{
-			SessionID: "s-del-proj-cross-prompt",
-			Content:   project + " prompt",
-			Project:   project,
-		}); err != nil {
-			t.Fatalf("add %s prompt: %v", project, err)
-		}
+	if _, err := s.AddPrompt(AddPromptParams{
+		SessionID: "s-del-proj-cross-prompt",
+		Content:   "alpha prompt",
+		Project:   "alpha",
+	}); err != nil {
+		t.Fatalf("add alpha prompt: %v", err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES (?, ?, ?, ?)`, newSyncID("prompt"), "s-del-proj-cross-prompt", "beta prompt", "beta"); err != nil {
+		t.Fatalf("seed beta prompt: %v", err)
 	}
 
 	if _, err := s.DeleteProject("alpha", true); err != nil {


### PR DESCRIPTION
## Summary

- Reject project reassignment for existing `project_owned` sessions before any observation, prompt, session, or sync mutation is written.
- Treat legacy sessions with a non-empty project and unknown ownership mode as ambiguous instead of silently treating them as shared.
- Preserve cross-project writes for explicitly `shared` runtime sessions and safely adopt legacy sessions whose project is null, empty, or whitespace-only.
- Make MCP project resolution ownership-aware and add mutation-free regression coverage for explicit and recovery flows.

## Related Issue

Closes #712

## Changes

### Primary File

- `internal/store/store.go` — enforce the ownership boundary during session creation, session start, and write-project resolution; safely classify compatible blank modes and preserve legacy project adoption.

### Supporting Files

- `internal/mcp/mcp.go` — keep implicit sessions shared, reject unclassified cross-project resolution, and return an actionable ambiguity envelope.
- `internal/store/store_test.go` — cover create/write mismatch rejection, no-mutation guarantees, and legacy adoption.
- `internal/store/session_ownership_test.go` — cover unknown-mode fail-closed behavior, prompt rejection, shared-session writes, and mode classification.
- `internal/mcp/mcp_test.go` — cover mode-aware MCP writes plus explicit and recovery rejection without mutation.

## Testing

- [x] `go test -json -count=1 -timeout 10m ./internal/store`
- [x] `go test -json -count=1 -timeout 10m ./internal/mcp`
- [x] `go test -count=1 -timeout 15m -tags e2e ./internal/server/...`
- [ ] `go test -count=1 -timeout 15m ./...` — six pre-existing Windows failures in `internal/setup/TestWriteClaudeCodeUserMCP`; reproduced unchanged on clean `main` at `3bf63fa`.
- [x] GitHub CI passed on the initial commit; checks rerun after the review correction.

## Review

- Addressed the CodeRabbit finding by failing closed for NULL, blank, or unknown ownership modes when the stored and requested projects differ.
- Native four-lens review approved the exact correction tree before delivery.
- The current commit tree matches the reviewed candidate: `8377b3a68dee3227b44e33453619789e0c0772bc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shared sessions can now support writes associated with different projects without changing session ownership.
  * Project-owned sessions correctly reject writes or prompts associated with another project, while preserving existing data and synchronization state.
  * Legacy sessions with incomplete project information are correctly associated with the applicable project.
  * Project-scoped operations, including cleanup and exports, now maintain stronger isolation between projects.
  * Sessions with unclear ownership now return a structured error and recovery guidance instead of allowing ambiguous cross-project writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->