### PR TITLE
fix(cli): require dry-run consolidation selection

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2478,17 +2478,19 @@ func cmdProjectsConsolidate(cfg store.Config) {
 			fmt.Printf("  [%d] %-30s %3d obs  (%s)\n", i+1, sm.Name, obs, sm.MatchType)
 		}
 
-		if dryRun {
-			fmt.Printf("\n[dry-run] Would merge %d project(s) into %q\n", len(similar), canonical)
-			return
-		}
-
 		fmt.Printf("\nSelect which to merge into %q (comma-separated numbers, 'all', or 'none'): ", canonical)
 		var answer string
-		scanInputLine(&answer)
+		if n, err := scanInputLine(&answer); err != nil && dryRun && n == 0 {
+			fatal(fmt.Errorf("dry-run requires a confirmed selection: %w", err))
+			return
+		}
 		answer = strings.TrimSpace(strings.ToLower(answer))
 
 		if answer == "none" || answer == "n" || answer == "" {
+			if dryRun && answer == "" {
+				fatal(errors.New("dry-run requires a confirmed selection"))
+				return
+			}
 			fmt.Println("Cancelled.")
 			return
 		}
@@ -2505,6 +2507,9 @@ func cmdProjectsConsolidate(cfg store.Config) {
 				idx := 0
 				if _, err := fmt.Sscanf(part, "%d", &idx); err != nil || idx < 1 || idx > len(similar) {
 					fmt.Fprintf(os.Stderr, "Invalid selection: %q (expected 1-%d)\n", part, len(similar))
+					if dryRun {
+						exitFunc(1)
+					}
 					return
 				}
 				sources = append(sources, similar[idx-1].Name)
@@ -2513,6 +2518,10 @@ func cmdProjectsConsolidate(cfg store.Config) {
 
 		if len(sources) == 0 {
 			fmt.Println("Nothing selected.")
+			return
+		}
+		if dryRun {
+			fmt.Printf("\n[dry-run] Would merge %d project(s) into %q\n", len(sources), canonical)
 			return
 		}
 

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1669,7 +1669,7 @@ func TestCmdProjectsConsolidateDryRunRequiresSelection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
 	}
-	defer s.Close()
+	t.Cleanup(func() { _ = s.Close() })
 	names, err := s.ListProjectNames()
 	if err != nil {
 		t.Fatalf("ListProjectNames: %v", err)
@@ -1756,7 +1756,7 @@ func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
 	}
-	defer s.Close()
+	t.Cleanup(func() { _ = s.Close() })
 	names, err := s.ListProjectNames()
 	if err != nil {
 		t.Fatalf("ListProjectNames: %v", err)

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -1594,21 +1594,30 @@ func TestCmdProjectsConsolidateDryRun(t *testing.T) {
 	// Seed a canonical name and rewrite a second project's records as a legacy case variant.
 	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
 	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	mustSeedObservation(t, cfg, "s-padded", "padded-source", "note", "padded note", "content", "project")
 	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
+	rewriteLegacyProjectName(t, cfg, "padded-source", " ENGRAM ")
 
 	old := detectProject
 	detectProject = func(string) string { return "engram" }
 	t.Cleanup(func() { detectProject = old })
+
+	oldScan := scanInputLine
+	scanInputLine = func(a ...any) (int, error) {
+		*a[0].(*string) = "1"
+		return 1, nil
+	}
+	t.Cleanup(func() { scanInputLine = oldScan })
 
 	withArgs(t, "engram", "projects", "consolidate", "--dry-run")
 	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
 	if stderr != "" {
 		t.Fatalf("expected no stderr, got: %q", stderr)
 	}
-	if !strings.Contains(stdout, "dry-run") {
-		t.Fatalf("expected dry-run message, got: %q", stdout)
+	if !strings.Contains(stdout, "[dry-run] Would merge 1 project(s)") {
+		t.Fatalf("expected selected dry-run plan, got: %q", stdout)
 	}
-	// Verify no actual merge happened (both project names still exist).
+	// Verify no actual merge happened.
 	s, err := store.New(cfg)
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
@@ -1618,9 +1627,55 @@ func TestCmdProjectsConsolidateDryRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListProjectNames: %v", err)
 	}
-	// Should still have both names (no merge happened)
-	if len(names) != 2 || names[0] != "ENGRAM" || names[1] != "engram" {
+	// All three names remain because dry-run performs no merge.
+	if len(names) != 3 || !slices.Contains(names, " ENGRAM ") || !slices.Contains(names, "ENGRAM") || !slices.Contains(names, "engram") {
 		t.Fatalf("expected legacy and canonical names after dry-run, got: %v", names)
+	}
+}
+
+func TestCmdProjectsConsolidateDryRunRequiresSelection(t *testing.T) {
+	cfg := testConfig(t)
+
+	mustSeedObservation(t, cfg, "s-eng", "engram", "note", "eng note", "content", "project")
+	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
+	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
+
+	oldDetect := detectProject
+	detectProject = func(string) string { return "engram" }
+	t.Cleanup(func() { detectProject = oldDetect })
+
+	oldScan := scanInputLine
+	scanInputLine = func(...any) (int, error) { return 0, io.EOF }
+	t.Cleanup(func() { scanInputLine = oldScan })
+
+	exitCode := 0
+	oldExit := exitFunc
+	exitFunc = func(code int) { exitCode = code }
+	t.Cleanup(func() { exitFunc = oldExit })
+
+	withArgs(t, "engram", "projects", "consolidate", "--dry-run")
+	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr, "dry-run requires a confirmed selection") {
+		t.Fatalf("expected selection error, got: %q", stderr)
+	}
+	if strings.Contains(stdout, "[dry-run] Would merge") {
+		t.Fatalf("dry-run emitted an unselected merge plan: %q", stdout)
+	}
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+	names, err := s.ListProjectNames()
+	if err != nil {
+		t.Fatalf("ListProjectNames: %v", err)
+	}
+	if len(names) != 2 || names[0] != "ENGRAM" || names[1] != "engram" {
+		t.Fatalf("dry-run without selection mutated projects: %v", names)
 	}
 }
 
@@ -1678,6 +1733,13 @@ func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	mustSeedObservation(t, cfg, "s-legacy", "legacy-source", "note", "legacy note", "content", "project")
 	rewriteLegacyProjectName(t, cfg, "legacy-source", "ENGRAM")
 
+	oldScan := scanInputLine
+	scanInputLine = func(...any) (int, error) {
+		t.Fatal("--all dry-run must not require a selection")
+		return 0, nil
+	}
+	t.Cleanup(func() { scanInputLine = oldScan })
+
 	withArgs(t, "engram", "projects", "consolidate", "--all", "--dry-run")
 	stdout, stderr := captureOutput(t, func() { cmdProjectsConsolidate(cfg) })
 	if stderr != "" {
@@ -1688,6 +1750,19 @@ func TestCmdProjectsConsolidateAllDryRun(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `Would merge into "engram"`) {
 		t.Fatalf("expected normalized canonical in dry-run output, got: %q", stdout)
+	}
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+	names, err := s.ListProjectNames()
+	if err != nil {
+		t.Fatalf("ListProjectNames: %v", err)
+	}
+	if len(names) != 2 || names[0] != "ENGRAM" || names[1] != "engram" {
+		t.Fatalf("--all dry-run mutated projects: %v", names)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1007

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Make single-project consolidation dry runs honor the confirmed candidate selection.
- Fail closed when dry-run input is empty, EOF, or invalid instead of previewing every candidate.
- Preserve explicit `--all --dry-run` behavior and prove that dry runs do not mutate projects.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Move dry-run planning after candidate selection and return a non-zero result for unconfirmed input. |
| `cmd/engram/main_test.go` | Cover selected-subset, EOF rejection, explicit-all, and no-mutation behavior. |

## 🧪 Test Plan

- [x] Focused unit tests pass: `go test ./cmd/engram -run 'TestCmdProjectsConsolidate' -count=1`
- [x] `gofmt` and `git diff --check` pass.
- [x] Native RDD review completed successfully for the committed candidate.
- [ ] Full unit, E2E, and lint suites were not duplicated locally; CI owns the broad checks for this PR.

---

## 🤖 Automated Checks

These run automatically and must pass before merge.

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue is approved | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | Repository unit suite | ⏳ |
| **E2E Tests** | Server E2E suite | ⏳ |
| **Plugin Tests** | Pi plugin suite | ⏳ |
| **Lint** | golangci-lint reports no new findings | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked approved issue #1007.
- [x] I added exactly one `type:*` label.
- [ ] I ran the full unit suite locally; only the focused package test was run because CI owns broad-suite evidence.
- [ ] I ran E2E locally; this CLI-only change does not touch the server E2E boundary.
- [ ] I ran the full lint target locally; formatting and diff checks passed and CI owns the lint gate.
- [x] Documentation impact was reviewed; no new flag or user workflow was introduced, so no external documentation changed.
- [x] The commit follows Conventional Commits.
- [x] The commit has no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

The review recorded one non-blocking suggestion to add a dedicated invalid-selection dry-run assertion. The command already returns non-zero for that path; the current focused suite passed and the suggestion did not require correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project consolidation dry runs now require a confirmed project selection.
  - Empty, unreadable, or invalid selections now fail clearly instead of proceeding.
  - Dry-run plans now report the number of selected projects accurately.
  - Dry-run operations leave projects unchanged, including when consolidating all projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->