### PR TITLE
fix(tui): bound observation detail scrolling

### DIFF
--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -20,6 +20,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
 		m.Height = msg.Height
+		m = m.clampViewport()
 		return m, nil
 
 	case tea.KeyMsg:
@@ -544,13 +545,16 @@ func (m Model) handleRecentKeys(key string) (tea.Model, tea.Cmd) {
 // ─── Observation Detail ──────────────────────────────────────────────────────
 
 func (m Model) handleObservationDetailKeys(key string) (tea.Model, tea.Cmd) {
+	m.DetailScroll = m.clampDetailScroll()
 	switch key {
 	case "up", "k":
 		if m.DetailScroll > 0 {
 			m.DetailScroll--
 		}
 	case "down", "j":
-		m.DetailScroll++
+		if m.DetailScroll < m.observationDetailMaxScroll() {
+			m.DetailScroll++
+		}
 	case "c":
 		if m.SelectedObservation != nil {
 			return m, copyToClipboard(m.SelectedObservation.Content)
@@ -701,6 +705,14 @@ func (m Model) handleSessionDetailKeys(key string) (tea.Model, tea.Cmd) {
 		return m, loadRecentSessions(m.store)
 	}
 	return m, nil
+}
+
+func (m Model) clampViewport() Model {
+	switch m.Screen {
+	case ScreenObservationDetail:
+		m.DetailScroll = m.clampDetailScroll()
+	}
+	return m
 }
 
 // ─── Setup ───────────────────────────────────────────────────────────────────

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -930,8 +930,8 @@ func TestHandleSearchResultsAndObservationDetailRemainingBranches(t *testing.T) 
 	m.SelectedObservation = &store.Observation{ID: 5}
 	updatedModel, _ = m.handleObservationDetailKeys("down")
 	updated = updatedModel.(Model)
-	if updated.DetailScroll != 1 {
-		t.Fatal("down should increase detail scroll")
+	if updated.DetailScroll != 0 {
+		t.Fatal("detail scroll should stay at zero without an available viewport")
 	}
 	updatedModel, _ = updated.handleObservationDetailKeys("up")
 	if updatedModel.(Model).DetailScroll != 0 {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -412,92 +412,20 @@ func (m Model) viewRecent() string {
 // ─── Observation Detail ──────────────────────────────────────────────────────
 
 func (m Model) viewObservationDetail() string {
-	var b strings.Builder
-
 	if m.SelectedObservation == nil {
+		var b strings.Builder
 		b.WriteString(headerStyle.Render("  Observation Detail"))
 		b.WriteString("\n")
 		b.WriteString(noResultsStyle.Render("Loading..."))
 		return b.String()
 	}
 
-	obs := m.SelectedObservation
+	contentLines := m.observationDetailContentLines()
+	maxLines := m.observationDetailViewport()
+	m.DetailScroll = m.clampDetailScroll()
 
-	header := fmt.Sprintf("  Observation #%d", obs.ID)
-	b.WriteString(headerStyle.Render(header))
-	b.WriteString("\n")
-
-	// Metadata rows
-	b.WriteString(fmt.Sprintf("%s %s\n",
-		detailLabelStyle.Render("Type:"),
-		typeBadgeStyle.Render(obs.Type)))
-
-	b.WriteString(fmt.Sprintf("%s %s\n",
-		detailLabelStyle.Render("Title:"),
-		detailValueStyle.Bold(true).Render(obs.Title)))
-
-	b.WriteString(fmt.Sprintf("%s %s\n",
-		detailLabelStyle.Render("Session:"),
-		idStyle.Render(obs.SessionID)))
-
-	b.WriteString(fmt.Sprintf("%s %s\n",
-		detailLabelStyle.Render("Created:"),
-		timestampStyle.Render(localTime(obs.CreatedAt))))
-
-	b.WriteString(fmt.Sprintf("%s %s\n",
-		detailLabelStyle.Render("State:"),
-		renderObservationState(obs.State())))
-
-	b.WriteString(fmt.Sprintf("%s %s\n",
-		detailLabelStyle.Render("Pinned:"),
-		detailValueStyle.Render(fmt.Sprintf("%t", obs.Pinned))))
-
-	if obs.ReviewAfter != nil {
-		b.WriteString(fmt.Sprintf("%s %s\n",
-			detailLabelStyle.Render("Review:"),
-			timestampStyle.Render(formatReviewDate(*obs.ReviewAfter))))
-	}
-
-	if obs.ToolName != nil {
-		b.WriteString(fmt.Sprintf("%s %s\n",
-			detailLabelStyle.Render("Tool:"),
-			detailValueStyle.Render(*obs.ToolName)))
-	}
-
-	if obs.Project != nil {
-		b.WriteString(fmt.Sprintf("%s %s\n",
-			detailLabelStyle.Render("Project:"),
-			projectStyle.Render(*obs.Project)))
-	}
-
-	// Content section
-	b.WriteString("\n")
-	b.WriteString(sectionHeadingStyle.Render("  Content"))
-	b.WriteString("\n")
-
-	// Wrap content based on terminal width
-	wrapWidth := m.Width - 6 // basic padding
-	if wrapWidth < 20 {
-		wrapWidth = 20
-	}
-	wrappedContent := detailContentStyle.Width(wrapWidth).Render(obs.Content)
-
-	// Split wrapped content into lines
-	contentLines := strings.Split(wrappedContent, "\n")
-	maxLines := m.Height - 16
-	if maxLines < 5 {
-		maxLines = 5
-	}
-
-	// Clamp scroll
-	maxScroll := len(contentLines) - maxLines
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
-	if m.DetailScroll > maxScroll {
-		m.DetailScroll = maxScroll
-	}
-
+	var b strings.Builder
+	b.WriteString(m.observationDetailChrome())
 	end := m.DetailScroll + maxLines
 	if end > len(contentLines) {
 		end = len(contentLines)
@@ -508,7 +436,7 @@ func (m Model) viewObservationDetail() string {
 		b.WriteString("\n")
 	}
 
-	if len(contentLines) > maxLines {
+	if maxLines > 0 && len(contentLines) > maxLines {
 		b.WriteString(fmt.Sprintf("\n  %s",
 			timestampStyle.Render(fmt.Sprintf("line %d-%d of %d", m.DetailScroll+1, end, len(contentLines)))))
 	}
@@ -891,6 +819,88 @@ func (m Model) renderObservationListItem(index int, id int64, obsType, title, co
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+func (m Model) viewportHeight(chrome string) int {
+	available := m.Height - lipgloss.Height(appStyle.Render(chrome))
+	if available < 0 {
+		return 0
+	}
+	return available
+}
+
+func (m Model) observationDetailChrome() string {
+	obs := m.SelectedObservation
+	if obs == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(headerStyle.Render(fmt.Sprintf("  Observation #%d", obs.ID)))
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Type:"), typeBadgeStyle.Render(obs.Type)))
+	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Title:"), detailValueStyle.Bold(true).Render(obs.Title)))
+	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Session:"), idStyle.Render(obs.SessionID)))
+	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Created:"), timestampStyle.Render(localTime(obs.CreatedAt))))
+	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("State:"), renderObservationState(obs.State())))
+	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Pinned:"), detailValueStyle.Render(fmt.Sprintf("%t", obs.Pinned))))
+	if obs.ReviewAfter != nil {
+		b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Review:"), timestampStyle.Render(formatReviewDate(*obs.ReviewAfter))))
+	}
+	if obs.ToolName != nil {
+		b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Tool:"), detailValueStyle.Render(*obs.ToolName)))
+	}
+	if obs.Project != nil {
+		b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Project:"), projectStyle.Render(*obs.Project)))
+	}
+	b.WriteString("\n")
+	b.WriteString(sectionHeadingStyle.Render("  Content"))
+	b.WriteString("\n")
+	return b.String()
+}
+
+func (m Model) observationDetailContentLines() []string {
+	if m.SelectedObservation == nil {
+		return nil
+	}
+	wrapWidth := m.Width - 6
+	if m.Width <= 0 {
+		wrapWidth = 20
+	} else if wrapWidth < 1 {
+		wrapWidth = 1
+	}
+	return strings.Split(detailContentStyle.Width(wrapWidth).Render(m.SelectedObservation.Content), "\n")
+}
+
+func (m Model) observationDetailViewport() int {
+	if m.Height <= 0 {
+		return 5
+	}
+	chrome := m.observationDetailChrome() +
+		fmt.Sprintf("\n  %s", timestampStyle.Render("line 1-1 of 1")) +
+		helpStyle.Render("\n  j/k scroll • c copy • t timeline • esc back")
+	return m.viewportHeight(chrome)
+}
+
+func (m Model) observationDetailMaxScroll() int {
+	visibleLines := m.observationDetailViewport()
+	if visibleLines == 0 {
+		return 0
+	}
+	maxScroll := len(m.observationDetailContentLines()) - visibleLines
+	if maxScroll < 0 {
+		return 0
+	}
+	return maxScroll
+}
+
+func (m Model) clampDetailScroll() int {
+	if m.DetailScroll < 0 {
+		return 0
+	}
+	if maxScroll := m.observationDetailMaxScroll(); m.DetailScroll > maxScroll {
+		return maxScroll
+	}
+	return m.DetailScroll
+}
 
 // localTime converts a UTC timestamp string from SQLite to local time for display.
 func localTime(utc string) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Gentleman-Programming/engram/v2/internal/store"
 	"github.com/Gentleman-Programming/engram/v2/internal/timeutil"
 	"github.com/Gentleman-Programming/engram/v2/internal/version"
 	"github.com/charmbracelet/lipgloss"
@@ -441,7 +442,7 @@ func (m Model) viewObservationDetail() string {
 			timestampStyle.Render(fmt.Sprintf("line %d-%d of %d", m.DetailScroll+1, end, len(contentLines)))))
 	}
 
-	b.WriteString(helpStyle.Render("\n  j/k scroll • c copy • t timeline • esc back"))
+	b.WriteString(observationDetailHelp())
 
 	return b.String()
 }
@@ -833,28 +834,51 @@ func (m Model) observationDetailChrome() string {
 	if obs == nil {
 		return ""
 	}
+	metadata := []string{
+		fmt.Sprintf("%s %s", detailLabelStyle.Render("Type:"), typeBadgeStyle.Render(obs.Type)),
+		fmt.Sprintf("%s %s", detailLabelStyle.Render("Title:"), detailValueStyle.Bold(true).Render(obs.Title)),
+		fmt.Sprintf("%s %s", detailLabelStyle.Render("Session:"), idStyle.Render(obs.SessionID)),
+		fmt.Sprintf("%s %s", detailLabelStyle.Render("Created:"), timestampStyle.Render(localTime(obs.CreatedAt))),
+		fmt.Sprintf("%s %s", detailLabelStyle.Render("State:"), renderObservationState(obs.State())),
+		fmt.Sprintf("%s %s", detailLabelStyle.Render("Pinned:"), detailValueStyle.Render(fmt.Sprintf("%t", obs.Pinned))),
+	}
+	if obs.ReviewAfter != nil {
+		metadata = append(metadata, fmt.Sprintf("%s %s", detailLabelStyle.Render("Review:"), timestampStyle.Render(formatReviewDate(*obs.ReviewAfter))))
+	}
+	if obs.ToolName != nil {
+		metadata = append(metadata, fmt.Sprintf("%s %s", detailLabelStyle.Render("Tool:"), detailValueStyle.Render(*obs.ToolName)))
+	}
+	if obs.Project != nil {
+		metadata = append(metadata, fmt.Sprintf("%s %s", detailLabelStyle.Render("Project:"), projectStyle.Render(*obs.Project)))
+	}
+
+	// On short terminals, remove trailing metadata until chrome leaves one content row.
+	for {
+		chrome := renderObservationDetailChrome(obs, metadata)
+		footer := fmt.Sprintf("\n  %s", timestampStyle.Render("line 1-1 of 1")) + observationDetailHelp()
+		if m.Height <= 0 || m.viewportHeight(chrome+footer) > 0 || len(metadata) == 0 {
+			return chrome
+		}
+		metadata = metadata[:len(metadata)-1]
+	}
+}
+
+func renderObservationDetailChrome(obs *store.Observation, metadata []string) string {
 	var b strings.Builder
 	b.WriteString(headerStyle.Render(fmt.Sprintf("  Observation #%d", obs.ID)))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Type:"), typeBadgeStyle.Render(obs.Type)))
-	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Title:"), detailValueStyle.Bold(true).Render(obs.Title)))
-	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Session:"), idStyle.Render(obs.SessionID)))
-	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Created:"), timestampStyle.Render(localTime(obs.CreatedAt))))
-	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("State:"), renderObservationState(obs.State())))
-	b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Pinned:"), detailValueStyle.Render(fmt.Sprintf("%t", obs.Pinned))))
-	if obs.ReviewAfter != nil {
-		b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Review:"), timestampStyle.Render(formatReviewDate(*obs.ReviewAfter))))
-	}
-	if obs.ToolName != nil {
-		b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Tool:"), detailValueStyle.Render(*obs.ToolName)))
-	}
-	if obs.Project != nil {
-		b.WriteString(fmt.Sprintf("%s %s\n", detailLabelStyle.Render("Project:"), projectStyle.Render(*obs.Project)))
+	for _, line := range metadata {
+		b.WriteString(line)
+		b.WriteString("\n")
 	}
 	b.WriteString("\n")
 	b.WriteString(sectionHeadingStyle.Render("  Content"))
 	b.WriteString("\n")
 	return b.String()
+}
+
+func observationDetailHelp() string {
+	return helpStyle.Render("\n  j/k scroll • c copy • t timeline • esc back")
 }
 
 func (m Model) observationDetailContentLines() []string {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -533,3 +533,45 @@ func TestObservationDetailScrollStopsAtContentBottom(t *testing.T) {
 		t.Fatalf("resized detail scroll = %d, want maximum %d", m.DetailScroll, m.observationDetailMaxScroll())
 	}
 }
+
+func TestObservationDetailScrollsInShortViewport(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenObservationDetail
+	m.Width = 80
+	m.Height = 16
+	m.SelectedObservation = &store.Observation{
+		ID:        1,
+		Type:      "artifact",
+		Title:     "Long observation",
+		SessionID: "session-1",
+		CreatedAt: "2026-01-01",
+		Content:   strings.Repeat("scrollable line\n", 141),
+	}
+
+	if got := m.observationDetailViewport(); got < 1 {
+		t.Fatalf("short detail viewport = %d, want at least one content line", got)
+	}
+	maxScroll := m.observationDetailMaxScroll()
+	if maxScroll == 0 {
+		t.Fatal("long observation should overflow the short detail viewport")
+	}
+	for range maxScroll + 10 {
+		updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		m = updatedModel.(Model)
+	}
+	if m.DetailScroll != maxScroll {
+		t.Fatalf("detail scroll = %d, want maximum %d", m.DetailScroll, maxScroll)
+	}
+	updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	m = updatedModel.(Model)
+	if m.DetailScroll != maxScroll-1 {
+		t.Fatalf("first up after bottom = %d, want %d", m.DetailScroll, maxScroll-1)
+	}
+	out := m.View()
+	if got := lipgloss.Height(out); got > m.Height {
+		t.Fatalf("render height = %d, terminal height = %d", got, m.Height)
+	}
+	if !strings.Contains(out, "scrollable line") || !strings.Contains(out, "j/k scroll") {
+		t.Fatal("short detail view should show content and scroll help")
+	}
+}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/Gentleman-Programming/engram/v2/internal/setup"
 	"github.com/Gentleman-Programming/engram/v2/internal/store"
 	"github.com/Gentleman-Programming/engram/v2/internal/version"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestTruncateStr(t *testing.T) {
@@ -222,7 +224,7 @@ func TestViewDashboardSearchAndRecent(t *testing.T) {
 
 func TestViewObservationDetailTimelineSessionsAndSessionDetail(t *testing.T) {
 	m := New(nil, "")
-	m.Height = 22
+	m.Height = 40
 
 	out := m.viewObservationDetail()
 	if !strings.Contains(out, "Loading") {
@@ -483,4 +485,51 @@ func TestViewSetupAllowlistPrompt(t *testing.T) {
 			t.Fatal("should show error message")
 		}
 	})
+}
+
+func TestObservationDetailScrollStopsAtContentBottom(t *testing.T) {
+	m := New(nil, "")
+	m.Screen = ScreenObservationDetail
+	m.Width = 80
+	m.Height = 24
+	m.SelectedObservation = &store.Observation{
+		ID:        1,
+		Type:      "artifact",
+		Title:     "Long observation",
+		SessionID: "session-1",
+		CreatedAt: "2026-01-01",
+		Content:   strings.Repeat("scrollable line\n", 141),
+	}
+
+	maxScroll := m.observationDetailMaxScroll()
+	if maxScroll == 0 {
+		t.Fatal("long observation should overflow the detail viewport")
+	}
+	for range maxScroll + 10 {
+		updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		m = updatedModel.(Model)
+	}
+	if m.DetailScroll != maxScroll {
+		t.Fatalf("detail scroll = %d, want maximum %d", m.DetailScroll, maxScroll)
+	}
+
+	updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	m = updatedModel.(Model)
+	if m.DetailScroll != maxScroll-1 {
+		t.Fatalf("first up after bottom = %d, want %d", m.DetailScroll, maxScroll-1)
+	}
+	out := m.View()
+	if got := lipgloss.Height(out); got > m.Height {
+		t.Fatalf("render height = %d, terminal height = %d", got, m.Height)
+	}
+	if !strings.Contains(out, "j/k scroll") {
+		t.Fatal("detail help should remain visible in an 80x24 terminal")
+	}
+
+	m.DetailScroll = 999
+	updatedModel, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updatedModel.(Model)
+	if m.DetailScroll != m.observationDetailMaxScroll() {
+		t.Fatalf("resized detail scroll = %d, want maximum %d", m.DetailScroll, m.observationDetailMaxScroll())
+	}
 }

--- a/internal/tui/wrap_test.go
+++ b/internal/tui/wrap_test.go
@@ -10,7 +10,7 @@ import (
 func TestViewObservationDetailWrapping(t *testing.T) {
 	m := Model{
 		Width:  40,
-		Height: 20,
+		Height: 0,
 		Screen: ScreenObservationDetail,
 		SelectedObservation: &store.Observation{
 			ID:      1,


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #544

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Bound Observation Detail scrolling to the rendered content viewport.
- Clamp stale scroll offsets during navigation and terminal resize.
- Add deterministic 80x24 regression coverage for long observations and visible help.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/tui/update.go` | Clamp detail scrolling during key handling and resize. |
| `internal/tui/view.go` | Measure the styled detail viewport and render only visible content lines. |
| `internal/tui/update_test.go` | Align no-viewport navigation expectations with bounded scrolling. |
| `internal/tui/view_test.go` | Cover the reported 80x24 overflow, bottom bound, recovery, help, and resize behavior. |
| `internal/tui/wrap_test.go` | Preserve wrapping behavior before terminal height initialization. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` — timed out after 10 minutes without a reported assertion failure.
- [x] Focused TUI tests pass locally: `go test ./internal/tui -count=1`.
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`.
- [ ] Manually tested the interactive TUI; deterministic Bubble Tea model/view regression coverage was used instead.

---

## 🤖 Automated Checks

These run automatically and all must pass before merge.

| Check | What it verifies | Status |
|-------|-----------------|--------|
| Check Issue Reference | PR body contains `Closes #N` | ⏳ |
| Check Issue Has status:approved | Linked issue has `status:approved` | ⏳ |
| Check PR Has type:* Label | PR has exactly one `type:*` label | ⏳ |
| Unit Tests | `go test ./...` passes | ⏳ |
| E2E Tests | Server E2E suite passes | ⏳ |
| Plugin Tests | Pi plugin tests pass | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #544`).
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran unit tests locally: the complete suite timed out after 10 minutes.
- [x] I ran e2e tests locally.
- [x] Docs updated if behavior changed: no documentation surface changed.
- [x] Commits follow conventional commits format.
- [x] No `Co-Authored-By` trailers in commits.

---

## 💬 Notes for Reviewers

The frozen five-file candidate completed four-lens RDD review and was acknowledged as approved. The focused TUI suite and server E2E suite pass. The complete local Go suite exceeded the 10-minute bound, so CI must complete that evidence before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scrolling in observation details so it stops at the available content and cannot move beyond the beginning or end.
  - Adjusted detail views automatically when the terminal window is resized.
  - Improved handling of small, empty, or invalid display dimensions while keeping content within the available screen.
  - Prevented scroll indicators from appearing when scrolling is unavailable.
  - Ensured observation details remain usable in short terminal windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->