### PR TITLE
test(mcp): benchmark mem_judge latency layers

### DIFF
--- a/internal/mcp/judge_bench_test.go
+++ b/internal/mcp/judge_bench_test.go
@@ -1,0 +1,236 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Gentleman-Programming/engram/v2/internal/store"
+	"github.com/mark3labs/mcp-go/client"
+	mcppkg "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const judgeMCPBenchmarkProject = "judge-mcp-benchmark"
+
+type judgeMCPBenchmarkFixture struct {
+	store *store.Store
+	ids   []string
+}
+
+type judgeMCPBenchmarkCall func(string) error
+
+func TestJudgeMCPStdioBenchmarkHelper(t *testing.T) {
+	if os.Getenv("ENGRAM_JUDGE_BENCH_STDIO") != "1" {
+		return
+	}
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.DataDir = os.Getenv("ENGRAM_DATA_DIR")
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := server.ServeStdio(NewServerWithTools(s, map[string]bool{"mem_judge": true})); err != nil {
+		t.Error(err)
+	}
+}
+
+func newJudgeMCPBenchmarkFixture(b *testing.B, enrolled bool) *judgeMCPBenchmarkFixture {
+	b.Helper()
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		b.Fatalf("default store config: %v", err)
+	}
+	cfg.DataDir = b.TempDir()
+	s, err := store.New(cfg)
+	if err != nil {
+		b.Fatalf("create benchmark store: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+	if err := s.CreateSession("judge-mcp-benchmark-session", judgeMCPBenchmarkProject, cfg.DataDir); err != nil {
+		b.Fatalf("create benchmark session: %v", err)
+	}
+	add := func(label string) string {
+		id, err := s.AddObservation(store.AddObservationParams{SessionID: "judge-mcp-benchmark-session", Type: "benchmark", Title: "MCP judge benchmark " + label, Content: "benchmark fixture", Project: judgeMCPBenchmarkProject, Scope: "project"})
+		if err != nil {
+			b.Fatalf("add benchmark %s observation: %v", label, err)
+		}
+		observation, err := s.GetObservation(id)
+		if err != nil {
+			b.Fatalf("get benchmark %s observation: %v", label, err)
+		}
+		return observation.SyncID
+	}
+	sourceID, targetID := add("source"), add("target")
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("rel-judge-mcp-benchmark-%d", i+1)
+		if _, err := s.SaveRelation(store.SaveRelationParams{SyncID: ids[i], SourceID: sourceID, TargetID: targetID}); err != nil {
+			b.Fatalf("seed benchmark relation %d: %v", i+1, err)
+		}
+	}
+	if enrolled {
+		if err := s.EnrollProject(judgeMCPBenchmarkProject); err != nil {
+			b.Fatalf("enroll benchmark project: %v", err)
+		}
+	}
+	return &judgeMCPBenchmarkFixture{store: s, ids: ids}
+}
+
+func judgeMCPBenchmarkRequest(id string) mcppkg.CallToolRequest {
+	return mcppkg.CallToolRequest{Params: mcppkg.CallToolParams{Arguments: map[string]any{"judgment_id": id, "relation": "not_conflict", "confidence": 0.9}}}
+}
+
+func callJudgeMCPHandler(handler server.ToolHandlerFunc, id string) error {
+	result, err := handler(context.Background(), judgeMCPBenchmarkRequest(id))
+	if err != nil {
+		return err
+	}
+	if result == nil || result.IsError {
+		return errors.New("mem_judge handler returned an error result")
+	}
+	return nil
+}
+
+func callJudgeMCPInProcess(s *server.MCPServer, id string) error {
+	request, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": map[string]any{"name": "mem_judge", "arguments": judgeMCPBenchmarkRequest(id).Params.Arguments}})
+	if err != nil {
+		return err
+	}
+	response, err := json.Marshal(s.HandleMessage(context.Background(), request))
+	if err != nil {
+		return err
+	}
+	var envelope struct {
+		Error  json.RawMessage `json:"error"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(response, &envelope); err != nil {
+		return err
+	}
+	if len(envelope.Error) != 0 && string(envelope.Error) != "null" {
+		return errors.New("in-process MCP server returned a protocol error")
+	}
+	var result mcppkg.CallToolResult
+	if err := json.Unmarshal(envelope.Result, &result); err != nil {
+		return err
+	}
+	if result.IsError {
+		return errors.New("in-process MCP server returned an error result")
+	}
+	return nil
+}
+
+func newJudgeMCPStdioCall(b *testing.B, fixture *judgeMCPBenchmarkFixture) judgeMCPBenchmarkCall {
+	c, err := client.NewStdioMCPClient(os.Args[0], append(os.Environ(), "ENGRAM_JUDGE_BENCH_STDIO=1", "ENGRAM_DATA_DIR="+fixture.store.DataDir()), "-test.run=^TestJudgeMCPStdioBenchmarkHelper$")
+	if err != nil {
+		b.Fatalf("start stdio benchmark helper: %v", err)
+	}
+	b.Cleanup(func() { _ = c.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	init := mcppkg.InitializeRequest{}
+	init.Params.ProtocolVersion = mcppkg.LATEST_PROTOCOL_VERSION
+	init.Params.ClientInfo = mcppkg.Implementation{Name: "judge-benchmark", Version: "1"}
+	if _, err := c.Initialize(ctx, init); err != nil {
+		b.Fatalf("initialize stdio benchmark helper: %v", err)
+	}
+	return func(id string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		request := judgeMCPBenchmarkRequest(id)
+		request.Params.Name = "mem_judge"
+		result, err := c.CallTool(ctx, request)
+		if err != nil {
+			return err
+		}
+		if result == nil || result.IsError {
+			return errors.New("stdio MCP server returned an error result")
+		}
+		return nil
+	}
+}
+
+func benchmarkJudgeMCPCalls(b *testing.B, fixture *judgeMCPBenchmarkFixture, call judgeMCPBenchmarkCall, calls int, concurrent bool) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if !concurrent {
+			for _, id := range fixture.ids[:calls] {
+				if err := call(id); err != nil {
+					b.Fatal(err)
+				}
+			}
+			continue
+		}
+		b.StopTimer()
+		start, errs := make(chan struct{}), make(chan error, calls)
+		var ready sync.WaitGroup
+		ready.Add(calls)
+		for _, id := range fixture.ids[:calls] {
+			go func(id string) { ready.Done(); <-start; errs <- call(id) }(id)
+		}
+		ready.Wait()
+		b.StartTimer()
+		close(start)
+		for range calls {
+			if err := <-errs; err != nil {
+				b.StopTimer()
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+	}
+}
+
+func benchmarkJudgeMCPLayer(b *testing.B, newCall func(*testing.B, *judgeMCPBenchmarkFixture) judgeMCPBenchmarkCall) {
+	for _, scenario := range []struct {
+		name                 string
+		enrolled, concurrent bool
+		calls                int
+	}{
+		{"One/Unenrolled", false, false, 1}, {"One/Enrolled", true, false, 1},
+		{"SequentialThree/Unenrolled", false, false, 3}, {"ConcurrentThree/Unenrolled", false, true, 3},
+	} {
+		b.Run(scenario.name, func(b *testing.B) {
+			fixture := newJudgeMCPBenchmarkFixture(b, scenario.enrolled)
+			benchmarkJudgeMCPCalls(b, fixture, newCall(b, fixture), scenario.calls, scenario.concurrent)
+		})
+	}
+}
+
+// BenchmarkJudgeMCP compares direct, queued, and in-process JSON-RPC layers.
+// InProcessJSONRPC includes JSON serialization but excludes stdio/process transport.
+func BenchmarkJudgeMCP(b *testing.B) {
+	for _, layer := range []struct {
+		name string
+		call func(*testing.B, *judgeMCPBenchmarkFixture) judgeMCPBenchmarkCall
+	}{
+		{"DirectHandler", func(_ *testing.B, f *judgeMCPBenchmarkFixture) judgeMCPBenchmarkCall {
+			handler := handleJudge(f.store, NewSessionActivity(10*time.Minute))
+			return func(id string) error { return callJudgeMCPHandler(handler, id) }
+		}},
+		{"QueuedHandler", func(b *testing.B, f *judgeMCPBenchmarkFixture) judgeMCPBenchmarkCall {
+			queue := newWriteQueue(defaultMCPWriteQueueSize)
+			b.Cleanup(func() { close(queue.jobs) })
+			handler := queuedWriteHandler(queue, handleJudge(f.store, NewSessionActivity(10*time.Minute)))
+			return func(id string) error { return callJudgeMCPHandler(handler, id) }
+		}},
+		{"InProcessJSONRPC", func(_ *testing.B, f *judgeMCPBenchmarkFixture) judgeMCPBenchmarkCall {
+			s := NewServerWithTools(f.store, map[string]bool{"mem_judge": true})
+			return func(id string) error { return callJudgeMCPInProcess(s, id) }
+		}},
+		{"StdioProcess", newJudgeMCPStdioCall},
+	} {
+		b.Run(layer.name, func(b *testing.B) { benchmarkJudgeMCPLayer(b, layer.call) })
+	}
+}

--- a/internal/mcp/judge_bench_test.go
+++ b/internal/mcp/judge_bench_test.go
@@ -199,7 +199,8 @@ func benchmarkJudgeMCPLayer(b *testing.B, newCall func(*testing.B, *judgeMCPBenc
 		calls                int
 	}{
 		{"One/Unenrolled", false, false, 1}, {"One/Enrolled", true, false, 1},
-		{"SequentialThree/Unenrolled", false, false, 3}, {"ConcurrentThree/Unenrolled", false, true, 3},
+		{"SequentialThree/Unenrolled", false, false, 3}, {"SequentialThree/Enrolled", true, false, 3},
+		{"ConcurrentThree/Unenrolled", false, true, 3}, {"ConcurrentThree/Enrolled", true, true, 3},
 	} {
 		b.Run(scenario.name, func(b *testing.B) {
 			fixture := newJudgeMCPBenchmarkFixture(b, scenario.enrolled)

--- a/internal/store/judge_relation_bench_test.go
+++ b/internal/store/judge_relation_bench_test.go
@@ -1,0 +1,159 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const judgeRelationBenchmarkProject = "judge-benchmark"
+
+type judgeRelationBenchmarkFixture struct {
+	store *Store
+	ids   []string
+}
+
+func newJudgeRelationBenchmarkFixture(b *testing.B, enrolled bool) *judgeRelationBenchmarkFixture {
+	b.Helper()
+	cfg, err := DefaultConfig()
+	if err != nil {
+		b.Fatalf("default store config: %v", err)
+	}
+	cfg.DataDir = b.TempDir()
+	s, err := New(cfg)
+	if err != nil {
+		b.Fatalf("create benchmark store: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+	if err := s.CreateSession("judge-benchmark-session", judgeRelationBenchmarkProject, cfg.DataDir); err != nil {
+		b.Fatalf("create benchmark session: %v", err)
+	}
+	add := func(label string) string {
+		id, err := s.AddObservation(AddObservationParams{SessionID: "judge-benchmark-session", Type: "benchmark", Title: "judge relation benchmark " + label, Content: "benchmark fixture", Project: judgeRelationBenchmarkProject, Scope: "project"})
+		if err != nil {
+			b.Fatalf("add benchmark %s observation: %v", label, err)
+		}
+		observation, err := s.GetObservation(id)
+		if err != nil {
+			b.Fatalf("get benchmark %s observation: %v", label, err)
+		}
+		return observation.SyncID
+	}
+	sourceID, targetID := add("source"), add("target")
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("rel-judge-benchmark-%d", i+1)
+		if _, err := s.SaveRelation(SaveRelationParams{SyncID: ids[i], SourceID: sourceID, TargetID: targetID}); err != nil {
+			b.Fatalf("seed benchmark relation %d: %v", i+1, err)
+		}
+	}
+	if enrolled {
+		if err := s.EnrollProject(judgeRelationBenchmarkProject); err != nil {
+			b.Fatalf("enroll benchmark project: %v", err)
+		}
+	}
+	return &judgeRelationBenchmarkFixture{store: s, ids: ids}
+}
+
+func judgeRelationBenchmarkParams(id string) JudgeRelationParams {
+	confidence := 0.9
+	return JudgeRelationParams{JudgmentID: id, Relation: "not_conflict", Confidence: &confidence, MarkedByActor: "benchmark", MarkedByKind: "agent"}
+}
+
+func benchmarkJudgeRelationCalls(b *testing.B, enrolled bool, calls int, concurrent bool) {
+	fixture := newJudgeRelationBenchmarkFixture(b, enrolled)
+	judge := func(id string) error {
+		_, err := fixture.store.JudgeRelation(judgeRelationBenchmarkParams(id))
+		return err
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if !concurrent {
+			for _, id := range fixture.ids[:calls] {
+				if err := judge(id); err != nil {
+					b.Fatal(err)
+				}
+			}
+			continue
+		}
+		b.StopTimer()
+		start, errs := make(chan struct{}), make(chan error, calls)
+		var ready sync.WaitGroup
+		ready.Add(calls)
+		for _, id := range fixture.ids[:calls] {
+			go func(id string) { ready.Done(); <-start; errs <- judge(id) }(id)
+		}
+		ready.Wait()
+		b.StartTimer()
+		close(start)
+		for range calls {
+			if err := <-errs; err != nil {
+				b.StopTimer()
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+	}
+}
+
+func benchmarkJudgeRelationExternalSQLiteLock(b *testing.B) {
+	fixture := newJudgeRelationBenchmarkFixture(b, true)
+	external, err := sql.Open("sqlite", filepath.Join(fixture.store.DataDir(), "engram.db"))
+	if err != nil {
+		b.Fatalf("open external SQLite handle: %v", err)
+	}
+	external.SetMaxOpenConns(1)
+	b.Cleanup(func() { _ = external.Close() })
+	const hold = 25 * time.Millisecond
+	b.ReportAllocs()
+	b.ReportMetric(float64(hold/time.Millisecond), "lock-hold-ms")
+	b.ResetTimer()
+	for range b.N {
+		b.StopTimer()
+		if _, err := external.Exec("BEGIN EXCLUSIVE"); err != nil {
+			b.Fatalf("acquire external SQLite lock: %v", err)
+		}
+		start, done := make(chan struct{}), make(chan error, 1)
+		go func() {
+			<-start
+			_, err := fixture.store.JudgeRelation(judgeRelationBenchmarkParams(fixture.ids[0]))
+			done <- err
+		}()
+		b.StartTimer()
+		close(start)
+		time.Sleep(hold)
+		if _, err := external.Exec("COMMIT"); err != nil {
+			b.StopTimer()
+			b.Fatal(err)
+		}
+		if err := <-done; err != nil {
+			b.StopTimer()
+			b.Fatal(err)
+		}
+		b.StopTimer()
+	}
+}
+
+// BenchmarkJudgeRelation attributes Store-only work with seeded relations.
+func BenchmarkJudgeRelation(b *testing.B) {
+	for _, scenario := range []struct {
+		name                 string
+		enrolled, concurrent bool
+		calls                int
+	}{
+		{"One/Unenrolled", false, false, 1}, {"One/Enrolled", true, false, 1},
+		{"SequentialThree/Unenrolled", false, false, 3}, {"SequentialThree/Enrolled", true, false, 3},
+		{"ConcurrentThree/Unenrolled", false, true, 3}, {"ConcurrentThree/Enrolled", true, true, 3},
+	} {
+		b.Run(scenario.name, func(b *testing.B) {
+			benchmarkJudgeRelationCalls(b, scenario.enrolled, scenario.calls, scenario.concurrent)
+		})
+	}
+	b.Run("ExternalSQLiteLock/Enrolled", benchmarkJudgeRelationExternalSQLiteLock)
+}

--- a/internal/store/judge_relation_bench_test.go
+++ b/internal/store/judge_relation_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -104,6 +105,12 @@ func benchmarkJudgeRelationCalls(b *testing.B, enrolled bool, calls int, concurr
 
 func benchmarkJudgeRelationExternalSQLiteLock(b *testing.B) {
 	fixture := newJudgeRelationBenchmarkFixture(b, true)
+	if _, err := fixture.store.DB().Exec("PRAGMA busy_timeout = 0"); err != nil {
+		b.Fatalf("disable Store SQLite busy timeout: %v", err)
+	}
+	originalBackoffs := sqliteWriteRetryBackoffs
+	sqliteWriteRetryBackoffs = make([]time.Duration, len(originalBackoffs))
+	b.Cleanup(func() { sqliteWriteRetryBackoffs = originalBackoffs })
 	external, err := sql.Open("sqlite", filepath.Join(fixture.store.DataDir(), "engram.db"))
 	if err != nil {
 		b.Fatalf("open external SQLite handle: %v", err)
@@ -111,15 +118,29 @@ func benchmarkJudgeRelationExternalSQLiteLock(b *testing.B) {
 	external.SetMaxOpenConns(1)
 	b.Cleanup(func() { _ = external.Close() })
 	const hold = 25 * time.Millisecond
+	originalExec := fixture.store.hooks.exec
+	var blocked chan<- struct{}
+	var retry <-chan struct{}
+	fixture.store.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
+		result, err := originalExec(db, query, args...)
+		if strings.Contains(query, "UPDATE memory_relations") && isRetryableSQLiteLockError(err) {
+			blocked <- struct{}{}
+			<-retry
+		}
+		return result, err
+	}
+	b.Cleanup(func() { fixture.store.hooks.exec = originalExec })
 	b.ReportAllocs()
 	b.ReportMetric(float64(hold/time.Millisecond), "lock-hold-ms")
 	b.ResetTimer()
 	for range b.N {
 		b.StopTimer()
-		if _, err := external.Exec("BEGIN EXCLUSIVE"); err != nil {
+		if _, err := external.Exec("BEGIN IMMEDIATE"); err != nil {
 			b.Fatalf("acquire external SQLite lock: %v", err)
 		}
 		start, done := make(chan struct{}), make(chan error, 1)
+		updateBlocked, retryUpdate := make(chan struct{}), make(chan struct{})
+		blocked, retry = updateBlocked, retryUpdate
 		go func() {
 			<-start
 			_, err := fixture.store.JudgeRelation(judgeRelationBenchmarkParams(fixture.ids[0]))
@@ -127,11 +148,22 @@ func benchmarkJudgeRelationExternalSQLiteLock(b *testing.B) {
 		}()
 		b.StartTimer()
 		close(start)
+		select {
+		case <-updateBlocked:
+		case <-time.After(time.Second):
+			b.StopTimer()
+			_, _ = external.Exec("ROLLBACK")
+			close(retryUpdate)
+			b.Fatal("Store UPDATE did not report a SQLite lock")
+		}
 		time.Sleep(hold)
 		if _, err := external.Exec("COMMIT"); err != nil {
 			b.StopTimer()
+			_, _ = external.Exec("ROLLBACK")
+			close(retryUpdate)
 			b.Fatal(err)
 		}
+		close(retryUpdate)
 		if err := <-done; err != nil {
 			b.StopTimer()
 			b.Fatal(err)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #881

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add fixed-work benchmarks that isolate Store, MCP queue, in-process JSON-RPC, and stdio-process `mem_judge` latency.
- Cover enrolled and unenrolled candidates plus sequential, concurrent, and externally locked Store scenarios without changing production behavior.
- Establish a Windows baseline for deciding whether any optimization is justified.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/judge_relation_bench_test.go` | Adds Store benchmarks for judgment paths, concurrency, enrollment, and deterministic external SQLite lock contention. |
| `internal/mcp/judge_bench_test.go` | Adds direct, queued, JSON-RPC, and real stdio-process MCP benchmark layers with complete enrolled/unenrolled coverage. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` — exceeded the authorized 600-second Windows limit; tracked by #1018, #1019, and #1020.
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — not run after the unit suite did not complete.
- [x] Manually tested the affected functionality — the original baseline suites completed with 30 fixed-work samples; correction verification also passed relevant Store tests, the MCP helper test, all 12 selected enrolled MCP benchmark rows, and the self-verifying SQLite lock/recovery benchmark.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Pending |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Pending |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | Pending |
| **Unit Tests** | `go test ./...` passes | Pending |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Pending |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | Pending |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed) — not applicable; this PR adds benchmark-only test code.
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Hosted CI passed before the review correction; #1018, #1019, and #1020 remain separate local Windows follow-up reports. Commit `647a1f9` addresses both actionable review findings by completing the enrolled MCP matrix and proving SQLite contention at the actual Store write. The measured stdio layer added sub-millisecond median overhead relative to in-process JSON-RPC, so this PR records evidence rather than selecting an optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmark coverage for memory judgment operations across direct, queued, in-process, JSON-RPC, and stdio invocation methods.
  * Added scenarios for enrolled and unenrolled projects, sequential and concurrent execution, and one- or three-relation workloads.
  * Added performance measurements for allocations, invocation behavior, and execution while database locks are held.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->