### PR TITLE
fix(pi): propagate tool cancellation to memory requests

### DIFF
--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -113,6 +113,7 @@ compacted summary appears without that guidance, save it immediately with
 interface FetchOptions {
   method?: string;
   body?: unknown;
+  signal?: AbortSignal;
 }
 
 interface EngramFetchResult<TResponse> {
@@ -214,7 +215,9 @@ async function engramFetchResult<TResponse = unknown>(path: string, opts: FetchO
         method,
         headers: opts.body ? { "Content-Type": "application/json" } : undefined,
         body: opts.body ? JSON.stringify(redactValue(opts.body)) : undefined,
-        signal: AbortSignal.timeout(ENGRAM_FETCH_TIMEOUT_MS),
+        signal: opts.signal
+          ? AbortSignal.any([AbortSignal.timeout(ENGRAM_FETCH_TIMEOUT_MS), opts.signal])
+          : AbortSignal.timeout(ENGRAM_FETCH_TIMEOUT_MS),
       });
       break;
     } catch (error) {
@@ -223,6 +226,7 @@ async function engramFetchResult<TResponse = unknown>(path: string, opts: FetchO
       // key). Only pre-send connection failures — the macOS wake-settle case this retry
       // exists for — are safe to repeat, and a hung server will not recover by retrying.
       if (isTimeoutError(error)) {
+        if (opts.signal?.aborted) throw error;
         timedOut = true;
         break;
       }
@@ -266,11 +270,11 @@ async function engramFetch<TResponse = unknown>(path: string, opts: FetchOptions
   return (await engramFetchResult<TResponse>(path, opts)).data;
 }
 
-function createMemoryToolTransport(): { fetch: EngramFetcher; timedOutMethod: () => string | undefined } {
+function createMemoryToolTransport(signal?: AbortSignal): { fetch: EngramFetcher; timedOutMethod: () => string | undefined } {
   let timedOutMethod: string | undefined;
   return {
     async fetch<TResponse = unknown>(path: string, opts: FetchOptions = {}): Promise<TResponse | null> {
-      const result = await engramFetchResult<TResponse>(path, opts);
+      const result = await engramFetchResult<TResponse>(path, { ...opts, signal });
       if (result.timedOutMethod) timedOutMethod = result.timedOutMethod;
       return result.data;
     },
@@ -455,6 +459,37 @@ function stripPrivateTags(str: string): string {
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// A tool call may stop awaiting shared startup work, but must not cancel it for other callers.
+function awaitWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  const cancelled = () => new Error("Engram tool execution was cancelled");
+  if (signal.aborted) {
+    void promise.then(
+      () => undefined,
+      () => undefined,
+    );
+    return Promise.reject(cancelled());
+  }
+  return new Promise<T>((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(cancelled());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 function spawnDetached(command: string, args: readonly string[], cwd?: string): Promise<boolean> {
@@ -713,17 +748,17 @@ async function ensureSession(sessionId: string, sessionProject = project, fetch:
   }
 }
 
-async function detectServerProject(cwd: string): Promise<CurrentProjectResponse | undefined> {
+async function detectServerProject(cwd: string, fetch: EngramFetcher = engramFetch, signal?: AbortSignal): Promise<CurrentProjectResponse | undefined> {
   for (let attempt = 0; attempt < 5; attempt += 1) {
     try {
-      const detected = await engramFetch<CurrentProjectResponse>(`/project/current${queryString({ cwd })}`);
+      const detected = await fetch<CurrentProjectResponse>(`/project/current${queryString({ cwd })}`, { signal });
       if (detected) return detected;
     } catch (error) {
       if (error instanceof EngramHttpError && error.status === 404) {
         return detectLocalConfigProject(cwd) || projectCurrentUnsupportedError(cwd);
       }
     }
-    if (attempt < 4) await wait(200);
+    if (attempt < 4) await awaitWithAbort(wait(200), signal);
   }
   return undefined;
 }
@@ -760,9 +795,9 @@ function applyDetectedProject(detected: CurrentProjectResponse | undefined): boo
   return false;
 }
 
-async function refreshProjectDetection(cwd: string): Promise<void> {
+async function refreshProjectDetection(cwd: string, fetch: EngramFetcher = engramFetch, signal?: AbortSignal): Promise<void> {
   if (!projectDetectionPending && !projectResolutionError) return;
-  applyDetectedProject(await detectServerProject(cwd));
+  applyDetectedProject(await detectServerProject(cwd, fetch, signal));
 }
 
 function forgetKnownSession(sessionId: string): void {
@@ -1213,17 +1248,17 @@ function unreachableMessage(timedOutMethod: string | undefined): string {
   return `gentle-engram could not reach the Engram HTTP server at ${ENGRAM_URL}. The Pi-native mem_* tools are registered, but the native memory provider is not currently responding. Run mem_doctor or restart Engram.`;
 }
 
-async function executeMemoryTool(toolName: string, params: Record<string, unknown>, ctx: MemoryToolContext) {
+async function executeMemoryTool(toolName: string, params: Record<string, unknown>, ctx: MemoryToolContext, signal?: AbortSignal) {
   const action = humanToolName(toolName);
-  const transport = createMemoryToolTransport();
+  const transport = createMemoryToolTransport(signal);
 
   try {
     // Initialization runs inside the guarded path: a rejected startup must reach the agent as
     // a normalized tool error, not as a rejection escaping the Pi tool boundary.
-    await initOnce(ctx.cwd);
-    await refreshProjectDetection(ctx.cwd);
+    await awaitWithAbort(initOnce(ctx.cwd), signal);
+    await refreshProjectDetection(ctx.cwd, engramFetch, signal);
     ctx.ui?.setStatus?.("engram", `🧠 ${project} · ${action}…`);
-    const data = await callMemoryTool(toolName, params, ctx, transport.fetch);
+    const data = await awaitWithAbort(callMemoryTool(toolName, params, ctx, transport.fetch), signal);
     const timedOutMethod = transport.timedOutMethod();
     if (timedOutMethod) throw new Error(unreachableMessage(timedOutMethod));
     const result = { content: [{ type: "text" as const, text: textResult(data, toolName) }], details: { data } };
@@ -1255,8 +1290,8 @@ function registerMemoryTools(pi: ExtensionAPI): void {
       promptSnippet: `Engram memory: ${humanToolName(toolName)}`,
       parameters: MEMORY_TOOL_SCHEMAS[toolName],
       renderShell: "self",
-      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-        return executeMemoryTool(toolName, params as Record<string, unknown>, ctx as MemoryToolContext);
+      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+        return executeMemoryTool(toolName, params as Record<string, unknown>, ctx as MemoryToolContext, signal);
       },
       renderCall(args) {
         return new Text(renderCallText(toolName, args), 0, 0);

--- a/plugin/pi/index.ts
+++ b/plugin/pi/index.ts
@@ -1270,6 +1270,7 @@ async function executeMemoryTool(toolName: string, params: Record<string, unknow
     ctx.ui?.setStatus?.("engram", `🧠 ${project} · ${compactResultStatus(toolName, result)}`);
     return result;
   } catch (error) {
+    if (signal?.aborted) throw error;
     const timedOutMethod = transport.timedOutMethod();
     const message = timedOutMethod ? unreachableMessage(timedOutMethod) : error instanceof Error ? error.message : String(error);
     const details = error instanceof EngramHttpError

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -26,12 +26,26 @@ function flush(times = 2) {
     : new Promise((resolve) => setTimeout(resolve, 0)).then(() => flush(times - 1));
 }
 
+function buildAwaitWithAbortForTest() {
+  const body = extractFunctionBody("awaitWithAbort", "{\n  if (!signal)")
+    .replace("new Promise<T>", "new Promise")
+    .replace("(error: unknown) =>", "(error) =>");
+  return new Function(`
+    function awaitWithAbort(promise, signal) {
+      ${body}
+    }
+    return awaitWithAbort;
+  `)();
+}
+
 function buildEngramFetchForTest({
   wait = () => Promise.resolve(),
   timeoutMs = 3000,
   maxAttempts = 3,
   backoffBaseMs = 150,
   recover = async () => false,
+  abortSignal = AbortSignal,
+  url = "http://127.0.0.1:7437",
 } = {}) {
   const body = extractFunctionBody("engramFetchResult", "{\n  const method")
     .replace("let res: Response | undefined;", "let res;")
@@ -47,6 +61,7 @@ function buildEngramFetchForTest({
     "ENGRAM_FETCH_TIMEOUT_MS",
     "ENGRAM_FETCH_MAX_ATTEMPTS",
     "ENGRAM_FETCH_BACKOFF_BASE_MS",
+    "AbortSignal",
     "recoverImplicitEngramServer",
     `
     class EngramHttpError extends Error {
@@ -81,10 +96,11 @@ function buildEngramFetchForTest({
     wait,
     (value) => value,
     (value) => value,
-    "http://127.0.0.1:7437",
+    url,
     timeoutMs,
     maxAttempts,
     backoffBaseMs,
+    abortSignal,
     recover,
   );
 }
@@ -954,6 +970,140 @@ test("native tool fetch backs off exponentially and attaches a per-request timeo
     globalThis.fetch = originalFetch;
     AbortSignal.timeout = originalAbortSignalTimeout;
   }
+});
+
+test("Pi tool cancellation composes with the native request timeout", async () => {
+  const originalFetch = globalThis.fetch;
+  const callbackSignal = new AbortController().signal;
+  const timeoutSignal = new AbortController().signal;
+  let timeoutMs;
+  let composedSignals;
+  let requestSignal;
+  const abortSignal = {
+    timeout(ms) {
+      timeoutMs = ms;
+      return timeoutSignal;
+    },
+    any(signals) {
+      composedSignals = signals;
+      return { kind: "combined" };
+    },
+  };
+  globalThis.fetch = async (_url, init) => {
+    requestSignal = init?.signal;
+    return { ok: true, async json() { return { status: "ok" }; } };
+  };
+  try {
+    const { engramFetch } = buildEngramFetchForTest({ abortSignal });
+    assert.deepEqual(await engramFetch("/health", { signal: callbackSignal }), { status: "ok" });
+    assert.equal(timeoutMs, 3000, "the existing timeout policy remains active");
+    assert.deepEqual(composedSignals, [timeoutSignal, callbackSignal]);
+    assert.deepEqual(requestSignal, { kind: "combined" });
+    assert.match(source, /async execute\(_toolCallId, params, signal, _onUpdate, ctx\)[\s\S]*executeMemoryTool\(toolName, params as Record<string, unknown>, ctx as MemoryToolContext, signal\)/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a native request without a Pi signal keeps timeout-only behavior", async () => {
+  const originalFetch = globalThis.fetch;
+  const timeoutSignal = new AbortController().signal;
+  let timeoutMs;
+  let anyCalls = 0;
+  let requestSignal;
+  const abortSignal = {
+    timeout(ms) {
+      timeoutMs = ms;
+      return timeoutSignal;
+    },
+    any() {
+      anyCalls += 1;
+      return new AbortController().signal;
+    },
+  };
+  globalThis.fetch = async (_url, init) => {
+    requestSignal = init?.signal;
+    return { ok: true, async json() { return { status: "ok" }; } };
+  };
+  try {
+    const { engramFetch } = buildEngramFetchForTest({ abortSignal });
+    assert.deepEqual(await engramFetch("/health"), { status: "ok" });
+    assert.equal(timeoutMs, 3000, "the existing timeout policy remains active");
+    assert.equal(anyCalls, 0, "a request without Pi cancellation must not compose signals");
+    assert.equal(requestSignal, timeoutSignal);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("Pi cancellation aborts a held native HTTP request before it can return a late result", async () => {
+  const { createServer } = await import("node:http");
+  let markRequestStarted;
+  let markRequestAborted;
+  const requestStarted = new Promise((resolve) => { markRequestStarted = resolve; });
+  const requestAborted = new Promise((resolve) => { markRequestAborted = resolve; });
+  const server = createServer((request) => {
+    markRequestStarted();
+    request.once("aborted", markRequestAborted);
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const controller = new AbortController();
+  const { engramFetch } = buildEngramFetchForTest({
+    url: `http://127.0.0.1:${port}`,
+    maxAttempts: 1,
+  });
+
+  try {
+    const pending = engramFetch("/held", { signal: controller.signal });
+    await requestStarted;
+    controller.abort();
+    await assert.rejects(pending, (error) => error?.name === "AbortError");
+    await requestAborted;
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+test("Pi cancellation stops awaiting execution preflight without cancelling shared initialization", async () => {
+  const awaitWithAbort = buildAwaitWithAbortForTest();
+  const controller = new AbortController();
+  let resolveShared;
+  let sharedSettled = false;
+  const sharedInitialization = new Promise((resolve) => {
+    resolveShared = () => {
+      sharedSettled = true;
+      resolve();
+    };
+  });
+
+  const waiting = awaitWithAbort(sharedInitialization, controller.signal);
+  controller.abort();
+  await assert.rejects(waiting, /cancelled/);
+  assert.equal(sharedSettled, false, "cancelling one tool call must not cancel shared initialization");
+  resolveShared();
+  await sharedInitialization;
+
+  assert.match(source, /await awaitWithAbort\(initOnce\(ctx\.cwd\), signal\);[\s\S]*await refreshProjectDetection\(ctx\.cwd, engramFetch, signal\);/);
+  assert.match(source, /async function detectServerProject[\s\S]*fetch<CurrentProjectResponse>\([^\n]*\{ signal \}\)[\s\S]*await awaitWithAbort\(wait\(200\), signal\)/);
+});
+
+test("already-cancelled preflight observes a later shared initialization rejection", async () => {
+  const awaitWithAbort = buildAwaitWithAbortForTest();
+  const controller = new AbortController();
+  controller.abort();
+  let rejectShared;
+  const sharedInitialization = new Promise((_, reject) => {
+    rejectShared = reject;
+  });
+  const waiting = awaitWithAbort(sharedInitialization, controller.signal);
+
+  await assert.rejects(waiting, /cancelled/);
+  rejectShared(new Error("shared startup failed"));
+  await flush();
+
+  assert.match(source, /if \(signal\.aborted\) \{\s*void promise\.then\(/);
+  assert.match(source, /const data = await awaitWithAbort\(callMemoryTool\(toolName, params, ctx, transport\.fetch\), signal\);/);
 });
 
 test("a timed-out write is not re-sent, so a slow-but-applied mem_save cannot be duplicated", async () => {

--- a/plugin/pi/test/index-source.test.mjs
+++ b/plugin/pi/test/index-source.test.mjs
@@ -38,6 +38,37 @@ function buildAwaitWithAbortForTest() {
   `)();
 }
 
+function buildExecuteMemoryToolForTest({ awaitWithAbort, initOnce, refreshProjectDetection, callMemoryTool, scheduleEngramSelfHeal }) {
+  const body = extractFunctionBody("executeMemoryTool", "{\n  const action")
+    .replaceAll('type: "text" as const', 'type: "text"');
+  const factory = new Function(
+    "awaitWithAbort",
+    "initOnce",
+    "refreshProjectDetection",
+    "callMemoryTool",
+    "scheduleEngramSelfHeal",
+    `
+    let project = "engram";
+    class EngramHttpError extends Error {}
+    const humanToolName = (toolName) => toolName;
+    const createMemoryToolTransport = () => ({
+      fetch: async () => null,
+      timedOutMethod: () => undefined,
+    });
+    const unreachableMessage = () => "unreachable";
+    const textResult = () => "result";
+    const compactResultStatus = () => "complete";
+    const errorStatusLabel = () => "error";
+    const engramFetch = async () => null;
+    async function executeMemoryTool(toolName, params, ctx, signal) {
+      ${body}
+    }
+    return executeMemoryTool;
+    `,
+  );
+  return factory(awaitWithAbort, initOnce, refreshProjectDetection, callMemoryTool, scheduleEngramSelfHeal);
+}
+
 function buildEngramFetchForTest({
   wait = () => Promise.resolve(),
   timeoutMs = 3000,
@@ -1086,6 +1117,74 @@ test("Pi cancellation stops awaiting execution preflight without cancelling shar
 
   assert.match(source, /await awaitWithAbort\(initOnce\(ctx\.cwd\), signal\);[\s\S]*await refreshProjectDetection\(ctx\.cwd, engramFetch, signal\);/);
   assert.match(source, /async function detectServerProject[\s\S]*fetch<CurrentProjectResponse>\([^\n]*\{ signal \}\)[\s\S]*await awaitWithAbort\(wait\(200\), signal\)/);
+});
+
+test("cancelling initialization, project detection, or active memory work propagates without an outage status or recovery", async () => {
+  for (const stage of ["initialization", "project detection", "active memory work"]) {
+    const awaitWithAbort = buildAwaitWithAbortForTest();
+    const controller = new AbortController();
+    const statuses = [];
+    let release;
+    let entered;
+    let recoveries = 0;
+    const blocked = new Promise((resolve) => { release = resolve; });
+    const enterStage = new Promise((resolve) => { entered = resolve; });
+    const executeMemoryTool = buildExecuteMemoryToolForTest({
+      awaitWithAbort,
+      initOnce: () => {
+        if (stage === "initialization") {
+          entered();
+          return blocked;
+        }
+        return Promise.resolve();
+      },
+      refreshProjectDetection: async (_cwd, _fetch, signal) => {
+        if (stage === "project detection") {
+          entered();
+          return awaitWithAbort(blocked, signal);
+        }
+      },
+      callMemoryTool: () => {
+        if (stage === "active memory work") {
+          entered();
+          return blocked;
+        }
+        return Promise.resolve({});
+      },
+      scheduleEngramSelfHeal: () => { recoveries += 1; },
+    });
+
+    const execution = executeMemoryTool("mem_search", {}, { ...sessionCtx("session", statuses), cwd: "/work" }, controller.signal);
+    await enterStage;
+    controller.abort();
+
+    await assert.rejects(execution, /cancelled/);
+    release();
+    await blocked;
+    await flush();
+    assert.equal(statuses.some(([, text]) => text?.includes("error")), false, `${stage} cancellation must not show an error status`);
+    assert.equal(recoveries, 0, `${stage} cancellation must not schedule recovery`);
+  }
+  assert.match(source, /catch \(error\) \{\s*if \(signal\?\.aborted\) throw error;/);
+});
+
+test("a non-cancellation initialization failure still reports an outage and schedules recovery", async () => {
+  const statuses = [];
+  let recoveries = 0;
+  const executeMemoryTool = buildExecuteMemoryToolForTest({
+    awaitWithAbort: buildAwaitWithAbortForTest(),
+    initOnce: async () => { throw new Error("startup failed"); },
+    refreshProjectDetection: async () => assert.fail("failed initialization must not reach project detection"),
+    callMemoryTool: async () => assert.fail("failed initialization must not call memory"),
+    scheduleEngramSelfHeal: () => { recoveries += 1; },
+  });
+
+  const result = await executeMemoryTool("mem_search", {}, { ...sessionCtx("session", statuses), cwd: "/work" });
+
+  assert.equal(result.isError, true);
+  assert.equal(result.details.error, "startup failed");
+  assert.deepEqual(statuses, [["engram", "🧠 engram · error"]]);
+  assert.equal(recoveries, 1);
 });
 
 test("already-cancelled preflight observes a later shared initialization rejection", async () => {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1089

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Propagate the Pi tool callback AbortSignal through Engram preflight and HTTP memory requests.
- Preserve the existing 3000 ms request timeout while preventing successful late tool results after cancellation.
- Keep shared initialization alive for other callers and isolate project-detection timeouts from mutation outcome tracking.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/pi/index.ts` | Compose caller cancellation with request timeouts and guard preflight/tool completion. |
| `plugin/pi/test/index-source.test.mjs` | Add Windows Node runtime coverage for held-request cancellation and negative controls. |

## 🧪 Test Plan

- [x] Pi plugin tests pass locally: `npm test --prefix plugin/pi` (123/123).
- [x] Focused cancellation suite passes locally: `node --test plugin/pi/test/index-source.test.mjs` (67/67).
- [x] Runtime boundary tested with a held local HTTP request on Windows; caller abort produced `AbortError` before any late response.
- [x] `git diff --check` passes.
- [ ] Repository-wide `go test ./...` is clean locally; attempted, but unrelated Windows project-detection/config and temporary-directory permission failures remain.
- [ ] E2E suite run locally; candidate does not modify Go server behavior.
- [ ] Lint run locally; candidate is limited to the Pi TypeScript plugin and source tests.

---

## 🤖 Automated Checks

These run automatically and must pass before merge.

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue is approved | ⏳ |
| **Check PR Has type:* Label** | Exactly one type label | ⏳ |
| **Unit Tests** | `go test ./...` | ⏳ |
| **E2E Tests** | Server E2E tests | ⏳ |
| **Plugin Tests** | Pi plugin tests | ⏳ |
| **Lint** | No new lint findings | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked approved issue #1089.
- [x] I added exactly one `type:*` label.
- [x] Relevant Pi unit and runtime tests pass locally.
- [ ] The repository-wide Go suite is clean locally; the attempted Windows run hit unrelated environment-sensitive failures.
- [ ] I ran the Go E2E suite locally.
- [ ] I ran repository-wide lint locally.
- [x] Docs were reviewed; no setup, API, or documented workflow changes are required.
- [x] Commits follow Conventional Commits format.
- [x] No `Co-Authored-By` trailers are present.

---

## 💬 Notes for Reviewers

Provider-owned RDD approved and acknowledged the final candidate before commit. The commit tree exactly matches the reviewed candidate tree.

This PR fixes the proven dropped Pi cancellation signal. It intentionally does not claim to identify or fix the separate project-dependent indefinite Windows stall reported in the issue; that remains a residual unknown pending reproducible runtime evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling across Pi tool operations, including project detection and memory actions.
  - User-initiated cancellations now stop waiting promptly without being misreported as timeouts or service outages.
  - Ongoing shared initialization continues safely for other requests when one request is cancelled.
  - Requests now distinguish caller cancellation from native request timeouts.
  - Cancelled operations no longer trigger unnecessary recovery actions or error reporting.
- **Tests**
  - Added coverage for cancellation, timeout behavior, interrupted requests, shared initialization, and project detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->