### PR TITLE
fix(obsidian): surface export write failures

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -2204,6 +2204,7 @@ func cmdObsidianExport(cfg store.Config) {
 		for _, e := range result.Errors {
 			fmt.Fprintf(os.Stderr, "    - %v\n", e)
 		}
+		exitFunc(1)
 	}
 }
 

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -2579,6 +2579,52 @@ func TestObsidianExportCallsInjectedExporter(t *testing.T) {
 	}
 }
 
+func TestObsidianExportReportErrorsExitNonzero(t *testing.T) {
+	t.Run("completed export with a write error reports counts and exits nonzero", func(t *testing.T) {
+		cfg := testConfig(t)
+		vault := t.TempDir()
+		id := mustSeedObservation(t, cfg, "obsidian-write-error", "obsidian-errors", "bugfix", "Blocked export", "content", "project")
+		blockedPath := filepath.Join(vault, "engram", "obsidian-errors", "bugfix", fmt.Sprintf("blocked-export-%d.md", id))
+		if err := os.MkdirAll(blockedPath, 0755); err != nil {
+			t.Fatalf("setup blocked output directory: %v", err)
+		}
+
+		withArgs(t, "engram", "obsidian-export", "--vault", vault, "--project", "obsidian-errors")
+		stdout, stderr, exitCode := captureExitPanic(t, func() { cmdObsidianExport(cfg) })
+
+		if exitCode != 1 {
+			t.Fatalf("exit code = %d, want 1", exitCode)
+		}
+		for _, line := range []string{"Created: 0", "Updated: 0", "Deleted: 0", "Skipped: 0", "Hubs:    0"} {
+			if !strings.Contains(stdout, line) {
+				t.Fatalf("stdout missing %q: %q", line, stdout)
+			}
+		}
+		if !strings.Contains(stderr, "Errors: 1") || !strings.Contains(stderr, "write") {
+			t.Fatalf("stderr = %q, want one write error", stderr)
+		}
+	})
+
+	t.Run("successful export keeps zero exit status and empty stderr", func(t *testing.T) {
+		cfg := testConfig(t)
+		vault := t.TempDir()
+		mustSeedObservation(t, cfg, "obsidian-success", "obsidian-success", "bugfix", "Successful export", "content", "project")
+
+		withArgs(t, "engram", "obsidian-export", "--vault", vault, "--project", "obsidian-success")
+		stdout, stderr, exitCode := captureExitPanic(t, func() { cmdObsidianExport(cfg) })
+
+		if exitCode != 0 {
+			t.Fatalf("exit code = %d, want 0", exitCode)
+		}
+		if stderr != "" {
+			t.Fatalf("stderr = %q, want empty", stderr)
+		}
+		if !strings.Contains(stdout, "Created: 1") || !strings.Contains(stdout, "Hubs:    1") {
+			t.Fatalf("stdout = %q, want successful report counts", stdout)
+		}
+	})
+}
+
 // TestObsidianExportMinimalFlags verifies that --vault uses the current project.
 func TestObsidianExportMinimalFlags(t *testing.T) {
 	cfg := testConfig(t)

--- a/internal/obsidian/exporter.go
+++ b/internal/obsidian/exporter.go
@@ -339,7 +339,9 @@ func writeSessionHub(sessionsDir, name, content string) error {
 	if err != nil {
 		return err
 	}
-	defer root.Close()
+	defer func() {
+		_ = root.Close()
+	}()
 
 	if err := root.MkdirAll(filepath.Dir(name), 0755); err != nil {
 		return fmt.Errorf("mkdir session hub parent: %w", err)

--- a/internal/obsidian/exporter.go
+++ b/internal/obsidian/exporter.go
@@ -293,8 +293,14 @@ func (e *Exporter) Export() (*ExportResult, error) {
 			continue
 		}
 		hubPath := filepath.Join(sessionsDir, sessionID+".md")
+		cleanSessionsDir := filepath.Clean(sessionsDir)
+		cleanHubPath := filepath.Clean(hubPath)
+		if !strings.HasPrefix(cleanHubPath, cleanSessionsDir+string(filepath.Separator)) {
+			result.Errors = append(result.Errors, fmt.Errorf("unsafe session hub path rejected (would escape sessions dir): %s", cleanHubPath))
+			continue
+		}
 		content := SessionHubMarkdown(sessionID, refs)
-		if err := os.WriteFile(hubPath, []byte(content), 0644); err != nil {
+		if err := writeSessionHub(sessionsDir, sessionID+".md", content); err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("write session hub %s: %w", hubPath, err))
 			continue
 		}
@@ -326,6 +332,27 @@ func (e *Exporter) Export() (*ExportResult, error) {
 	}
 
 	return result, nil
+}
+
+func writeSessionHub(sessionsDir, name, content string) error {
+	root, err := os.OpenRoot(sessionsDir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	if err := root.MkdirAll(filepath.Dir(name), 0755); err != nil {
+		return fmt.Errorf("mkdir session hub parent: %w", err)
+	}
+	file, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 // obsToRef converts a store.Observation to a lightweight ObsRef for hub building.

--- a/internal/obsidian/exporter_test.go
+++ b/internal/obsidian/exporter_test.go
@@ -1,6 +1,8 @@
 package obsidian
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -546,6 +548,250 @@ func TestExporterCallsGraphConfig(t *testing.T) {
 			t.Errorf("expected .obsidian/graph.json to NOT be created with zero-value GraphConfig, but it exists")
 		}
 	})
+}
+
+func TestExportSessionHubsCreateNestedDirectories(t *testing.T) {
+	for _, sessionID := range []string{
+		"sdd/change-2026-09-10/summary",
+		"sdd-apply/change-2026-09-10/apply",
+	} {
+		t.Run(sessionID, func(t *testing.T) {
+			vault := t.TempDir()
+			ms := &mockStore{
+				exportData: &store.ExportData{
+					Sessions: []store.Session{{ID: sessionID, Project: "engram"}},
+					Observations: []store.Observation{{
+						ID:        1,
+						SessionID: sessionID,
+						Type:      "bugfix",
+						Title:     "Nested session hub",
+						Content:   "content",
+						Scope:     "project",
+						CreatedAt: "2026-09-10T00:00:00Z",
+						UpdatedAt: "2026-09-10T00:00:00Z",
+						Project:   strPtr("engram"),
+					}},
+				},
+			}
+
+			result, err := NewExporter(ms, ExportConfig{VaultPath: vault, GraphConfig: GraphConfigSkip}).Export()
+			if err != nil {
+				t.Fatalf("Export() error: %v", err)
+			}
+			if result.Created != 1 || result.HubsCreated != 1 || len(result.Errors) != 0 {
+				t.Fatalf("result = %+v, want one observation and one hub without errors", result)
+			}
+
+			hubPath := filepath.Join(vault, "engram", "_sessions", sessionID+".md")
+			if _, err := os.Stat(hubPath); err != nil {
+				t.Fatalf("nested session hub %q: %v", hubPath, err)
+			}
+
+			state, err := ReadState(filepath.Join(vault, "engram", ".engram-sync-state.json"))
+			if err != nil {
+				t.Fatalf("ReadState: %v", err)
+			}
+			if got, want := state.SessionHubs[sessionID], filepath.Join("_sessions", sessionID+".md"); got != want {
+				t.Fatalf("state.SessionHubs[%q] = %q, want %q", sessionID, got, want)
+			}
+		})
+	}
+}
+
+func TestExportRejectsSessionHubPathsOutsideSessionsDirectory(t *testing.T) {
+	vault := t.TempDir()
+	sessionID := "../../outside/escape"
+	ms := &mockStore{
+		exportData: &store.ExportData{
+			Sessions: []store.Session{{ID: sessionID, Project: "engram"}},
+			Observations: []store.Observation{{
+				ID:        1,
+				SessionID: sessionID,
+				Type:      "bugfix",
+				Title:     "Traversal session hub",
+				Content:   "content",
+				Scope:     "project",
+				CreatedAt: "2026-09-10T00:00:00Z",
+				UpdatedAt: "2026-09-10T00:00:00Z",
+				Project:   strPtr("engram"),
+			}},
+		},
+	}
+
+	result, err := NewExporter(ms, ExportConfig{VaultPath: vault, GraphConfig: GraphConfigSkip}).Export()
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if result.Created != 1 || result.HubsCreated != 0 || len(result.Errors) != 1 {
+		t.Fatalf("result = %+v, want one observation, no hub, and one path error", result)
+	}
+	if !strings.Contains(result.Errors[0].Error(), "unsafe session hub path") {
+		t.Fatalf("error = %v, want unsafe session hub path error", result.Errors[0])
+	}
+
+	outsideHub := filepath.Join(vault, "outside", "escape.md")
+	if _, err := os.Stat(outsideHub); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside hub %q exists or could not be checked: %v", outsideHub, err)
+	}
+	state, err := ReadState(filepath.Join(vault, "engram", ".engram-sync-state.json"))
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if _, exists := state.SessionHubs[sessionID]; exists {
+		t.Fatalf("state recorded rejected session hub %q", sessionID)
+	}
+}
+
+func TestExportRecordsSessionHubParentCreationFailure(t *testing.T) {
+	vault := t.TempDir()
+	sessionID := "sdd/blocked/summary"
+	blockingFile := filepath.Join(vault, "engram", "_sessions", "sdd")
+	if err := os.MkdirAll(filepath.Dir(blockingFile), 0755); err != nil {
+		t.Fatalf("setup session hub parent: %v", err)
+	}
+	if err := os.WriteFile(blockingFile, []byte("not a directory"), 0644); err != nil {
+		t.Fatalf("setup blocking file: %v", err)
+	}
+
+	ms := &mockStore{
+		exportData: &store.ExportData{
+			Sessions: []store.Session{{ID: sessionID, Project: "engram"}},
+			Observations: []store.Observation{{
+				ID:        1,
+				SessionID: sessionID,
+				Type:      "bugfix",
+				Title:     "Blocked session hub",
+				Content:   "content",
+				Scope:     "project",
+				CreatedAt: "2026-09-10T00:00:00Z",
+				UpdatedAt: "2026-09-10T00:00:00Z",
+				Project:   strPtr("engram"),
+			}},
+		},
+	}
+
+	result, err := NewExporter(ms, ExportConfig{VaultPath: vault, GraphConfig: GraphConfigSkip}).Export()
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if result.Created != 1 || result.HubsCreated != 0 || len(result.Errors) != 1 {
+		t.Fatalf("result = %+v, want one observation, no hub, and one parent error", result)
+	}
+	if !strings.Contains(result.Errors[0].Error(), "mkdir session hub") {
+		t.Fatalf("error = %v, want session hub parent creation error", result.Errors[0])
+	}
+
+	state, err := ReadState(filepath.Join(vault, "engram", ".engram-sync-state.json"))
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if _, exists := state.SessionHubs[sessionID]; exists {
+		t.Fatalf("state recorded failed session hub %q", sessionID)
+	}
+	if _, err := os.Stat(filepath.Join(vault, "engram", "_sessions", "sdd", "blocked", "summary.md")); err == nil {
+		t.Fatal("session hub was written despite blocked parent")
+	}
+}
+
+func TestExportRejectsSessionHubSymlinkEscape(t *testing.T) {
+	vault := t.TempDir()
+	outside := t.TempDir()
+	sessionID := "sdd/escape"
+	sessionsDir := filepath.Join(vault, "engram", "_sessions")
+	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
+		t.Fatalf("setup sessions directory: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(sessionsDir, "sdd")); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	ms := &mockStore{
+		exportData: &store.ExportData{
+			Sessions: []store.Session{{ID: sessionID, Project: "engram"}},
+			Observations: []store.Observation{{
+				ID:        1,
+				SessionID: sessionID,
+				Type:      "bugfix",
+				Title:     "Symlink session hub",
+				Content:   "content",
+				Scope:     "project",
+				CreatedAt: "2026-09-10T00:00:00Z",
+				UpdatedAt: "2026-09-10T00:00:00Z",
+				Project:   strPtr("engram"),
+			}},
+		},
+	}
+
+	result, err := NewExporter(ms, ExportConfig{VaultPath: vault, GraphConfig: GraphConfigSkip}).Export()
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if result.Created != 1 || result.HubsCreated != 0 || len(result.Errors) != 1 {
+		t.Fatalf("result = %+v, want one observation, no hub, and one symlink error", result)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "escape.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside hub exists or could not be checked: %v", err)
+	}
+
+	state, err := ReadState(filepath.Join(vault, "engram", ".engram-sync-state.json"))
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if _, exists := state.SessionHubs[sessionID]; exists {
+		t.Fatalf("state recorded rejected session hub %q", sessionID)
+	}
+}
+
+func TestExportRecordsGenuineObservationWriteFailures(t *testing.T) {
+	vault := t.TempDir()
+	blockedPath := filepath.Join(vault, "engram", "engram", "bugfix", "blocked-export-1.md")
+	if err := os.MkdirAll(blockedPath, 0755); err != nil {
+		t.Fatalf("setup blocked output directory: %v", err)
+	}
+
+	ms := &mockStore{
+		exportData: &store.ExportData{
+			Sessions: []store.Session{{ID: "session-1", Project: "engram"}},
+			Observations: []store.Observation{
+				{
+					ID:        1,
+					SessionID: "session-1",
+					Type:      "bugfix",
+					Title:     "Blocked export",
+					Content:   "blocked",
+					Scope:     "project",
+					CreatedAt: "2026-09-10T00:00:00Z",
+					UpdatedAt: "2026-09-10T00:00:00Z",
+					Project:   strPtr("engram"),
+				},
+				{
+					ID:        2,
+					SessionID: "session-1",
+					Type:      "bugfix",
+					Title:     "Successful export",
+					Content:   "written",
+					Scope:     "project",
+					CreatedAt: "2026-09-10T00:00:00Z",
+					UpdatedAt: "2026-09-10T00:00:00Z",
+					Project:   strPtr("engram"),
+				},
+			},
+		},
+	}
+
+	result, err := NewExporter(ms, ExportConfig{VaultPath: vault, GraphConfig: GraphConfigSkip}).Export()
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if result.Created != 1 || result.HubsCreated != 1 || len(result.Errors) != 1 {
+		t.Fatalf("result = %+v, want one created observation, one hub, and one write error", result)
+	}
+	if !strings.Contains(result.Errors[0].Error(), "write") {
+		t.Fatalf("error = %v, want write failure", result.Errors[0])
+	}
+	if !fileExists(filepath.Join(vault, "engram", "engram", "bugfix", "successful-export-2.md")) {
+		t.Fatal("successful observation was not exported")
+	}
 }
 
 // ─── Security: TestPathTraversalPrevention (Issue #180) ──────────────────────


### PR DESCRIPTION
## Linked Issue

Closes #1085

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Create missing nested session-hub parents through root-confined filesystem operations.
- Return a non-zero command result whenever an Obsidian export report contains errors, while preserving existing stdout/stderr placement.
- Prevent traversal through lexical escapes, symlinks, and Windows reparse points when writing session hubs.

## Changes

| File | Change |
|------|--------|
| `internal/obsidian/exporter.go` | Confine nested session-hub directory creation and writes with `os.OpenRoot`; explicitly handle root cleanup for lint. |
| `internal/obsidian/exporter_test.go` | Cover nested paths, blocked parents, traversal, symlink escape, genuine write failures, and successful exports. |
| `cmd/engram/main.go` | Exit with status 1 when the completed export report contains errors. |
| `cmd/engram/main_test.go` | Verify report counts, streams, error exit status, and successful exit status. |

## Test Plan

- [x] Focused exporter tests: `go test ./internal/obsidian -count=1`
- [x] Focused CLI tests: `go test ./cmd/engram -run 'Test.*Obsidian.*' -count=1`
- [x] Focused lint: `golangci-lint run ./internal/obsidian`
- [x] Windows symlink/reparse-point regression executed locally.
- [x] Provider-owned RDD approved the implementation and the follow-up lint correction.
- [ ] Full local unit suite: `go test ./...`
- [ ] Local E2E suite: `go test -tags e2e ./internal/server/...`

The bounded local run of `go test ./cmd/engram -count=1` has an unrelated environment-sensitive failure in `TestCmdSyncDefaultProjectNoData` (expected `repo-name`, observed `blackie`). It reproduces in isolation and does not touch the changed Obsidian paths. CI is authoritative for the full suite.

---

## Automated Checks

See the GitHub Checks section for current status. The PR validation, unit, E2E, plugin, Windows setup, cloud wrapper, and lint workflows run automatically.

---

## Contributor Checklist

- [x] Linked an approved issue (`Closes #1085`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Ran focused tests for the affected exporter and CLI behavior
- [x] Ran focused lint for the changed package
- [x] Assessed documentation impact; no documentation surface changed
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## Notes for Reviewers

The final change is 324 lines (323 additions, 1 deletion), below the 400-line review budget. The committed implementation and the subsequent lint-only cleanup each match their provider-reviewed candidates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Obsidian exports now return a failure status when files cannot be written, while displaying clear error information.
  * Exported session hubs are prevented from being written outside the designated sessions folder, including through symlink paths.
  * Nested session-hub folders are created automatically when needed.
  * Failed session-hub and observation exports are no longer recorded as successfully synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
