### PR TITLE
fix(cloud): compress versioned sync chunk transport

### DIFF
--- a/docs/engram-cloud/README.md
+++ b/docs/engram-cloud/README.md
@@ -80,9 +80,10 @@ For a direct registry-based deploy example, use:
 Current chunk-sync clients send `POST /sync/push` using the versioned
 `application/vnd.engram.sync+gzip; version=1` envelope. The server decompresses
 it before its existing validation and storage steps. Chunk pulls use the same
-format only when the client explicitly advertises it with `Accept`; otherwise
-they remain legacy JSON. The server continues to accept legacy JSON pushes, and
-current clients accept both compressed and legacy JSON pull responses.
+format only when the client explicitly advertises it with `Accept` and the
+decoded chunk is at most 8 MiB; otherwise pulls remain legacy JSON. The server
+continues to accept legacy JSON pushes, and current clients accept both
+compressed and legacy JSON pull responses.
 
 This envelope is compression/obfuscation intended to reduce false-positive WAF
 inspection. It is **not encryption** and does not provide confidentiality; use

--- a/docs/engram-cloud/README.md
+++ b/docs/engram-cloud/README.md
@@ -75,6 +75,19 @@ For a direct registry-based deploy example, use:
 - `GET /sync/pull`, `POST /sync/push`
 - `GET /dashboard/*` (browser surfaces)
 
+### Chunk transport compatibility and security
+
+Current chunk-sync clients send `POST /sync/push` using the versioned
+`application/vnd.engram.sync+gzip; version=1` envelope. The server decompresses
+it before its existing validation and storage steps. Chunk pulls use the same
+format only when the client explicitly advertises it with `Accept`; otherwise
+they remain legacy JSON. The server continues to accept legacy JSON pushes, and
+current clients accept both compressed and legacy JSON pull responses.
+
+This envelope is compression/obfuscation intended to reduce false-positive WAF
+inspection. It is **not encryption** and does not provide confidentiality; use
+HTTPS and appropriate deployment controls for transport security.
+
 ---
 
 ## Cloud Docs Map

--- a/internal/cloud/chunkcodec/envelope.go
+++ b/internal/cloud/chunkcodec/envelope.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
+	"strconv"
 	"strings"
 )
 
@@ -55,10 +57,17 @@ func IsCompressedEnvelopeContentType(contentType string) (bool, error) {
 // envelope. Requests without that explicit advertisement receive legacy JSON.
 func AcceptsCompressedEnvelope(accept string) bool {
 	for _, value := range strings.Split(accept, ",") {
-		ok, err := IsCompressedEnvelopeContentType(strings.TrimSpace(value))
-		if err == nil && ok {
-			return true
+		mediaType, params, err := mime.ParseMediaType(strings.TrimSpace(value))
+		if err != nil || mediaType != CompressedEnvelopeMediaType || params["version"] != envelopeVersion {
+			continue
 		}
+		if quality, ok := params["q"]; ok {
+			qualityValue, err := strconv.ParseFloat(quality, 64)
+			if err != nil || math.IsNaN(qualityValue) || qualityValue < 0 || qualityValue > 1 || qualityValue == 0 {
+				continue
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/internal/cloud/chunkcodec/envelope.go
+++ b/internal/cloud/chunkcodec/envelope.go
@@ -1,0 +1,99 @@
+package chunkcodec
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"strings"
+)
+
+const (
+	// CompressedEnvelopeMediaType identifies the versioned compressed chunk transport.
+	// It reduces false-positive inspection of sync payloads; it does not provide secrecy.
+	CompressedEnvelopeMediaType = "application/vnd.engram.sync+gzip"
+	envelopeVersion             = "1"
+
+	// DefaultMaxDecodedBytes bounds decompression when a peer does not provide a
+	// negotiated payload limit. It matches the default cloud push body limit.
+	DefaultMaxDecodedBytes int64 = 8 * 1024 * 1024
+)
+
+var (
+	ErrPayloadTooLarge            = errors.New("compressed payload exceeds decoded size limit")
+	ErrUnsupportedEnvelopeVersion = errors.New("unsupported compressed envelope version")
+)
+
+// CompressedEnvelopeContentType returns the exact media type for the supported envelope.
+func CompressedEnvelopeContentType() string {
+	return CompressedEnvelopeMediaType + "; version=" + envelopeVersion
+}
+
+// IsCompressedEnvelopeContentType reports whether contentType is the supported envelope.
+// A recognized envelope media type with another version is rejected rather than decoded as
+// legacy JSON.
+func IsCompressedEnvelopeContentType(contentType string) (bool, error) {
+	if strings.TrimSpace(contentType) == "" {
+		return false, nil
+	}
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false, fmt.Errorf("parse content type: %w", err)
+	}
+	if mediaType != CompressedEnvelopeMediaType {
+		return false, nil
+	}
+	if params["version"] != envelopeVersion {
+		return false, ErrUnsupportedEnvelopeVersion
+	}
+	return true, nil
+}
+
+// AcceptsCompressedEnvelope reports whether an Accept header advertises the supported
+// envelope. Requests without that explicit advertisement receive legacy JSON.
+func AcceptsCompressedEnvelope(accept string) bool {
+	for _, value := range strings.Split(accept, ",") {
+		ok, err := IsCompressedEnvelopeContentType(strings.TrimSpace(value))
+		if err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// EncodeCompressedEnvelope gzip-compresses a canonical JSON payload for transport.
+func EncodeCompressedEnvelope(payload []byte) ([]byte, error) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(payload); err != nil {
+		return nil, fmt.Errorf("compress payload: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("finish compressed payload: %w", err)
+	}
+	return compressed.Bytes(), nil
+}
+
+// DecodeCompressedEnvelope decodes a gzip envelope and refuses decoded payloads that
+// exceed maxBytes, preventing compressed inputs from bypassing request body limits.
+func DecodeCompressedEnvelope(payload []byte, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("decoded size limit must be positive")
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("open compressed payload: %w", err)
+	}
+	defer reader.Close()
+
+	decoded, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("decode compressed payload: %w", err)
+	}
+	if int64(len(decoded)) > maxBytes {
+		return nil, ErrPayloadTooLarge
+	}
+	return decoded, nil
+}

--- a/internal/cloud/chunkcodec/envelope_test.go
+++ b/internal/cloud/chunkcodec/envelope_test.go
@@ -1,0 +1,85 @@
+package chunkcodec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCompressedEnvelopeRoundTripDoesNotExposePayloadText(t *testing.T) {
+	payload := []byte(`{"observations":[{"content":"WAF-SENTINEL-738"}]}`)
+
+	encoded, err := EncodeCompressedEnvelope(payload)
+	if err != nil {
+		t.Fatalf("EncodeCompressedEnvelope: %v", err)
+	}
+	if bytes.Contains(encoded, []byte("WAF-SENTINEL-738")) {
+		t.Fatal("compressed envelope exposed observation text")
+	}
+
+	decoded, err := DecodeCompressedEnvelope(encoded, int64(len(payload)))
+	if err != nil {
+		t.Fatalf("DecodeCompressedEnvelope: %v", err)
+	}
+	if !bytes.Equal(decoded, payload) {
+		t.Fatalf("decoded payload = %q, want %q", decoded, payload)
+	}
+}
+
+func TestCompressedEnvelopeRejectsMalformedUnsupportedAndOversizedPayloads(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func() error
+		want error
+	}{
+		{
+			name: "malformed compressed data",
+			run: func() error {
+				_, err := DecodeCompressedEnvelope([]byte("not-gzip"), 32)
+				return err
+			},
+		},
+		{
+			name: "decoded size limit",
+			run: func() error {
+				encoded, err := EncodeCompressedEnvelope([]byte(strings.Repeat("a", 33)))
+				if err != nil {
+					return err
+				}
+				_, err = DecodeCompressedEnvelope(encoded, 32)
+				return err
+			},
+			want: ErrPayloadTooLarge,
+		},
+		{
+			name: "unsupported version",
+			run: func() error {
+				_, err := IsCompressedEnvelopeContentType(CompressedEnvelopeMediaType + "; version=2")
+				return err
+			},
+			want: ErrUnsupportedEnvelopeVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if tt.want != nil && !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompressedEnvelopeAcceptNegotiation(t *testing.T) {
+	if !AcceptsCompressedEnvelope("application/json, " + CompressedEnvelopeContentType()) {
+		t.Fatal("expected supported envelope in Accept header")
+	}
+	if AcceptsCompressedEnvelope(CompressedEnvelopeMediaType + "; version=2") {
+		t.Fatal("unsupported envelope version must not be accepted")
+	}
+}

--- a/internal/cloud/chunkcodec/envelope_test.go
+++ b/internal/cloud/chunkcodec/envelope_test.go
@@ -84,6 +84,8 @@ func TestCompressedEnvelopeAcceptNegotiation(t *testing.T) {
 		{name: "supported envelope", accept: "application/json, " + CompressedEnvelopeContentType(), want: true},
 		{name: "supported envelope with parameters", accept: "application/json; q=0.5, " + CompressedEnvelopeMediaType + "; feature=chunk-pull; version=1", want: true},
 		{name: "quality zero", accept: CompressedEnvelopeContentType() + "; q=0", want: false},
+		{name: "quality below zero", accept: CompressedEnvelopeContentType() + "; q=-0.1", want: false},
+		{name: "quality above one", accept: CompressedEnvelopeContentType() + "; q=1.1", want: false},
 		{name: "invalid quality", accept: CompressedEnvelopeContentType() + "; q=invalid", want: false},
 		{name: "multiple ranges with acceptable envelope", accept: CompressedEnvelopeContentType() + "; q=0, " + CompressedEnvelopeContentType() + "; q=0.5", want: true},
 		{name: "unsupported envelope version", accept: CompressedEnvelopeMediaType + "; version=2", want: false},

--- a/internal/cloud/chunkcodec/envelope_test.go
+++ b/internal/cloud/chunkcodec/envelope_test.go
@@ -76,10 +76,24 @@ func TestCompressedEnvelopeRejectsMalformedUnsupportedAndOversizedPayloads(t *te
 }
 
 func TestCompressedEnvelopeAcceptNegotiation(t *testing.T) {
-	if !AcceptsCompressedEnvelope("application/json, " + CompressedEnvelopeContentType()) {
-		t.Fatal("expected supported envelope in Accept header")
+	tests := []struct {
+		name   string
+		accept string
+		want   bool
+	}{
+		{name: "supported envelope", accept: "application/json, " + CompressedEnvelopeContentType(), want: true},
+		{name: "supported envelope with parameters", accept: "application/json; q=0.5, " + CompressedEnvelopeMediaType + "; feature=chunk-pull; version=1", want: true},
+		{name: "quality zero", accept: CompressedEnvelopeContentType() + "; q=0", want: false},
+		{name: "invalid quality", accept: CompressedEnvelopeContentType() + "; q=invalid", want: false},
+		{name: "multiple ranges with acceptable envelope", accept: CompressedEnvelopeContentType() + "; q=0, " + CompressedEnvelopeContentType() + "; q=0.5", want: true},
+		{name: "unsupported envelope version", accept: CompressedEnvelopeMediaType + "; version=2", want: false},
 	}
-	if AcceptsCompressedEnvelope(CompressedEnvelopeMediaType + "; version=2") {
-		t.Fatal("unsupported envelope version must not be accepted")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AcceptsCompressedEnvelope(tt.accept); got != tt.want {
+				t.Fatalf("AcceptsCompressedEnvelope(%q) = %t, want %t", tt.accept, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -469,6 +469,7 @@ func (s *CloudServer) handlePullChunk(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("read chunk: %v", err), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Add("Vary", "Accept")
 	if chunkcodec.AcceptsCompressedEnvelope(r.Header.Get("Accept")) && int64(len(chunk)) <= chunkcodec.DefaultMaxDecodedBytes {
 		compressed, err := chunkcodec.EncodeCompressedEnvelope(chunk)

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -468,6 +469,16 @@ func (s *CloudServer) handlePullChunk(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("read chunk: %v", err), http.StatusInternalServerError)
 		return
 	}
+	if chunkcodec.AcceptsCompressedEnvelope(r.Header.Get("Accept")) {
+		compressed, err := chunkcodec.EncodeCompressedEnvelope(chunk)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("compress chunk: %v", err), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", chunkcodec.CompressedEnvelopeContentType())
+		_, _ = w.Write(compressed)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(chunk)
 }
@@ -475,17 +486,33 @@ func (s *CloudServer) handlePullChunk(w http.ResponseWriter, r *http.Request) {
 func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
 	maxPushBodyBytes := s.pushBodyLimit()
 	r.Body = http.MaxBytesReader(w, r.Body, maxPushBodyBytes)
-	var req struct {
-		ChunkID         string          `json:"chunk_id"`
-		CreatedBy       string          `json:"created_by"`
-		ClientCreatedAt string          `json:"client_created_at"`
-		Project         string          `json:"project"`
-		Data            json.RawMessage `json:"data"`
+	var req chunkPushRequest
+	compressed, contentTypeErr := chunkcodec.IsCompressedEnvelopeContentType(r.Header.Get("Content-Type"))
+	if contentTypeErr != nil {
+		writeActionableError(w, http.StatusUnsupportedMediaType, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadInvalid, fmt.Sprintf("unsupported push payload: %v", contentTypeErr))
+		return
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	var err error
+	if compressed {
+		var encoded []byte
+		encoded, err = io.ReadAll(r.Body)
+		if err == nil {
+			encoded, err = chunkcodec.DecodeCompressedEnvelope(encoded, maxPushBodyBytes)
+		}
+		if err == nil {
+			err = json.Unmarshal(encoded, &req)
+		}
+	} else {
+		err = json.NewDecoder(r.Body).Decode(&req)
+	}
+	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			writeActionableError(w, http.StatusRequestEntityTooLarge, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadTooLarge, fmt.Sprintf("push payload too large (max %d bytes)", maxPushBodyBytes))
+			return
+		}
+		if errors.Is(err, chunkcodec.ErrPayloadTooLarge) {
+			writeActionableError(w, http.StatusRequestEntityTooLarge, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadTooLarge, fmt.Sprintf("decoded push payload too large (max %d bytes)", maxPushBodyBytes))
 			return
 		}
 		writeActionableError(w, http.StatusBadRequest, constants.UpgradeErrorClassRepairable, constants.UpgradeErrorCodePayloadInvalid, fmt.Sprintf("invalid push payload: %v", err))
@@ -605,6 +632,14 @@ func (s *CloudServer) handlePushChunk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonResponse(w, http.StatusOK, map[string]any{"status": "ok", "chunk_id": computedChunkID})
+}
+
+type chunkPushRequest struct {
+	ChunkID         string          `json:"chunk_id"`
+	CreatedBy       string          `json:"created_by"`
+	ClientCreatedAt string          `json:"client_created_at"`
+	Project         string          `json:"project"`
+	Data            json.RawMessage `json:"data"`
 }
 
 func chunkIDFromPayload(payload []byte) string {

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -469,6 +469,7 @@ func (s *CloudServer) handlePullChunk(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("read chunk: %v", err), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Add("Vary", "Accept")
 	if chunkcodec.AcceptsCompressedEnvelope(r.Header.Get("Accept")) && int64(len(chunk)) <= chunkcodec.DefaultMaxDecodedBytes {
 		compressed, err := chunkcodec.EncodeCompressedEnvelope(chunk)
 		if err != nil {

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -469,7 +469,7 @@ func (s *CloudServer) handlePullChunk(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("read chunk: %v", err), http.StatusInternalServerError)
 		return
 	}
-	if chunkcodec.AcceptsCompressedEnvelope(r.Header.Get("Accept")) {
+	if chunkcodec.AcceptsCompressedEnvelope(r.Header.Get("Accept")) && int64(len(chunk)) <= chunkcodec.DefaultMaxDecodedBytes {
 		compressed, err := chunkcodec.EncodeCompressedEnvelope(chunk)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("compress chunk: %v", err), http.StatusInternalServerError)

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -258,6 +258,69 @@ func TestHandlerSyncCompressedPushPullRoundTrip(t *testing.T) {
 	}
 }
 
+func TestHandlerPullChunkCompressionNegotiationAndDecodedSizeLimit(t *testing.T) {
+	const chunkID = "chunk-1"
+	makePayload := func(size int) []byte {
+		prefix := []byte(`{"padding":"`)
+		suffix := []byte(`"}`)
+		return append(append(prefix, bytes.Repeat([]byte("x"), size-len(prefix)-len(suffix))...), suffix...)
+	}
+
+	tests := []struct {
+		name            string
+		accept          string
+		payload         []byte
+		wantContentType string
+	}{
+		{
+			name:            "decoded payload at client limit is compressed",
+			accept:          chunkcodec.CompressedEnvelopeContentType(),
+			payload:         makePayload(int(chunkcodec.DefaultMaxDecodedBytes)),
+			wantContentType: chunkcodec.CompressedEnvelopeContentType(),
+		},
+		{
+			name:            "decoded payload over client limit falls back to legacy JSON",
+			accept:          chunkcodec.CompressedEnvelopeContentType(),
+			payload:         makePayload(int(chunkcodec.DefaultMaxDecodedBytes) + 1),
+			wantContentType: "application/json",
+		},
+		{
+			name:            "quality zero falls back to legacy JSON",
+			accept:          chunkcodec.CompressedEnvelopeContentType() + "; q=0",
+			payload:         []byte(`{"sessions":[]}`),
+			wantContentType: "application/json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := New(&fakeStore{chunks: map[string][]byte{chunkID: tt.payload}}, fakeAuth{}, 0)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/sync/pull/"+chunkID+"?project=proj-a", nil)
+			req.Header.Set("Accept", tt.accept)
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d body=%q", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			if got := rec.Header().Get("Content-Type"); got != tt.wantContentType {
+				t.Fatalf("Content-Type = %q, want %q", got, tt.wantContentType)
+			}
+			body := rec.Body.Bytes()
+			if tt.wantContentType == chunkcodec.CompressedEnvelopeContentType() {
+				var err error
+				body, err = chunkcodec.DecodeCompressedEnvelope(body, chunkcodec.DefaultMaxDecodedBytes)
+				if err != nil {
+					t.Fatalf("DecodeCompressedEnvelope: %v", err)
+				}
+			}
+			if !bytes.Equal(body, tt.payload) {
+				t.Fatalf("response payload length = %d, want %d", len(body), len(tt.payload))
+			}
+		})
+	}
+}
+
 func TestHandlerCompressedPushRejectsMalformedUnsupportedAndOversizedPayloads(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -271,24 +271,28 @@ func TestHandlerPullChunkCompressionNegotiationAndDecodedSizeLimit(t *testing.T)
 		accept          string
 		payload         []byte
 		wantContentType string
+		wantVary        string
 	}{
 		{
 			name:            "decoded payload at client limit is compressed",
 			accept:          chunkcodec.CompressedEnvelopeContentType(),
 			payload:         makePayload(int(chunkcodec.DefaultMaxDecodedBytes)),
 			wantContentType: chunkcodec.CompressedEnvelopeContentType(),
+			wantVary:        "Accept",
 		},
 		{
 			name:            "decoded payload over client limit falls back to legacy JSON",
 			accept:          chunkcodec.CompressedEnvelopeContentType(),
 			payload:         makePayload(int(chunkcodec.DefaultMaxDecodedBytes) + 1),
 			wantContentType: "application/json",
+			wantVary:        "Accept",
 		},
 		{
 			name:            "quality zero falls back to legacy JSON",
 			accept:          chunkcodec.CompressedEnvelopeContentType() + "; q=0",
 			payload:         []byte(`{"sessions":[]}`),
 			wantContentType: "application/json",
+			wantVary:        "Accept",
 		},
 	}
 
@@ -305,6 +309,9 @@ func TestHandlerPullChunkCompressionNegotiationAndDecodedSizeLimit(t *testing.T)
 			}
 			if got := rec.Header().Get("Content-Type"); got != tt.wantContentType {
 				t.Fatalf("Content-Type = %q, want %q", got, tt.wantContentType)
+			}
+			if got := rec.Header().Get("Vary"); got != tt.wantVary {
+				t.Fatalf("Vary = %q, want %q", got, tt.wantVary)
 			}
 			body := rec.Body.Bytes()
 			if tt.wantContentType == chunkcodec.CompressedEnvelopeContentType() {

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -335,7 +335,7 @@ func TestHandlerPullChunkCompressionNegotiationAndDecodedSizeLimit(t *testing.T)
 	}
 }
 
-func TestHandlerCompressedPushRejectsMalformedUnsupportedAndOversizedPayloads(t *testing.T) {
+func TestHandlerCompressedPushRejectsMalformedUnsupportedAndDecodedSizeLimitedPayloads(t *testing.T) {
 	tests := []struct {
 		name        string
 		body        []byte
@@ -377,6 +377,31 @@ func TestHandlerCompressedPushRejectsMalformedUnsupportedAndOversizedPayloads(t 
 				t.Fatalf("status = %d, want %d body=%q", rec.Code, tt.wantStatus, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestHandlerCompressedPushRejectsCompressedWireBodyOverLimit(t *testing.T) {
+	const wireLimit = int64(128)
+	const lowCompressibilityAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	fixtureData := make([]byte, 384)
+	state := uint32(1)
+	for i := range fixtureData {
+		state = state*1664525 + 1013904223
+		fixtureData[i] = lowCompressibilityAlphabet[(state>>24)%uint32(len(lowCompressibilityAlphabet))]
+	}
+	wireBody := mustEncodeCompressedEnvelope(t, []byte(`{"project":"proj-a","data":"`+string(fixtureData)+`"}`))
+	if int64(len(wireBody)) <= wireLimit {
+		t.Fatalf("compressed wire fixture = %d bytes, must exceed configured wire limit %d", len(wireBody), wireLimit)
+	}
+
+	srv := New(&fakeStore{}, fakeAuth{}, 0, WithMaxPushBodyBytes(wireLimit))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/push", bytes.NewReader(wireBody))
+	req.Header.Set("Content-Type", chunkcodec.CompressedEnvelopeContentType())
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d body=%q", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
 	}
 }
 

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	cloudauth "github.com/Gentleman-Programming/engram/v2/internal/cloud/auth"
+	"github.com/Gentleman-Programming/engram/v2/internal/cloud/chunkcodec"
 	"github.com/Gentleman-Programming/engram/v2/internal/cloud/cloudstore"
 	"github.com/Gentleman-Programming/engram/v2/internal/cloud/dashboard"
 	"github.com/Gentleman-Programming/engram/v2/internal/store"
@@ -206,6 +207,109 @@ func TestHandlerSyncPushPullRoundTrip(t *testing.T) {
 	if string(bytes.TrimSpace(pullChunk.Body.Bytes())) != string(normalizedPayload) {
 		t.Fatalf("unexpected chunk body=%q", pullChunk.Body.String())
 	}
+}
+
+func TestHandlerSyncCompressedPushPullRoundTrip(t *testing.T) {
+	st := &fakeStore{}
+	srv := New(st, fakeAuth{}, 0)
+	const sentinel = "WAF-SENTINEL-738"
+	payload := []byte(`{"sessions":[{"id":"s-1","directory":"/tmp/s-1"}],"observations":[{"sync_id":"o-1","session_id":"s-1","type":"discovery","title":"sentinel observation","content":"` + sentinel + `","scope":"project"}]}`)
+	pushPayload := []byte(`{"project":"proj-a","created_by":"tester","data":` + string(payload) + `}`)
+	wireBody, err := chunkcodec.EncodeCompressedEnvelope(pushPayload)
+	if err != nil {
+		t.Fatalf("EncodeCompressedEnvelope: %v", err)
+	}
+	if bytes.Contains(wireBody, []byte(sentinel)) {
+		t.Fatal("compressed push body exposed observation text")
+	}
+
+	pushRec := httptest.NewRecorder()
+	pushReq := httptest.NewRequest(http.MethodPost, "/sync/push", bytes.NewReader(wireBody))
+	pushReq.Header.Set("Content-Type", chunkcodec.CompressedEnvelopeContentType())
+	srv.Handler().ServeHTTP(pushRec, pushReq)
+	if pushRec.Code != http.StatusOK {
+		t.Fatalf("expected compressed /sync/push=200, got %d body=%q", pushRec.Code, pushRec.Body.String())
+	}
+
+	normalizedPayload, err := coerceChunkProject(payload, "proj-a")
+	if err != nil {
+		t.Fatalf("coerce payload: %v", err)
+	}
+	chunkID := chunkIDFromPayload(normalizedPayload)
+	pullRec := httptest.NewRecorder()
+	pullReq := httptest.NewRequest(http.MethodGet, "/sync/pull/"+chunkID+"?project=proj-a", nil)
+	pullReq.Header.Set("Accept", chunkcodec.CompressedEnvelopeContentType())
+	srv.Handler().ServeHTTP(pullRec, pullReq)
+	if pullRec.Code != http.StatusOK {
+		t.Fatalf("expected compressed /sync/pull=200, got %d body=%q", pullRec.Code, pullRec.Body.String())
+	}
+	if pullRec.Header().Get("Content-Type") != chunkcodec.CompressedEnvelopeContentType() {
+		t.Fatalf("Content-Type = %q, want compressed envelope", pullRec.Header().Get("Content-Type"))
+	}
+	if bytes.Contains(pullRec.Body.Bytes(), []byte(sentinel)) {
+		t.Fatal("compressed pull body exposed observation text")
+	}
+	decoded, err := chunkcodec.DecodeCompressedEnvelope(pullRec.Body.Bytes(), chunkcodec.DefaultMaxDecodedBytes)
+	if err != nil {
+		t.Fatalf("DecodeCompressedEnvelope: %v", err)
+	}
+	if !bytes.Equal(decoded, normalizedPayload) {
+		t.Fatalf("decoded pull payload = %q, want %q", decoded, normalizedPayload)
+	}
+}
+
+func TestHandlerCompressedPushRejectsMalformedUnsupportedAndOversizedPayloads(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        []byte
+		contentType string
+		limit       int64
+		wantStatus  int
+	}{
+		{
+			name:        "malformed compressed payload",
+			body:        []byte("not-gzip"),
+			contentType: chunkcodec.CompressedEnvelopeContentType(),
+			limit:       1024,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "unsupported envelope version",
+			body:        []byte(`{}`),
+			contentType: chunkcodec.CompressedEnvelopeMediaType + "; version=2",
+			limit:       1024,
+			wantStatus:  http.StatusUnsupportedMediaType,
+		},
+		{
+			name:        "decoded payload exceeds limit",
+			body:        mustEncodeCompressedEnvelope(t, []byte(`{"project":"proj-a","data":"`+strings.Repeat("a", 512)+`"}`)),
+			contentType: chunkcodec.CompressedEnvelopeContentType(),
+			limit:       128,
+			wantStatus:  http.StatusRequestEntityTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := New(&fakeStore{}, fakeAuth{}, 0, WithMaxPushBodyBytes(tt.limit))
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/sync/push", bytes.NewReader(tt.body))
+			req.Header.Set("Content-Type", tt.contentType)
+			srv.Handler().ServeHTTP(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d body=%q", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+func mustEncodeCompressedEnvelope(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	encoded, err := chunkcodec.EncodeCompressedEnvelope(payload)
+	if err != nil {
+		t.Fatalf("EncodeCompressedEnvelope: %v", err)
+	}
+	return encoded
 }
 
 func TestHandlerReturnsUnauthorizedWhenAuthFails(t *testing.T) {

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -267,32 +267,36 @@ func TestHandlerPullChunkCompressionNegotiationAndDecodedSizeLimit(t *testing.T)
 	}
 
 	tests := []struct {
-		name            string
-		accept          string
-		payload         []byte
-		wantContentType string
-		wantVary        string
+		name             string
+		accept           string
+		payload          []byte
+		wantContentType  string
+		wantVary         string
+		wantCacheControl string
 	}{
 		{
-			name:            "decoded payload at client limit is compressed",
-			accept:          chunkcodec.CompressedEnvelopeContentType(),
-			payload:         makePayload(int(chunkcodec.DefaultMaxDecodedBytes)),
-			wantContentType: chunkcodec.CompressedEnvelopeContentType(),
-			wantVary:        "Accept",
+			name:             "decoded payload at client limit is compressed",
+			accept:           chunkcodec.CompressedEnvelopeContentType(),
+			payload:          makePayload(int(chunkcodec.DefaultMaxDecodedBytes)),
+			wantContentType:  chunkcodec.CompressedEnvelopeContentType(),
+			wantVary:         "Accept",
+			wantCacheControl: "no-store",
 		},
 		{
-			name:            "decoded payload over client limit falls back to legacy JSON",
-			accept:          chunkcodec.CompressedEnvelopeContentType(),
-			payload:         makePayload(int(chunkcodec.DefaultMaxDecodedBytes) + 1),
-			wantContentType: "application/json",
-			wantVary:        "Accept",
+			name:             "decoded payload over client limit falls back to legacy JSON",
+			accept:           chunkcodec.CompressedEnvelopeContentType(),
+			payload:          makePayload(int(chunkcodec.DefaultMaxDecodedBytes) + 1),
+			wantContentType:  "application/json",
+			wantVary:         "Accept",
+			wantCacheControl: "no-store",
 		},
 		{
-			name:            "quality zero falls back to legacy JSON",
-			accept:          chunkcodec.CompressedEnvelopeContentType() + "; q=0",
-			payload:         []byte(`{"sessions":[]}`),
-			wantContentType: "application/json",
-			wantVary:        "Accept",
+			name:             "quality zero falls back to legacy JSON",
+			accept:           chunkcodec.CompressedEnvelopeContentType() + "; q=0",
+			payload:          []byte(`{"sessions":[]}`),
+			wantContentType:  "application/json",
+			wantVary:         "Accept",
+			wantCacheControl: "no-store",
 		},
 	}
 
@@ -312,6 +316,9 @@ func TestHandlerPullChunkCompressionNegotiationAndDecodedSizeLimit(t *testing.T)
 			}
 			if got := rec.Header().Get("Vary"); got != tt.wantVary {
 				t.Fatalf("Vary = %q, want %q", got, tt.wantVary)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != tt.wantCacheControl {
+				t.Fatalf("Cache-Control = %q, want %q", got, tt.wantCacheControl)
 			}
 			body := rec.Body.Bytes()
 			if tt.wantContentType == chunkcodec.CompressedEnvelopeContentType() {

--- a/internal/cloud/remote/transport.go
+++ b/internal/cloud/remote/transport.go
@@ -219,7 +219,7 @@ func (rt *RemoteTransport) WriteChunk(chunkID string, data []byte, entry engrams
 		chunkID = canonicalChunkID
 	}
 
-	body, err := json.Marshal(map[string]any{
+	pushPayload, err := json.Marshal(map[string]any{
 		"chunk_id":          canonicalChunkID,
 		"created_by":        entry.CreatedBy,
 		"client_created_at": strings.TrimSpace(entry.CreatedAt),
@@ -229,6 +229,10 @@ func (rt *RemoteTransport) WriteChunk(chunkID string, data []byte, entry engrams
 	if err != nil {
 		return fmt.Errorf("cloud: marshal push request: %w", err)
 	}
+	body, err := chunkcodec.EncodeCompressedEnvelope(pushPayload)
+	if err != nil {
+		return fmt.Errorf("cloud: compress push request: %w", err)
+	}
 	pushURL, err := rt.endpointURL(nil, "sync", "push")
 	if err != nil {
 		return err
@@ -237,7 +241,7 @@ func (rt *RemoteTransport) WriteChunk(chunkID string, data []byte, entry engrams
 	if err != nil {
 		return fmt.Errorf("cloud: build push request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", chunkcodec.CompressedEnvelopeContentType())
 	rt.setAuthorization(req)
 
 	resp, err := rt.writeHTTPClient.Do(req)
@@ -261,6 +265,7 @@ func (rt *RemoteTransport) ReadChunk(chunkID string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cloud: build pull request: %w", err)
 	}
+	req.Header.Set("Accept", chunkcodec.CompressedEnvelopeContentType())
 	rt.setAuthorization(req)
 	resp, err := rt.httpClient.Do(req)
 	if err != nil {
@@ -280,6 +285,16 @@ func (rt *RemoteTransport) ReadChunk(chunkID string) ([]byte, error) {
 	}
 	if len(data) == 0 {
 		return nil, errors.New("cloud: empty chunk payload")
+	}
+	compressed, err := chunkcodec.IsCompressedEnvelopeContentType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, fmt.Errorf("cloud: parse chunk response encoding: %w", err)
+	}
+	if compressed {
+		data, err = chunkcodec.DecodeCompressedEnvelope(data, chunkcodec.DefaultMaxDecodedBytes)
+		if err != nil {
+			return nil, fmt.Errorf("cloud: decode compressed chunk %s: %w", chunkID, err)
+		}
 	}
 	return data, nil
 }

--- a/internal/cloud/remote/transport_test.go
+++ b/internal/cloud/remote/transport_test.go
@@ -231,6 +231,7 @@ func TestWriteChunkCanonicalizesPayloadAndChunkID(t *testing.T) {
 	var gotChunkID string
 	var gotClientCreatedAt string
 	var gotData json.RawMessage
+	const sentinel = "WAF-SENTINEL-738"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/sync/push" {
@@ -240,6 +241,16 @@ func TestWriteChunkCanonicalizesPayloadAndChunkID(t *testing.T) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("read body: %v", err)
+		}
+		if r.Header.Get("Content-Type") != chunkcodec.CompressedEnvelopeContentType() {
+			t.Fatalf("Content-Type = %q, want %q", r.Header.Get("Content-Type"), chunkcodec.CompressedEnvelopeContentType())
+		}
+		if strings.Contains(string(body), sentinel) {
+			t.Fatal("wire request exposed observation text")
+		}
+		body, err = chunkcodec.DecodeCompressedEnvelope(body, chunkcodec.DefaultMaxDecodedBytes)
+		if err != nil {
+			t.Fatalf("decode request envelope: %v", err)
 		}
 		var req struct {
 			ChunkID         string          `json:"chunk_id"`
@@ -262,7 +273,7 @@ func TestWriteChunkCanonicalizesPayloadAndChunkID(t *testing.T) {
 		t.Fatalf("NewRemoteTransport: %v", err)
 	}
 
-	originalPayload := []byte(`{"sessions":[{"id":"s-1","directory":"/tmp/s-1"}]}`)
+	originalPayload := []byte(`{"sessions":[{"id":"s-1","directory":"/tmp/s-1"}],"observations":[{"content":"` + sentinel + `"}]}`)
 	createdAt := "2026-04-01T12:30:00Z"
 	if err := rt.WriteChunk("deadbeef", originalPayload, engramsync.ChunkEntry{CreatedBy: "tester", CreatedAt: createdAt}); err != nil {
 		t.Fatalf("WriteChunk: %v", err)
@@ -282,6 +293,48 @@ func TestWriteChunkCanonicalizesPayloadAndChunkID(t *testing.T) {
 	}
 	if strings.TrimSpace(string(gotData)) != strings.TrimSpace(string(canonicalPayload)) {
 		t.Fatalf("expected canonical payload %s, got %s", string(canonicalPayload), string(gotData))
+	}
+}
+
+func TestReadChunkAcceptsCompressedAndLegacyResponses(t *testing.T) {
+	payload := []byte(`{"sessions":[{"id":"s-1","directory":"/tmp/s-1"}]}`)
+	compressed, err := chunkcodec.EncodeCompressedEnvelope(payload)
+	if err != nil {
+		t.Fatalf("EncodeCompressedEnvelope: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        []byte
+	}{
+		{name: "compressed", contentType: chunkcodec.CompressedEnvelopeContentType(), body: compressed},
+		{name: "legacy JSON", contentType: "application/json", body: payload},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Accept") != chunkcodec.CompressedEnvelopeContentType() {
+					t.Fatalf("Accept = %q, want compressed envelope", r.Header.Get("Accept"))
+				}
+				w.Header().Set("Content-Type", tt.contentType)
+				_, _ = w.Write(tt.body)
+			}))
+			defer srv.Close()
+
+			rt, err := NewRemoteTransport(srv.URL, "", "proj-a")
+			if err != nil {
+				t.Fatalf("NewRemoteTransport: %v", err)
+			}
+			got, err := rt.ReadChunk("chunk-1")
+			if err != nil {
+				t.Fatalf("ReadChunk: %v", err)
+			}
+			if string(got) != string(payload) {
+				t.Fatalf("payload = %q, want %q", got, payload)
+			}
+		})
 	}
 }
 

--- a/internal/cloud/remote/transport_test.go
+++ b/internal/cloud/remote/transport_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -333,6 +334,58 @@ func TestReadChunkAcceptsCompressedAndLegacyResponses(t *testing.T) {
 			}
 			if string(got) != string(payload) {
 				t.Fatalf("payload = %q, want %q", got, payload)
+			}
+		})
+	}
+}
+
+func TestReadChunkRejectsInvalidCompressedResponses(t *testing.T) {
+	overLimit, err := chunkcodec.EncodeCompressedEnvelope(bytes.Repeat([]byte("x"), int(chunkcodec.DefaultMaxDecodedBytes)+1))
+	if err != nil {
+		t.Fatalf("EncodeCompressedEnvelope: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        []byte
+		want        error
+	}{
+		{
+			name:        "malformed gzip",
+			contentType: chunkcodec.CompressedEnvelopeContentType(),
+			body:        []byte("not-gzip"),
+		},
+		{
+			name:        "unsupported envelope version",
+			contentType: chunkcodec.CompressedEnvelopeMediaType + "; version=2",
+			body:        []byte("ignored"),
+			want:        chunkcodec.ErrUnsupportedEnvelopeVersion,
+		},
+		{
+			name:        "decoded payload over client limit",
+			contentType: chunkcodec.CompressedEnvelopeContentType(),
+			body:        overLimit,
+			want:        chunkcodec.ErrPayloadTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				_, _ = w.Write(tt.body)
+			}))
+			defer srv.Close()
+
+			rt, err := NewRemoteTransport(srv.URL, "", "proj-a")
+			if err != nil {
+				t.Fatalf("NewRemoteTransport: %v", err)
+			}
+			if _, err := rt.ReadChunk("chunk-1"); err == nil {
+				t.Fatal("expected ReadChunk error")
+			} else if tt.want != nil && !errors.Is(err, tt.want) {
+				t.Fatalf("ReadChunk error = %v, want %v", err, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #738

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds a versioned gzip envelope for cloud-sync chunk transport, preserving content-derived chunk identities and legacy JSON compatibility.
- Adds bounded decoding plus client and server negotiation coverage for the compressed transport.
- Compression mitigates WAF false positives from cleartext observation JSON. It is not encryption and does not provide confidentiality.

## 📂 Changes

| File | Change |
|------|--------|
| `docs/engram-cloud/README.md` | Documents the versioned compressed transport and its confidentiality boundary. |
| `internal/cloud/chunkcodec/envelope.go` | Adds the shared versioned gzip chunk envelope and bounded decoder. |
| `internal/cloud/chunkcodec/envelope_test.go` | Covers envelope encoding, decoding, bounds, and legacy compatibility. |
| `internal/cloud/cloudserver/cloudserver.go` | Negotiates and serves the compressed chunk representation. |
| `internal/cloud/cloudserver/cloudserver_test.go` | Verifies server negotiation and compressed response behavior. |
| `internal/cloud/remote/transport.go` | Sends compressed chunk payloads through the remote client transport. |
| `internal/cloud/remote/transport_test.go` | Verifies client transport behavior and compatibility fallback. |

## 🧪 Test Plan

- [x] Focused cloud tests passed locally: `go test ./internal/cloud/...`
- [ ] Unit tests pass locally: `go test ./...` (incomplete: timed out once after 10 minutes; not retried)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run)
- [ ] Manually tested the affected functionality (not recorded for this delivery)

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | Incomplete locally: timed out once after 10 minutes |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Not run locally |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (incomplete: timed out once after 10 minutes)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run)
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This cohesive work unit changes 426 lines (415 additions, 11 deletions), 26 lines over the 400-line review budget. The shared codec, remote transport, server negotiation, tests, and user-facing documentation must land together to preserve protocol compatibility, so the maintainer-approved `size:exception` is requested. Focused cloud-package verification passed. The full suite is incomplete because `go test ./...` timed out once after 10 minutes and was not retried.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compressed, versioned transport for cloud chunk synchronization.
  * Chunk uploads and downloads now support compressed envelopes while maintaining compatibility with legacy JSON.
  * Added safeguards that reject malformed, unsupported, or oversized payloads.
* **Documentation**
  * Documented transport compatibility and security considerations, including that compression is not encryption and HTTPS remains recommended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->