### PR TITLE
docs(cloud): add production boundary checklist

### DIFF
--- a/docs/engram-cloud/README.md
+++ b/docs/engram-cloud/README.md
@@ -96,6 +96,7 @@ HTTPS and appropriate deployment controls for transport security.
 | Doc | Purpose |
 |---|---|
 | [Quickstart](./quickstart.md) | One recommended path first, then authenticated mode |
+| [Production Checklist](./production-checklist.md) | Self-hosted production boundaries, recovery, and operator responsibilities |
 | [GHCR Compose Example](./docker-compose.ghcr.yml) | Pull-and-run deployment sample for Dokploy/Coolify/Portainer/VPS |
 | [Branding](./branding.md) | Engram Cloud visual identity, asset usage, previews |
 | [Technical Cloud Reference](../../DOCS.md#cloud-cli-opt-in) | Full CLI + env/runtime details |

--- a/docs/engram-cloud/production-checklist.md
+++ b/docs/engram-cloud/production-checklist.md
@@ -1,0 +1,52 @@
+[← Back to Engram Cloud](./README.md)
+
+# Engram Cloud Production Checklist
+
+Use this checklist before operating a self-hosted Engram Cloud endpoint for users. Engram provides the Cloud runtime; the operator owns the surrounding production platform, its security boundaries, and its recovery process. The Compose examples are starting points, not a complete production platform.
+
+## Before public operation
+
+### Transport and ingress
+
+- [ ] Terminate TLS at a reverse proxy or equivalent boundary that you operate, then configure clients with that HTTPS endpoint using `engram cloud config --server https://<cloud-host>`.
+- [ ] Keep bearer-token traffic on HTTPS. Authenticated clients require HTTPS, including after redirects; `ENGRAM_CLOUD_INSECURE_NO_AUTH=1` is local/development smoke mode only and must not be used in production.
+- [ ] Expose only the intended Cloud endpoint to public ingress. Restrict administrative access to the proxy, host, and deployment controls according to your environment.
+- [ ] Keep PostgreSQL and other private dependencies off public ingress. A Compose port mapping or `ENGRAM_CLOUD_HOST` bind address controls where a process listens or is published; it is not a firewall policy.
+
+### Configuration and secrets
+
+- [ ] Configure the required Cloud runtime values: `ENGRAM_DATABASE_URL`, `ENGRAM_CLOUD_ALLOWED_PROJECTS`, `ENGRAM_CLOUD_TOKEN`, and a non-default `ENGRAM_JWT_SECRET` for authenticated mode.
+- [ ] Store secret values outside source control and restrict access to the operators and deployment processes that need them. The reference Compose flow keeps its `.env` file on the server and out of Git.
+- [ ] Treat `ENGRAM_DATABASE_URL`, `ENGRAM_CLOUD_TOKEN`, `ENGRAM_JWT_SECRET`, and, when used, `ENGRAM_CLOUD_ADMIN` and `ENGRAM_CLOUD_TOKEN_PEPPER` as deployment secrets. The reference Compose example also uses `POSTGRES_PASSWORD`.
+- [ ] If managed-token authentication is enabled, keep `ENGRAM_CLOUD_TOKEN_PEPPER` distinct from `ENGRAM_JWT_SECRET`. It is required both when issuing managed tokens and when the running Cloud runtime authenticates them.
+- [ ] Define who may change each secret, where its current value is stored, and how rotation triggers a safe redeployment. Operators own rotation and redeployment; this guide does not provide a secret manager or rotation automation.
+
+### Data protection and recovery
+
+- [ ] Use durable storage for Cloud PostgreSQL data. The reference Compose file mounts `engram-cloud-pg` at `/var/lib/postgresql/data`; choose equivalent durable storage for your platform.
+- [ ] Own backups for the Cloud database, including retention, access protection, and an off-host or otherwise independent copy where appropriate for your environment. Engram does not provide backup tooling or recovery objectives.
+- [ ] Preserve local SQLite data as well. Engram is local-first: local SQLite remains authoritative and Cloud is optional replication and browser visibility.
+- [ ] Document a restore procedure that does not overwrite a live service during rehearsal.
+
+## Rehearse and verify
+
+### Restore rehearsal
+
+- [ ] Restore a backup into an isolated environment, using a separate endpoint and database from production.
+- [ ] Start the restored Cloud runtime with its own protected configuration; do not reuse production credentials merely to perform the rehearsal.
+- [ ] Verify the restored endpoint responds at `GET /health` and that an authorized test client can complete `engram sync --cloud --project <project>`.
+- [ ] Confirm observable success: `engram sync --cloud --status --project <project>` reports the expected restored remote chunks and a pending-import state you understand, and the expected replicated data is visible in the isolated dashboard. Record the result and any gaps before relying on the backup process.
+
+### Health and version checks
+
+- [ ] Probe the documented Cloud health endpoint through the production ingress: `GET /health`. A healthy Cloud runtime returns `{"status": "ok", "service": "engram-cloud"}`.
+- [ ] Use `engram cloud status` to verify client configuration and auth readiness, then use `engram sync --cloud --status --project <project>` to inspect replication progress.
+- [ ] Use `engram version` to record the client binary version. For the Cloud runtime, record the image reference configured by your deployment; the documented Cloud `/health` response does not expose a server version.
+
+## Responsibility boundary and non-goals
+
+| Engram runtime | Operator and platform |
+|---|---|
+| Cloud sync API, dashboard, authenticated-mode configuration requirements, and the documented health endpoint | TLS termination, reverse proxy, ingress/firewall rules, secret storage and rotation, durable storage, backups, restore rehearsal, and deployment version selection |
+
+This checklist does not configure infrastructure, select a provider, implement high availability, supply backup or monitoring products, define recovery objectives, or change PostgreSQL configuration. Use the [Quickstart](./quickstart.md) for the supported setup and runtime variables, and the [Technical Cloud Reference](../../DOCS.md#cloud-cli-opt-in) for the full command and endpoint contract.

--- a/docs/engram-cloud/quickstart.md
+++ b/docs/engram-cloud/quickstart.md
@@ -188,6 +188,8 @@ docker compose restart cloud
 If you upgrade the `engram` image tag, redeploy or restart the container so the
 running server picks up the new binary.
 
+Before exposing this deployment to users, complete the [Production Checklist](./production-checklist.md). The Compose example is a starting point, not a complete production platform.
+
 ### Client-side token setup
 
 On the machine that runs the Engram CLI, set the client token in the shell before


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1034

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add a vendor-neutral production boundary checklist for self-hosted Engram Cloud operators.
- Link the checklist from the Cloud Quickstart and documentation map.

## 📂 Changes

| File | Change |
|------|--------|
| `docs/engram-cloud/production-checklist.md` | Document TLS, ingress, secrets, backups, restore rehearsal, health/version checks, and responsibility boundaries. |
| `docs/engram-cloud/quickstart.md` | Direct operators to the production checklist before public use. |
| `docs/engram-cloud/README.md` | Add the checklist to the Cloud documentation map. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Focused documentation validation:

- Confirmed all introduced relative links resolve.
- Confirmed operational claims against current Cloud documentation and implementation.
- Ran `git diff --check` successfully; only CRLF conversion warnings were emitted.
- Completed an independent read-only review with no findings.
- Broad Go suites were not run locally because this is a documentation-only change; CI remains the broad-suite owner.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This change documents operator-owned production boundaries without implementing infrastructure, prescribing a provider, changing runtime defaults, or taking over PostgreSQL canonicalization tracked by #949.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a production checklist for self-hosted Engram Cloud deployments, covering security, configuration, storage, backups, restoration, health checks, and operational responsibilities.
  - Added the checklist to the Engram Cloud documentation map.
  - Updated the Quickstart to recommend completing the production checklist before exposing a deployment to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->