### PR TITLE
fix(tui): ensure contrast on light terminals

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -26,6 +26,7 @@ var (
 	// App frame
 	appStyle = lipgloss.NewStyle().
 			Foreground(colorText).
+			Background(colorBase).
 			Padding(1, 2)
 
 	// Header bar

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -91,6 +91,12 @@ func TestViewRouterAndErrorRendering(t *testing.T) {
 	}
 }
 
+func TestAppStyleUsesDarkBaseBackground(t *testing.T) {
+	if got := appStyle.GetBackground(); got != colorBase {
+		t.Fatalf("appStyle background = %v, want %v", got, colorBase)
+	}
+}
+
 func TestViewSearchResultsAndScrollIndicator(t *testing.T) {
 	m := New(nil, "")
 	m.Screen = ScreenSearchResults


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #530

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Apply the existing Catppuccin base color as the root TUI background.
- Preserve readable foreground contrast when the terminal uses a light theme.
- Add focused regression coverage for the root style contract.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/tui/styles.go` | Apply `colorBase` to the root `appStyle` background. |
| `internal/tui/view_test.go` | Assert the explicit dark background contract. |

## 🧪 Test Plan

- [x] Focused TUI package tests pass locally: `go test ./internal/tui`
- [ ] Full unit suite: delegated to required CI checks
- [ ] E2E server suite: unrelated to this TUI-only change; delegated to CI
- [ ] Interactive light-terminal rendering was not performed

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #530`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` — focused TUI tests ran locally; broad suite is CI-owned
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` — unrelated server suite is CI-owned
- [x] Docs reviewed; no update is needed because the documented fixed Mocha palette is preserved
- [x] Commits follow conventional commit format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

RDD approved the exact committed candidate. Residual validation is limited to viewing the TUI in an actual light-themed terminal; the style contract is covered deterministically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added a dark background color to the application interface for a more consistent visual appearance.

- **Tests**
  - Added coverage to verify that the application uses the expected dark base background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->