### PR TITLE
ci(workflows): reject transient pull request artifacts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,7 +69,7 @@ These run automatically and **all must pass** before merge:
 | **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
 | **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
 | **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
-| **Check PR Has No Transient Artifacts** | PR files do not include transient local or generated artifacts | ⏳ |
+| **Check PR Has No Transient Artifacts** | PR files comply with the [Transient Artifact Policy](https://github.com/Gentleman-Programming/engram/blob/main/CONTRIBUTING.md#transient-artifact-policy) | ⏳ |
 | **Unit Tests** | `go test ./...` passes | ⏳ |
 | **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
 | **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |
@@ -87,7 +87,7 @@ These run automatically and **all must pass** before merge:
 - [ ] Docs updated (if behavior changed)
 - [ ] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
 - [ ] No `Co-Authored-By` trailers in commits
-- [ ] No transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts are included
+- [ ] I checked every changed path against the [Transient Artifact Policy](https://github.com/Gentleman-Programming/engram/blob/main/CONTRIBUTING.md#transient-artifact-policy)
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,6 +69,7 @@ These run automatically and **all must pass** before merge:
 | **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
 | **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
 | **Check PR Has type:\* Label** | PR has exactly one `type:*` label | ⏳ |
+| **Check PR Has No Transient Artifacts** | PR files do not include transient local or generated artifacts | ⏳ |
 | **Unit Tests** | `go test ./...` passes | ⏳ |
 | **E2E Tests** | `go test -tags e2e ./internal/server/...` passes | ⏳ |
 | **Plugin Tests** | `npm test` passes in `plugin/pi` | ⏳ |
@@ -86,6 +87,7 @@ These run automatically and **all must pass** before merge:
 - [ ] Docs updated (if behavior changed)
 - [ ] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
 - [ ] No `Co-Authored-By` trailers in commits
+- [ ] No transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts are included
 
 ---
 

--- a/.github/scripts/transient-artifacts.mjs
+++ b/.github/scripts/transient-artifacts.mjs
@@ -1,0 +1,122 @@
+const generatedAgentLinkDirectories = [
+  ['.claude', 'skills'],
+  ['.codex', 'skills'],
+  ['.github', 'skills'],
+  ['.gemini', 'skills'],
+];
+
+const rootBinaryPaths = new Set([
+  'engram',
+  'cmd/engram/main',
+  'cmd/engram/gentle-creation',
+  'cmd/engram/engram',
+]);
+
+const rootTransientDocumentNames = new Set([
+  'plan.md',
+  'agent-report.md',
+  'agent-handoff.md',
+  'handoff.md',
+]);
+
+const transientProcessArtifactDirectories = [
+  ['openspec', 'changes'],
+  ['sdd', 'changes'],
+];
+
+function normalizePath(filePath) {
+  return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function pathSegments(filePath) {
+  return normalizePath(filePath).split('/');
+}
+
+function hasDirectory(filePath, directory) {
+  return pathSegments(filePath).includes(directory);
+}
+
+function hasRootSubpath(filePath, subpath) {
+  const segments = pathSegments(filePath);
+  return subpath.every((segment, index) => segments[index] === segment);
+}
+
+function fileName(filePath) {
+  const segments = pathSegments(filePath);
+  return segments.at(-1);
+}
+
+export function transientArtifactReason(filePath) {
+  const normalizedPath = normalizePath(filePath);
+  const name = fileName(normalizedPath);
+
+  if (hasDirectory(normalizedPath, '.atl')) {
+    return '.atl artifact';
+  }
+  if (generatedAgentLinkDirectories.some(directory => hasRootSubpath(normalizedPath, directory))) {
+    return 'generated agent-link directory';
+  }
+  if (hasDirectory(normalizedPath, 'engram-dev')) {
+    return 'engram-dev artifact';
+  }
+  if (rootTransientDocumentNames.has(normalizedPath)) {
+    return 'transient development document';
+  }
+  if (transientProcessArtifactDirectories.some(directory => hasRootSubpath(normalizedPath, directory))) {
+    return 'transient process artifact';
+  }
+  if (name === '.release-notes-beta.md') {
+    return 'release-notes beta artifact';
+  }
+  if (name.endsWith('.db') || name.endsWith('.db-wal') || name.endsWith('.db-shm')) {
+    return 'local database';
+  }
+  if (name === 'engram-export.json') {
+    return 'local export';
+  }
+  if (rootBinaryPaths.has(normalizedPath) || name.endsWith('.exe')) {
+    return 'binary';
+  }
+  if (name === '.DS_Store' || name === 'Thumbs.db') {
+    return 'OS metadata';
+  }
+  if (hasDirectory(normalizedPath, '.idea') || hasDirectory(normalizedPath, '.vscode')) {
+    return 'editor metadata';
+  }
+  if (name.endsWith('.swp') || name.endsWith('.swo') || name.endsWith('~')) {
+    return 'editor or backup file';
+  }
+
+  return null;
+}
+
+export function isTransientArtifactPath(filePath) {
+  return transientArtifactReason(filePath) !== null;
+}
+
+export function findTransientArtifacts(files) {
+  return files
+    .filter(file => file.status !== 'removed')
+    .map(file => ({ ...file, reason: transientArtifactReason(file.filename) }))
+    .filter(file => file.reason !== null);
+}
+
+export async function listPullRequestFiles(github, { owner, repo, pullNumber }) {
+  const { data: pullRequest } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pullNumber,
+    per_page: 100,
+  });
+  if (files.length !== pullRequest.changed_files) {
+    throw new Error(
+      `PR #${pullNumber} reports ${pullRequest.changed_files} changed files, but the file API returned ${files.length}; refusing incomplete artifact validation`,
+    );
+  }
+  return files;
+}

--- a/.github/scripts/transient-artifacts.test.mjs
+++ b/.github/scripts/transient-artifacts.test.mjs
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  findTransientArtifacts,
+  isTransientArtifactPath,
+  listPullRequestFiles,
+} from './transient-artifacts.mjs';
+
+test('identifies evidence-backed transient artifact paths', () => {
+  const rejectedPaths = [
+    '.atl/skill-registry.md',
+    '.DS_Store',
+    'foo.db',
+    'foo.swp',
+    'foo~',
+    'foo.exe',
+    'engram-export.json',
+    'plan.md',
+    'agent-report.md',
+    'agent-handoff.md',
+    'handoff.md',
+    'openspec/changes/reject-artifacts/proposal.md',
+    'sdd/changes/reject-artifacts/tasks.md',
+  ];
+
+  for (const filePath of rejectedPaths) {
+    assert.equal(isTransientArtifactPath(filePath), true, filePath);
+  }
+});
+
+test('allows reviewed and documented files', () => {
+  const allowedPaths = [
+    'docs/new-guide.md',
+    'CONTRIBUTING.md',
+    '.deadcode-baseline.txt',
+    '.perf-baseline.txt',
+    'internal/cloud/dashboard/page_templ.go',
+    'docs/plan.md',
+    'specs/transient-artifact-policy.md',
+  ];
+
+  for (const filePath of allowedPaths) {
+    assert.equal(isTransientArtifactPath(filePath), false, filePath);
+  }
+});
+
+test('restricts generated agent-link rules to repository-root paths', () => {
+  assert.equal(isTransientArtifactPath('.claude/skills/skill.md'), true);
+  assert.equal(isTransientArtifactPath('fixtures/.claude/skills/skill.md'), false);
+});
+
+test('allows deleted artifacts and rejects renamed destinations', () => {
+  const artifacts = findTransientArtifacts([
+    { filename: 'cmd/engram/main.go', status: 'added' },
+    { filename: 'docs/new-guide.md', status: 'modified' },
+    { filename: 'old.db', status: 'removed' },
+    { filename: 'plan.md', status: 'added' },
+    { filename: 'openspec/changes/reject-artifacts/proposal.md', status: 'copied' },
+    { filename: 'new.db', status: 'renamed' },
+  ]);
+
+  assert.deepEqual(artifacts.map(file => file.filename), [
+    'plan.md',
+    'openspec/changes/reject-artifacts/proposal.md',
+    'new.db',
+  ]);
+});
+
+test('enumerates all pull request files through GitHub pagination', async () => {
+  const get = async parameters => {
+    assert.deepEqual(parameters, {
+      owner: 'Gentleman-Programming',
+      repo: 'engram',
+      pull_number: 1093,
+    });
+    return { data: { changed_files: 1 } };
+  };
+  const listFiles = () => {};
+  const github = {
+    rest: { pulls: { get, listFiles } },
+    paginate: async (endpoint, parameters) => {
+      assert.equal(endpoint, listFiles);
+      assert.deepEqual(parameters, {
+        owner: 'Gentleman-Programming',
+        repo: 'engram',
+        pull_number: 1093,
+        per_page: 100,
+      });
+      return [{ filename: 'docs/new-guide.md', status: 'added' }];
+    },
+  };
+
+  const files = await listPullRequestFiles(github, {
+    owner: 'Gentleman-Programming',
+    repo: 'engram',
+    pullNumber: 1093,
+  });
+
+  assert.equal(files.length, 1);
+});
+
+test('rejects incomplete pull request file enumeration', async () => {
+  const github = {
+    rest: { pulls: { get: async () => ({ data: { changed_files: 2 } }), listFiles: () => {} } },
+    paginate: async () => [{ filename: 'docs/new-guide.md', status: 'added' }],
+  };
+
+  await assert.rejects(
+    listPullRequestFiles(github, { owner: 'Gentleman-Programming', repo: 'engram', pullNumber: 1093 }),
+    /PR #1093 reports 2 changed files, but the file API returned 1; refusing incomplete artifact validation/,
+  );
+});
+
+test('propagates pull request file enumeration failures', async () => {
+  const failure = new Error('GitHub API unavailable');
+  const github = {
+    rest: { pulls: { get: async () => ({ data: { changed_files: 1 } }), listFiles: () => {} } },
+    paginate: async () => {
+      throw failure;
+    },
+  };
+
+  await assert.rejects(
+    listPullRequestFiles(github, { owner: 'Gentleman-Programming', repo: 'engram', pullNumber: 1093 }),
+    failure,
+  );
+});

--- a/.github/scripts/transient-artifacts.test.mjs
+++ b/.github/scripts/transient-artifacts.test.mjs
@@ -7,25 +7,52 @@ import {
   listPullRequestFiles,
 } from './transient-artifacts.mjs';
 
-test('identifies evidence-backed transient artifact paths', () => {
-  const rejectedPaths = [
-    '.atl/skill-registry.md',
-    '.DS_Store',
-    'foo.db',
-    'foo.swp',
-    'foo~',
-    'foo.exe',
-    'engram-export.json',
-    'plan.md',
-    'agent-report.md',
-    'agent-handoff.md',
-    'handoff.md',
-    'openspec/changes/reject-artifacts/proposal.md',
-    'sdd/changes/reject-artifacts/tasks.md',
+test('identifies every configured transient artifact classifier and variant', () => {
+  const rejectedCases = [
+    { classifier: '.atl artifacts', paths: ['.atl/skill-registry.md'] },
+    {
+      classifier: 'generated agent-link roots',
+      paths: [
+        '.claude/skills/skill.md',
+        '.codex/skills/skill.md',
+        '.github/skills/skill.md',
+        '.gemini/skills/skill.md',
+      ],
+    },
+    { classifier: 'engram-dev artifacts', paths: ['engram-dev/state.json'] },
+    {
+      classifier: 'root transient development documents',
+      paths: ['plan.md', 'agent-report.md', 'agent-handoff.md', 'handoff.md'],
+    },
+    {
+      classifier: 'root transient process artifacts',
+      paths: [
+        'openspec/changes/reject-artifacts/proposal.md',
+        'sdd/changes/reject-artifacts/tasks.md',
+      ],
+    },
+    { classifier: 'release-notes beta artifacts', paths: ['.release-notes-beta.md'] },
+    { classifier: 'local databases', paths: ['foo.db', 'foo.db-wal', 'foo.db-shm'] },
+    { classifier: 'local exports', paths: ['engram-export.json'] },
+    {
+      classifier: 'binaries',
+      paths: [
+        'engram',
+        'cmd/engram/main',
+        'cmd/engram/gentle-creation',
+        'cmd/engram/engram',
+        'foo.exe',
+      ],
+    },
+    { classifier: 'OS metadata', paths: ['.DS_Store', 'Thumbs.db'] },
+    { classifier: 'editor metadata', paths: ['.idea/workspace.xml', '.vscode/settings.json'] },
+    { classifier: 'editor and backup files', paths: ['foo.swp', 'foo.swo', 'foo~'] },
   ];
 
-  for (const filePath of rejectedPaths) {
-    assert.equal(isTransientArtifactPath(filePath), true, filePath);
+  for (const { classifier, paths } of rejectedCases) {
+    for (const filePath of paths) {
+      assert.equal(isTransientArtifactPath(filePath), true, `${classifier}: ${filePath}`);
+    }
   }
 });
 
@@ -38,16 +65,19 @@ test('allows reviewed and documented files', () => {
     'internal/cloud/dashboard/page_templ.go',
     'docs/plan.md',
     'specs/transient-artifact-policy.md',
+    'fixtures/.claude/skills/skill.md',
+    'fixtures/.codex/skills/skill.md',
+    'fixtures/.github/skills/skill.md',
+    'fixtures/.gemini/skills/skill.md',
+    'fixtures/openspec/changes/reject-artifacts/proposal.md',
+    'fixtures/sdd/changes/reject-artifacts/tasks.md',
+    'tools/engram',
+    'fixtures/cmd/engram/main',
   ];
 
   for (const filePath of allowedPaths) {
     assert.equal(isTransientArtifactPath(filePath), false, filePath);
   }
-});
-
-test('restricts generated agent-link rules to repository-root paths', () => {
-  assert.equal(isTransientArtifactPath('.claude/skills/skill.md'), true);
-  assert.equal(isTransientArtifactPath('fixtures/.claude/skills/skill.md'), false);
 });
 
 test('allows deleted artifacts and rejects renamed destinations', () => {
@@ -119,6 +149,19 @@ test('propagates pull request file enumeration failures', async () => {
     paginate: async () => {
       throw failure;
     },
+  };
+
+  await assert.rejects(
+    listPullRequestFiles(github, { owner: 'Gentleman-Programming', repo: 'engram', pullNumber: 1093 }),
+    failure,
+  );
+});
+
+test('propagates pull request metadata failures', async () => {
+  const failure = new Error('GitHub pull request lookup unavailable');
+  const github = {
+    rest: { pulls: { get: async () => { throw failure; }, listFiles: () => {} } },
+    paginate: async () => assert.fail('pagination must not run after a pull request lookup failure'),
   };
 
   await assert.rejects(

--- a/.github/workflows/transient-artifacts.yml
+++ b/.github/workflows/transient-artifacts.yml
@@ -1,0 +1,60 @@
+name: Transient Artifact Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-transient-artifacts:
+    name: Check PR Has No Transient Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted base policy
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Reject transient artifacts
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let findTransientArtifacts;
+            let listPullRequestFiles;
+            try {
+              ({ findTransientArtifacts, listPullRequestFiles } = await import(
+                `${process.env.GITHUB_WORKSPACE}/.github/scripts/transient-artifacts.mjs`
+              ));
+            } catch (err) {
+              core.setFailed('❌ Could not load the trusted transient artifact policy: ' + err.message);
+              return;
+            }
+            const prNumber = context.payload.pull_request.number;
+            let files;
+
+            try {
+              files = await listPullRequestFiles(github, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pullNumber: prNumber,
+              });
+            } catch (err) {
+              core.setFailed('❌ Could not enumerate PR files: ' + err.message);
+              return;
+            }
+
+            const artifacts = findTransientArtifacts(files);
+            if (artifacts.length === 0) {
+              core.info('✅ No transient artifacts found in PR files.');
+              return;
+            }
+
+            core.setFailed(
+              '❌ PR contains transient artifacts that must not be committed:\n' +
+              artifacts.map(file => `- ${file.filename} (${file.reason})`).join('\n')
+            );

--- a/.github/workflows/transient-artifacts.yml
+++ b/.github/workflows/transient-artifacts.yml
@@ -2,7 +2,7 @@ name: Transient Artifact Check
 
 on:
   pull_request_target:
-    types: [opened, edited, labeled, unlabeled, synchronize]
+    types: [opened, edited, labeled, unlabeled, synchronize, reopened]
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Required checks run automatically on every PR:
 
 All required checks must pass before a PR can be merged.
 
-> **Repo admin note:** Set these as required status checks in branch protection rules for `main`: `Lint`, `Unit Tests`, `E2E Tests`, `Plugin Tests`, and `PR Validation`.
+> **Repo admin note:** Set these as required status checks in branch protection rules for `main`: `Lint`, `Unit Tests`, `E2E Tests`, `Plugin Tests`, `PR Validation`, and `Check PR Has No Transient Artifacts`.
 
 ## Transient Artifact Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Required checks run automatically on every PR:
 | **Check Issue Reference** | PR body contains `Closes #N`, `Fixes #N`, or `Resolves #N` |
 | **Check Issue Has status:approved** | The linked issue has the `status:approved` label |
 | **Check PR Has type:* Label** | PR has exactly one `type:*` label |
-| **Check PR Has No Transient Artifacts** | PR files do not include local, generated agent-link, binary, database/export, OS/editor, or backup artifacts |
+| **Check PR Has No Transient Artifacts** | PR files comply with the [Transient Artifact Policy](#transient-artifact-policy) |
 
 #### CI Tests
 
@@ -61,6 +61,25 @@ Required checks run automatically on every PR:
 All required checks must pass before a PR can be merged.
 
 > **Repo admin note:** Set these as required status checks in branch protection rules for `main`: `Lint`, `Unit Tests`, `E2E Tests`, `Plugin Tests`, and `PR Validation`.
+
+## Transient Artifact Policy
+
+PR validation inspects the complete changed-file set. Deleted artifacts are allowed; enforcement applies to added, modified, copied, and renamed destination paths. It rejects the following transient artifacts unless a path is explicitly described as repository-root-only:
+
+| Enforced class | Forbidden paths and variants |
+|---|---|
+| Agent-tool state | Any directory named `.atl` (at any depth) and `**/engram-dev/**` |
+| Generated agent links | Repository-root `.claude/skills/**`, `.codex/skills/**`, `.github/skills/**`, and `.gemini/skills/**` |
+| Transient development documents | Repository-root `plan.md`, `agent-report.md`, `agent-handoff.md`, and `handoff.md` |
+| Transient process artifacts | Repository-root `openspec/changes/**` and `sdd/changes/**` |
+| Release metadata | `**/.release-notes-beta.md` |
+| Local data | `**/*.db`, `**/*.db-wal`, `**/*.db-shm`, and `**/engram-export.json` |
+| Binaries | Repository-root `engram`, `cmd/engram/main`, `cmd/engram/gentle-creation`, `cmd/engram/engram`, and `**/*.exe` |
+| OS metadata | `**/.DS_Store` and `**/Thumbs.db` |
+| Editor metadata | `**/.idea/**` and `**/.vscode/**` |
+| Editor and backup files | `**/*.swp`, `**/*.swo`, and `**/*~` |
+
+Canonical, reviewable documentation is allowed. For example, `docs/plan.md` and `specs/transient-artifact-policy.md` are documentation, not root transient development documents. The four transient document names above are forbidden only at the repository root; do not use documentation paths to retain ephemeral local notes.
 
 ### Quality Ratchets
 
@@ -156,7 +175,7 @@ untracked, and latest committed changes compared with `HEAD~`.
 - Update docs in the same PR when behavior changes
 - Do not reference endpoints/scripts that do not exist in code
 - Do not include `Co-Authored-By` trailers in commits
-- Do not include transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts
+- Do not include paths prohibited by the [Transient Artifact Policy](#transient-artifact-policy)
 
 ### Conventional Commit Format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Required checks run automatically on every PR:
 | **Check Issue Reference** | PR body contains `Closes #N`, `Fixes #N`, or `Resolves #N` |
 | **Check Issue Has status:approved** | The linked issue has the `status:approved` label |
 | **Check PR Has type:* Label** | PR has exactly one `type:*` label |
+| **Check PR Has No Transient Artifacts** | PR files do not include local, generated agent-link, binary, database/export, OS/editor, or backup artifacts |
 
 #### CI Tests
 
@@ -155,6 +156,7 @@ untracked, and latest committed changes compared with `HEAD~`.
 - Update docs in the same PR when behavior changes
 - Do not reference endpoints/scripts that do not exist in code
 - Do not include `Co-Authored-By` trailers in commits
+- Do not include transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts
 
 ### Conventional Commit Format
 

--- a/docs/codebase/maintainer-playbook.md
+++ b/docs/codebase/maintainer-playbook.md
@@ -45,7 +45,14 @@
 4. Is there a test at the affected boundary?
 5. Did public docs stay aligned?
 6. Does the UI, if any, represent real behavior?
+7. Did the review inspect the complete changed-file set for prohibited transient artifacts?
 ```
+
+### Pull request artifact review
+
+- Inspect the complete changed-file set, including added, modified, copied, and renamed destinations.
+- Reject every class listed in the [Transient Artifact Policy](../../CONTRIBUTING.md#transient-artifact-policy); do not rely on a partial shorthand list.
+- Treat repository-root-only restrictions as scoped: canonical documentation such as `docs/plan.md` remains allowed.
 
 ## Guardrails that must not break
 

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -123,6 +123,7 @@ func TestPRValidationAndTransientArtifactWorkflowContracts(t *testing.T) {
 	artifactWorkflow := string(artifactWorkflowContent)
 	for _, required := range []string{
 		"pull_request_target:",
+		"types: [opened, edited, labeled, unlabeled, synchronize, reopened]",
 		"permissions:\n  contents: read\n  pull-requests: read",
 		"check-transient-artifacts:",
 		"name: Check PR Has No Transient Artifacts",

--- a/scripts/workflow_actions_test.go
+++ b/scripts/workflow_actions_test.go
@@ -86,6 +86,80 @@ func TestWorkflowExternalActionsArePinned(t *testing.T) {
 	}
 }
 
+func TestPRValidationAndTransientArtifactWorkflowContracts(t *testing.T) {
+	prCheckPath := filepath.Join(workflowDirectory(t), "pr-check.yml")
+	prCheckContent, err := os.ReadFile(prCheckPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", prCheckPath, err)
+	}
+
+	prCheck := string(prCheckContent)
+	for _, required := range []string{
+		"pull_request:",
+		"types: [opened, edited, labeled, unlabeled, synchronize]",
+		"check-issue-reference:",
+		"name: Check Issue Reference",
+		"check-issue-approved:",
+		"name: Check Issue Has status:approved",
+		"check-type-label:",
+		"name: Check PR Has type:* Label",
+	} {
+		if !strings.Contains(prCheck, required) {
+			t.Errorf("%s does not contain %q", prCheckPath, required)
+		}
+	}
+	for _, forbidden := range []string{"pull_request_target:", "check-transient-artifacts:"} {
+		if strings.Contains(prCheck, forbidden) {
+			t.Errorf("%s must not contain %q", prCheckPath, forbidden)
+		}
+	}
+
+	artifactWorkflowPath := filepath.Join(workflowDirectory(t), "transient-artifacts.yml")
+	artifactWorkflowContent, err := os.ReadFile(artifactWorkflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", artifactWorkflowPath, err)
+	}
+
+	artifactWorkflow := string(artifactWorkflowContent)
+	for _, required := range []string{
+		"pull_request_target:",
+		"permissions:\n  contents: read\n  pull-requests: read",
+		"check-transient-artifacts:",
+		"name: Check PR Has No Transient Artifacts",
+		"actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6",
+		"ref: ${{ github.event.pull_request.base.sha }}",
+		"persist-credentials: false",
+		"actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8",
+		".github/scripts/transient-artifacts.mjs",
+		"({ findTransientArtifacts, listPullRequestFiles } = await import(",
+		"await listPullRequestFiles(github, {",
+		"owner: context.repo.owner",
+		"repo: context.repo.repo",
+		"pullNumber: prNumber",
+		"findTransientArtifacts(files)",
+		"core.setFailed('❌ Could not load the trusted transient artifact policy: ' + err.message);",
+		"core.setFailed('❌ Could not enumerate PR files: ' + err.message);",
+	} {
+		if !strings.Contains(artifactWorkflow, required) {
+			t.Errorf("%s does not contain %q", artifactWorkflowPath, required)
+		}
+	}
+	for _, forbidden := range []string{"github.event.pull_request.head", "write", "gh pr diff", "status: 'modified'"} {
+		if strings.Contains(artifactWorkflow, forbidden) {
+			t.Errorf("%s must not contain %q", artifactWorkflowPath, forbidden)
+		}
+	}
+
+	helperPath := filepath.Join(filepath.Dir(filepath.Dir(workflowDirectory(t))), ".github", "scripts", "transient-artifacts.mjs")
+	helper, err := os.ReadFile(helperPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", helperPath, err)
+	}
+	if !strings.Contains(string(helper), "const files = await github.paginate(github.rest.pulls.listFiles, {") {
+		t.Errorf("%s does not use GitHub pagination for PR file enumeration", helperPath)
+	}
+}
+
 func workflowDirectory(t *testing.T) string {
 	t.Helper()
 	_, sourceFile, _, ok := runtime.Caller(0)

--- a/skills/branch-pr/SKILL.md
+++ b/skills/branch-pr/SKILL.md
@@ -136,8 +136,11 @@ All boxes must be checked:
 | PR Validation | `Check Issue Reference` | Body contains `Closes/Fixes/Resolves #N` |
 | PR Validation | `Check Issue Has status:approved` | Linked issue has `status:approved` |
 | PR Validation | `Check PR Has type:* Label` | PR has exactly one `type:*` label |
+| Transient Artifact Check | `Check PR Has No Transient Artifacts` | PR files comply with the [Transient Artifact Policy](../../CONTRIBUTING.md#transient-artifact-policy) |
 | CI | `Unit Tests` | `go test ./...` passes |
 | CI | `E2E Tests` | `go test -tags e2e ./internal/server/...` passes |
+| CI | `Plugin Tests` | `npm test` passes in `plugin/pi` |
+| CI | `Lint` | golangci-lint reports no new findings in Go changes |
 
 ---
 

--- a/skills/branch-pr/SKILL.md
+++ b/skills/branch-pr/SKILL.md
@@ -22,7 +22,7 @@ Use this skill when:
 
 1. **Every PR MUST link an approved issue** — no exceptions
 2. **Every PR MUST have exactly one `type:*` label**
-3. **5 automated checks must pass** before merge is possible
+3. **All required automated checks must pass** before merge is possible
 4. **Blank PRs without issue linkage will be blocked** by GitHub Actions
 
 ---
@@ -34,9 +34,10 @@ Use this skill when:
 2. Create branch: feat/*, fix/*, docs/*, refactor/*, chore/*
 3. Implement changes
 4. Run tests locally (unit + e2e)
-5. Open PR using the template
-6. Add exactly one type:* label
-7. Wait for 5 automated checks to pass
+5. Check every changed path against the [Transient Artifact Policy](../../CONTRIBUTING.md#transient-artifact-policy)
+6. Open PR using the template
+7. Add exactly one type:* label
+8. Wait for all required automated checks to pass
 ```
 
 ---
@@ -124,10 +125,11 @@ All boxes must be checked:
 - Docs updated if behavior changed
 - Conventional commit format
 - No `Co-Authored-By` trailers
+- Every changed path complies with the [Transient Artifact Policy](../../CONTRIBUTING.md#transient-artifact-policy)
 
 ---
 
-## Automated Checks (all 5 must pass)
+## Automated Checks (all required checks must pass)
 
 | Check | Job name | What it verifies |
 |-------|----------|-----------------|

--- a/skills/commit-hygiene/SKILL.md
+++ b/skills/commit-hygiene/SKILL.md
@@ -26,7 +26,7 @@ Use this skill when:
 3. Keep one logical change per commit
 4. Message should explain **why**, not only what
 5. **NEVER** include `Co-Authored-By` trailers
-6. **NEVER** commit generated/temp/local files
+6. **NEVER** commit paths prohibited by the [Transient Artifact Policy](../../CONTRIBUTING.md#transient-artifact-policy)
 
 ---
 
@@ -132,6 +132,6 @@ fix_something                    ← missing "/" separator
 - [ ] Branch name matches `type/description` format
 - [ ] Diff matches commit scope (no unrelated changes)
 - [ ] No secrets, credentials, or `.env` files
-- [ ] No binaries, coverage outputs, or local artifacts
+- [ ] Every changed path complies with the [Transient Artifact Policy](../../CONTRIBUTING.md#transient-artifact-policy)
 - [ ] No `Co-Authored-By` trailers
 - [ ] Tests relevant to the change pass


### PR DESCRIPTION
## Linked Issue

Closes #1093

---

## PR Type

- [ ] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no behavior change)
- [x] `type:chore` - Maintenance, dependencies, tooling
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Add a trusted-base `pull_request_target` check that rejects transient development artifacts.
- Fail closed when GitHub returns an incomplete pull-request file enumeration.
- Document the complete policy and align tests, contributor guidance, maintainer guidance, and relevant skills.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/transient-artifacts.yml` | Add the read-only trusted-base artifact check. |
| `.github/scripts/transient-artifacts.mjs` | Classify transient paths and enumerate PR files fail-closed. |
| `.github/scripts/transient-artifacts.test.mjs` | Test every configured classifier family, scope boundaries, pagination, truncation, and API errors. |
| `scripts/workflow_actions_test.go` | Protect workflow security and separation contracts. |
| `CONTRIBUTING.md` and PR template | Define and link the canonical transient-artifact policy. |
| Maintainer playbook and PR/commit skills | Align review and contribution guidance with the enforced policy. |

## Test Plan

- [x] `node --test .github/scripts/transient-artifacts.test.mjs` - 7 tests passed.
- [x] Focused Go workflow contract tests passed.
- [x] `npm test` in `plugin/pi` - 125 tests passed.
- [ ] `go test ./...` - attempted; unrelated project-detection and Bash-on-Windows tests fail in this environment.
- [ ] `go test -tags e2e ./internal/server/...` - attempted; unrelated project-detection tests fail in this environment.
- [ ] `make lint` - unavailable because `make` is not installed in this environment.
- [x] GitHub CI passed Unit Tests, E2E Tests, Windows Setup, Cloud Sync Wrapper Tests, Plugin Tests, and Lint for the initial commit.
- [x] Verified `.github/workflows/pr-check.yml` remains identical to `origin/main`.

---

## Automated Checks

The existing required checks should run normally. The newly added `pull_request_target` workflow cannot run on this introductory PR because workflow definitions are loaded from the base branch; it will apply after merge.

---

## Contributor Checklist

- [x] I linked an approved issue above (`Closes #N`)
- [x] I added exactly **one** `type:*` label to this PR
- [x] I ran unit tests locally: `go test ./...`
- [x] I ran e2e tests locally: `go test -tags e2e ./internal/server/...`
- [ ] I ran lint locally: `make lint`
- [x] Docs updated (if behavior changed)
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits
- [x] No transient local, generated agent-link, binary, database/export, OS/editor, or backup artifacts are included

---

## Notes for Reviewers

This replaces the blocked approach in #1125 without modifying the current required PR validation workflow. The policy implementation is loaded only from the trusted base commit and receives read-only permissions.

Maintainer-approved `size:exception`: the 479 changed lines keep enforcement, deterministic tests, contributor guidance, maintainer guidance, and relevant skills in one cohesive policy change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request validation to detect and reject transient artifacts, including local data, generated files, binaries, editor metadata, and backup files.
  * Added clear reporting that identifies each detected artifact and its reason.
* **Documentation**
  * Documented the Transient Artifact Policy and contributor requirements.
  * Updated pull request, contribution, and maintainer guidance to include the new validation check.
* **Tests**
  * Added coverage for artifact detection, changed-file handling, and workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->