### PR TITLE
ci(workflows): pin external actions to immutable shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25.10"
 
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25.10"
 
@@ -67,8 +67,8 @@ jobs:
     name: Cloud Sync Wrapper Tests (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25.10"
       - run: go test ./tools/ -run '^TestCloudSync(Wrappers|PowerShellMissingEngram)$' -v
@@ -82,12 +82,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # Must match publish-pi.yml: the suite imports index.ts directly and relies
       # on native TypeScript type stripping.
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
 

--- a/.github/workflows/cloud-image.yml
+++ b/.github/workflows/cloud-image.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -35,13 +35,13 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/gentleman-programming/engram
           tags: |
@@ -66,7 +66,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
 
       - name: Build and push multi-arch image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: docker/cloud/Dockerfile

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR links an issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const body = context.payload.pull_request.body || '';
@@ -34,7 +34,7 @@ jobs:
     needs: check-issue-reference
     steps:
       - name: Verify linked issue is approved
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR has a type label
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/publish-pi.yml
+++ b/.github/workflows/publish-pi.yml
@@ -13,9 +13,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.25.10"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           version: "~> v2"
           args: release --clean

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           stale-issue-message: >
             This issue has been inactive for 30 days. If it's still relevant,

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mark3labs/mcp-go v0.44.0
 	golang.org/x/net v0.52.0
 	golang.org/x/sys v0.43.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.45.0
 )
 
@@ -62,7 +63,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -1,72 +1,62 @@
 package scripts
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 var (
-	workflowActionPattern = regexp.MustCompile(`^\s*(?:-\s+)?uses:\s*(["']?)([^@\s"']+)@([^\s#"']+)(["']?)(?:\s+#\s*(.+?))?\s*$`)
 	fullSHAPattern        = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 	versionCommentPattern = regexp.MustCompile(`^v\d+(?:[.\w-]*)?$`)
 )
 
-func parseWorkflowAction(line string) (action, ref, comment string, ok bool) {
-	matches := workflowActionPattern.FindStringSubmatch(line)
-	if matches == nil || matches[1] != matches[4] {
-		return "", "", "", false
-	}
-	return matches[2], matches[3], matches[5], true
-}
-
 func TestWorkflowActionParsing(t *testing.T) {
 	const sha = "0123456789abcdef0123456789abcdef01234567"
 	tests := []struct {
-		name, line, action, ref, comment, classify string
-		matched, external, fullSHA, versionComment bool
+		name              string
+		workflow          string
+		wantErrors        []string
+		wantErrorContains string
 	}{
-		{name: "pinned", line: "uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
-		{name: "tag", line: "uses: actions/checkout@v6 # v6", action: "actions/checkout", ref: "v6", comment: "v6", classify: "actions/checkout", matched: true, external: true, versionComment: true},
-		{name: "branch", line: "uses: owner/action@main # v1", action: "owner/action", ref: "main", comment: "v1", classify: "owner/action", matched: true, external: true, versionComment: true},
-		{name: "wrong length SHA", line: "uses: actions/checkout@" + sha[:39] + " # v6", action: "actions/checkout", ref: sha[:39], comment: "v6", classify: "actions/checkout", matched: true, external: true, versionComment: true},
-		{name: "non-hex SHA", line: "uses: actions/checkout@" + strings.Repeat("g", 40) + " # v6", action: "actions/checkout", ref: strings.Repeat("g", 40), comment: "v6", classify: "actions/checkout", matched: true, external: true, versionComment: true},
-		{name: "missing comment", line: "uses: actions/checkout@" + sha, action: "actions/checkout", ref: sha, classify: "actions/checkout", matched: true, external: true, fullSHA: true},
-		{name: "malformed version comment", line: "uses: actions/checkout@" + sha + " # release-6", action: "actions/checkout", ref: sha, comment: "release-6", classify: "actions/checkout", matched: true, external: true, fullSHA: true},
-		{name: "list item", line: "- uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
-		{name: "double quoted", line: "uses: \"actions/checkout@" + sha + "\" # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
-		{name: "single quoted", line: "uses: 'actions/checkout@" + sha + "' # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
-		{name: "local", line: "uses: ./local-action", classify: "./local-action"},
-		{name: "Docker", line: "uses: docker://alpine@sha256:abc", action: "docker://alpine", ref: "sha256:abc", classify: "docker://alpine", matched: true},
-		{name: "malformed", line: "uses actions/checkout@v6"},
-		{name: "missing closing quote", line: "uses: \"actions/checkout@" + sha + " # v6"},
-		{name: "mismatched quotes", line: "uses: \"actions/checkout@" + sha + "' # v6"},
+		{name: "pinned step action", workflow: workflowWithStep("actions/checkout@" + sha + " # v6")},
+		{name: "double quoted step action", workflow: workflowWithStep("\"actions/checkout@" + sha + "\" # v6")},
+		{name: "single quoted step action", workflow: workflowWithStep("'actions/checkout@" + sha + "' # v6")},
+		{name: "pinned reusable workflow", workflow: "jobs:\n  call:\n    uses: owner/repo/.github/workflows/reusable.yml@" + sha + " # v1\n"},
+		{name: "mutable reusable workflow", workflow: "jobs:\n  call:\n    uses: owner/repo/.github/workflows/reusable.yml@main # v1\n", wantErrors: []string{"line 3: external action \"owner/repo/.github/workflows/reusable.yml\" must use a full 40-hex commit SHA"}},
+		{name: "local action", workflow: workflowWithStep("./local-action")},
+		{name: "Docker action", workflow: workflowWithStep("docker://alpine@sha256:abc")},
+		{name: "wrong length SHA", workflow: workflowWithStep("actions/checkout@" + sha[:39] + " # v6"), wantErrors: []string{"line 4: external action \"actions/checkout\" must use a full 40-hex commit SHA"}},
+		{name: "non-hex SHA", workflow: workflowWithStep("actions/checkout@" + strings.Repeat("g", 40) + " # v6"), wantErrors: []string{"line 4: external action \"actions/checkout\" must use a full 40-hex commit SHA"}},
+		{name: "missing version comment", workflow: workflowWithStep("actions/checkout@" + sha), wantErrors: []string{"line 4: external action \"actions/checkout\" must have an adjacent version comment"}},
+		{name: "malformed version comment", workflow: workflowWithStep("actions/checkout@" + sha + " # release-6"), wantErrors: []string{"line 4: external action \"actions/checkout\" must have an adjacent version comment"}},
+		{name: "scalar anchor", workflow: workflowWithStep("&checkout actions/checkout@" + sha + " # v6")},
+		{name: "scalar alias", workflow: "action: &checkout actions/checkout@" + sha + "\njobs:\n  test:\n    steps:\n      - uses: *checkout # v6\n"},
+		{name: "scalar alias requires an occurrence comment", workflow: "action: &checkout actions/checkout@" + sha + " # v6\njobs:\n  test:\n    steps:\n      - uses: *checkout\n", wantErrors: []string{"line 5: external action \"actions/checkout\" must have an adjacent version comment"}},
+		{name: "mutable scalar alias", workflow: "action: &checkout actions/checkout@main\njobs:\n  test:\n    steps:\n      - uses: *checkout # v6\n", wantErrors: []string{"line 5: external action \"actions/checkout\" must use a full 40-hex commit SHA"}},
+		{name: "non-scalar uses value", workflow: workflowWithStep("{action: actions/checkout@" + sha + "}"), wantErrors: []string{"line 4: uses value must resolve to a scalar, got mapping"}},
+		{name: "unrecognized uses value", workflow: workflowWithStep("checkout # v6"), wantErrors: []string{"line 4: uses value \"checkout\" is not a supported local, Docker, or GitHub action reference"}},
+		{name: "unresolved alias", workflow: workflowWithStep("*missing"), wantErrorContains: "parse workflow YAML:"},
+		{name: "malformed YAML", workflow: "jobs:\n  test: [\n", wantErrorContains: "parse workflow YAML:"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			action, ref, comment, matched := parseWorkflowAction(tt.line)
-			if matched != tt.matched {
-				t.Fatalf("matched = %v, want %v", matched, tt.matched)
-			}
-			if matched && (action != tt.action || ref != tt.ref || comment != tt.comment) {
-				t.Errorf("parsed = [%q %q %q], want [%q %q %q]", action, ref, comment, tt.action, tt.ref, tt.comment)
-			}
-			if matched && tt.external {
-				if got := fullSHAPattern.MatchString(ref); got != tt.fullSHA {
-					t.Errorf("fullSHAPattern.MatchString(%q) = %v, want %v", ref, got, tt.fullSHA)
+			got := errorStrings(validateWorkflowActions([]byte(tt.workflow)))
+			if tt.wantErrorContains != "" {
+				if len(got) != 1 || !strings.Contains(got[0], tt.wantErrorContains) {
+					t.Fatalf("errors = %v, want one error containing %q", got, tt.wantErrorContains)
 				}
-				if got := versionCommentPattern.MatchString(comment); got != tt.versionComment {
-					t.Errorf("versionCommentPattern.MatchString(%q) = %v, want %v", comment, got, tt.versionComment)
-				}
+				return
 			}
-			if tt.classify != "" {
-				if got := isExternalGitHubAction(tt.classify); got != tt.external {
-					t.Errorf("isExternalGitHubAction(%q) = %v, want %v", tt.classify, got, tt.external)
-				}
+			if diff := compareStringSlices(got, tt.wantErrors); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}
@@ -90,17 +80,8 @@ func TestWorkflowExternalActionsArePinned(t *testing.T) {
 			t.Fatalf("read %s: %v", path, err)
 		}
 
-		for lineNumber, line := range strings.Split(string(content), "\n") {
-			action, ref, comment, ok := parseWorkflowAction(line)
-			if !ok || !isExternalGitHubAction(action) {
-				continue
-			}
-			if !fullSHAPattern.MatchString(ref) {
-				t.Errorf("%s:%d: external action %q must use a full 40-hex commit SHA", path, lineNumber+1, action)
-			}
-			if !versionCommentPattern.MatchString(comment) {
-				t.Errorf("%s:%d: external action %q must have an adjacent version comment", path, lineNumber+1, action)
-			}
+		for _, err := range validateWorkflowActions(content) {
+			t.Errorf("%s: %v", path, err)
 		}
 	}
 }
@@ -123,4 +104,151 @@ func workflowDirectory(t *testing.T) string {
 
 func isExternalGitHubAction(action string) bool {
 	return !strings.HasPrefix(action, "./") && !strings.HasPrefix(action, "docker://") && strings.Contains(action, "/")
+}
+
+func workflowWithStep(uses string) string {
+	return "jobs:\n  test:\n    steps:\n      - uses: " + uses + "\n"
+}
+
+func validateWorkflowActions(content []byte) []error {
+	var document yaml.Node
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return []error{fmt.Errorf("parse workflow YAML: %w", err)}
+	}
+	if len(document.Content) != 1 {
+		return nil
+	}
+
+	var violations []error
+	for _, jobs := range mappingValues(document.Content[0], "jobs") {
+		jobs, err := resolveYAMLNode(jobs)
+		if err != nil || jobs.Kind != yaml.MappingNode {
+			continue
+		}
+		for index := 1; index < len(jobs.Content); index += 2 {
+			job := jobs.Content[index]
+			job, err = resolveYAMLNode(job)
+			if err != nil || job.Kind != yaml.MappingNode {
+				continue
+			}
+
+			for _, uses := range mappingValues(job, "uses") {
+				violations = append(violations, validateWorkflowUses(uses)...)
+			}
+			for _, steps := range mappingValues(job, "steps") {
+				steps, err = resolveYAMLNode(steps)
+				if err != nil || steps.Kind != yaml.SequenceNode {
+					continue
+				}
+				for _, step := range steps.Content {
+					step, err = resolveYAMLNode(step)
+					if err != nil || step.Kind != yaml.MappingNode {
+						continue
+					}
+					for _, uses := range mappingValues(step, "uses") {
+						violations = append(violations, validateWorkflowUses(uses)...)
+					}
+				}
+			}
+		}
+	}
+	return violations
+}
+
+func mappingValues(node *yaml.Node, key string) []*yaml.Node {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	var values []*yaml.Node
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		if node.Content[index].Value == key {
+			values = append(values, node.Content[index+1])
+		}
+	}
+	return values
+}
+
+func resolveYAMLNode(node *yaml.Node) (*yaml.Node, error) {
+	visited := make(map[*yaml.Node]struct{})
+	for node != nil && node.Kind == yaml.AliasNode {
+		if _, ok := visited[node]; ok {
+			return nil, fmt.Errorf("alias cycle")
+		}
+		visited[node] = struct{}{}
+		node = node.Alias
+	}
+	if node == nil {
+		return nil, fmt.Errorf("unresolved alias")
+	}
+	return node, nil
+}
+
+func validateWorkflowUses(uses *yaml.Node) []error {
+	resolved, err := resolveYAMLNode(uses)
+	if err != nil {
+		return []error{fmt.Errorf("line %d: uses value must resolve to a scalar: %v", uses.Line, err)}
+	}
+	if resolved.Kind != yaml.ScalarNode {
+		return []error{fmt.Errorf("line %d: uses value must resolve to a scalar, got %s", uses.Line, yamlNodeKind(resolved.Kind))}
+	}
+
+	value := resolved.Value
+	if strings.HasPrefix(value, "./") || strings.HasPrefix(value, "docker://") {
+		return nil
+	}
+	if !isExternalGitHubAction(value) {
+		return []error{fmt.Errorf("line %d: uses value %q is not a supported local, Docker, or GitHub action reference", uses.Line, value)}
+	}
+
+	action, ref, ok := strings.Cut(value, "@")
+	if !ok || action == "" || ref == "" {
+		return []error{fmt.Errorf("line %d: external action %q must use the form owner/action@ref", uses.Line, value)}
+	}
+
+	var violations []error
+	if !fullSHAPattern.MatchString(ref) {
+		violations = append(violations, fmt.Errorf("line %d: external action %q must use a full 40-hex commit SHA", uses.Line, action))
+	}
+	if !versionCommentPattern.MatchString(strings.TrimSpace(strings.TrimPrefix(uses.LineComment, "#"))) {
+		violations = append(violations, fmt.Errorf("line %d: external action %q must have an adjacent version comment", uses.Line, action))
+	}
+	return violations
+}
+
+func yamlNodeKind(kind yaml.Kind) string {
+	switch kind {
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.AliasNode:
+		return "alias"
+	default:
+		return "unknown"
+	}
+}
+
+func errorStrings(errs []error) []string {
+	values := make([]string, len(errs))
+	for index, err := range errs {
+		values[index] = err.Error()
+	}
+	return values
+}
+
+func compareStringSlices(got, want []string) string {
+	if len(got) != len(want) {
+		return fmt.Sprintf("errors = %v, want %v", got, want)
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return fmt.Sprintf("errors = %v, want %v", got, want)
+		}
+	}
+	return ""
 }

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -1,0 +1,69 @@
+package scripts
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var (
+	workflowActionPattern = regexp.MustCompile(`^\s*(?:-\s+)?uses:\s*([^@\s]+)@([^\s#]+)(?:\s+#\s*(.+?))?\s*$`)
+	fullSHAPattern        = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+	versionCommentPattern = regexp.MustCompile(`^v\d+(?:[.\w-]*)?$`)
+)
+
+func TestWorkflowExternalActionsArePinned(t *testing.T) {
+	workflowDir := workflowDirectory(t)
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		t.Fatalf("read workflow directory: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || (filepath.Ext(entry.Name()) != ".yml" && filepath.Ext(entry.Name()) != ".yaml") {
+			continue
+		}
+
+		path := filepath.Join(workflowDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		for lineNumber, line := range strings.Split(string(content), "\n") {
+			matches := workflowActionPattern.FindStringSubmatch(line)
+			if matches == nil || !isExternalGitHubAction(matches[1]) {
+				continue
+			}
+			if !fullSHAPattern.MatchString(matches[2]) {
+				t.Errorf("%s:%d: external action %q must use a full 40-hex commit SHA", path, lineNumber+1, matches[1])
+			}
+			if !versionCommentPattern.MatchString(matches[3]) {
+				t.Errorf("%s:%d: external action %q must have an adjacent version comment", path, lineNumber+1, matches[1])
+			}
+		}
+	}
+}
+
+func workflowDirectory(t *testing.T) string {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate workflow directory: runtime.Caller did not return the test source path")
+	}
+
+	workflowDir := filepath.Join(filepath.Dir(filepath.Dir(sourceFile)), ".github", "workflows")
+	if info, err := os.Stat(workflowDir); err != nil {
+		t.Fatalf("locate workflow directory from test source %q: %v", sourceFile, err)
+	} else if !info.IsDir() {
+		t.Fatalf("locate workflow directory from test source %q: %q is not a directory", sourceFile, workflowDir)
+	}
+	return workflowDir
+}
+
+func isExternalGitHubAction(action string) bool {
+	return !strings.HasPrefix(action, "./") && !strings.HasPrefix(action, "docker://") && strings.Contains(action, "/")
+}

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -15,6 +15,40 @@ var (
 	versionCommentPattern = regexp.MustCompile(`^v\d+(?:[.\w-]*)?$`)
 )
 
+func TestWorkflowActionParsing(t *testing.T) {
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	tests := []struct {
+		name, line, action, ref, comment, classify string
+		matched, external                          bool
+	}{
+		{name: "pinned", line: "uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true},
+		{name: "tag", line: "uses: actions/checkout@v6 # v6", action: "actions/checkout", ref: "v6", comment: "v6", classify: "actions/checkout", matched: true, external: true},
+		{name: "branch", line: "uses: owner/action@main # v1", action: "owner/action", ref: "main", comment: "v1", classify: "owner/action", matched: true, external: true},
+		{name: "missing comment", line: "uses: actions/checkout@" + sha, action: "actions/checkout", ref: sha, classify: "actions/checkout", matched: true, external: true},
+		{name: "list item", line: "- uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true},
+		{name: "local", line: "uses: ./local-action", classify: "./local-action"},
+		{name: "Docker", line: "uses: docker://alpine@sha256:abc", action: "docker://alpine", ref: "sha256:abc", classify: "docker://alpine", matched: true},
+		{name: "malformed", line: "uses actions/checkout@v6"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := workflowActionPattern.FindStringSubmatch(tt.line)
+			if (matches != nil) != tt.matched {
+				t.Fatalf("matched = %v, want %v", matches != nil, tt.matched)
+			}
+			if matches != nil && (matches[1] != tt.action || matches[2] != tt.ref || matches[3] != tt.comment) {
+				t.Errorf("groups = %q, want [%q %q %q]", matches[1:], tt.action, tt.ref, tt.comment)
+			}
+			if tt.classify != "" {
+				if got := isExternalGitHubAction(tt.classify); got != tt.external {
+					t.Errorf("isExternalGitHubAction(%q) = %v, want %v", tt.classify, got, tt.external)
+				}
+			}
+		})
+	}
+}
+
 func TestWorkflowExternalActionsArePinned(t *testing.T) {
 	workflowDir := workflowDirectory(t)
 	entries, err := os.ReadDir(workflowDir)

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -19,13 +19,16 @@ func TestWorkflowActionParsing(t *testing.T) {
 	const sha = "0123456789abcdef0123456789abcdef01234567"
 	tests := []struct {
 		name, line, action, ref, comment, classify string
-		matched, external                          bool
+		matched, external, fullSHA, versionComment bool
 	}{
-		{name: "pinned", line: "uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true},
-		{name: "tag", line: "uses: actions/checkout@v6 # v6", action: "actions/checkout", ref: "v6", comment: "v6", classify: "actions/checkout", matched: true, external: true},
-		{name: "branch", line: "uses: owner/action@main # v1", action: "owner/action", ref: "main", comment: "v1", classify: "owner/action", matched: true, external: true},
-		{name: "missing comment", line: "uses: actions/checkout@" + sha, action: "actions/checkout", ref: sha, classify: "actions/checkout", matched: true, external: true},
-		{name: "list item", line: "- uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true},
+		{name: "pinned", line: "uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
+		{name: "tag", line: "uses: actions/checkout@v6 # v6", action: "actions/checkout", ref: "v6", comment: "v6", classify: "actions/checkout", matched: true, external: true, versionComment: true},
+		{name: "branch", line: "uses: owner/action@main # v1", action: "owner/action", ref: "main", comment: "v1", classify: "owner/action", matched: true, external: true, versionComment: true},
+		{name: "wrong length SHA", line: "uses: actions/checkout@" + sha[:39] + " # v6", action: "actions/checkout", ref: sha[:39], comment: "v6", classify: "actions/checkout", matched: true, external: true, versionComment: true},
+		{name: "non-hex SHA", line: "uses: actions/checkout@" + strings.Repeat("g", 40) + " # v6", action: "actions/checkout", ref: strings.Repeat("g", 40), comment: "v6", classify: "actions/checkout", matched: true, external: true, versionComment: true},
+		{name: "missing comment", line: "uses: actions/checkout@" + sha, action: "actions/checkout", ref: sha, classify: "actions/checkout", matched: true, external: true, fullSHA: true},
+		{name: "malformed version comment", line: "uses: actions/checkout@" + sha + " # release-6", action: "actions/checkout", ref: sha, comment: "release-6", classify: "actions/checkout", matched: true, external: true, fullSHA: true},
+		{name: "list item", line: "- uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
 		{name: "local", line: "uses: ./local-action", classify: "./local-action"},
 		{name: "Docker", line: "uses: docker://alpine@sha256:abc", action: "docker://alpine", ref: "sha256:abc", classify: "docker://alpine", matched: true},
 		{name: "malformed", line: "uses actions/checkout@v6"},
@@ -39,6 +42,14 @@ func TestWorkflowActionParsing(t *testing.T) {
 			}
 			if matches != nil && (matches[1] != tt.action || matches[2] != tt.ref || matches[3] != tt.comment) {
 				t.Errorf("groups = %q, want [%q %q %q]", matches[1:], tt.action, tt.ref, tt.comment)
+			}
+			if matches != nil && tt.external {
+				if got := fullSHAPattern.MatchString(matches[2]); got != tt.fullSHA {
+					t.Errorf("fullSHAPattern.MatchString(%q) = %v, want %v", matches[2], got, tt.fullSHA)
+				}
+				if got := versionCommentPattern.MatchString(matches[3]); got != tt.versionComment {
+					t.Errorf("versionCommentPattern.MatchString(%q) = %v, want %v", matches[3], got, tt.versionComment)
+				}
 			}
 			if tt.classify != "" {
 				if got := isExternalGitHubAction(tt.classify); got != tt.external {

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -10,10 +10,18 @@ import (
 )
 
 var (
-	workflowActionPattern = regexp.MustCompile(`^\s*(?:-\s+)?uses:\s*([^@\s]+)@([^\s#]+)(?:\s+#\s*(.+?))?\s*$`)
+	workflowActionPattern = regexp.MustCompile(`^\s*(?:-\s+)?uses:\s*(["']?)([^@\s"']+)@([^\s#"']+)(["']?)(?:\s+#\s*(.+?))?\s*$`)
 	fullSHAPattern        = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 	versionCommentPattern = regexp.MustCompile(`^v\d+(?:[.\w-]*)?$`)
 )
+
+func parseWorkflowAction(line string) (action, ref, comment string, ok bool) {
+	matches := workflowActionPattern.FindStringSubmatch(line)
+	if matches == nil || matches[1] != matches[4] {
+		return "", "", "", false
+	}
+	return matches[2], matches[3], matches[5], true
+}
 
 func TestWorkflowActionParsing(t *testing.T) {
 	const sha = "0123456789abcdef0123456789abcdef01234567"
@@ -29,26 +37,30 @@ func TestWorkflowActionParsing(t *testing.T) {
 		{name: "missing comment", line: "uses: actions/checkout@" + sha, action: "actions/checkout", ref: sha, classify: "actions/checkout", matched: true, external: true, fullSHA: true},
 		{name: "malformed version comment", line: "uses: actions/checkout@" + sha + " # release-6", action: "actions/checkout", ref: sha, comment: "release-6", classify: "actions/checkout", matched: true, external: true, fullSHA: true},
 		{name: "list item", line: "- uses: actions/checkout@" + sha + " # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
+		{name: "double quoted", line: "uses: \"actions/checkout@" + sha + "\" # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
+		{name: "single quoted", line: "uses: 'actions/checkout@" + sha + "' # v6", action: "actions/checkout", ref: sha, comment: "v6", classify: "actions/checkout", matched: true, external: true, fullSHA: true, versionComment: true},
 		{name: "local", line: "uses: ./local-action", classify: "./local-action"},
 		{name: "Docker", line: "uses: docker://alpine@sha256:abc", action: "docker://alpine", ref: "sha256:abc", classify: "docker://alpine", matched: true},
 		{name: "malformed", line: "uses actions/checkout@v6"},
+		{name: "missing closing quote", line: "uses: \"actions/checkout@" + sha + " # v6"},
+		{name: "mismatched quotes", line: "uses: \"actions/checkout@" + sha + "' # v6"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matches := workflowActionPattern.FindStringSubmatch(tt.line)
-			if (matches != nil) != tt.matched {
-				t.Fatalf("matched = %v, want %v", matches != nil, tt.matched)
+			action, ref, comment, matched := parseWorkflowAction(tt.line)
+			if matched != tt.matched {
+				t.Fatalf("matched = %v, want %v", matched, tt.matched)
 			}
-			if matches != nil && (matches[1] != tt.action || matches[2] != tt.ref || matches[3] != tt.comment) {
-				t.Errorf("groups = %q, want [%q %q %q]", matches[1:], tt.action, tt.ref, tt.comment)
+			if matched && (action != tt.action || ref != tt.ref || comment != tt.comment) {
+				t.Errorf("parsed = [%q %q %q], want [%q %q %q]", action, ref, comment, tt.action, tt.ref, tt.comment)
 			}
-			if matches != nil && tt.external {
-				if got := fullSHAPattern.MatchString(matches[2]); got != tt.fullSHA {
-					t.Errorf("fullSHAPattern.MatchString(%q) = %v, want %v", matches[2], got, tt.fullSHA)
+			if matched && tt.external {
+				if got := fullSHAPattern.MatchString(ref); got != tt.fullSHA {
+					t.Errorf("fullSHAPattern.MatchString(%q) = %v, want %v", ref, got, tt.fullSHA)
 				}
-				if got := versionCommentPattern.MatchString(matches[3]); got != tt.versionComment {
-					t.Errorf("versionCommentPattern.MatchString(%q) = %v, want %v", matches[3], got, tt.versionComment)
+				if got := versionCommentPattern.MatchString(comment); got != tt.versionComment {
+					t.Errorf("versionCommentPattern.MatchString(%q) = %v, want %v", comment, got, tt.versionComment)
 				}
 			}
 			if tt.classify != "" {
@@ -79,15 +91,15 @@ func TestWorkflowExternalActionsArePinned(t *testing.T) {
 		}
 
 		for lineNumber, line := range strings.Split(string(content), "\n") {
-			matches := workflowActionPattern.FindStringSubmatch(line)
-			if matches == nil || !isExternalGitHubAction(matches[1]) {
+			action, ref, comment, ok := parseWorkflowAction(line)
+			if !ok || !isExternalGitHubAction(action) {
 				continue
 			}
-			if !fullSHAPattern.MatchString(matches[2]) {
-				t.Errorf("%s:%d: external action %q must use a full 40-hex commit SHA", path, lineNumber+1, matches[1])
+			if !fullSHAPattern.MatchString(ref) {
+				t.Errorf("%s:%d: external action %q must use a full 40-hex commit SHA", path, lineNumber+1, action)
 			}
-			if !versionCommentPattern.MatchString(matches[3]) {
-				t.Errorf("%s:%d: external action %q must have an adjacent version comment", path, lineNumber+1, matches[1])
+			if !versionCommentPattern.MatchString(comment) {
+				t.Errorf("%s:%d: external action %q must have an adjacent version comment", path, lineNumber+1, action)
 			}
 		}
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1051

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Pin all external GitHub Actions to immutable full commit SHAs while preserving current major versions.
- Add a focused regression guard requiring SHA pins and adjacent version comments.

## 📂 Changes

| File | Change |
|------|--------|
| `.github/workflows/*.yml` | Replace 23 mutable external action tags across six workflows with full SHAs and version comments. |
| `scripts/workflow_actions_test.go` | Enforce immutable external action references and readable version comments. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Manually tested the affected functionality

Focused verification completed:

- [x] `go test ./scripts`
- [x] `git diff --check`
- [ ] Full unit and E2E command completed locally — it timed out after 10 minutes without failure output; CI will provide the complete result.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1051`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` — timed out after 10 minutes
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` — not reached before the timeout
- [x] Docs updated (not applicable; workflow behavior and versions are unchanged)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The local focused workflow guard passed. The broader chained unit/E2E command produced no failure output but exceeded the 10-minute local budget, so complete verification is delegated to CI as explicitly approved for this delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved the security and reliability of CI, publishing, release, and maintenance workflows by pinning external automation components to immutable revisions.
  * Preserved version references to make workflow component versions easier to identify and review.
  * Existing workflow behavior remains unchanged.

* **Tests**
  * Added automated checks to verify that external workflow components use specific revisions and include version references.
  * Checks cover workflow formats and common configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->