### PR TITLE
fix(cloud): emit ownership-aware manifest version

### DIFF
--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Gentleman-Programming/engram/v2/internal/cloud/chunkcodec"
 	"github.com/Gentleman-Programming/engram/v2/internal/cloud/cloudstore"
 	"github.com/Gentleman-Programming/engram/v2/internal/cloud/dashboard"
+	"github.com/Gentleman-Programming/engram/v2/internal/cloud/remote"
 	"github.com/Gentleman-Programming/engram/v2/internal/store"
 	engramsync "github.com/Gentleman-Programming/engram/v2/internal/sync"
 )
@@ -166,7 +167,7 @@ func TestHandlerMountsDashboardAndHealth(t *testing.T) {
 }
 
 func TestHandlerSyncPushPullRoundTrip(t *testing.T) {
-	st := &fakeStore{}
+	st := &fakeStore{manifest: engramsync.Manifest{Version: 2}}
 	srv := New(st, fakeAuth{}, 0)
 
 	payload := []byte(`{"sessions":[{"id":"s-1","directory":"/tmp/s-1"}]}`)
@@ -192,6 +193,9 @@ func TestHandlerSyncPushPullRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(pullManifest.Body.Bytes(), &manifest); err != nil {
 		t.Fatalf("decode manifest: %v", err)
 	}
+	if manifest.Version != 2 {
+		t.Fatalf("expected /sync/pull manifest version 2, got %d", manifest.Version)
+	}
 	if len(manifest.Chunks) != 1 || manifest.Chunks[0].ID != chunkID {
 		t.Fatalf("unexpected manifest %+v", manifest.Chunks)
 	}
@@ -206,6 +210,45 @@ func TestHandlerSyncPushPullRoundTrip(t *testing.T) {
 	}
 	if string(bytes.TrimSpace(pullChunk.Body.Bytes())) != string(normalizedPayload) {
 		t.Fatalf("unexpected chunk body=%q", pullChunk.Body.String())
+	}
+}
+
+func TestRemoteTransportReadsV2ManifestAndBootstrapProjectVerifies(t *testing.T) {
+	server := httptest.NewServer(New(&fakeStore{manifest: engramsync.Manifest{Version: 2}}, fakeAuth{}, 0).Handler())
+	t.Cleanup(server.Close)
+
+	transport, err := remote.NewRemoteTransport(server.URL, "", "proj-a")
+	if err != nil {
+		t.Fatalf("create remote transport: %v", err)
+	}
+	manifest, err := transport.ReadManifest()
+	if err != nil {
+		t.Fatalf("read manifest through remote transport: %v", err)
+	}
+	if manifest.Version != 2 {
+		t.Fatalf("remote manifest version = %d, want 2", manifest.Version)
+	}
+
+	cfg, err := store.DefaultConfig()
+	if err != nil {
+		t.Fatalf("default store config: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	local, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("create local store: %v", err)
+	}
+	t.Cleanup(func() { _ = local.Close() })
+	if err := local.CreateSessionWithOwnershipMode("project-owned", "proj-a", "/tmp/project-owned", store.SessionOwnershipProjectOwned); err != nil {
+		t.Fatalf("create project-owned session: %v", err)
+	}
+
+	result, err := engramsync.BootstrapProject(local, transport, engramsync.UpgradeBootstrapOptions{Project: "proj-a", CreatedBy: "test"})
+	if err != nil {
+		t.Fatalf("bootstrap project through remote transport: %v", err)
+	}
+	if result.Stage != store.UpgradeStageBootstrapVerified {
+		t.Fatalf("bootstrap stage = %q, want %q", result.Stage, store.UpgradeStageBootstrapVerified)
 	}
 }
 

--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -168,7 +168,7 @@ func (cs *CloudStore) ReadManifest(ctx context.Context, project string) (*engram
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("cloudstore: iterate manifest: %w", err)
 	}
-	return &engramsync.Manifest{Version: 1, Chunks: toManifestEntries(manifestRows)}, nil
+	return &engramsync.Manifest{Version: 2, Chunks: toManifestEntries(manifestRows)}, nil
 }
 
 type manifestRow struct {

--- a/internal/cloud/cloudstore/cloudstore_test.go
+++ b/internal/cloud/cloudstore/cloudstore_test.go
@@ -373,6 +373,22 @@ func TestParseClientCreatedAt(t *testing.T) {
 	})
 }
 
+func TestReadManifestEmitsOwnershipModeVersion(t *testing.T) {
+	db, err := sql.Open(projectGrantBindingDriverName, "")
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	manifest, err := (&CloudStore{db: db}).ReadManifest(context.Background(), "proj-a")
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if manifest.Version != 2 {
+		t.Fatalf("manifest version = %d, want 2", manifest.Version)
+	}
+}
+
 func TestSortManifestRowsByServerCreatedAtForReplay(t *testing.T) {
 	rows := []manifestRow{
 		{

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2434,6 +2434,31 @@ func TestOwnershipManifestCompatibilityIsScopedToSynchronizedSessions(t *testing
 	}
 }
 
+func TestCloudImportAcceptsPendingProjectOwnedChunkFromV2Manifest(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSessionWithOwnershipMode("local-project-owned", "project-a", "/tmp/local", store.SessionOwnershipProjectOwned); err != nil {
+		t.Fatalf("create project-owned session: %v", err)
+	}
+	if err := s.EnrollProject("project-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+
+	transport := newFakeCloudTransport()
+	transport.manifest = &Manifest{Version: ownershipModeManifestVersion, Chunks: []ChunkEntry{{ID: "pending", CreatedAt: "2026-01-01T00:00:00Z"}}}
+	transport.chunks["pending"] = []byte(`{"sessions":[{"id":"shared-session","project":"project-a","directory":"/tmp/shared"}]}`)
+
+	result, err := NewCloudWithTransport(s, transport, "project-a").Import()
+	if err != nil {
+		t.Fatalf("import pending v2 cloud chunk: %v", err)
+	}
+	if result.ChunksImported != 1 || result.SessionsImported != 1 {
+		t.Fatalf("unexpected import result: %+v", result)
+	}
+	if _, err := s.GetSession("shared-session"); err != nil {
+		t.Fatalf("expected pending cloud session to import: %v", err)
+	}
+}
+
 func TestOwnershipManifestVersionDoesNotDowngradeFutureManifest(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.CreateSessionWithOwnershipMode("manual-save-project-a", "project-a", "/tmp/a", store.SessionOwnershipProjectOwned); err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1088
Closes #1073

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Make the cloud manifest materialization advertise ownership-mode manifest version 2.
- Preserve that version across `/sync/pull` and the real remote client transport.
- Unblock pending project-owned imports and cloud-upgrade bootstrap verification while retaining genuine-v1 rejection.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudstore/cloudstore.go` | Emit manifest version 2 from the cloud source of truth. |
| `internal/cloud/cloudstore/cloudstore_test.go` | Regress the manifest version at the cloud store boundary. |
| `internal/cloud/cloudserver/cloudserver_test.go` | Prove v2 survives CloudServer HTTP and RemoteTransport and bootstrap reaches verified. |
| `internal/sync/sync_test.go` | Prove pending project-owned chunks import under v2 while v1 controls remain. |

## 🧪 Test Plan

- [x] Focused packages: `go test -count=1 ./internal/cloud/cloudstore ./internal/cloud/cloudserver ./internal/cloud/remote ./internal/sync`
- [x] HTTP/bootstrap regression: `go test -count=1 ./internal/cloud/cloudserver -run '^TestRemoteTransportReadsV2ManifestAndBootstrapProjectVerifies$'`
- [x] Plugin tests: `npm test --prefix plugin/pi` (118 passed)
- [x] Lint: `golangci-lint run --new-from-rev=HEAD~` (0 issues)
- [x] Full unit and tagged server E2E suites were executed locally.

Full `go test -count=1 ./...` and `go test -count=1 -tags e2e ./internal/server/...` currently reproduce the same unrelated project-resolution/plugin failures on the frozen base. A four-file base overlay confirmed these failures are not introduced by this PR.

---

## 🤖 Automated Checks

These run automatically and must pass before merge.

---

## ✅ Contributor Checklist

- [x] I linked approved issues above (`Closes #1088`, `Closes #1073`)
- [x] I added exactly one `type:*` label to this PR
- [x] I ran unit tests locally
- [x] I ran E2E tests locally
- [x] I ran lint locally
- [x] Docs updated (not required; this restores the existing v2 ownership contract)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The cloud schema does not persist a manifest version. The hub materializes the manifest on pull, so advertising v2 at `CloudStore.ReadManifest` is the single source-of-truth correction. Provider-owned RDD approved the frozen candidate before delivery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cloud manifests now use version 2, supporting project ownership information.
  - Project-owned cloud stores can be bootstrapped and verified successfully.
  - Cloud import now supports pending project-owned sessions from version 2 manifests.
  - Sync push-and-pull operations preserve version 2 manifest data.

- **Bug Fixes**
  - Improved compatibility when reading and importing project-owned cloud data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->