### PR TITLE
fix(tui): defer clipboard discovery until paste

### DIFF
--- a/cmd/engram/dependencies_test.go
+++ b/cmd/engram/dependencies_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLinuxARM64DependencyGraphExcludesAtottoClipboard(t *testing.T) {
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate module root: runtime.Caller failed")
+	}
+
+	cmd := exec.Command("go", "list", "-deps", "-f", "{{.ImportPath}}", "./cmd/engram")
+	cmd.Dir = filepath.Join(filepath.Dir(sourceFile), "..", "..")
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=arm64")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list linux/arm64 command dependencies: %v\n%s", err, output)
+	}
+
+	for _, dependency := range strings.Fields(string(output)) {
+		if dependency == "github.com/atotto/clipboard" {
+			t.Fatal("linux/arm64 command dependency graph includes github.com/atotto/clipboard")
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Gentleman-Programming/engram/v2/internal/version"
 
 	"github.com/charmbracelet/bubbles/spinner"
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -171,7 +170,7 @@ type Model struct {
 	Stats *store.Stats
 
 	// Search
-	SearchInput   textinput.Model
+	SearchInput   textInput
 	SearchQuery   string
 	SearchResults []store.SearchResult
 
@@ -210,7 +209,7 @@ type Model struct {
 	SetupSpinner          spinner.Model
 
 	// Cloud configuration
-	CloudConfigInput       textinput.Model
+	CloudConfigInput       textInput
 	CloudConfigTokenSource string
 	CloudConfigError       string
 	CloudConfigFocus       int
@@ -236,11 +235,11 @@ type Model struct {
 
 // New creates a new TUI model connected to the given store.
 func New(s *store.Store, version string) Model {
-	ti := textinput.New()
+	ti := newTextInput()
 	ti.Placeholder = "Search memories..."
 	ti.CharLimit = 256
 	ti.Width = 60
-	ci := textinput.New()
+	ci := newTextInput()
 	ci.Placeholder = "https://cloud.example.com"
 	ci.CharLimit = 256
 	ci.Width = 60

--- a/internal/tui/textinput.go
+++ b/internal/tui/textinput.go
@@ -1,0 +1,219 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// textInput is the single-line input used by the TUI. Clipboard discovery is
+// intentionally deferred until the user requests a clipboard paste.
+type textInput struct {
+	Placeholder string
+	CharLimit   int
+	Width       int
+
+	value   []rune
+	cursor  int
+	focused bool
+}
+
+type textInputPasteMsg struct {
+	content string
+	err     error
+}
+
+var readInputClipboard = readSystemClipboard
+
+func newTextInput() textInput {
+	return textInput{}
+}
+
+func (m *textInput) SetValue(value string) {
+	m.value = sanitizeInput([]rune(value))
+	if m.CharLimit > 0 && len(m.value) > m.CharLimit {
+		m.value = m.value[:m.CharLimit]
+	}
+	m.cursor = len(m.value)
+}
+
+func (m textInput) Value() string {
+	return string(m.value)
+}
+
+func (m *textInput) Focus() tea.Cmd {
+	m.focused = true
+	return nil
+}
+
+func (m *textInput) Blur() {
+	m.focused = false
+}
+
+func (m textInput) Focused() bool {
+	return m.focused
+}
+
+func (m textInput) Update(msg tea.Msg) (textInput, tea.Cmd) {
+	switch msg := msg.(type) {
+	case textInputPasteMsg:
+		if msg.err == nil {
+			m.insert([]rune(msg.content))
+		}
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+v":
+			return m, func() tea.Msg {
+				content, err := readInputClipboard()
+				return textInputPasteMsg{content: content, err: err}
+			}
+		case "left", "ctrl+b":
+			m.moveCursor(-1)
+		case "right", "ctrl+f":
+			m.moveCursor(1)
+		case "home", "ctrl+a":
+			m.cursor = 0
+		case "end", "ctrl+e":
+			m.cursor = len(m.value)
+		case "backspace", "ctrl+h":
+			m.deleteBefore()
+		case "delete", "ctrl+d":
+			m.deleteAfter()
+		case "ctrl+u":
+			m.value = m.value[m.cursor:]
+			m.cursor = 0
+		case "ctrl+k":
+			m.value = m.value[:m.cursor]
+		case "ctrl+w":
+			m.deleteWordBefore()
+		case "alt+d":
+			m.deleteWordAfter()
+		default:
+			m.insert(msg.Runes)
+			return m, func() tea.Msg { return nil }
+		}
+	}
+	return m, nil
+}
+
+func (m textInput) View() string {
+	value := m.value
+	cursor := m.cursor
+	if m.Width > 0 && len(value) > m.Width {
+		start := max(0, cursor-m.Width+1)
+		end := min(len(value), start+m.Width)
+		value = value[start:end]
+		cursor -= start
+	}
+
+	if len(value) == 0 && m.Placeholder != "" {
+		if m.focused {
+			return "> " + lipgloss.NewStyle().Reverse(true).Render(string([]rune(m.Placeholder)[0])) + string([]rune(m.Placeholder)[1:])
+		}
+		return "> " + m.Placeholder
+	}
+
+	before := string(value[:cursor])
+	after := string(value[cursor:])
+	if !m.focused {
+		return "> " + before + after
+	}
+	if after == "" {
+		return "> " + before + lipgloss.NewStyle().Reverse(true).Render(" ")
+	}
+	first, rest := []rune(after)[0], []rune(after)[1:]
+	return "> " + before + lipgloss.NewStyle().Reverse(true).Render(string(first)) + string(rest)
+}
+
+func (m *textInput) insert(value []rune) {
+	value = sanitizeInput(value)
+	if m.CharLimit > 0 {
+		remaining := m.CharLimit - len(m.value)
+		if remaining <= 0 {
+			return
+		}
+		if len(value) > remaining {
+			value = value[:remaining]
+		}
+	}
+	m.value = append(m.value[:m.cursor], append(value, m.value[m.cursor:]...)...)
+	m.cursor += len(value)
+}
+
+func (m *textInput) moveCursor(delta int) {
+	m.cursor = min(len(m.value), max(0, m.cursor+delta))
+}
+
+func (m *textInput) deleteBefore() {
+	if m.cursor == 0 {
+		return
+	}
+	m.value = append(m.value[:m.cursor-1], m.value[m.cursor:]...)
+	m.cursor--
+}
+
+func (m *textInput) deleteAfter() {
+	if m.cursor >= len(m.value) {
+		return
+	}
+	m.value = append(m.value[:m.cursor], m.value[m.cursor+1:]...)
+}
+
+func (m *textInput) deleteWordBefore() {
+	for m.cursor > 0 && unicode.IsSpace(m.value[m.cursor-1]) {
+		m.deleteBefore()
+	}
+	for m.cursor > 0 && !unicode.IsSpace(m.value[m.cursor-1]) {
+		m.deleteBefore()
+	}
+}
+
+func (m *textInput) deleteWordAfter() {
+	for m.cursor < len(m.value) && unicode.IsSpace(m.value[m.cursor]) {
+		m.deleteAfter()
+	}
+	for m.cursor < len(m.value) && !unicode.IsSpace(m.value[m.cursor]) {
+		m.deleteAfter()
+	}
+}
+
+func sanitizeInput(value []rune) []rune {
+	return []rune(strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(string(value)))
+}
+
+func readSystemClipboard() (string, error) {
+	for _, command := range clipboardCommands() {
+		output, err := exec.Command(command[0], command[1:]...).Output()
+		if err == nil {
+			return string(output), nil
+		}
+	}
+	return "", fmt.Errorf("no supported clipboard command is available")
+}
+
+func clipboardCommands() [][]string {
+	switch runtime.GOOS {
+	case "darwin":
+		return [][]string{{"pbpaste"}}
+	case "windows":
+		return [][]string{{"powershell.exe", "Get-Clipboard"}}
+	default:
+		commands := make([][]string, 0, 5)
+		if os.Getenv("WAYLAND_DISPLAY") != "" {
+			commands = append(commands, []string{"wl-paste", "--no-newline"})
+		}
+		return append(commands,
+			[]string{"xclip", "-out", "-selection", "clipboard"},
+			[]string{"xsel", "--output", "--clipboard"},
+			[]string{"termux-clipboard-get"},
+			[]string{"powershell.exe", "Get-Clipboard"},
+		)
+	}
+}

--- a/internal/tui/textinput.go
+++ b/internal/tui/textinput.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -61,6 +60,10 @@ func (m textInput) Focused() bool {
 }
 
 func (m textInput) Update(msg tea.Msg) (textInput, tea.Cmd) {
+	if !m.focused {
+		return m, nil
+	}
+
 	switch msg := msg.(type) {
 	case textInputPasteMsg:
 		if msg.err == nil {
@@ -185,7 +188,18 @@ func (m *textInput) deleteWordAfter() {
 }
 
 func sanitizeInput(value []rune) []rune {
-	return []rune(strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(string(value)))
+	sanitized := make([]rune, 0, len(value))
+	for _, r := range value {
+		switch r {
+		case '\t', '\n', '\r':
+			sanitized = append(sanitized, ' ')
+		default:
+			if !unicode.IsControl(r) {
+				sanitized = append(sanitized, r)
+			}
+		}
+	}
+	return sanitized
 }
 
 func readSystemClipboard() (string, error) {

--- a/internal/tui/textinput_test.go
+++ b/internal/tui/textinput_test.go
@@ -1,0 +1,54 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTextInputCtrlVPastesClipboardLazily(t *testing.T) {
+	original := readInputClipboard
+	called := false
+	readInputClipboard = func() (string, error) {
+		called = true
+		return "one\ntwo", nil
+	}
+	t.Cleanup(func() { readInputClipboard = original })
+
+	input := newTextInput()
+	input.Focus()
+	updated, cmd := input.Update(tea.KeyMsg{Type: tea.KeyCtrlV})
+	if cmd == nil {
+		t.Fatal("ctrl+v command is nil")
+	}
+	if updated.Value() != "" {
+		t.Fatalf("value before clipboard command = %q, want empty", updated.Value())
+	}
+	if called {
+		t.Fatal("clipboard reader ran before the paste command")
+	}
+
+	updated, cmd = updated.Update(cmd())
+	if !called {
+		t.Fatal("clipboard reader did not run for the paste command")
+	}
+	if cmd != nil {
+		t.Fatal("clipboard result returned an unexpected command")
+	}
+	if updated.Value() != "one two" {
+		t.Fatalf("value after clipboard paste = %q, want %q", updated.Value(), "one two")
+	}
+}
+
+func TestTextInputPastedTerminalInputRespectsCharacterLimit(t *testing.T) {
+	input := newTextInput()
+	input.CharLimit = 4
+
+	updated, cmd := input.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("alpha"), Paste: true})
+	if cmd == nil {
+		t.Fatal("terminal paste command is nil")
+	}
+	if updated.Value() != "alph" {
+		t.Fatalf("value = %q, want %q", updated.Value(), "alph")
+	}
+}

--- a/internal/tui/textinput_test.go
+++ b/internal/tui/textinput_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -43,6 +44,7 @@ func TestTextInputCtrlVPastesClipboardLazily(t *testing.T) {
 func TestTextInputPastedTerminalInputRespectsCharacterLimit(t *testing.T) {
 	input := newTextInput()
 	input.CharLimit = 4
+	input.Focus()
 
 	updated, cmd := input.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("alpha"), Paste: true})
 	if cmd == nil {
@@ -50,5 +52,79 @@ func TestTextInputPastedTerminalInputRespectsCharacterLimit(t *testing.T) {
 	}
 	if updated.Value() != "alph" {
 		t.Fatalf("value = %q, want %q", updated.Value(), "alph")
+	}
+}
+
+func TestTextInputIgnoresUpdatesWhileBlurred(t *testing.T) {
+	input := newTextInput()
+	input.SetValue("saved")
+
+	for _, msg := range []tea.Msg{
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")},
+		textInputPasteMsg{content: "changed"},
+	} {
+		updated, cmd := input.Update(msg)
+		if cmd != nil || updated.Value() != "saved" {
+			t.Fatalf("blurred update = (%q, %v), want (saved, nil)", updated.Value(), cmd)
+		}
+	}
+
+	input.Focus()
+	updated, cmd := input.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	if cmd == nil || updated.Value() != "savedx" {
+		t.Fatalf("focused input = (%q, %v), want (savedx, non-nil)", updated.Value(), cmd)
+	}
+}
+
+func TestTextInputClipboardFailureLeavesValueUnchanged(t *testing.T) {
+	original := readInputClipboard
+	readInputClipboard = func() (string, error) { return "", errors.New("clipboard unavailable") }
+	t.Cleanup(func() { readInputClipboard = original })
+
+	input := newTextInput()
+	input.SetValue("saved")
+	input.Focus()
+	updated, cmd := input.Update(tea.KeyMsg{Type: tea.KeyCtrlV})
+	if cmd == nil {
+		t.Fatal("ctrl+v command is nil")
+	}
+	updated, _ = updated.Update(cmd())
+	if updated.Value() != "saved" {
+		t.Fatalf("value after failed clipboard paste = %q, want saved", updated.Value())
+	}
+}
+
+func TestTextInputSanitizesControlRunes(t *testing.T) {
+	input := newTextInput()
+	input.SetValue("a\tb\r\nc\x1bd\u0085e")
+	if input.Value() != "a b  cde" {
+		t.Fatalf("sanitized value = %q, want %q", input.Value(), "a b  cde")
+	}
+}
+
+func TestTextInputCursorAndDeletionBoundaries(t *testing.T) {
+	input := newTextInput()
+	input.SetValue("abc")
+	input.Focus()
+	input, _ = input.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	input, _ = input.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("X")})
+	if input.Value() != "abXc" {
+		t.Fatalf("cursor insertion = %q, want abXc", input.Value())
+	}
+
+	input.SetValue("abc")
+	for _, msg := range []tea.KeyMsg{{Type: tea.KeyHome}, {Type: tea.KeyBackspace}, {Type: tea.KeyEnd}, {Type: tea.KeyDelete}} {
+		input, _ = input.Update(msg)
+	}
+	if input.Value() != "abc" {
+		t.Fatalf("boundary deletions = %q, want abc", input.Value())
+	}
+
+	input.SetValue("abc")
+	input, _ = input.Update(tea.KeyMsg{Type: tea.KeyHome})
+	input, _ = input.Update(tea.KeyMsg{Type: tea.KeyRight})
+	input, _ = input.Update(tea.KeyMsg{Type: tea.KeyDelete})
+	if input.Value() != "ac" {
+		t.Fatalf("delete at cursor = %q, want ac", input.Value())
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1067

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Remove eager clipboard discovery from the Linux ARM64 command dependency graph.
- Preserve TUI text editing and defer clipboard process probing until an explicit paste.
- Add focused input regressions and a Linux ARM64 dependency guard.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/tui/model.go` | Replace the Bubbles text input fields with the local input. |
| `internal/tui/textinput.go` | Provide single-line editing and lazy platform clipboard reads. |
| `internal/tui/textinput_test.go` | Cover lazy Ctrl+V and terminal-paste limits. |
| `cmd/engram/dependencies_test.go` | Assert the Linux ARM64 binary graph excludes atotto clipboard. |

## 🧪 Test Plan

- [x] Linux ARM64 dependency regression passes.
- [x] Focused text-input tests pass.
- [x] Full `internal/tui` package tests pass.
- [x] Release-shaped Linux ARM64 and Windows builds pass.
- [x] Windows `--version` smoke passes.
- [ ] Original Android/Termux device confirmation (reporter follow-up).
- [ ] Full local unit suite (CI is the broad-suite owner).
- [ ] E2E suite (not applicable to this TUI startup fix).
- [ ] Local lint (CI will report repository lint status).

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue is approved | ⏳ |
| **Check PR Has type:* Label** | Exactly one type label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | Server E2E tests pass | ⏳ |
| **Plugin Tests** | Pi plugin tests pass | ⏳ |
| **Lint** | No new lint findings | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1067`).
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran the complete unit suite locally; focused and affected-package checks are recorded above.
- [ ] I ran E2E locally; it is not applicable to this change.
- [ ] I ran the full lint suite locally; CI owns this check.
- [x] Docs were reviewed; no user-facing documentation change is required.
- [x] Commits follow Conventional Commits format.
- [x] No `Co-Authored-By` trailers are present.

---

## 💬 Notes for Reviewers

Receipt-driven review approved the frozen candidate with no blocking findings. The command-package diagnostic completed and exposed only working-directory or host-configuration failures unrelated to this candidate; the issue-specific dependency guard passed. Reporter confirmation on the original Termux device remains the final external portability check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a streamlined text input experience in the terminal interface.
  - Clipboard pasting now works across macOS, Windows, and Linux environments.
  - Pasted content is sanitized and respects configured character limits.
  - Added support for cursor movement, word deletion, and other editing shortcuts.

- **Bug Fixes**
  - Improved compatibility for Linux ARM64 builds by preventing unsupported clipboard dependencies from being included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->