### PR TITLE
fix(tests): handle macOS temp path aliases

### DIFF
--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -748,12 +748,16 @@ func TestCmdSaveUsesDetectionSeamAndPrintsNormalizationWarning(t *testing.T) {
 	cfg := testConfig(t)
 	cwd := t.TempDir()
 	withCwd(t, cwd)
+	actualCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get current working directory: %v", err)
+	}
 	withArgs(t, "engram", "save", "resolved-title", "resolved-content")
 
 	originalDetectProjectFull := detectProjectFull
 	detectProjectFull = func(gotCWD string) project.DetectionResult {
-		if gotCWD != cwd {
-			t.Fatalf("detection cwd = %q, want %q", gotCWD, cwd)
+		if gotCWD != actualCWD {
+			t.Fatalf("detection cwd = %q, want %q", gotCWD, actualCWD)
 		}
 		return project.DetectionResult{Project: " Configured--Project "}
 	}

--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -902,7 +902,8 @@ func TestDetectProjectFull_SubmoduleUsesCheckoutRoot(t *testing.T) {
 }
 
 func TestDetectProjectFull_BareRepositoryUsesRepositoryName(t *testing.T) {
-	bare := filepath.Join(t.TempDir(), "canonical-repo.git")
+	parent := t.TempDir()
+	bare := filepath.Join(parent, "canonical-repo.git")
 	cmd := exec.Command("git", "init", "--bare", bare)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init --bare: %v\n%s", err, out)
@@ -912,7 +913,8 @@ func TestDetectProjectFull_BareRepositoryUsesRepositoryName(t *testing.T) {
 	if res.Source != SourceGitRoot || res.Project != "canonical-repo" {
 		t.Fatalf("bare repository result = %+v, want git-root canonical-repo", res)
 	}
-	if got, want := canonicalizePath(res.Path), canonicalizePath(filepath.Join(filepath.Dir(bare), "canonical-repo")); got != want {
+	canonicalParent := canonicalizePath(parent)
+	if got, want := canonicalizePath(res.Path), filepath.Join(canonicalParent, "canonical-repo"); got != want {
 		t.Fatalf("bare repository path = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #880

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Make two test expectations compare canonical working-directory paths when macOS exposes `/var` through `/private/var`.
- Keep production behavior unchanged.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main_test.go` | Compare the detector seam with the post-`Chdir` working-directory spelling. |
| `internal/project/detect_test.go` | Canonicalize the existing temporary parent before deriving the bare-repository expected path. |

## 🧪 Test Plan

- [x] Focused tests and affected packages pass locally: `go test ./cmd/engram ./internal/project -count=1`
- [ ] Unit tests pass locally: `go test ./...` (not run; focused affected-package coverage was used)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run; this is a test-only portability change)
- [ ] Manually tested the affected functionality (not applicable; no production behavior changed)

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Expected on PR |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Expected on PR |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | Expected on PR |
| **Unit Tests** | `go test ./...` passes | Expected on PR |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Expected on PR |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | Expected on PR |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #880`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (not run; focused affected-package coverage passed)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run; not applicable to this test-only portability change)
- [x] Docs updated (not applicable; behavior did not change)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

macOS CI is the platform-specific confirmation for `/var` and `/private/var` temporary-path aliases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved project-detection test coverage by verifying the actual working directory after directory changes.
  * Updated bare repository detection tests to use canonicalized paths consistently.
  * Test behavior and public functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->