### PR TITLE
chore(pi): enforce release version coherence

### DIFF
--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Verify Pi release version
         if: github.event_name == 'push'
         working-directory: plugin/pi
-        run: node test/release-contract.mjs "${{ github.ref_name }}"
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node test/release-contract.mjs "$RELEASE_TAG"
 
       - name: Publish to npm with provenance
         working-directory: plugin/pi

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -30,6 +30,11 @@ jobs:
           fi
           echo "Active npm: $(npm --version)"
 
+      - name: Verify Pi release version
+        if: github.event_name == 'push'
+        working-directory: plugin/pi
+        run: node test/release-contract.mjs "${{ github.ref_name }}"
+
       - name: Publish to npm with provenance
         working-directory: plugin/pi
         run: npm publish --provenance --access public

--- a/plugin/pi/cli.js
+++ b/plugin/pi/cli.js
@@ -3,7 +3,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-const PACKAGE_NAME = "npm:gentle-engram@0.1.11";
+const packageMetadata = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8"));
+const PACKAGE_NAME = `npm:${packageMetadata.name}@${packageMetadata.version}`;
 const LEGACY_PACKAGE_NAME = "npm:gentle-engram@0.1.8";
 const MCP_ADAPTER_PACKAGE = "npm:pi-mcp-adapter";
 const HELP = `pi-engram
@@ -13,7 +14,7 @@ Usage:
 
 Creates Pi's Engram MCP config in the Pi agent dir and ensures pi-mcp-adapter
 is declared in settings.json. The Pi extension itself is loaded by installing
-the package with: pi install npm:gentle-engram@0.1.11
+the package with: pi install ${PACKAGE_NAME}
 `;
 
 const MCP_LAUNCHER =

--- a/plugin/pi/test/package-contract.test.mjs
+++ b/plugin/pi/test/package-contract.test.mjs
@@ -25,6 +25,7 @@ const LEGACY_PACKAGE_NAME = "npm:gentle-engram@0.1.8";
 const MCP_ADAPTER_PACKAGE = "npm:pi-mcp-adapter";
 const CLI_PATH = fileURLToPath(new URL("../cli.js", import.meta.url));
 const RELEASE_CONTRACT_PATH = fileURLToPath(new URL("./release-contract.mjs", import.meta.url));
+const PUBLISH_WORKFLOW_SOURCE = readFileSync(new URL("../../../.github/workflows/publish-pi.yml", import.meta.url), "utf8");
 
 function runCli(agentDir, ...args) {
 	return execFileSync(process.execPath, [CLI_PATH, ...args], {
@@ -165,4 +166,17 @@ test("Pi release contract rejects a tag that differs from the package version", 
 	const result = runReleaseContract("pi-v0.0.0");
 	assert.notEqual(result.status, 0);
 	assert.match(result.stderr, /must match package version/);
+});
+
+test("Pi publish workflow passes the release tag through a shell environment variable", () => {
+	assert.match(
+		PUBLISH_WORKFLOW_SOURCE,
+		/env:\s*\n\s+RELEASE_TAG:\s*\$\{\{\s*github\.ref_name\s*\}\}\s*\n\s+run:\s*node test\/release-contract\.mjs "\$RELEASE_TAG"/,
+		"the release tag must be provided as RELEASE_TAG and quoted when passed to the release contract",
+	);
+	assert.doesNotMatch(
+		PUBLISH_WORKFLOW_SOURCE,
+		/run:\s*node test\/release-contract\.mjs\s+[^\n]*\$\{\{/,
+		"the release contract shell command must not interpolate a GitHub expression directly",
+	);
 });

--- a/plugin/pi/test/package-contract.test.mjs
+++ b/plugin/pi/test/package-contract.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,10 +20,11 @@ const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url),
 const indexSource = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
 
 const PI_TUI = "@earendil-works/pi-tui";
-const PACKAGE_NAME = "npm:gentle-engram@0.1.11";
+const PACKAGE_NAME = `npm:${pkg.name}@${pkg.version}`;
 const LEGACY_PACKAGE_NAME = "npm:gentle-engram@0.1.8";
 const MCP_ADAPTER_PACKAGE = "npm:pi-mcp-adapter";
 const CLI_PATH = fileURLToPath(new URL("../cli.js", import.meta.url));
+const RELEASE_CONTRACT_PATH = fileURLToPath(new URL("./release-contract.mjs", import.meta.url));
 
 function runCli(agentDir, ...args) {
 	return execFileSync(process.execPath, [CLI_PATH, ...args], {
@@ -34,6 +35,10 @@ function runCli(agentDir, ...args) {
 
 function readPackages(agentDir) {
 	return JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf8")).packages;
+}
+
+function runReleaseContract(tag) {
+	return spawnSync(process.execPath, [RELEASE_CONTRACT_PATH, tag], { encoding: "utf8" });
 }
 
 /**
@@ -149,4 +154,15 @@ test("pi-engram init replaces legacy package entries without disturbing other pa
 	} finally {
 		rmSync(agentDir, { recursive: true, force: true });
 	}
+});
+
+test("Pi release contract accepts the package version tag and CLI guidance", () => {
+	const result = runReleaseContract(`pi-v${pkg.version}`);
+	assert.equal(result.status, 0, result.stderr);
+});
+
+test("Pi release contract rejects a tag that differs from the package version", () => {
+	const result = runReleaseContract("pi-v0.0.0");
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /must match package version/);
 });

--- a/plugin/pi/test/release-contract.mjs
+++ b/plugin/pi/test/release-contract.mjs
@@ -1,0 +1,18 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const packageMetadata = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const packageName = `npm:${packageMetadata.name}@${packageMetadata.version}`;
+const expectedTag = `pi-v${packageMetadata.version}`;
+const releaseTag = process.argv[2];
+const cliPath = fileURLToPath(new URL("../cli.js", import.meta.url));
+
+if (releaseTag !== expectedTag) {
+	throw new Error(`Pi release tag ${JSON.stringify(releaseTag)} must match package version ${expectedTag}`);
+}
+
+const help = execFileSync(process.execPath, [cliPath], { encoding: "utf8" });
+if (!help.includes(`pi install ${packageName}`)) {
+	throw new Error(`Pi CLI help must include the current package ${packageName}`);
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1052

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Make `plugin/pi/package.json` authoritative for the CLI installation guidance.
- Reject tag-triggered publication when the Pi tag, package version, and CLI guidance disagree.
- Preserve manual dispatch behavior and the legacy `0.1.8` migration path.

## 📂 Changes

| File | Change |
|------|--------|
| `.github/workflows/publish-pi.yml` | Run the release coherence contract before tag-triggered publication. |
| `plugin/pi/cli.js` | Derive the package install identifier from package metadata. |
| `plugin/pi/test/package-contract.test.mjs` | Cover matching and mismatched release versions. |
| `plugin/pi/test/release-contract.mjs` | Validate the tag, package version, and CLI help without dependencies. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality
- [x] Pi plugin tests pass locally: `npm test` (116 passed)
- [x] Matching release tag exits successfully and a mismatched tag exits nonzero

`go test ./...` does not pass on this Windows host because `TestClaudeHookMaxTimeNormalization` invokes the WSL `bash` launcher while no WSL distribution is installed. A focused investigation reproduced the same failure in unchanged Claude-hook code; the four-file Pi candidate does not touch that path. CI remains the authority for the broad unit suite.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1052`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (environmental failure documented above)
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] Docs updated or not required (the CLI guidance now derives from package metadata)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The candidate is 44 additions and 4 deletions in one work-unit commit. Rollback is the four listed paths; reverting the commit restores the prior independent tag and CLI version behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Installation guidance in the Pi plugin’s CLI now automatically reflects the current package name and version.
  * Release publishing now verifies that the release tag matches the package version before proceeding, reducing the risk of publishing mismatched versions.

* **Tests**
  * Added automated checks to confirm release tags and CLI installation guidance remain consistent with the published package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->