### PR TITLE
feat(setup): add Cline CLI as supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Run the setup command for the agent you use, then restart that agent. `engram se
 | Cursor | `engram setup cursor` |
 | VS Code (Copilot) | `engram setup vscode-copilot` |
 | Kilo Code | `engram setup kilocode` |
+| Cline | `engram setup cline` |
 | Another MCP-compatible agent | [Manual MCP setup](docs/AGENT-SETUP.md#any-other-mcp-agent) |
 
 See [Agent Setup](docs/AGENT-SETUP.md) for per-agent configuration, plugin behavior, manual MCP setup, compaction resilience, and troubleshooting. Pi users can also find the package at [`gentle-engram`](plugin/pi/README.md).

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -3212,7 +3212,7 @@ Commands:
                        --paths-only  Limit pruning to project names containing / or \
   setup [agent]      Install/setup agent integration (opencode, pi, claude-code,
                      gemini-cli, codex, antigravity-cli, windsurf, qwen, kiro,
-                     cursor, vscode-copilot, kilocode)
+                     cursor, vscode-copilot, kilocode, cline)
   sync               Export new memories as compressed chunk to .engram/
                          --import   Import new chunks from .engram/ into local DB
                          --status   Show sync status

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -309,7 +309,7 @@ func TestPrintUsage(t *testing.T) {
 	if !strings.Contains(stdout, "search <query>") || !strings.Contains(stdout, "setup [agent]") {
 		t.Fatalf("usage missing expected commands: %q", stdout)
 	}
-	for _, agent := range []string{"opencode", "pi", "claude-code", "gemini-cli", "codex", "antigravity-cli", "windsurf", "qwen", "kiro", "cursor", "vscode-copilot", "kilocode"} {
+	for _, agent := range []string{"opencode", "pi", "claude-code", "gemini-cli", "codex", "antigravity-cli", "windsurf", "qwen", "kiro", "cursor", "vscode-copilot", "kilocode", "cline"} {
 		if !strings.Contains(stdout, agent) {
 			t.Fatalf("usage missing setup agent %q: %q", agent, stdout)
 		}
@@ -426,6 +426,11 @@ func TestPrintPostInstall(t *testing.T) {
 			name:    "kilocode",
 			result:  &setup.Result{Agent: "kilocode"},
 			expects: []string{"Restart Kilo Code", "~/.config/kilo/opencode.json"},
+		},
+		{
+			name:    "cline",
+			result:  &setup.Result{Agent: "cline"},
+			expects: []string{"Restart Cline", "~/.cline/data/settings/cline_mcp_settings.json", "~/.cline/rules/engram.md"},
 		},
 		{
 			name:   "unknown",

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -28,6 +28,7 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 | Cursor          | `engram setup cursor`                                                                        | [Details](#cursor)                                 |
 | VS Code Copilot | `engram setup vscode-copilot`                                                                | [Details](#vs-code-copilot--claude-code-extension) |
 | Kilo Code       | `engram setup kilocode`                                                                      | [Details](#kilo-code)                              |
+| Cline           | `engram setup cline`                                                                         | [Details](#cline)                                  |
 | Any MCP agent   | `engram mcp` (stdio)                                                                         | [Details](#any-other-mcp-agent)                    |
 
 > **Native setup for all agents above.** `engram setup <agent>` writes the right
@@ -716,6 +717,18 @@ engram setup kilocode
 ```
 
 Registers the engram server under the OpenCode-style `mcp` object in `~/.config/kilo/opencode.json` and writes the Memory Protocol as a marker block in `~/.config/kilo/AGENTS.md`.
+
+---
+
+## Cline
+
+**Automated:**
+
+```bash
+engram setup cline
+```
+
+Registers `mcpServers.engram` in `~/.cline/data/settings/cline_mcp_settings.json` and writes the Memory Protocol to `~/.cline/rules/engram.md`. Cline combines every `.md` file in `~/.cline/rules/` into one ruleset, so the protocol gets its own engram-owned file there instead of sharing one with your own rules.
 
 ---
 

--- a/internal/setup/agents.go
+++ b/internal/setup/agents.go
@@ -160,6 +160,20 @@ func agentAdapters() []agentAdapter {
 				"Verify ~/.config/kilo/AGENTS.md has the Memory Protocol block",
 			},
 		},
+		{
+			slug:        "cline",
+			description: "Cline — MCP registration in ~/.cline/data/settings/cline_mcp_settings.json plus a dedicated rules file Memory Protocol",
+			mcpPath:     clineMCPPath,
+			mcpFormat:   mcpServersObject,
+			instructions: []instrSurface{
+				{path: clineRulesPath, style: wholeFile, body: memoryProtocolMarkdown},
+			},
+			postInstall: []string{
+				"Restart Cline so MCP config is reloaded",
+				"Verify ~/.cline/data/settings/cline_mcp_settings.json includes mcpServers.engram",
+				"Verify ~/.cline/rules/engram.md has the Memory Protocol",
+			},
+		},
 	}
 }
 
@@ -290,4 +304,23 @@ func kilocodeConfigPath() string {
 
 func kilocodeAgentsPath() string {
 	return filepath.Join(kilocodeConfigDir(), "AGENTS.md")
+}
+
+// ─── Cline paths ─────────────────────────────────────────────────────────────
+//
+// Cline stores its MCP registration under ~/.cline/data/settings/ and combines
+// every .md file in ~/.cline/rules/ into one ruleset, so the Memory Protocol
+// gets its own engram-owned file there instead of a marker block in a shared one.
+
+func clineDir() string {
+	home, _ := userHome()
+	return filepath.Join(home, ".cline")
+}
+
+func clineMCPPath() string {
+	return filepath.Join(clineDir(), "data", "settings", "cline_mcp_settings.json")
+}
+
+func clineRulesPath() string {
+	return filepath.Join(clineDir(), "rules", "engram.md")
 }

--- a/internal/setup/registry_test.go
+++ b/internal/setup/registry_test.go
@@ -31,6 +31,7 @@ func declarativeAgents() []declarativeAgent {
 		{"cursor", cursorMCPPath, "mcpServers", mcpServersObject, cursorMemoryProtocolPath, wholeFile},
 		{"vscode-copilot", vscodeMCPPath, "servers", serversObject, vscodePromptPath, wholeFile},
 		{"kilocode", kilocodeConfigPath, "mcp", opencodeObject, kilocodeAgentsPath, markerBlock},
+		{"cline", clineMCPPath, "mcpServers", mcpServersObject, clineRulesPath, wholeFile},
 	}
 }
 
@@ -58,7 +59,7 @@ func TestSupportedAgentsIncludesAllRegistryAgents(t *testing.T) {
 	want := []string{
 		"opencode", "pi", "claude-code", "gemini-cli", "codex",
 		"antigravity-cli", "windsurf", "qwen", "kiro", "cursor",
-		"vscode-copilot", "kilocode",
+		"vscode-copilot", "kilocode", "cline",
 	}
 	for _, slug := range want {
 		if !got[slug] {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #554

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds `cline` as a **declarative** agent in `agentAdapters()` — no new installer code, the generic `injectMCP` / `writeInstruction` driver handles both writes.
- `engram setup cline` registers `mcpServers.engram` in `~/.cline/data/settings/cline_mcp_settings.json` (the `mcpServersObject` format already used by Cursor, Windsurf, Qwen, Kiro and Antigravity).
- Writes the Memory Protocol to `~/.cline/rules/engram.md` using `wholeFile`, so the file stays engram-owned. Cline combines every `.md` under `~/.cline/rules/` into a single ruleset, so a dedicated file is the correct surface here — a marker block would mean sharing a file engram does not own.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/setup/agents.go` | New `cline` registry entry plus `clineDir` / `clineMCPPath` / `clineRulesPath` helpers |
| `internal/setup/registry_test.go` | `cline` row in the `declarativeAgents()` table and in the expected `SupportedAgents()` set |
| `cmd/engram/main.go` | `cline` added to the `setup [agent]` usage line |
| `cmd/engram/main_test.go` | `cline` in the usage agent list and a `printPostInstall` case |
| `README.md` | `Cline` row in the supported-agents table |
| `docs/AGENT-SETUP.md` | `Cline` row in the agent table and a `## Cline` section |

## 🧪 Test Plan

- [x] Unit tests pass locally: `go test ./...`
- [x] E2E tests pass locally: `go test -tags e2e ./internal/server/...`
- [x] Lint passes locally: `make lint` — `0 issues.` on golangci-lint v2.13.2
- [x] Dead-code ratchet passes: `make deadcode-check` — `no newly unreachable functions`
- [x] Binary self-test passes: `./engram test --quick`
- [x] Manually tested the affected functionality

Manual verification — `engram setup cline` against an isolated `HOME`:

```
✓ Installed cline plugin (2 files)

.cline
├── data
│   └── settings
│       └── cline_mcp_settings.json
└── rules
    └── engram.md
```

```json
{
  "mcpServers": {
    "engram": {
      "args": ["mcp", "--tools=agent"],
      "command": "/absolute/path/to/engram"
    }
  }
}
```

Re-running the command is idempotent: the MCP entry is updated in place and the rules file is rewritten.

**Note on the local suite:** nine tests fail on my macOS host both with and without this change (Unix-socket `bind: invalid argument` from the `sun_path` length limit under `/var/folders/...`, a UTF-8 locale assertion, and `jq`-dependent hook tests). I captured `go test ./...` on a clean `upstream/main` and on this branch: the failing set is byte-for-byte identical, so this PR introduces no regressions. All of them are environment-specific and are expected to pass on the Ubuntu runners.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |
| **Lint** | golangci-lint reports no new findings | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #554`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [x] I ran lint locally: `make lint`
- [x] Docs updated (if behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

Two design points worth a look:

1. **`wholeFile` instead of `markerBlock`.** Every other rules-directory agent uses a marker block in a shared file. Cline is different: it reads *all* `.md` files under `~/.cline/rules/`, so engram can have its own file rather than editing one the user owns. This follows the same reasoning as the Cursor adapter.
2. **No plugin, no hooks.** Cline's hooks are SDK/TypeScript plugins. Adding one would pull in a Node runtime dependency and break the thin-adapter principle, so this PR stays MCP + rules, exactly as scoped in the issue.

The adapter reuses `userHome()` for path resolution, so the unresolvable-home guard in `installFromAdapter` applies unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting up Cline with Engram.
  * The setup process configures Cline’s MCP connection and installs the Memory Protocol rules.
  * Added post-install guidance to restart Cline and verify the configuration.

* **Documentation**
  * Added Cline to the supported-agent reference and setup documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->