### PR TITLE
fix(store): batch scan candidate ranking at page level

### DIFF
--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -351,11 +351,15 @@ type JudgeRelationParams struct {
 //
 // Errors from this method are expected to be logged and swallowed by callers —
 // detection failure must never fail the originating save.
+// defaultCandidateLimit is the fallback per-source candidate budget shared by
+// FindCandidates and the page-batched scan path when no positive limit is set.
+const defaultCandidateLimit = 3
+
 func (s *Store) FindCandidates(savedID int64, opts CandidateOptions) ([]Candidate, error) {
 	// Apply defaults.
 	limit := opts.Limit
 	if limit <= 0 {
-		limit = 3
+		limit = defaultCandidateLimit
 	}
 	query, threshold, err := candidateRankQuery(opts)
 	if err != nil {

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -70,6 +70,10 @@ func isValidConfidence(confidence float64) bool {
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+// defaultCandidateLimit is the fallback per-source candidate budget shared by
+// FindCandidates and the page-batched scan path when no positive limit is set.
+const defaultCandidateLimit = 3
+
 // CandidateOptions controls the FindCandidates query.
 type CandidateOptions struct {
 	// Project filters candidates to the same project as the saved observation.
@@ -351,10 +355,6 @@ type JudgeRelationParams struct {
 //
 // Errors from this method are expected to be logged and swallowed by callers —
 // detection failure must never fail the originating save.
-// defaultCandidateLimit is the fallback per-source candidate budget shared by
-// FindCandidates and the page-batched scan path when no positive limit is set.
-const defaultCandidateLimit = 3
-
 func (s *Store) FindCandidates(savedID int64, opts CandidateOptions) ([]Candidate, error) {
 	// Apply defaults.
 	limit := opts.Limit

--- a/internal/store/relations.go
+++ b/internal/store/relations.go
@@ -1103,33 +1103,9 @@ func validBM25Rank(rank float64) bool {
 // FindCandidates returns documents with ANY term overlap (not all terms).
 // Using implicit AND (sanitizeFTS) is too strict for candidate detection:
 // the full saved title would require every word to appear in candidates.
-// OR semantics give broader recall; BM25 score still captures relevance.
+// OR semantics give broader recall; the score still captures relevance.
 func sanitizeFTSCandidates(title string) string {
-	words := strings.Fields(title)
-	if len(words) == 0 {
-		return ""
-	}
-	quoted := make([]string, 0, len(words))
-	for _, w := range words {
-		w = strings.Trim(w, `"`)
-		if w != "" {
-			var escaped strings.Builder
-			for i := 0; i < len(w); i++ {
-				if w[i] == '"' {
-					// FTS5 escapes a literal quote by doubling it. Preserve an
-					// already escaped pair so callers do not get double escaped.
-					escaped.WriteString(`""`)
-					if i+1 < len(w) && w[i+1] == '"' {
-						i++
-					}
-					continue
-				}
-				escaped.WriteByte(w[i])
-			}
-			quoted = append(quoted, `"`+escaped.String()+`"`)
-		}
-	}
-	return strings.Join(quoted, " OR ")
+	return strings.Join(candidateTerms(title), " OR ")
 }
 
 // joinStrings joins a slice of strings with the given separator.
@@ -1374,7 +1350,7 @@ func (s *Store) scanProject(opts ScanOptions, allProjects bool) (ScanResult, err
 
 	// Load one ID-ordered page and one sentinel row before running candidate queries.
 	obsQuery := `
-		SELECT id, ifnull(sync_id,''), scope
+		SELECT id, ifnull(sync_id,''), scope, title, ifnull(project,'')
 		FROM observations
 		WHERE deleted_at IS NULL
 	`
@@ -1396,14 +1372,16 @@ func (s *Store) scanProject(opts ScanOptions, allProjects bool) (ScanResult, err
 	}
 
 	type obsRow struct {
-		id     int64
-		syncID string
-		scope  string
+		id      int64
+		syncID  string
+		scope   string
+		title   string
+		project string
 	}
 	observations := make([]obsRow, 0, limit+1)
 	for obsRows.Next() {
 		var o obsRow
-		if err := obsRows.Scan(&o.id, &o.syncID, &o.scope); err != nil {
+		if err := obsRows.Scan(&o.id, &o.syncID, &o.scope, &o.title, &o.project); err != nil {
 			obsRows.Close()
 			return result, fmt.Errorf("ScanProject: scan obs row: %w", err)
 		}
@@ -1418,6 +1396,28 @@ func (s *Store) scanProject(opts ScanOptions, allProjects bool) (ScanResult, err
 	hasMoreObservations := len(observations) > limit
 	if hasMoreObservations {
 		observations = observations[:limit]
+	}
+
+	// ── Page-level batched candidate ranking (#955) ──────────────────────────
+	// One bounded single-term FTS query per distinct page term instead of one
+	// multi-term scan per inspected observation; deterministic conflict scoring
+	// replaces the bm25 ordering per the issue contract. On batch failure the
+	// loop below falls back to the legacy per-source query so source-level
+	// failure behavior is unchanged.
+	batchSources := make([]scanSourceRow, len(observations))
+	for i, obs := range observations {
+		batchSources[i] = scanSourceRow{
+			id:      obs.id,
+			syncID:  obs.syncID,
+			scope:   obs.scope,
+			project: obs.project,
+			title:   obs.title,
+		}
+	}
+	batched, batchErr := s.scanCandidateBatch(batchSources, scanCandidateLimit)
+	if batchErr != nil {
+		log.Printf("[store] ScanProject: batched candidates failed, falling back to per-source ranking: %v", batchErr)
+		batched = nil
 	}
 
 	// ── Phase 4: collect all (source, candidate) pairs for semantic scan ──────
@@ -1437,20 +1437,27 @@ scan:
 		result.Inspected++
 		result.RankedQueries++
 
-		// Find candidates without inserting (SkipInsert=true per design §5).
-		candidateProject := opts.Project
-		if allProjects {
-			candidateProject = ""
-		}
-		candidates, err := s.FindCandidates(obs.id, CandidateOptions{
-			Project:    candidateProject,
-			Scope:      obs.scope,
-			Limit:      10,
-			SkipInsert: true,
-		})
-		if err != nil {
-			log.Printf("[store] ScanProject: FindCandidates obs=%s: %v", obs.syncID, err)
-			continue
+		// Page-batched candidates (#955) without inserting (SkipInsert=true per
+		// design §5); legacy per-source query when the batch could not run.
+		var candidates []Candidate
+		if batched != nil {
+			candidates = batched[obs.id]
+		} else {
+			candidateProject := opts.Project
+			if allProjects {
+				candidateProject = ""
+			}
+			var err error
+			candidates, err = s.FindCandidates(obs.id, CandidateOptions{
+				Project:    candidateProject,
+				Scope:      obs.scope,
+				Limit:      scanCandidateLimit,
+				SkipInsert: true,
+			})
+			if err != nil {
+				log.Printf("[store] ScanProject: FindCandidates obs=%s: %v", obs.syncID, err)
+				continue
+			}
 		}
 		result.CandidatesFound += len(candidates)
 

--- a/internal/store/relations_scan_batch.go
+++ b/internal/store/relations_scan_batch.go
@@ -1,0 +1,321 @@
+package store
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// scanCandidateLimit is the per-source candidate budget used by ScanProject.
+const scanCandidateLimit = 10
+
+// scanChunkSize bounds IN (...) parameter lists in batched lookups so the
+// batched path stays well under SQLite's variable limit.
+const scanChunkSize = 500
+
+// scanSourceRow carries the page fields the batched candidate ranking needs.
+type scanSourceRow struct {
+	id      int64
+	syncID  string
+	scope   string
+	project string
+	title   string
+}
+
+// candidateTerms splits a title into the quoted FTS5 phrases used for
+// candidate detection (ANY-term overlap recall). It preserves duplicates and
+// order so sanitizeFTSCandidates keeps its exact legacy output.
+func candidateTerms(title string) []string {
+	words := strings.Fields(title)
+	if len(words) == 0 {
+		return nil
+	}
+	quoted := make([]string, 0, len(words))
+	for _, w := range words {
+		w = strings.Trim(w, `"`)
+		if w == "" {
+			continue
+		}
+		var escaped strings.Builder
+		for i := 0; i < len(w); i++ {
+			if w[i] == '"' {
+				// FTS5 escapes a literal quote by doubling it. Preserve an
+				// already escaped pair so callers do not get double escaped.
+				escaped.WriteString(`""`)
+				if i+1 < len(w) && w[i+1] == '"' {
+					i++
+				}
+				continue
+			}
+			escaped.WriteByte(w[i])
+		}
+		quoted = append(quoted, `"`+escaped.String()+`"`)
+	}
+	return quoted
+}
+
+// scanCandidateMeta holds the candidate-side fields needed for per-source
+// filtering (project, scope) alongside the returned Candidate payload.
+type scanCandidateMeta struct {
+	cand    Candidate
+	scope   string
+	project string
+}
+
+// scanCandidateBatch computes conflict candidates for a whole scan page with
+// bounded page-level FTS batching (#955).
+//
+// Contract (issue #955 reopen): candidate recall (ANY-term overlap, answered
+// by FTS5 itself), project/scope/deleted/self/judged-relation filters,
+// per-source limits, and counters stay identical to the legacy per-source
+// FindCandidates query. The internal score and ordering are replaced by a
+// deterministic conflict-specific score: the number of distinct source title
+// terms that FTS-matched the candidate, ordered score descending with
+// candidate id ascending as the tie-break.
+//
+// Batching: every distinct quoted term across the page is issued exactly once
+// as a single-phrase FTS query (deterministic maximum query size, cf. #718),
+// so the number of FTS index scans per page is the page's distinct-term
+// vocabulary instead of one multi-term scan per inspected observation.
+//
+// Any error aborts the batch so the caller can fall back to the legacy
+// per-source path, preserving source-level failure behavior.
+func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) (map[int64][]Candidate, error) {
+	result := make(map[int64][]Candidate, len(sources))
+	if len(sources) == 0 || candidateLimit <= 0 {
+		return result, nil
+	}
+
+	// ── Phase 1: distinct page vocabulary → one bounded FTS query per term ──
+	termRowids := make(map[string][]int64)
+	for _, src := range sources {
+		for _, term := range candidateTerms(src.title) {
+			if _, seen := termRowids[term]; seen {
+				continue
+			}
+			termRowids[term] = nil // reserve before querying so failures retry cleanly
+			rows, err := s.db.Query(
+				`SELECT rowid FROM observations_fts WHERE observations_fts MATCH ?`, term,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("scanCandidateBatch: term %s: %w", term, err)
+			}
+			var ids []int64
+			for rows.Next() {
+				var id int64
+				if err := rows.Scan(&id); err != nil {
+					rows.Close()
+					return nil, fmt.Errorf("scanCandidateBatch: scan term %s: %w", term, err)
+				}
+				ids = append(ids, id)
+			}
+			if err := rows.Err(); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scanCandidateBatch: term %s rows: %w", term, err)
+			}
+			if err := rows.Close(); err != nil {
+				return nil, fmt.Errorf("scanCandidateBatch: close term %s: %w", term, err)
+			}
+			termRowids[term] = ids
+		}
+	}
+
+	// ── Phase 2: candidate metadata for every matched rowid (one pass) ──────
+	rowidUnion := make([]int64, 0, len(termRowids))
+	for _, ids := range termRowids {
+		rowidUnion = append(rowidUnion, ids...)
+	}
+	sort.Slice(rowidUnion, func(i, j int) bool { return rowidUnion[i] < rowidUnion[j] })
+	rowidUnion = dedupSortedInt64(rowidUnion)
+
+	metaByID := make(map[int64]scanCandidateMeta, len(rowidUnion))
+	for _, chunk := range chunkInt64(rowidUnion, scanChunkSize) {
+		placeholders := make([]string, len(chunk))
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := s.db.Query(fmt.Sprintf(`
+			SELECT o.id, ifnull(o.sync_id,''), o.title, o.type, o.topic_key,
+			       o.scope, ifnull(o.project,'')
+			FROM observations o
+			WHERE o.deleted_at IS NULL AND o.id IN (%s)
+		`, joinStrings(placeholders, ",")), args...)
+		if err != nil {
+			return nil, fmt.Errorf("scanCandidateBatch: candidate metadata: %w", err)
+		}
+		for rows.Next() {
+			var meta scanCandidateMeta
+			if err := rows.Scan(
+				&meta.cand.ID, &meta.cand.SyncID, &meta.cand.Title, &meta.cand.Type,
+				&meta.cand.TopicKey, &meta.scope, &meta.project,
+			); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scanCandidateBatch: scan metadata: %w", err)
+			}
+			metaByID[meta.cand.ID] = meta
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scanCandidateBatch: metadata rows: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("scanCandidateBatch: close metadata: %w", err)
+		}
+	}
+
+	// ── Phase 3: judged-relation exclusions for the page's sources ──────────
+	pageSyncIDs := make([]string, 0, len(sources))
+	for _, src := range sources {
+		pageSyncIDs = append(pageSyncIDs, src.syncID)
+	}
+	pageSyncIDs = dedupStrings(pageSyncIDs)
+
+	judgedPairs := make(map[string]struct{})
+	for _, chunk := range chunkStrings(pageSyncIDs, scanChunkSize) {
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for i, id := range chunk {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+		rows, err := s.db.Query(fmt.Sprintf(`
+			SELECT ifnull(source_id,''), ifnull(target_id,'')
+			FROM memory_relations
+			WHERE judgment_status = 'judged'
+			  AND (source_id IN (%s) OR target_id IN (%s))
+		`, joinStrings(placeholders, ","), joinStrings(placeholders, ",")), args...)
+		if err != nil {
+			return nil, fmt.Errorf("scanCandidateBatch: judged relations: %w", err)
+		}
+		for rows.Next() {
+			var a, b string
+			if err := rows.Scan(&a, &b); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scanCandidateBatch: scan judged: %w", err)
+			}
+			judgedPairs[judgedPairKey(a, b)] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scanCandidateBatch: judged rows: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("scanCandidateBatch: close judged: %w", err)
+		}
+	}
+
+	// ── Phase 4: deterministic per-source scoring, ordering, and limit ──────
+	for _, src := range sources {
+		scored := make(map[int64]int)
+		for _, term := range dedupStrings(candidateTerms(src.title)) {
+			for _, id := range termRowids[term] {
+				meta, ok := metaByID[id]
+				if !ok {
+					continue // row is missing or soft-deleted
+				}
+				if id == src.id {
+					continue // self
+				}
+				if meta.project != src.project {
+					continue // project filter
+				}
+				if meta.scope != src.scope {
+					continue // scope filter
+				}
+				if _, judged := judgedPairs[judgedPairKey(src.syncID, meta.cand.SyncID)]; judged {
+					continue // existing judged relation in either direction
+				}
+				scored[id]++
+			}
+		}
+		if len(scored) == 0 {
+			result[src.id] = nil
+			continue
+		}
+		order := make([]int64, 0, len(scored))
+		for id := range scored {
+			order = append(order, id)
+		}
+		sort.Slice(order, func(i, j int) bool {
+			if scored[order[i]] != scored[order[j]] {
+				return scored[order[i]] > scored[order[j]] // score descending
+			}
+			return order[i] < order[j] // deterministic tie-break: id ascending
+		})
+		if len(order) > candidateLimit {
+			order = order[:candidateLimit]
+		}
+		candidates := make([]Candidate, 0, len(order))
+		for _, id := range order {
+			meta := metaByID[id]
+			meta.cand.Score = float64(scored[id])
+			candidates = append(candidates, meta.cand)
+		}
+		result[src.id] = candidates
+	}
+
+	return result, nil
+}
+
+// judgedPairKey canonicalizes an unordered relation pair.
+func judgedPairKey(a, b string) string {
+	if a > b {
+		a, b = b, a
+	}
+	return a + "\x00" + b
+}
+
+func dedupSortedInt64(ids []int64) []int64 {
+	if len(ids) == 0 {
+		return ids
+	}
+	out := ids[:1]
+	for _, id := range ids[1:] {
+		if id != out[len(out)-1] {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func dedupStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func chunkInt64(items []int64, size int) [][]int64 {
+	var chunks [][]int64
+	for len(items) > size {
+		chunks = append(chunks, items[:size])
+		items = items[size:]
+	}
+	if len(items) > 0 {
+		chunks = append(chunks, items)
+	}
+	return chunks
+}
+
+func chunkStrings(items []string, size int) [][]string {
+	var chunks [][]string
+	for len(items) > size {
+		chunks = append(chunks, items[:size])
+		items = items[size:]
+	}
+	if len(items) > 0 {
+		chunks = append(chunks, items)
+	}
+	return chunks
+}

--- a/internal/store/relations_scan_batch.go
+++ b/internal/store/relations_scan_batch.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"cmp"
 	"fmt"
 	"sort"
 	"strings"
@@ -82,8 +83,13 @@ type scanCandidateMeta struct {
 // per-source path, preserving source-level failure behavior.
 func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) (map[int64][]Candidate, error) {
 	result := make(map[int64][]Candidate, len(sources))
-	if len(sources) == 0 || candidateLimit <= 0 {
+	if len(sources) == 0 {
 		return result, nil
+	}
+	if candidateLimit <= 0 {
+		// Mirror the legacy FindCandidates default so a zero limit can never
+		// silently return no candidates where the legacy path returned three.
+		candidateLimit = defaultCandidateLimit
 	}
 
 	// ── Phase 1: distinct page vocabulary → one bounded FTS query per term ──
@@ -93,28 +99,31 @@ func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) 
 			if _, seen := termRowids[term]; seen {
 				continue
 			}
-			termRowids[term] = nil // reserve before querying so failures retry cleanly
+			termRowids[term] = nil // reserve before querying so a repeated term is never queried twice
 			rows, err := s.db.Query(
 				`SELECT rowid FROM observations_fts WHERE observations_fts MATCH ?`, term,
 			)
 			if err != nil {
-				return nil, fmt.Errorf("scanCandidateBatch: term %s: %w", term, err)
+				// Error strings deliberately omit the term: terms derive from user
+				// observation titles and these errors reach the store log via the
+				// fallback path (review finding R1 on PR #1017).
+				return nil, fmt.Errorf("scanCandidateBatch: term query: %w", err)
 			}
 			var ids []int64
 			for rows.Next() {
 				var id int64
 				if err := rows.Scan(&id); err != nil {
 					rows.Close()
-					return nil, fmt.Errorf("scanCandidateBatch: scan term %s: %w", term, err)
+					return nil, fmt.Errorf("scanCandidateBatch: scan term row: %w", err)
 				}
 				ids = append(ids, id)
 			}
 			if err := rows.Err(); err != nil {
 				rows.Close()
-				return nil, fmt.Errorf("scanCandidateBatch: term %s rows: %w", term, err)
+				return nil, fmt.Errorf("scanCandidateBatch: term rows: %w", err)
 			}
 			if err := rows.Close(); err != nil {
-				return nil, fmt.Errorf("scanCandidateBatch: close term %s: %w", term, err)
+				return nil, fmt.Errorf("scanCandidateBatch: close term rows: %w", err)
 			}
 			termRowids[term] = ids
 		}
@@ -126,10 +135,10 @@ func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) 
 		rowidUnion = append(rowidUnion, ids...)
 	}
 	sort.Slice(rowidUnion, func(i, j int) bool { return rowidUnion[i] < rowidUnion[j] })
-	rowidUnion = dedupSortedInt64(rowidUnion)
+	rowidUnion = dedupSorted(rowidUnion)
 
 	metaByID := make(map[int64]scanCandidateMeta, len(rowidUnion))
-	for _, chunk := range chunkInt64(rowidUnion, scanChunkSize) {
+	for _, chunk := range chunk(rowidUnion, scanChunkSize) {
 		placeholders := make([]string, len(chunk))
 		args := make([]any, len(chunk))
 		for i, id := range chunk {
@@ -170,10 +179,10 @@ func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) 
 	for _, src := range sources {
 		pageSyncIDs = append(pageSyncIDs, src.syncID)
 	}
-	pageSyncIDs = dedupStrings(pageSyncIDs)
+	pageSyncIDs = dedupUnsorted(pageSyncIDs)
 
 	judgedPairs := make(map[string]struct{})
-	for _, chunk := range chunkStrings(pageSyncIDs, scanChunkSize) {
+	for _, chunk := range chunk(pageSyncIDs, scanChunkSize) {
 		placeholders := make([]string, len(chunk))
 		args := make([]any, 0, len(chunk)*2)
 		for i, id := range chunk {
@@ -212,7 +221,7 @@ func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) 
 	// ── Phase 4: deterministic per-source scoring, ordering, and limit ──────
 	for _, src := range sources {
 		scored := make(map[int64]int)
-		for _, term := range dedupStrings(candidateTerms(src.title)) {
+		for _, term := range dedupUnsorted(candidateTerms(src.title)) {
 			for _, id := range termRowids[term] {
 				meta, ok := metaByID[id]
 				if !ok {
@@ -270,22 +279,22 @@ func judgedPairKey(a, b string) string {
 	return a + "\x00" + b
 }
 
-func dedupSortedInt64(ids []int64) []int64 {
-	if len(ids) == 0 {
-		return ids
+func dedupSorted[T cmp.Ordered](items []T) []T {
+	if len(items) == 0 {
+		return items
 	}
-	out := ids[:1]
-	for _, id := range ids[1:] {
-		if id != out[len(out)-1] {
-			out = append(out, id)
+	out := items[:1]
+	for _, item := range items[1:] {
+		if item != out[len(out)-1] {
+			out = append(out, item)
 		}
 	}
 	return out
 }
 
-func dedupStrings(items []string) []string {
-	seen := make(map[string]struct{}, len(items))
-	out := make([]string, 0, len(items))
+func dedupUnsorted[T comparable](items []T) []T {
+	seen := make(map[T]struct{}, len(items))
+	out := make([]T, 0, len(items))
 	for _, item := range items {
 		if _, ok := seen[item]; ok {
 			continue
@@ -296,20 +305,8 @@ func dedupStrings(items []string) []string {
 	return out
 }
 
-func chunkInt64(items []int64, size int) [][]int64 {
-	var chunks [][]int64
-	for len(items) > size {
-		chunks = append(chunks, items[:size])
-		items = items[size:]
-	}
-	if len(items) > 0 {
-		chunks = append(chunks, items)
-	}
-	return chunks
-}
-
-func chunkStrings(items []string, size int) [][]string {
-	var chunks [][]string
+func chunk[T any](items []T, size int) [][]T {
+	var chunks [][]T
 	for len(items) > size {
 		chunks = append(chunks, items[:size])
 		items = items[size:]

--- a/internal/store/relations_scan_batch.go
+++ b/internal/store/relations_scan_batch.go
@@ -138,10 +138,10 @@ func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) 
 	rowidUnion = dedupSorted(rowidUnion)
 
 	metaByID := make(map[int64]scanCandidateMeta, len(rowidUnion))
-	for _, chunk := range chunk(rowidUnion, scanChunkSize) {
-		placeholders := make([]string, len(chunk))
-		args := make([]any, len(chunk))
-		for i, id := range chunk {
+	for _, idChunk := range chunk(rowidUnion, scanChunkSize) {
+		placeholders := make([]string, len(idChunk))
+		args := make([]any, len(idChunk))
+		for i, id := range idChunk {
 			placeholders[i] = "?"
 			args[i] = id
 		}
@@ -182,14 +182,14 @@ func (s *Store) scanCandidateBatch(sources []scanSourceRow, candidateLimit int) 
 	pageSyncIDs = dedupUnsorted(pageSyncIDs)
 
 	judgedPairs := make(map[string]struct{})
-	for _, chunk := range chunk(pageSyncIDs, scanChunkSize) {
-		placeholders := make([]string, len(chunk))
-		args := make([]any, 0, len(chunk)*2)
-		for i, id := range chunk {
+	for _, syncChunk := range chunk(pageSyncIDs, scanChunkSize) {
+		placeholders := make([]string, len(syncChunk))
+		args := make([]any, 0, len(syncChunk)*2)
+		for i, id := range syncChunk {
 			placeholders[i] = "?"
 			args = append(args, id)
 		}
-		for _, id := range chunk {
+		for _, id := range syncChunk {
 			args = append(args, id)
 		}
 		rows, err := s.db.Query(fmt.Sprintf(`

--- a/internal/store/scan_batch_test.go
+++ b/internal/store/scan_batch_test.go
@@ -1,0 +1,261 @@
+package store
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// scanBatchSeed describes one observation inserted by scanBatchStore.
+type scanBatchSeed struct {
+	title   string
+	content string
+	project string
+	scope   string
+	deleted bool
+}
+
+// scanBatchStore builds a mixed corpus for page-batched candidate ranking
+// fixtures (#955): multiple projects, scopes, a soft-deleted row, judged and
+// pending relations, all-short-term sources, and an over-limit candidate pool.
+func scanBatchStore(t *testing.T) *Store {
+	t.Helper()
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.DataDir = t.TempDir()
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.CreateSession("batch-session", "batch-alpha", "/tmp/batch"); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func scanBatchAdd(t *testing.T, s *Store, seed scanBatchSeed) int64 {
+	t.Helper()
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "batch-session",
+		Type:      "decision",
+		Title:     seed.title,
+		Content:   seed.content,
+		Project:   seed.project,
+		Scope:     seed.scope,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seed.deleted {
+		if _, err := s.db.Exec(`UPDATE observations SET deleted_at = datetime('now') WHERE id = ?`, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return id
+}
+
+func scanBatchInsertRelation(t *testing.T, s *Store, syncID, sourceID, targetID, status string) {
+	t.Helper()
+	if _, err := s.db.Exec(`
+		INSERT INTO memory_relations
+			(sync_id, source_id, target_id, relation, judgment_status, created_at, updated_at)
+		VALUES (?, ?, ?, 'pending', ?, datetime('now'), datetime('now'))
+	`, syncID, sourceID, targetID, status); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func scanBatchSources(t *testing.T, s *Store, ids ...int64) []scanSourceRow {
+	t.Helper()
+	sources := make([]scanSourceRow, 0, len(ids))
+	for _, id := range ids {
+		var row scanSourceRow
+		row.id = id
+		if err := s.db.QueryRow(
+			`SELECT ifnull(sync_id,''), scope, ifnull(project,''), title FROM observations WHERE id = ?`, id,
+		).Scan(&row.syncID, &row.scope, &row.project, &row.title); err != nil {
+			t.Fatal(err)
+		}
+		sources = append(sources, row)
+	}
+	return sources
+}
+
+func scanBatchCandidateIDs(candidates []Candidate) []int64 {
+	ids := make([]int64, 0, len(candidates))
+	for _, c := range candidates {
+		ids = append(ids, c.ID)
+	}
+	return ids
+}
+
+func scanBatchSortedIDs(ids []int64) []int64 {
+	sorted := slices.Clone(ids)
+	slices.Sort(sorted)
+	return sorted
+}
+
+// TestScanCandidateBatch_MatchesLegacyRecall pins the recall contract: the
+// page-batched path must surface exactly the same candidate set per source as
+// the legacy per-source FindCandidates query, including every filter
+// (project, scope, deleted, self, judged relations in either direction) and
+// the all-short-term edge case. Recall semantics are ANY-term overlap across
+// every indexed FTS column — a source term like "alpha" matches any row whose
+// project column is "batch-alpha" — so this fixture exercises cross-column
+// matching, not just title overlap.
+func TestScanCandidateBatch_MatchesLegacyRecall(t *testing.T) {
+	s := scanBatchStore(t)
+
+	// Source S1 first so its sync_id is available for relation seeds.
+	s1 := scanBatchAdd(t, s, scanBatchSeed{title: "alpha deploy pipeline notes", content: "source row", project: "batch-alpha", scope: "project"})
+	var s1Sync string
+	if err := s.db.QueryRow(`SELECT ifnull(sync_id,'') FROM observations WHERE id = ?`, s1).Scan(&s1Sync); err != nil {
+		t.Fatal(err)
+	}
+
+	twin := scanBatchAdd(t, s, scanBatchSeed{title: "alpha deploy pipeline twin", content: "title overlap", project: "batch-alpha", scope: "project"})
+	judgedPartner := scanBatchAdd(t, s, scanBatchSeed{title: "alpha deploy rollback guide", content: "judged pair", project: "batch-alpha", scope: "project"})
+	gardening := scanBatchAdd(t, s, scanBatchSeed{title: "unrelated gardening tips", content: "no title overlap", project: "batch-alpha", scope: "project"})
+	scanBatchAdd(t, s, scanBatchSeed{title: "alpha deploy scope mismatch row", content: "scope mismatch", project: "batch-alpha", scope: "personal"})
+	scanBatchAdd(t, s, scanBatchSeed{title: "alpha deploy pipeline notes", content: "other project", project: "batch-beta", scope: "project"})
+	scanBatchAdd(t, s, scanBatchSeed{title: "alpha deploy pipeline notes", content: "deleted row", project: "batch-alpha", scope: "project", deleted: true})
+	pendingRow := scanBatchAdd(t, s, scanBatchSeed{title: "alpha deploy pending pair row", content: "pending pair", project: "batch-alpha", scope: "project"})
+	shortTerm := scanBatchAdd(t, s, scanBatchSeed{title: "ab cd", content: "short terms only", project: "batch-alpha", scope: "project"})
+
+	var judgedSync, pendingSync string
+	if err := s.db.QueryRow(`SELECT ifnull(sync_id,'') FROM observations WHERE id = ?`, judgedPartner).Scan(&judgedSync); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.QueryRow(`SELECT ifnull(sync_id,'') FROM observations WHERE id = ?`, pendingRow).Scan(&pendingSync); err != nil {
+		t.Fatal(err)
+	}
+	scanBatchInsertRelation(t, s, "rel-batch-judged", s1Sync, judgedSync, "judged")
+	scanBatchInsertRelation(t, s, "rel-batch-pending", s1Sync, pendingSync, "pending")
+
+	sources := scanBatchSources(t, s, s1, shortTerm)
+	batch, err := s.scanCandidateBatch(sources, 10)
+	if err != nil {
+		t.Fatalf("scanCandidateBatch: %v", err)
+	}
+
+	for _, src := range sources {
+		legacy, err := s.FindCandidates(src.id, CandidateOptions{Project: "batch-alpha", Scope: src.scope, Limit: 10, SkipInsert: true})
+		if err != nil {
+			t.Fatalf("FindCandidates id=%d: %v", src.id, err)
+		}
+		got := scanBatchSortedIDs(scanBatchCandidateIDs(batch[src.id]))
+		want := scanBatchSortedIDs(scanBatchCandidateIDs(legacy))
+		if !slices.Equal(got, want) {
+			t.Errorf("source id=%d title=%q: batch candidates %v, legacy %v", src.id, src.title, got, want)
+		}
+	}
+
+	// S1 must see exactly: the title twin, the gardening row (matched via the
+	// indexed project column "batch-alpha" containing the term "alpha"), the
+	// pending pair row, and the short-term row (also matched via the project
+	// column). Excluded: itself, the judged partner, the scope-mismatch row,
+	// the other-project row, and the soft-deleted row.
+	gotIDs := scanBatchSortedIDs(scanBatchCandidateIDs(batch[s1]))
+	wantIDs := scanBatchSortedIDs([]int64{twin, gardening, pendingRow, shortTerm})
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("S1 candidate ids = %v, want %v", gotIDs, wantIDs)
+	}
+	if len(batch[shortTerm]) != 0 {
+		t.Fatalf("all-short-term source must match nothing, got %v", scanBatchCandidateIDs(batch[shortTerm]))
+	}
+}
+
+// TestScanCandidateBatch_DeterministicOrderAndScore pins the replacement
+// scoring contract: candidates are ordered by matched-term count descending
+// with candidate id ascending as the deterministic tie-break, the per-source
+// limit is honored, and scores are deterministic integers reported as floats.
+func TestScanCandidateBatch_DeterministicOrderAndScore(t *testing.T) {
+	s := scanBatchStore(t)
+
+	// Twelve mutual candidates that all share the full term set.
+	pool := make([]int64, 0, 12)
+	for i := 0; i < 12; i++ {
+		pool = append(pool, scanBatchAdd(t, s, scanBatchSeed{
+			title:   fmt.Sprintf("shared ranking corpus alpha omega %02d", i),
+			content: "shared ranking corpus alpha omega body",
+			project: "batch-alpha",
+			scope:   "project",
+		}))
+	}
+	// One weaker candidate sharing only two terms.
+	weak := scanBatchAdd(t, s, scanBatchSeed{title: "shared ranking something else", content: "weak overlap", project: "batch-alpha", scope: "project"})
+	source := scanBatchAdd(t, s, scanBatchSeed{title: "shared ranking corpus alpha omega unique", content: "source row", project: "batch-alpha", scope: "project"})
+
+	sources := scanBatchSources(t, s, source)
+	batch, err := s.scanCandidateBatch(sources, 10)
+	if err != nil {
+		t.Fatalf("scanCandidateBatch: %v", err)
+	}
+	got := batch[source]
+	if len(got) != 10 {
+		t.Fatalf("limit: got %d candidates, want 10", len(got))
+	}
+	// The weak candidate (fewer matched terms) must lose every seat when the
+	// pool alone already fills the limit.
+	for _, c := range got {
+		if c.ID == weak {
+			t.Fatalf("weak candidate must not displace a full-term candidate: %+v", got)
+		}
+	}
+	// All winners share the full term set: order must be id-ascending.
+	for i := 1; i < len(got); i++ {
+		if got[i-1].ID >= got[i].ID {
+			t.Fatalf("deterministic order violated: %+v", scanBatchCandidateIDs(got))
+		}
+	}
+	wantScore := float64(5) // shared, ranking, corpus, alpha, omega
+	for _, c := range got {
+		if c.Score != wantScore {
+			t.Fatalf("candidate id=%d score = %f, want %f", c.ID, c.Score, wantScore)
+		}
+	}
+	// Determinism: a second batch run returns the identical slice.
+	again, err := s.scanCandidateBatch(sources, 10)
+	if err != nil {
+		t.Fatalf("scanCandidateBatch (2nd): %v", err)
+	}
+	if !slices.Equal(scanBatchCandidateIDs(got), scanBatchCandidateIDs(again[source])) {
+		t.Fatalf("non-deterministic batch: %v vs %v", scanBatchCandidateIDs(got), scanBatchCandidateIDs(again[source]))
+	}
+}
+
+// TestScanProject_BatchFallbackWhenFTSBroken pins the failure contract: when
+// the batched path cannot run, the scan falls back to the legacy per-source
+// path, which logs and skips sources — the scan still succeeds with inspected
+// counters intact and zero candidates, exactly as on main.
+func TestScanProject_BatchFallbackWhenFTSBroken(t *testing.T) {
+	s := scanBatchStore(t)
+	ids := make([]int64, 0, 3)
+	for i := 0; i < 3; i++ {
+		ids = append(ids, scanBatchAdd(t, s, scanBatchSeed{
+			title:   fmt.Sprintf("fallback corpus probe %d", i),
+			content: "fallback corpus body",
+			project: "batch-alpha",
+			scope:   "project",
+		}))
+	}
+	if _, err := s.db.Exec(`DROP TABLE observations_fts`); err != nil {
+		t.Fatalf("drop fts: %v", err)
+	}
+	result, err := s.ScanProject(ScanOptions{Project: "batch-alpha", Limit: 2})
+	if err != nil {
+		t.Fatalf("ScanProject with broken FTS: %v", err)
+	}
+	if result.Inspected != 2 || result.RankedQueries != 2 {
+		t.Fatalf("counters with broken FTS: %+v", result)
+	}
+	if result.CandidatesFound != 0 {
+		t.Fatalf("candidates with broken FTS: %+v", result)
+	}
+	if result.NextCursor == nil || *result.NextCursor != ids[1] {
+		t.Fatalf("pagination with broken FTS: %+v", result)
+	}
+}

--- a/internal/store/scan_batch_test.go
+++ b/internal/store/scan_batch_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -224,6 +225,52 @@ func TestScanCandidateBatch_DeterministicOrderAndScore(t *testing.T) {
 	}
 	if !slices.Equal(scanBatchCandidateIDs(got), scanBatchCandidateIDs(again[source])) {
 		t.Fatalf("non-deterministic batch: %v vs %v", scanBatchCandidateIDs(got), scanBatchCandidateIDs(again[source]))
+	}
+}
+
+// TestScanCandidateBatch_NonPositiveLimitMirrorsLegacyDefault pins the R3
+// follow-up from the PR #1017 review: a non-positive candidate limit mirrors
+// the legacy FindCandidates default instead of silently returning nothing.
+func TestScanCandidateBatch_NonPositiveLimitMirrorsLegacyDefault(t *testing.T) {
+	s := scanBatchStore(t)
+	source := scanBatchAdd(t, s, scanBatchSeed{title: "limit probe mutual vocabulary row", content: "source", project: "batch-alpha", scope: "project"})
+	for i := 0; i < 5; i++ {
+		scanBatchAdd(t, s, scanBatchSeed{
+			title:   fmt.Sprintf("limit probe mutual vocabulary twin %d", i),
+			content: "twin",
+			project: "batch-alpha",
+			scope:   "project",
+		})
+	}
+	sources := scanBatchSources(t, s, source)
+	batch, err := s.scanCandidateBatch(sources, 0)
+	if err != nil {
+		t.Fatalf("scanCandidateBatch: %v", err)
+	}
+	if len(batch[source]) != defaultCandidateLimit {
+		t.Fatalf("zero limit: got %d candidates, want the legacy default %d", len(batch[source]), defaultCandidateLimit)
+	}
+}
+
+// TestScanCandidateBatch_ErrorsOmitTitleTerms pins the R1 follow-up from the
+// PR #1017 review: batch error strings never embed title-derived FTS terms,
+// because those errors reach the store log via the fallback path and the
+// legacy path logged only observation sync IDs.
+func TestScanCandidateBatch_ErrorsOmitTitleTerms(t *testing.T) {
+	s := scanBatchStore(t)
+	source := scanBatchAdd(t, s, scanBatchSeed{title: "secretword unshared token", content: "source", project: "batch-alpha", scope: "project"})
+	if _, err := s.db.Exec(`DROP TABLE observations_fts`); err != nil {
+		t.Fatalf("drop fts: %v", err)
+	}
+	sources := scanBatchSources(t, s, source)
+	_, err := s.scanCandidateBatch(sources, 10)
+	if err == nil {
+		t.Fatal("expected an error with the FTS table dropped")
+	}
+	for _, term := range []string{"secretword", "unshared", "token"} {
+		if strings.Contains(err.Error(), term) {
+			t.Fatalf("batch error leaks title-derived term %q: %v", term, err)
+		}
 	}
 }
 

--- a/internal/store/scan_page_test.go
+++ b/internal/store/scan_page_test.go
@@ -68,6 +68,79 @@ func BenchmarkScanProject_Page5000(b *testing.B) {
 		_ = scanPage(b, s, ScanOptions{Project: "scan-page"})
 	}
 }
+
+// scanUniquePageStore builds the unique-vocabulary worst case for the batched
+// scan: every observation title carries tokens that appear in no other
+// observation, so the page's distinct-term vocabulary is maximal and no
+// term's posting list is shared across sources.
+func scanUniquePageStore(tb testing.TB, count int) (*Store, []int64) {
+	tb.Helper()
+	cfg, err := DefaultConfig()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	cfg.DataDir = tb.TempDir()
+	s, err := New(cfg)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = s.Close() })
+	if err := s.CreateSession("scan-uniq-session", "scan-uniq", "/tmp/scan-uniq"); err != nil {
+		tb.Fatal(err)
+	}
+	ids := make([]int64, 0, count)
+	if err := s.withTx(func(tx *sql.Tx) error {
+		for i := 0; i < count; i++ {
+			result, err := tx.Exec(`INSERT INTO observations (sync_id, session_id, type, title, content, project, scope, normalized_hash, revision_count, duplicate_count, created_at, updated_at) VALUES (?, ?, 'decision', ?, ?, 'scan-uniq', 'project', ?, 1, 1, datetime('now'), datetime('now'))`,
+				fmt.Sprintf("scan-uniq-%04d", i), "scan-uniq-session",
+				fmt.Sprintf("uniq%04da uniq%04db uniq%04dc", i, i, i),
+				"scan benchmark body",
+				fmt.Sprintf("scan-uniq-hash-%04d", i))
+			if err != nil {
+				return err
+			}
+			id, err := result.LastInsertId()
+			if err != nil {
+				return err
+			}
+			ids = append(ids, id)
+		}
+		return nil
+	}); err != nil {
+		tb.Fatal(err)
+	}
+	return s, ids
+}
+
+// BenchmarkScanProject_UniqueVocab5000 measures the batched scan on the
+// unique-vocabulary worst case (review finding R4 on PR #1017): a full
+// DefaultScanLimit page whose sources share no term, so Phase 1 issues one
+// single-phrase query per distinct term with no shared posting lists.
+func BenchmarkScanProject_UniqueVocab5000(b *testing.B) {
+	s, _ := scanUniquePageStore(b, scanPageBenchmarkObservations)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = scanPage(b, s, ScanOptions{Project: "scan-uniq"})
+	}
+}
+
+// BenchmarkScanLegacyRanking_UniqueVocab5000 measures the legacy per-source
+// ranking cost on the same unique-vocabulary corpus: one FindCandidates call
+// per inspected observation for a full page, the exact work ScanProject
+// performed before the batched path. Comparing it with
+// BenchmarkScanProject_UniqueVocab5000 bounds the worst-case tradeoff of the
+// batching change instead of relying on the repetitive-vocabulary shape alone.
+func BenchmarkScanLegacyRanking_UniqueVocab5000(b *testing.B) {
+	s, ids := scanUniquePageStore(b, scanPageBenchmarkObservations)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < DefaultScanLimit; j++ {
+			if _, err := s.FindCandidates(ids[j], CandidateOptions{Project: "scan-uniq", Scope: "project", Limit: scanCandidateLimit, SkipInsert: true}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
 func scanPage(tb testing.TB, s *Store, opts ScanOptions) ScanResult {
 	tb.Helper()
 	result, err := s.ScanProject(opts)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #955

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

---

## 📝 Summary

- Replaces ScanProject's per-observation FTS5 ranking query with a page-level batched path: every distinct quoted title term across the page is issued exactly once as a single-phrase `MATCH` (bounded query size, in the direction of #718), candidate metadata and judged-relation exclusions are fetched once in chunked lookups, and each source is scored deterministically by matched-term count (score desc, candidate id asc).
- Implements the revised implementation contract from #955: recall (ANY-term overlap, answered by FTS5 itself), project/scope/deleted/self/existing-relation filters, limits, counters, pagination, and dry-run/apply behavior are unchanged; the internal BM25 score and ordering change, which the contract now allows. On any batch failure the scan falls back to the legacy per-source query, preserving source-level failure behavior.
- `FindCandidates` itself is untouched for its MCP callers; only `ScanProject`'s internal use switches to the batched path.
- Follow-up commits address every finding from two native four-lens reviews (see receipt below): log hardening (no title-derived terms in error strings), shared candidate-limit default, generic dedup/chunk helpers, the unique-vocabulary worst-case benchmark pair, and two readability nits.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/relations_scan_batch.go` | New: `scanCandidateBatch` (four-phase batched ranking), `candidateTerms`, deterministic scoring, generic chunked helpers. |
| `internal/store/relations.go` | `scanProject` precomputes the page batch with legacy fallback; page SELECT extended with title/project; `sanitizeFTSCandidates` delegates to `candidateTerms` (identical output); shared `defaultCandidateLimit`. |
| `internal/store/scan_batch_test.go` | Behavior fixtures: batch↔legacy recall equality (cross-column matching, judged/pending relations, scope/project/deleted filters, short terms), deterministic ordering and scores, fallback with broken FTS, error-string hygiene, mirrored limit default. |
| `internal/store/scan_page_test.go` | Worst-case benchmarks: `BenchmarkScanProject_UniqueVocab5000` (batched) vs `BenchmarkScanLegacyRanking_UniqueVocab5000` (pre-change per-source loop) over a corpus whose titles share no term. |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./... -count=1` (28 packages ok)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Benchmark evidence (same machine, `go test ./internal/store/ -run '^$' -bench ... -benchtime=1s -count=5`, benchstat):

```
Repetitive-vocabulary shape (the regression from the issue):
ScanProject_Page5000       5964.8m → 617.8m   -89.64% (p=0.008 n=5)

Unique-vocabulary worst case (one single-phrase query per distinct term):
ScanProject_UniqueVocab5000   127.1m
ScanLegacyRanking_UniqueVocab5000  357.2m   → worst case still ~2.8x faster than legacy
```

The repetitive-shape number is unchanged within noise after the follow-up commits (interleaved A/B, p=0.818). Search-path benchmarks are unaffected.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|------------------|--------|
| **Check Issue Reference** | PR body contains `Closes #955` | ✅ |
| **Check Issue Has status:approved** | #955 has `status:approved` | ✅ |
| **Check PR Has type:\* Label** | `type:bug` (maintainer: please add) | ⏳ |
| **Unit Tests** | `go test ./...` passes | ✅ locally |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` | ⏳ CI |
| **Plugin Tests** | `npm test` in `plugin/pi` | ⏳ CI |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #955`)
- [x] I added exactly **one** `type:*` label to this PR *(cannot set as outside contributor — maintainer, please add `type:bug`)*
- [x] I ran the relevant Store unit tests locally: `go test ./internal/store -count=1`
- [x] I ran the repository-wide unit suite: `go test ./... -count=1`
- [ ] I did not rerun the E2E suite: `go test -tags e2e ./internal/server/...`
- [x] No docs update needed (internal scoring contract documented in code; no user-facing behavior change)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

### Review receipts

Two native four-lens RDD reviews, both **approved with zero blockers**:

1. **Base candidate** `23f7b9b` (679 changed lines, tier high, lineage `review-37cb4b60c60a4856`): approved; 2 WARNINGs + 3 SUGGESTIONs — **all five addressed by the follow-up commits below**.
2. **Follow-up delta** `3e9a9df`+`8e4594e` (193 changed lines, tier high, lineage `review-c419dda0a3063f5e`): approved; 2 advisory SUGGESTIONs (doc-comment attachment, chunk name shadowing) — addressed by `85815f9` (comments/identifiers only, no behavior change).

### Follow-up commits

- `3e9a9df` — harden scan batch errors (no title-derived terms in error strings) and align the candidate limit default with the legacy `FindCandidates` behavior (shared `defaultCandidateLimit`); generic dedup/chunk helpers; fixtures pin both.
- `8e4594e` — worst-case benchmarks: unique-vocabulary corpus, batched vs legacy-equivalent ranking.
- `85815f9` — readability-only: restore the `FindCandidates` doc comment, unshadow the generic `chunk` helper.

### Behavior notes

- When a source has more than ten matching candidates, the selected subset can differ from the legacy bm25 top ten (matched-term count with id tie-break) — the ordering change #955's revised contract explicitly allows.
- `Candidate.Score` on the scan path is now a positive matched-term count instead of a negative bm25 rank; no scan-path consumer thresholds on it, and `FindCandidates` (MCP) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Project scans now evaluate candidate matches in batches, improving efficiency on pages with many observations.
  * Candidate results are ranked consistently by matching-term counts, with stable tie-breaking and per-source result limits.

* **Reliability**
  * Scans continue using the existing matching behavior if batched candidate evaluation encounters an error.
  * Candidate filtering continues to respect project scope, deleted items, self-matches, and previously judged relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->