### PR TITLE
fix(cloud): preserve autosync contributor attribution

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -122,6 +122,10 @@ Dashboard route tree (`engram cloud serve`):
 
 Engram is local-first: local SQLite is authoritative; cloud features are optional replication/shared access and enrollment controls.
 
+### Mutation materialization attribution
+
+For an accepted `POST /sync/mutations/push`, each future materialized cloud chunk records the authenticated server principal's display name. If it is blank, the server uses the principal ID, then `unknown`. The mutation-envelope `created_by` value cannot control accepted chunk attribution. This is distinct from explicit `POST /sync/push`, which preserves its chunk `created_by` metadata. Existing cloud rows are not repaired or rewritten by this behavior.
+
 ### Health
 
 - Local runtime (`engram serve`): `GET /health` — Returns `{"status": "ok", "service": "engram", "version": "0.1.0"}`

--- a/cmd/engram/cloud_runtime_e2e_test.go
+++ b/cmd/engram/cloud_runtime_e2e_test.go
@@ -186,6 +186,149 @@ func TestCloudRuntimeWiresManagedTokenAuthEndToEnd(t *testing.T) {
 	}
 }
 
+func TestCloudRuntimeMutationPushAttributionUsesAuthenticatedPrincipal(t *testing.T) {
+	testDSN := openIsolatedCloudRuntimeSchema(t)
+
+	const legacySyncToken = "e2e-attribution-legacy-token"
+	const tokenPepper = "e2e-attribution-token-pepper-at-least-32-bytes"
+	const project = "attribution-e2e"
+	t.Setenv("ENGRAM_CLOUD_TOKEN", legacySyncToken)
+	t.Setenv("ENGRAM_CLOUD_INSECURE_NO_AUTH", "")
+
+	rt, err := newCloudRuntime(cloud.Config{
+		DSN:              testDSN,
+		JWTSecret:        "e2e-attribution-jwt-secret-32-bytes-plus",
+		AllowedProjects:  []string{project},
+		TokenPepper:      tokenPepper,
+		MaxPushBodyBytes: cloud.DefaultMaxPushBodyBytes,
+	})
+	if err != nil {
+		t.Fatalf("newCloudRuntime: %v", err)
+	}
+	dcr, ok := rt.(*defaultCloudRuntime)
+	if !ok {
+		t.Fatalf("expected *defaultCloudRuntime, got %T", rt)
+	}
+	t.Cleanup(func() { _ = dcr.store.Close() })
+	ctx := context.Background()
+	managedUser, err := dcr.store.CreateHumanUser(ctx, cloudstore.CreateHumanUserParams{
+		Username:    "managed-attribution-user",
+		DisplayName: "Managed E2E User",
+		Role:        cloudstore.PrincipalRoleMember,
+	})
+	if err != nil {
+		t.Fatalf("CreateHumanUser: %v", err)
+	}
+	if _, err := dcr.store.CreateProjectGrant(ctx, cloudstore.CreateProjectGrantParams{
+		PrincipalID:          managedUser.PrincipalID,
+		Project:              project,
+		GrantedByPrincipalID: managedUser.PrincipalID,
+	}); err != nil {
+		t.Fatalf("CreateProjectGrant: %v", err)
+	}
+	managedToken, err := cloudauth.GenerateManagedToken("test")
+	if err != nil {
+		t.Fatalf("GenerateManagedToken: %v", err)
+	}
+	hasher, err := cloudauth.NewManagedTokenHasher([]byte(tokenPepper))
+	if err != nil {
+		t.Fatalf("NewManagedTokenHasher: %v", err)
+	}
+	tokenHash, err := hasher.Hash(managedToken.Raw)
+	if err != nil {
+		t.Fatalf("hash managed token: %v", err)
+	}
+	if _, err := dcr.store.CreatePrincipalToken(ctx, cloudstore.CreatePrincipalTokenParams{
+		PrincipalID: managedUser.PrincipalID,
+		TokenPrefix: managedToken.Prefix,
+		TokenHash:   tokenHash,
+		Name:        "attribution-e2e-token",
+	}); err != nil {
+		t.Fatalf("CreatePrincipalToken: %v", err)
+	}
+
+	body := `{"created_by":"forged-client-identity","entries":[{"project":"attribution-e2e","entity":"session","entity_key":"session-1","op":"upsert","payload":{"id":"session-1","directory":"/tmp/session-1"}}]}`
+	unauthorized := httptest.NewRecorder()
+	unauthorizedRequest := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", strings.NewReader(body))
+	unauthorizedRequest.Header.Set("Content-Type", "application/json")
+	dcr.server.Handler().ServeHTTP(unauthorized, unauthorizedRequest)
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized mutation push status = %d, want %d", unauthorized.Code, http.StatusUnauthorized)
+	}
+	manifest, err := dcr.store.ReadManifest(ctx, project)
+	if err != nil {
+		t.Fatalf("ReadManifest after rejected mutation push: %v", err)
+	}
+	if len(manifest.Chunks) != 0 {
+		t.Fatalf("rejected mutation push materialized %d chunks", len(manifest.Chunks))
+	}
+
+	push := httptest.NewRecorder()
+	pushRequest := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", strings.NewReader(body))
+	pushRequest.Header.Set("Authorization", "Bearer "+managedToken.Raw)
+	pushRequest.Header.Set("Content-Type", "application/json")
+	dcr.server.Handler().ServeHTTP(push, pushRequest)
+	if push.Code != http.StatusOK {
+		t.Fatalf("authenticated mutation push status = %d, want %d body=%q", push.Code, http.StatusOK, push.Body.String())
+	}
+
+	manifest, err = dcr.store.ReadManifest(ctx, project)
+	if err != nil {
+		t.Fatalf("ReadManifest after accepted mutation push: %v", err)
+	}
+	if len(manifest.Chunks) != 1 {
+		t.Fatalf("materialized chunks = %d, want 1", len(manifest.Chunks))
+	}
+	if manifest.Chunks[0].CreatedBy != managedUser.DisplayName {
+		t.Fatalf("materialized chunk created_by = %q, want authenticated principal %q", manifest.Chunks[0].CreatedBy, managedUser.DisplayName)
+	}
+	contributors, err := dcr.store.ListContributors("")
+	if err != nil {
+		t.Fatalf("ListContributors: %v", err)
+	}
+	if len(contributors) != 1 || contributors[0].CreatedBy != managedUser.DisplayName {
+		t.Fatalf("contributors = %+v, want authenticated principal %q", contributors, managedUser.DisplayName)
+	}
+
+	replay := httptest.NewRecorder()
+	replayRequest := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", strings.NewReader(body))
+	replayRequest.Header.Set("Authorization", "Bearer "+managedToken.Raw)
+	replayRequest.Header.Set("Content-Type", "application/json")
+	dcr.server.Handler().ServeHTTP(replay, replayRequest)
+	if replay.Code != http.StatusOK {
+		t.Fatalf("replayed mutation push status = %d, want %d body=%q", replay.Code, http.StatusOK, replay.Body.String())
+	}
+	manifest, err = dcr.store.ReadManifest(ctx, project)
+	if err != nil {
+		t.Fatalf("ReadManifest after replay: %v", err)
+	}
+	if len(manifest.Chunks) != 1 || manifest.Chunks[0].CreatedBy != managedUser.DisplayName {
+		t.Fatalf("replay changed materialized attribution: %+v", manifest.Chunks)
+	}
+
+	explicitPush := httptest.NewRecorder()
+	explicitPushRequest := httptest.NewRequest(http.MethodPost, "/sync/push", strings.NewReader(`{"project":"attribution-e2e","created_by":"explicit-client-attribution","data":{"sessions":[{"id":"session-explicit","directory":"/tmp/session-explicit"}]}}`))
+	explicitPushRequest.Header.Set("Authorization", "Bearer "+managedToken.Raw)
+	explicitPushRequest.Header.Set("Content-Type", "application/json")
+	dcr.server.Handler().ServeHTTP(explicitPush, explicitPushRequest)
+	if explicitPush.Code != http.StatusOK {
+		t.Fatalf("explicit chunk push status = %d, want %d body=%q", explicitPush.Code, http.StatusOK, explicitPush.Body.String())
+	}
+	manifest, err = dcr.store.ReadManifest(ctx, project)
+	if err != nil {
+		t.Fatalf("ReadManifest after explicit chunk push: %v", err)
+	}
+	foundExplicitAttribution := false
+	for _, chunk := range manifest.Chunks {
+		if chunk.CreatedBy == "explicit-client-attribution" {
+			foundExplicitAttribution = true
+		}
+	}
+	if !foundExplicitAttribution {
+		t.Fatalf("explicit chunk push attribution missing from manifest: %+v", manifest.Chunks)
+	}
+}
+
 func doBearerRequest(t *testing.T, handler http.Handler, method, path, bearerToken string) (int, string) {
 	t.Helper()
 	req := httptest.NewRequest(method, path, nil)

--- a/internal/cloud/cloudserver/mutations.go
+++ b/internal/cloud/cloudserver/mutations.go
@@ -182,6 +182,7 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 	// Canonicalize every entry before storage so accepted legacy sparse payloads
 	// materialize the same way as later chunk replay. Any failure rejects the
 	// ENTIRE batch before InsertMutationBatch is called.
+	createdBy := mutationPushCreatedBy(r.Context())
 	var invalid []map[string]any
 	normalizedEntries := make([]MutationEntry, 0, len(req.Entries))
 	for i, entry := range req.Entries {
@@ -200,6 +201,7 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 			})
 			continue
 		}
+		normalized.CreatedBy = createdBy
 		normalizedEntries = append(normalizedEntries, normalized)
 	}
 	if len(invalid) > 0 {
@@ -226,6 +228,20 @@ func (s *CloudServer) handleMutationPush(w http.ResponseWriter, r *http.Request)
 		"project_source": project.SourceRequestBody,
 		"project_path":   "",
 	})
+}
+
+func mutationPushCreatedBy(ctx context.Context) string {
+	principal, ok := PrincipalFromContext(ctx)
+	if !ok {
+		return "unknown"
+	}
+	if displayName := strings.TrimSpace(principal.DisplayName); displayName != "" {
+		return displayName
+	}
+	if id := strings.TrimSpace(principal.ID); id != "" {
+		return id
+	}
+	return "unknown"
 }
 
 // canonicalMutationEntry reuses the production chunk canonicalizer instead of

--- a/internal/cloud/cloudserver/principal_auth_test.go
+++ b/internal/cloud/cloudserver/principal_auth_test.go
@@ -161,6 +161,12 @@ func TestMutationPushCreatedByFallbacks(t *testing.T) {
 	}
 }
 
+func TestMutationPushCreatedByWithoutPrincipal(t *testing.T) {
+	if got := mutationPushCreatedBy(context.Background()); got != "unknown" {
+		t.Errorf("mutationPushCreatedBy() = %q, want %q", got, "unknown")
+	}
+}
+
 func TestLegacyAuthServiceResolvesSyncPrincipalIntoRequestContext(t *testing.T) {
 	svc, err := cloudauth.NewService(&cloudstore.CloudStore{}, strings.Repeat("x", 32))
 	if err != nil {

--- a/internal/cloud/cloudserver/principal_auth_test.go
+++ b/internal/cloud/cloudserver/principal_auth_test.go
@@ -102,6 +102,37 @@ func TestPrincipalResolverStoresPrincipalInRequestContext(t *testing.T) {
 	}
 }
 
+func TestMutationPushUsesResolvedPrincipalNotEnvelopeCreatedBy(t *testing.T) {
+	authn := resolvingAuth{principals: map[string]cloudauth.Principal{
+		"managed-token": {
+			ID:          "principal-1",
+			Kind:        cloudauth.PrincipalKindHuman,
+			DisplayName: "Server Alice",
+			Role:        cloudauth.RoleMember,
+			Source:      cloudauth.PrincipalSourceManagedToken,
+			Enabled:     true,
+		},
+	}}
+	ms := newFakeMutationStore()
+	srv := New(ms, authn, 0)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sync/mutations/push", strings.NewReader(`{"created_by":"forged-client-identity","entries":[{"project":"proj-a","entity":"session","entity_key":"session-1","op":"upsert","payload":{"id":"session-1","directory":"/tmp/session-1"}}]}`))
+	req.Header.Set("Authorization", "Bearer managed-token")
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mutation push status = %d, want %d body=%q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(ms.mutations) != 1 {
+		t.Fatalf("stored mutations = %d, want 1", len(ms.mutations))
+	}
+	if ms.mutations[0].CreatedBy != "Server Alice" {
+		t.Fatalf("stored mutation created_by = %q, want resolved principal %q", ms.mutations[0].CreatedBy, "Server Alice")
+	}
+}
+
 func TestLegacyAuthServiceResolvesSyncPrincipalIntoRequestContext(t *testing.T) {
 	svc, err := cloudauth.NewService(&cloudstore.CloudStore{}, strings.Repeat("x", 32))
 	if err != nil {

--- a/internal/cloud/cloudserver/principal_auth_test.go
+++ b/internal/cloud/cloudserver/principal_auth_test.go
@@ -133,6 +133,34 @@ func TestMutationPushUsesResolvedPrincipalNotEnvelopeCreatedBy(t *testing.T) {
 	}
 }
 
+func TestMutationPushCreatedByFallbacks(t *testing.T) {
+	tests := []struct {
+		name      string
+		principal cloudauth.Principal
+		want      string
+	}{
+		{
+			name:      "uses trimmed principal ID when display name is blank",
+			principal: cloudauth.Principal{DisplayName: " \t ", ID: " principal-1 "},
+			want:      "principal-1",
+		},
+		{
+			name:      "uses unknown when display name and ID are blank",
+			principal: cloudauth.Principal{DisplayName: " \t ", ID: " \n "},
+			want:      "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithPrincipal(context.Background(), tt.principal)
+			if got := mutationPushCreatedBy(ctx); got != tt.want {
+				t.Errorf("mutationPushCreatedBy() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLegacyAuthServiceResolvesSyncPrincipalIntoRequestContext(t *testing.T) {
 	svc, err := cloudauth.NewService(&cloudstore.CloudStore{}, strings.Repeat("x", 32))
 	if err != nil {

--- a/internal/cloud/cloudstore/cloudstore.go
+++ b/internal/cloud/cloudstore/cloudstore.go
@@ -803,6 +803,7 @@ type MutationEntry struct {
 	EntityKey string          `json:"entity_key"`
 	Op        string          `json:"op"`
 	Payload   json.RawMessage `json:"payload"`
+	CreatedBy string          `json:"-"`
 }
 
 // StoredMutation mirrors cloudserver.StoredMutation to avoid a circular import.
@@ -876,11 +877,15 @@ func (cs *CloudStore) InsertMutationBatch(ctx context.Context, batch []MutationE
 		seqs = append(seqs, seq)
 	}
 	for _, chunk := range chunks {
+		createdBy := strings.TrimSpace(chunk.createdBy)
+		if createdBy == "" {
+			createdBy = "unknown"
+		}
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO cloud_chunks (project_name, chunk_id, created_by, payload, sessions_count, observations_count, prompts_count)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (project_name, chunk_id) DO NOTHING`,
-			chunk.project, chunk.id, "mutation-push", chunk.payload, chunk.counts.sessions, chunk.counts.observations, chunk.counts.prompts,
+			chunk.project, chunk.id, createdBy, chunk.payload, chunk.counts.sessions, chunk.counts.observations, chunk.counts.prompts,
 		); err != nil {
 			return nil, fmt.Errorf("cloudstore: materialize mutation batch chunk: %w", err)
 		}
@@ -1041,10 +1046,11 @@ func (cs *CloudStore) existingChunkMutationSignatures(ctx context.Context, proje
 }
 
 type materializedMutationChunk struct {
-	project string
-	id      string
-	payload []byte
-	counts  chunkSummary
+	project   string
+	id        string
+	createdBy string
+	payload   []byte
+	counts    chunkSummary
 }
 
 func materializedMutationBatchChunks(batch []MutationEntry) ([]materializedMutationChunk, error) {
@@ -1073,7 +1079,13 @@ func materializedMutationBatchChunks(batch []MutationEntry) ([]materializedMutat
 		if len(payload) == 0 {
 			continue
 		}
-		chunks = append(chunks, materializedMutationChunk{project: project, id: chunkIDFromPayload(payload), payload: payload, counts: counts})
+		chunks = append(chunks, materializedMutationChunk{
+			project:   project,
+			id:        chunkIDFromPayload(payload),
+			createdBy: strings.TrimSpace(groups[project][0].CreatedBy),
+			payload:   payload,
+			counts:    counts,
+		})
 	}
 	return chunks, nil
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1079

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Preserve the authenticated server principal when autosync mutations materialize cloud chunks.
- Prevent mutation-envelope `created_by` from overriding server-owned attribution.
- Cover manifest and dashboard contributors while preserving replay and explicit chunk behavior.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudserver/mutations.go` | Derive accepted mutation attribution from the authenticated request principal. |
| `internal/cloud/cloudstore/cloudstore.go` | Carry server-owned attribution into materialized chunks. |
| `internal/cloud/cloudserver/principal_auth_test.go` | Prove forged client attribution cannot override the resolved principal. |
| `cmd/engram/cloud_runtime_e2e_test.go` | Add managed-principal runtime/PostgreSQL coverage for manifest, dashboard, replay, rejection, and explicit chunks. |
| `DOCS.md` | Document attribution ownership and fallback behavior. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...`
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [ ] Lint passes locally: `make lint`
- [ ] Manually tested the affected functionality

Focused checks completed:

- [x] `go test ./internal/cloud/cloudserver -count=1`
- [x] `go test ./internal/cloud/cloudstore -count=1`
- [x] `git diff --check`

Local environment limitations:

- `go test ./...` reached the pre-existing environment-sensitive `TestCmdSyncDefaultProjectNoData` failure for local project `blackie` and then timed out.
- The repository E2E suite also encountered existing local project-resolution failures involving `blackie`.
- The new PostgreSQL-backed attribution E2E requires `CLOUDSTORE_TEST_DSN`; no reachable PostgreSQL or Docker executable is available locally.
- `make lint` could not start because `make` is unavailable. CI must provide the terminal verification before merge.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\*** Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |
| **Lint** | golangci-lint reports no new findings | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...`
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] I ran lint locally: `make lint`
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

The exact candidate completed independent read-only validation and provider-owned high-risk RDD with no blocking findings. Runtime PostgreSQL execution remains intentionally disclosed as pending CI evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mutation-push operations now attribute materialized cloud chunks to the authenticated principal.
  * Attribution falls back to the principal ID or “unknown” when a display name is unavailable.
  * Explicit sync pushes continue to preserve their supplied attribution.

* **Bug Fixes**
  * Mutation-push attribution can no longer be overridden by a client-supplied envelope value.
  * Unauthenticated mutation-push requests are rejected without creating cloud chunks.

* **Documentation**
  * Added documentation describing attribution behavior and its effect on existing cloud data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->