### PR TITLE
fix(opencode): close sessions on graceful disposal

### DIFF
--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -510,6 +510,11 @@ export const Engram: Plugin = async (ctx) => {
 	}
 
   return {
+    dispose: async () => {
+      const rootSessionIDs = [...knownSessions].filter(isKnownAuthoritativeRootSession)
+      await Promise.all(rootSessionIDs.map(closeDeletedRootSession))
+    },
+
     // ─── Event Listeners ───────────────────────────────────────────
 
     event: async ({ event }) => {

--- a/plugin/opencode/engram.test.mjs
+++ b/plugin/opencode/engram.test.mjs
@@ -179,6 +179,7 @@ async function createRuntime(t, {
   })
   return {
     plugin,
+    dispose: plugin.dispose,
     event: (type, info) => plugin.event({ event: { type, properties: { info } } }),
     before: plugin["tool.execute.before"],
     chat: plugin["chat.message"],
@@ -964,4 +965,24 @@ test("deleting a parent invalidates descendants and prevents later writes or re-
   }
 
   assert.deepEqual(runtime.registeredIDs, ["parent"], "invalid descendants must never re-register as top-level sessions")
+})
+
+test("plugin disposal closes registered roots, not children, and waits for session ends", async (t) => {
+  const rootID = "root/with space"
+  const end = deferredResponse()
+  const runtime = await createRuntime(t, { sessionEndResponse: end.handler })
+  await runtime.event("session.created", session(rootID))
+  await runtime.event("session.created", session("child", rootID))
+
+  let settled = false
+  const pending = runtime.dispose().then(() => { settled = true })
+  await end.started
+  await Promise.resolve()
+  assert.equal(settled, false)
+  end.resolve(httpResponse({}))
+  await pending
+
+  const endRequests = runtime.requests.filter(({ path }) => path.startsWith("/sessions/") && path.endsWith("/end"))
+  assert.equal(endRequests.length, 1)
+  assert.equal(endRequests[0].path, `/sessions/${encodeURIComponent(rootID)}/end`)
 })

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -510,6 +510,11 @@ export const Engram: Plugin = async (ctx) => {
 	}
 
   return {
+    dispose: async () => {
+      const rootSessionIDs = [...knownSessions].filter(isKnownAuthoritativeRootSession)
+      await Promise.all(rootSessionIDs.map(closeDeletedRootSession))
+    },
+
     // ─── Event Listeners ───────────────────────────────────────────
 
     event: async ({ event }) => {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1083

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Close successfully registered root sessions when OpenCode performs awaited graceful plugin disposal.
- Reuse the existing deletion close path so confirmed closures deduplicate and failed end requests remain retryable.

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/opencode/engram.ts` | Add the awaited graceful-disposal closure path. |
| `internal/setup/plugins/opencode/engram.ts` | Keep the shipped setup copy byte-identical. |
| `plugin/opencode/engram.test.mjs` | Cover awaited root closure while excluding child sessions. |

## 🧪 Test Plan

- [x] `node --experimental-strip-types --test plugin/opencode/engram.test.mjs` — 67 passed, 0 failed
- [x] `go test ./internal/setup -run '^TestEmbeddedOpenCodePluginMatchesSourceByteForByte$'`
- [x] `git diff --check`
- [x] Shipped adapter copies are byte-identical
- [x] Frozen-base regression: 66/67 passed; disposal test failed because `runtime.dispose` was absent
- [ ] Full repository and host-shutdown E2E suites were not run locally; CI remains authoritative

---

## 🤖 Automated Checks

These run automatically and must pass before merge.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1083`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] Focused unit tests pass locally
- [ ] Full repository E2E tests were not run locally
- [ ] Full lint was not run locally
- [x] Docs are unchanged because this is a localized adapter lifecycle correction
- [x] Commits follow conventional commit format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Native RDD approved and acknowledged the exact commit tree (`0d99589bc08542beecae0a60dad41577198e673a`) under target `sha256:25f81435cdcceaf711444a83eddafdd0d3bc47eaf7b441e9f6f327d6bc8733fe`.

Residual limit: hard kills, crashes, `TerminateProcess`, and power loss cannot await plugin disposal and remain outside this fix. PR #1102 is an independent store-level stale-recency mitigation and does not touch this adapter lifecycle path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic session cleanup when the OpenCode plugin shuts down.
  - Registered root sessions are now closed before shutdown completes.
  - Child sessions remain unaffected.
  - Session identifiers are handled safely, including identifiers containing special characters.
  - Shutdown waits for confirmation that each session closure has completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->