### PR TITLE
ci(workflows): reject transient PR artifacts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,6 +69,7 @@ These run automatically and **all must pass** before merge:
 | **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
 | **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
 | **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
+| **Check PR Has No Transient Artifacts** | PR files do not include transient local or generated artifacts | ⏳ |
 | **Unit Tests** | `go test ./...` passes | ⏳ |
 | **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
 | **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |
@@ -86,6 +87,7 @@ These run automatically and **all must pass** before merge:
 - [ ] Docs updated (if behavior changed)
 - [ ] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
 - [ ] No `Co-Authored-By` trailers in commits
+- [ ] No transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts are included
 
 ---
 

--- a/.github/scripts/transient-artifacts.mjs
+++ b/.github/scripts/transient-artifacts.mjs
@@ -1,0 +1,93 @@
+const generatedAgentLinkDirectories = [
+  ['.claude', 'skills'],
+  ['.codex', 'skills'],
+  ['.github', 'skills'],
+  ['.gemini', 'skills'],
+];
+
+const rootBinaryPaths = new Set([
+  'engram',
+  'cmd/engram/main',
+  'cmd/engram/gentle-creation',
+  'cmd/engram/engram',
+]);
+
+function normalizePath(filePath) {
+  return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function pathSegments(filePath) {
+  return normalizePath(filePath).split('/');
+}
+
+function hasDirectory(filePath, directory) {
+  return pathSegments(filePath).includes(directory);
+}
+
+function hasRootSubpath(filePath, subpath) {
+  const segments = pathSegments(filePath);
+  return subpath.every((segment, index) => segments[index] === segment);
+}
+
+function fileName(filePath) {
+  const segments = pathSegments(filePath);
+  return segments.at(-1);
+}
+
+export function transientArtifactReason(filePath) {
+  const normalizedPath = normalizePath(filePath);
+  const name = fileName(normalizedPath);
+
+  if (hasDirectory(normalizedPath, '.atl')) {
+    return '.atl artifact';
+  }
+  if (generatedAgentLinkDirectories.some(directory => hasRootSubpath(normalizedPath, directory))) {
+    return 'generated agent-link directory';
+  }
+  if (hasDirectory(normalizedPath, 'engram-dev')) {
+    return 'engram-dev artifact';
+  }
+  if (name === '.release-notes-beta.md') {
+    return 'release-notes beta artifact';
+  }
+  if (name.endsWith('.db') || name.endsWith('.db-wal') || name.endsWith('.db-shm')) {
+    return 'local database';
+  }
+  if (name === 'engram-export.json') {
+    return 'local export';
+  }
+  if (rootBinaryPaths.has(normalizedPath) || name.endsWith('.exe')) {
+    return 'binary';
+  }
+  if (name === '.DS_Store' || name === 'Thumbs.db') {
+    return 'OS metadata';
+  }
+  if (hasDirectory(normalizedPath, '.idea') || hasDirectory(normalizedPath, '.vscode')) {
+    return 'editor metadata';
+  }
+  if (name.endsWith('.swp') || name.endsWith('.swo') || name.endsWith('~')) {
+    return 'editor or backup file';
+  }
+
+  return null;
+}
+
+export function isTransientArtifactPath(filePath) {
+  return transientArtifactReason(filePath) !== null;
+}
+
+export function findTransientArtifacts(files) {
+  return files
+    .filter(file => file.status !== 'removed')
+    .map(file => ({ ...file, reason: transientArtifactReason(file.filename) }))
+    .filter(file => file.reason !== null);
+}
+
+export async function listPullRequestFiles(github, { owner, repo, pullNumber }) {
+  return github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100,
+  });
+}

--- a/.github/scripts/transient-artifacts.mjs
+++ b/.github/scripts/transient-artifacts.mjs
@@ -12,6 +12,18 @@ const rootBinaryPaths = new Set([
   'cmd/engram/engram',
 ]);
 
+const rootTransientDocumentNames = new Set([
+  'plan.md',
+  'agent-report.md',
+  'agent-handoff.md',
+  'handoff.md',
+]);
+
+const transientProcessArtifactDirectories = [
+  ['openspec', 'changes'],
+  ['sdd', 'changes'],
+];
+
 function normalizePath(filePath) {
   return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
 }
@@ -46,6 +58,12 @@ export function transientArtifactReason(filePath) {
   }
   if (hasDirectory(normalizedPath, 'engram-dev')) {
     return 'engram-dev artifact';
+  }
+  if (rootTransientDocumentNames.has(normalizedPath)) {
+    return 'transient development document';
+  }
+  if (transientProcessArtifactDirectories.some(directory => hasRootSubpath(normalizedPath, directory))) {
+    return 'transient process artifact';
   }
   if (name === '.release-notes-beta.md') {
     return 'release-notes beta artifact';

--- a/.github/scripts/transient-artifacts.test.mjs
+++ b/.github/scripts/transient-artifacts.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  findTransientArtifacts,
+  isTransientArtifactPath,
+  listPullRequestFiles,
+} from './transient-artifacts.mjs';
+
+test('identifies evidence-backed transient artifact paths', () => {
+  const rejectedPaths = [
+    '.atl/skill-registry.md',
+    '.DS_Store',
+    'foo.db',
+    'foo.swp',
+    'foo~',
+    'foo.exe',
+    'engram-export.json',
+  ];
+
+  for (const filePath of rejectedPaths) {
+    assert.equal(isTransientArtifactPath(filePath), true, filePath);
+  }
+});
+
+test('allows reviewed and documented files', () => {
+  const allowedPaths = [
+    'docs/new-guide.md',
+    'CONTRIBUTING.md',
+    '.deadcode-baseline.txt',
+    '.perf-baseline.txt',
+    'internal/cloud/dashboard/page_templ.go',
+  ];
+
+  for (const filePath of allowedPaths) {
+    assert.equal(isTransientArtifactPath(filePath), false, filePath);
+  }
+});
+
+test('restricts generated agent-link rules to repository-root paths', () => {
+  assert.equal(isTransientArtifactPath('.claude/skills/skill.md'), true);
+  assert.equal(isTransientArtifactPath('fixtures/.claude/skills/skill.md'), false);
+});
+
+test('allows deleted artifacts and rejects renamed destinations', () => {
+  const artifacts = findTransientArtifacts([
+    { filename: 'old.db', status: 'removed' },
+    { filename: 'new.db', status: 'renamed' },
+  ]);
+
+  assert.deepEqual(artifacts.map(file => file.filename), ['new.db']);
+});
+
+test('enumerates all pull request files through GitHub pagination', async () => {
+  const listFiles = () => {};
+  const github = {
+    rest: { pulls: { listFiles } },
+    paginate: async (endpoint, parameters) => {
+      assert.equal(endpoint, listFiles);
+      assert.deepEqual(parameters, {
+        owner: 'Gentleman-Programming',
+        repo: 'engram',
+        pull_number: 1093,
+        per_page: 100,
+      });
+      return [{ filename: 'docs/new-guide.md', status: 'added' }];
+    },
+  };
+
+  const files = await listPullRequestFiles(github, {
+    owner: 'Gentleman-Programming',
+    repo: 'engram',
+    pullNumber: 1093,
+  });
+
+  assert.equal(files.length, 1);
+});
+
+test('propagates pull request file enumeration failures', async () => {
+  const failure = new Error('GitHub API unavailable');
+  const github = {
+    rest: { pulls: { listFiles: () => {} } },
+    paginate: async () => {
+      throw failure;
+    },
+  };
+
+  await assert.rejects(
+    listPullRequestFiles(github, { owner: 'Gentleman-Programming', repo: 'engram', pullNumber: 1093 }),
+    failure,
+  );
+});

--- a/.github/scripts/transient-artifacts.test.mjs
+++ b/.github/scripts/transient-artifacts.test.mjs
@@ -16,6 +16,12 @@ test('identifies evidence-backed transient artifact paths', () => {
     'foo~',
     'foo.exe',
     'engram-export.json',
+    'plan.md',
+    'agent-report.md',
+    'agent-handoff.md',
+    'handoff.md',
+    'openspec/changes/reject-artifacts/proposal.md',
+    'sdd/changes/reject-artifacts/tasks.md',
   ];
 
   for (const filePath of rejectedPaths) {
@@ -30,6 +36,8 @@ test('allows reviewed and documented files', () => {
     '.deadcode-baseline.txt',
     '.perf-baseline.txt',
     'internal/cloud/dashboard/page_templ.go',
+    'docs/plan.md',
+    'specs/transient-artifact-policy.md',
   ];
 
   for (const filePath of allowedPaths) {
@@ -44,11 +52,19 @@ test('restricts generated agent-link rules to repository-root paths', () => {
 
 test('allows deleted artifacts and rejects renamed destinations', () => {
   const artifacts = findTransientArtifacts([
+    { filename: 'cmd/engram/main.go', status: 'added' },
+    { filename: 'docs/new-guide.md', status: 'modified' },
     { filename: 'old.db', status: 'removed' },
+    { filename: 'plan.md', status: 'added' },
+    { filename: 'openspec/changes/reject-artifacts/proposal.md', status: 'copied' },
     { filename: 'new.db', status: 'renamed' },
   ]);
 
-  assert.deepEqual(artifacts.map(file => file.filename), ['new.db']);
+  assert.deepEqual(artifacts.map(file => file.filename), [
+    'plan.md',
+    'openspec/changes/reject-artifacts/proposal.md',
+    'new.db',
+  ]);
 });
 
 test('enumerates all pull request files through GitHub pagination', async () => {

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,8 +1,16 @@
 name: PR Validation
 
 on:
-  pull_request:
+  # The policy runs from the target branch. Never check out or execute PR content here.
+  # This change is introduced through the existing PR validation; after it lands, each
+  # subsequent PR imports the helper from its trusted base commit.
+  pull_request_target:
     types: [opened, edited, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   check-issue-reference:
@@ -119,3 +127,53 @@ jobs:
             } else {
               core.info(`✅ PR has type label: ${typeLabels[0]}`);
             }
+
+  check-transient-artifacts:
+    name: Check PR Has No Transient Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted base policy
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Reject transient artifacts
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let findTransientArtifacts;
+            let listPullRequestFiles;
+            try {
+              ({ findTransientArtifacts, listPullRequestFiles } = await import(
+                `${process.env.GITHUB_WORKSPACE}/.github/scripts/transient-artifacts.mjs`
+              ));
+            } catch (err) {
+              core.setFailed('❌ Could not load the trusted transient artifact policy: ' + err.message);
+              return;
+            }
+            const prNumber = context.payload.pull_request.number;
+            let files;
+
+            try {
+              files = await listPullRequestFiles(github, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pullNumber: prNumber,
+              });
+            } catch (err) {
+              core.setFailed('❌ Could not enumerate PR files: ' + err.message);
+              return;
+            }
+
+            const artifacts = findTransientArtifacts(files);
+            if (artifacts.length === 0) {
+              core.info('✅ No transient artifacts found in PR files.');
+              return;
+            }
+
+            core.setFailed(
+              '❌ PR contains transient artifacts that must not be committed:\n' +
+              artifacts.map(file => `- ${file.filename} (${file.reason})`).join('\n')
+            );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Required checks run automatically on every PR:
 | **Check Issue Reference** | PR body contains `Closes #N`, `Fixes #N`, or `Resolves #N` |
 | **Check Issue Has status:approved** | The linked issue has the `status:approved` label |
 | **Check PR Has type:* Label** | PR has exactly one `type:*` label |
+| **Check PR Has No Transient Artifacts** | PR files do not include local, generated agent-link, binary, database/export, OS/editor, or backup artifacts |
 
 #### CI Tests
 
@@ -155,6 +156,7 @@ untracked, and latest committed changes compared with `HEAD~`.
 - Update docs in the same PR when behavior changes
 - Do not reference endpoints/scripts that do not exist in code
 - Do not include `Co-Authored-By` trailers in commits
+- Do not include transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts
 
 ### Conventional Commit Format
 

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -86,6 +86,42 @@ func TestWorkflowExternalActionsArePinned(t *testing.T) {
 	}
 }
 
+func TestPRCheckRejectsTransientArtifacts(t *testing.T) {
+	workflowPath := filepath.Join(workflowDirectory(t), "pr-check.yml")
+	content, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowPath, err)
+	}
+
+	workflow := string(content)
+	for _, required := range []string{
+		"check-transient-artifacts:",
+		"name: Check PR Has No Transient Artifacts",
+		"pull_request_target:",
+		"ref: ${{ github.event.pull_request.base.sha }}",
+		".github/scripts/transient-artifacts.mjs",
+		"await listPullRequestFiles(github, {",
+		"core.setFailed('❌ Could not load the trusted transient artifact policy: ' + err.message);",
+		"core.setFailed('❌ Could not enumerate PR files: ' + err.message);",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("%s does not contain %q", workflowPath, required)
+		}
+	}
+	if strings.Contains(workflow, "github.event.pull_request.head") {
+		t.Errorf("%s must not check out or execute candidate PR content", workflowPath)
+	}
+
+	helperPath := filepath.Join(filepath.Dir(filepath.Dir(workflowDirectory(t))), ".github", "scripts", "transient-artifacts.mjs")
+	helper, err := os.ReadFile(helperPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", helperPath, err)
+	}
+	if !strings.Contains(string(helper), "return github.paginate(github.rest.pulls.listFiles, {") {
+		t.Errorf("%s does not use GitHub pagination for PR file enumeration", helperPath)
+	}
+}
+
 func workflowDirectory(t *testing.T) string {
 	t.Helper()
 	_, sourceFile, _, ok := runtime.Caller(0)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1093

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [x] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Reject transient development artifacts through a trusted-base pull request policy check.
- Add focused matcher and workflow-contract tests, plus aligned contributor guidance.

## 📂 Changes

| File | Change |
|------|--------|
| `.github/workflows/pr-check.yml` | Run the policy from `pull_request_target`, load trusted base bytes, paginate PR files, and fail closed. |
| `.github/scripts/transient-artifacts.mjs` | Define the evidence-backed artifact matcher and PR-file enumeration helper. |
| `.github/scripts/transient-artifacts.test.mjs` | Cover rejected and allowed paths, removals, renames, pagination, and API failures. |
| `scripts/workflow_actions_test.go` | Verify trusted workflow provenance and wiring. |
| `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | Document the new required check. |

## 🧪 Test Plan

- [x] `node --test .github/scripts/transient-artifacts.test.mjs` (6/6 passed)
- [x] `go test ./scripts -run '^TestPRCheckRejectsTransientArtifacts$'`
- [x] `git diff --check 5d5bf835c235f7fb950ead819aca57f45f50c5fd`
- [x] Independent candidate validation passed with no blocking findings
- [ ] Full `go test ./...` (left to CI; the local Windows script harness has unrelated pre-existing failures)
- [ ] E2E suite (not applicable to this workflow-only change)
- [ ] `make lint` (left to CI)

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body links approved issue #1093 | ⏳ |
| **Check Issue Has status:approved** | Linked issue is approved | ⏳ |
| **Check PR Has type:* Label** | PR has exactly one type label | ⏳ |
| **Unit Tests** | Repository unit suite | ⏳ |
| **E2E Tests** | Repository E2E suite | ⏳ |
| **Plugin Tests** | Pi plugin tests | ⏳ |
| **Lint** | golangci-lint | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1093`)
- [x] I added exactly one `type:*` label to this PR
- [x] I ran the focused unit and workflow-contract tests locally
- [ ] I ran the full E2E suite locally (not applicable; CI remains authoritative)
- [ ] I ran `make lint` locally (CI remains authoritative)
- [x] Docs updated because contributor behavior changed
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers are present
- [x] No transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts are included

---

## 💬 Notes for Reviewers

Native RDD completed with no blocking findings. Informational follow-ups noted case-sensitive suffix matching and GitHub's 3,000-file API ceiling; neither reopens this candidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests now automatically detect and reject transient local, generated, binary, database/export, OS/editor, and backup artifacts.
  * Validation identifies affected files and explains why they were flagged.

* **Documentation**
  * Contributor guidance and pull request templates now clarify which transient artifacts are prohibited.

* **Tests**
  * Added coverage for artifact detection, file handling, pagination, workflow configuration, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->