### PR TITLE
feat(cli): expose search match mode

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1032,7 +1032,7 @@ func cmdTUI(cfg store.Config) {
 
 func cmdSearch(cfg store.Config) {
 	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "usage: engram search <query> [--type TYPE] [--project PROJECT|--all] [--scope SCOPE] [--limit N] [--match-mode all|any]")
+		fmt.Fprintln(os.Stderr, "usage: engram search <query> [--type TYPE] [--project PROJECT|--all] [--scope SCOPE] [--limit N] [--match all|any]")
 		exitFunc(1)
 	}
 
@@ -1067,7 +1067,7 @@ func cmdSearch(cfg store.Config) {
 				opts.Scope = os.Args[i+1]
 				i++
 			}
-		case "--match-mode":
+		case "--match":
 			if i+1 < len(os.Args) {
 				opts.MatchMode = os.Args[i+1]
 				i++
@@ -3236,7 +3236,7 @@ Commands:
   test [suite] [--quick] [--json]
                      Run isolated local reliability and performance self-tests
                        suites: reliability, performance (default: both)
-  search <query>     Search memories [--type TYPE] [--project PROJECT|--all] [--scope SCOPE] [--limit N]
+  search <query>     Search memories [--type TYPE] [--project PROJECT|--all] [--scope SCOPE] [--limit N] [--match all|any]
   save <title> <msg> Save a memory  [--type TYPE] [--project PROJECT] [--scope SCOPE]
   delete <obs_id>    Delete an observation [--hard] (soft-delete by default; --hard removes permanently)
   delete session <id>

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1032,7 +1032,7 @@ func cmdTUI(cfg store.Config) {
 
 func cmdSearch(cfg store.Config) {
 	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "usage: engram search <query> [--type TYPE] [--project PROJECT|--all] [--scope SCOPE] [--limit N]")
+		fmt.Fprintln(os.Stderr, "usage: engram search <query> [--type TYPE] [--project PROJECT|--all] [--scope SCOPE] [--limit N] [--match-mode all|any]")
 		exitFunc(1)
 	}
 
@@ -1065,6 +1065,11 @@ func cmdSearch(cfg store.Config) {
 		case "--scope":
 			if i+1 < len(os.Args) {
 				opts.Scope = os.Args[i+1]
+				i++
+			}
+		case "--match-mode":
+			if i+1 < len(os.Args) {
+				opts.MatchMode = os.Args[i+1]
 				i++
 			}
 		default:

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -4115,7 +4115,7 @@ func TestCmdSearchForwardsMatchModeWithoutChangingQuery(t *testing.T) {
 	}
 	t.Cleanup(func() { storeSearch = oldStoreSearch })
 
-	withArgs(t, "engram", "search", "auth compliance session", "--all", "--match-mode", "any")
+	withArgs(t, "engram", "search", "auth", "compliance", "session", "--all", "--match", "any")
 	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSearch(cfg) })
 	if recovered != nil || stderr != "" {
 		t.Fatalf("search failed, panic=%v stderr=%q", recovered, stderr)

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -4102,6 +4102,32 @@ func TestCmdSearchAndSaveDanglingFlags(t *testing.T) {
 	}
 }
 
+func TestCmdSearchForwardsMatchModeWithoutChangingQuery(t *testing.T) {
+	cfg := testConfig(t)
+
+	var gotQuery string
+	var gotOpts store.SearchOptions
+	oldStoreSearch := storeSearch
+	storeSearch = func(_ *store.Store, query string, opts store.SearchOptions) ([]store.SearchResult, error) {
+		gotQuery = query
+		gotOpts = opts
+		return nil, nil
+	}
+	t.Cleanup(func() { storeSearch = oldStoreSearch })
+
+	withArgs(t, "engram", "search", "auth compliance session", "--all", "--match-mode", "any")
+	_, stderr, recovered := captureOutputAndRecover(t, func() { cmdSearch(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("search failed, panic=%v stderr=%q", recovered, stderr)
+	}
+	if gotOpts.MatchMode != "any" {
+		t.Fatalf("match mode=%q want any", gotOpts.MatchMode)
+	}
+	if gotQuery != "auth compliance session" {
+		t.Fatalf("query=%q want %q", gotQuery, "auth compliance session")
+	}
+}
+
 func TestCmdSetupHyphenArgFallsBackToInteractive(t *testing.T) {
 	stubRuntimeHooks(t)
 	stubExitWithPanic(t)

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -306,7 +306,7 @@ func TestPrintUsage(t *testing.T) {
 	if !strings.Contains(stdout, "engram vtest-version") {
 		t.Fatalf("usage missing version: %q", stdout)
 	}
-	if !strings.Contains(stdout, "search <query>") || !strings.Contains(stdout, "setup [agent]") {
+	if !strings.Contains(stdout, "search <query>") || !strings.Contains(stdout, "[--match all|any]") || !strings.Contains(stdout, "setup [agent]") {
 		t.Fatalf("usage missing expected commands: %q", stdout)
 	}
 	for _, agent := range []string{"opencode", "pi", "claude-code", "gemini-cli", "codex", "antigravity-cli", "windsurf", "qwen", "kiro", "cursor", "vscode-copilot", "kilocode"} {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -255,7 +255,7 @@ engram setup [agent]      Install/setup agent integration (opencode, claude-code
 engram serve [port]       Start HTTP API server (default: 7437)
 engram mcp                Start MCP server (stdio transport)
 engram tui                Launch interactive terminal UI
-engram search <query>     Search memories [--project P|--all]
+engram search <query>     Search memories [--project P|--all] [--match-mode all|any]
 engram save <title> <msg> Save a memory
 engram delete <obs_id>    Delete an observation [--hard] (soft-delete by default; --hard removes permanently)
 engram delete session <id>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -255,7 +255,7 @@ engram setup [agent]      Install/setup agent integration (opencode, claude-code
 engram serve [port]       Start HTTP API server (default: 7437)
 engram mcp                Start MCP server (stdio transport)
 engram tui                Launch interactive terminal UI
-engram search <query>     Search memories [--project P|--all] [--match-mode all|any]
+engram search <query>     Search memories [--project P|--all] [--match all|any]
 engram save <title> <msg> Save a memory
 engram delete <obs_id>    Delete an observation [--hard] (soft-delete by default; --hard removes permanently)
 engram delete session <id>


### PR DESCRIPTION
## Linked Issue

Closes #861

---

## PR Type

- [ ] `type:bug` - Bug fix
- [x] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [ ] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Expose the existing search `match_mode` semantics through `engram search --match`.
- Preserve query text while forwarding `all` or `any` to the store-owned validation path.
- Align top-level help, focused regression coverage, and CLI documentation.

## Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Parse and document `--match all|any`. |
| `cmd/engram/main_extra_test.go` | Verify separate query arguments are reconstructed while forwarding `any`. |
| `cmd/engram/main_test.go` | Verify top-level help advertises the new option. |
| `docs/ARCHITECTURE.md` | Document the CLI option. |

## Test Plan

- [ ] Unit tests pass locally: `go test ./...` - delegated to CI for this scoped change
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` - unaffected server behavior; delegated to CI
- [ ] Lint passes locally: `make lint` - delegated to CI
- [ ] Manually tested the affected functionality
- [x] Focused CLI tests pass: `go test ./cmd/engram -run 'Test(PrintUsage|CmdSearchForwardsMatchModeWithoutChangingQuery)$'`
- [x] Existing store match-mode tests pass: `go test ./internal/store -run TestSearchMatchMode_`
- [x] Independent focused validation passed
- [x] Corrected candidate passed a fresh four-lens RDD review and acknowledgement

---

## Automated Checks

These run automatically and all must pass before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | Pending |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | Pending |
| **Check PR Has type:* Label** | PR has exactly one `type:*` label | Pending |
| **Unit Tests** | `go test ./...` passes | Pending |
| **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | Pending |
| **Plugin Tests** | `npm test` passes in `plugin/pi` | Pending |
| **Lint** | golangci-lint reports no new findings | Pending |

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly one `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` - CI-owned for this scoped change
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` - CI-owned and unaffected
- [ ] I ran lint locally: `make lint` - CI-owned
- [x] Docs updated (if behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits

---

## Notes for Reviewers

The store remains the canonical owner of match-mode validation and AND/OR behavior. This PR only adds CLI argument translation, help text, documentation, and regression coverage.
