### PR TITLE
chore(release): gate Pi publish on tests

### DIFF
--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -30,6 +30,10 @@ jobs:
           fi
           echo "Active npm: $(npm --version)"
 
+      - name: Run Pi plugin tests
+        working-directory: plugin/pi
+        run: npm test
+
       - name: Publish to npm with provenance
         working-directory: plugin/pi
         run: npm publish --provenance --access public

--- a/plugin/pi/test/publish-workflow.test.mjs
+++ b/plugin/pi/test/publish-workflow.test.mjs
@@ -3,24 +3,32 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const workflow = readFileSync(new URL("../../../.github/workflows/publish-pi.yml", import.meta.url), "utf8").replaceAll("\r\n", "\n");
-const testStep = "      - name: Run Pi plugin tests\n        working-directory: plugin/pi\n        run: npm test\n";
-const publishStep = "      - name: Publish to npm with provenance";
+
+function namedStep(name) {
+	const match = workflow.match(new RegExp(
+		`^      - name: ${name}\\n[\\s\\S]*?(?=^      - |(?![\\s\\S]))`,
+		"m",
+	));
+
+	assert.ok(match, `the publish workflow must contain the ${name} step`);
+	return { index: match.index, end: match.index + match[0].length, text: match[0] };
+}
 
 test("Pi publication tests run fail-closed immediately before publishing", () => {
-	const testStepIndex = workflow.indexOf(testStep);
-	const publishStepIndex = workflow.indexOf(publishStep);
+	const testStep = namedStep("Run Pi plugin tests");
+	const publishStep = namedStep("Publish to npm with provenance");
 
-	assert.ok(testStepIndex >= 0, "the publish workflow must run npm test from plugin/pi");
-	assert.ok(publishStepIndex >= 0, "the publish workflow must publish the Pi package");
-	assert.ok(testStepIndex < publishStepIndex, "npm test must run before npm publish");
-	assert.match(
-		workflow.slice(testStepIndex + testStep.length, publishStepIndex),
-		/^\s*$/,
-		"the test step must immediately precede the publish step",
-	);
+	assert.match(testStep.text, /^        working-directory: plugin\/pi$/m, "the test step must run from plugin/pi");
+	assert.match(testStep.text, /^        run: npm test$/m, "the test step must run npm test");
+	assert.match(publishStep.text, /^        working-directory: plugin\/pi$/m, "the publish step must run from plugin/pi");
+	assert.match(publishStep.text, /^        run: npm publish --provenance --access public$/m, "the publish step must run the required npm publish command");
+	assert.equal(testStep.end, publishStep.index, "the test step must immediately precede the publish step");
 	assert.doesNotMatch(
-		workflow.slice(testStepIndex, publishStepIndex),
-		/continue-on-error\s*:/,
+		testStep.text,
+		/^        continue-on-error\s*:/m,
 		"the test step must not opt out of fail-fast behavior",
 	);
+	assert.doesNotMatch(testStep.text, /^        if\s*:/m, "the test step must not be conditional");
+	assert.doesNotMatch(publishStep.text, /^        if\s*:/m, "the publish step must not be conditional");
+	assert.doesNotMatch(publishStep.text, /^        continue-on-error\s*:/m, "the publish step must not opt out of fail-fast behavior");
 });

--- a/plugin/pi/test/publish-workflow.test.mjs
+++ b/plugin/pi/test/publish-workflow.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const workflow = readFileSync(new URL("../../../.github/workflows/publish-pi.yml", import.meta.url), "utf8").replaceAll("\r\n", "\n");
+const testStep = "      - name: Run Pi plugin tests\n        working-directory: plugin/pi\n        run: npm test\n";
+const publishStep = "      - name: Publish to npm with provenance";
+
+test("Pi publication tests run fail-closed immediately before publishing", () => {
+	const testStepIndex = workflow.indexOf(testStep);
+	const publishStepIndex = workflow.indexOf(publishStep);
+
+	assert.ok(testStepIndex >= 0, "the publish workflow must run npm test from plugin/pi");
+	assert.ok(publishStepIndex >= 0, "the publish workflow must publish the Pi package");
+	assert.ok(testStepIndex < publishStepIndex, "npm test must run before npm publish");
+	assert.match(
+		workflow.slice(testStepIndex + testStep.length, publishStepIndex),
+		/^\s*$/,
+		"the test step must immediately precede the publish step",
+	);
+	assert.doesNotMatch(
+		workflow.slice(testStepIndex, publishStepIndex),
+		/continue-on-error\s*:/,
+		"the test step must not opt out of fail-fast behavior",
+	);
+});


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1048

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Run the existing Pi plugin test suite before npm publication.
- Add a regression test that keeps the publish gate fail-closed and ordered before publish.

## 📂 Changes

| File | Change |
|------|--------|
| `.github/workflows/publish-pi.yml` | Run `npm test` from `plugin/pi` immediately before `npm publish`. |
| `plugin/pi/test/publish-workflow.test.mjs` | Assert the test command, directory, fail-closed behavior, and ordering. |

## 🧪 Test Plan

- [x] Focused workflow regression: `node --test test/publish-workflow.test.mjs` (1 passed)
- [x] Affected Pi package suite: `npm test` (115 passed)
- [ ] Repository-wide Go unit tests were not run locally; CI owns the broad suite for this workflow-only change.
- [ ] E2E tests were not run locally; no runtime behavior changed.

---

## 🤖 Automated Checks

These run automatically and must pass before merge.

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1048`)
- [x] I added exactly one `type:*` label to this PR
- [ ] I ran unit tests locally: broad repository tests are CI-owned for this change
- [ ] I ran e2e tests locally: not applicable to this workflow-only change
- [x] Docs updated or not applicable (no user-facing behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

RDD completed with no blocking findings. One informational readability suggestion noted that the static workflow assertion is intentionally text-shape-sensitive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved publishing reliability by validating the Pi plugin before packages are released.
  - Publishing now stops automatically when the plugin test suite reports failures.

- **Tests**
  - Added automated checks to confirm validation runs immediately before publishing.
  - Verified that validation failures cannot be ignored or bypassed during the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->