### PR TITLE
ci(templ): fail on generated dashboard output drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           go-version: "1.25.10"
 
+      - name: Verify generated templ output
+        run: |
+          make templ
+          git diff --exit-code -- internal/cloud/dashboard/*_templ.go
+
       - name: Run dead-code ratchet
         run: make deadcode-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,13 @@ jobs:
       - name: Verify generated templ output
         run: |
           make templ
-          git diff --exit-code -- internal/cloud/dashboard/*_templ.go
+          git diff --exit-code -- 'internal/cloud/dashboard/*_templ.go'
+          untracked_templ_outputs=$(git ls-files --others --exclude-standard -- 'internal/cloud/dashboard/*_templ.go')
+          if [[ -n "${untracked_templ_outputs}" ]]; then
+            echo '::error::Untracked generated templ output detected:' >&2
+            printf '%s\n' "${untracked_templ_outputs}" >&2
+            exit 1
+          fi
 
       - name: Run dead-code ratchet
         run: make deadcode-check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: templ perf-check perf-baseline deadcode-check deadcode-baseline
 
 templ:
-	go tool templ generate ./internal/cloud/dashboard/...
+	go run github.com/a-h/templ/cmd/templ generate ./internal/cloud/dashboard/...
 
 perf-check:
 	@if [ -n "$(PERF_RATCHET_AGAINST)" ]; then \


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1049

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Add CI parity enforcement for tracked and untracked dashboard `templ` output.
- Run the module-pinned `templ` generator through `make templ` before checking generated-file drift.

## 📂 Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Regenerate dashboard templ output and fail CI when generated files differ or generated output is untracked. |
| `Makefile` | Invoke the module-pinned templ generator through `go run` for deterministic generation. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` (not run; verification was scoped to this CI/tooling change)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (not run; no runtime behavior changed)
- [x] Manually tested the affected functionality

- [x] Direct generation passed: `make templ`
- [x] Scoped parity passed: `git diff --exit-code -- 'internal/cloud/dashboard/*_templ.go'`
- [x] Scoped untracked generated-output negative probe passed.
- [x] Focused dashboard templ policy test passed.
- Shellcheck was not run because this change modifies no shell scripts.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (not run; scoped verification only)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (not run; no runtime behavior changed)
- [x] Docs updated (if behavior changed; no user-facing behavior or documentation changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

This is a scoped CI guard for dashboard `*_templ.go` output, covering tracked drift and untracked generated output. The scoped untracked generated-output negative proof now passes. A deleted generated-output blind spot remains a separate follow-up and is not a blocker for this reviewed correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now verifies that generated dashboard files are up to date.
  * Builds fail when generated files differ from tracked versions or when unexpected generated files are untracked.

* **Chores**
  * Updated the templating generation command used by the build process.
  * Generation continues to use the same paths and arguments, ensuring consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
