### PR TITLE
feat(store): improve search ranking and filtering

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -310,6 +310,17 @@ const (
 	decayDecisionMonths   = 6
 	decayPolicyMonths     = 12
 	decayPreferenceMonths = 3
+
+	// Observation FTS reranking preserves the raw BM25 projection and applies
+	// bounded multiplicative boosts only to its SQL ordering.
+	searchFTSTitleWeight            = 5.0
+	searchFTSContentWeight          = 1.0
+	searchFTSTopicKeyWeight         = 3.0
+	searchPinnedBoost               = 0.10
+	searchRecencyBoost              = 0.06
+	searchRecencyHalfScoreDays      = 30.0
+	searchStabilityBoost            = 0.04
+	searchStabilityDiminishingScale = 4.0
 )
 
 // decayReviewAfterMonths maps observation type → month offset for review_after.
@@ -1132,6 +1143,7 @@ func (s *Store) migrate() error {
 	if _, err := s.execHook(s.db, `
 		CREATE INDEX IF NOT EXISTS idx_obs_scope ON observations(scope);
 		CREATE INDEX IF NOT EXISTS idx_obs_sync_id ON observations(sync_id);
+		CREATE INDEX IF NOT EXISTS idx_obs_project_lower ON observations(LOWER(project));
 		CREATE INDEX IF NOT EXISTS idx_obs_topic ON observations(topic_key, project, scope, updated_at DESC);
 		CREATE INDEX IF NOT EXISTS idx_obs_deleted ON observations(deleted_at);
 		CREATE INDEX IF NOT EXISTS idx_obs_dedupe ON observations(normalized_hash, project, scope, type, title, created_at DESC);
@@ -4254,9 +4266,29 @@ func buildSearchPreviewFTSQuery(ftsQuery string, opts SearchOptions, limit int) 
 }
 
 func buildSearchFTSQueryWithColumns(columns, ftsQuery string, opts SearchOptions, limit int) (string, []any) {
+	rawRank := fmt.Sprintf(
+		"bm25(observations_fts, %.1f, %.1f, 0.0, 0.0, 0.0, %.1f)",
+		searchFTSTitleWeight,
+		searchFTSContentWeight,
+		searchFTSTopicKeyWeight,
+	)
+	compositeRank := fmt.Sprintf(`
+		%s * (
+			1.0 +
+			CASE WHEN o.pinned THEN %.2f ELSE 0.0 END +
+			%.2f * (1.0 / (1.0 + MAX(0.0, julianday('now') - COALESCE(julianday(o.last_seen_at), julianday(o.updated_at), julianday(o.created_at), julianday('now'))) / %.1f)) +
+			%.2f * ((MAX(0, COALESCE(o.revision_count, 0)) + MAX(0, COALESCE(o.duplicate_count, 0))) / (MAX(0, COALESCE(o.revision_count, 0)) + MAX(0, COALESCE(o.duplicate_count, 0)) + %.1f))
+		)`,
+		rawRank,
+		searchPinnedBoost,
+		searchRecencyBoost,
+		searchRecencyHalfScoreDays,
+		searchStabilityBoost,
+		searchStabilityDiminishingScale,
+	)
 	sqlQ := `
 		SELECT ` + columns + `,
-		       bm25(observations_fts, 5.0, 1.0, 0.0, 0.0, 0.0, 3.0) as rank
+		       ` + rawRank + ` AS rank
 		FROM observations_fts fts
 		CROSS JOIN observations o ON o.id = fts.rowid
 		WHERE observations_fts MATCH ? AND o.deleted_at IS NULL
@@ -4276,7 +4308,7 @@ func buildSearchFTSQueryWithColumns(columns, ftsQuery string, opts SearchOptions
 		args = append(args, normalizeScope(opts.Scope))
 	}
 
-	sqlQ += " ORDER BY rank LIMIT ?"
+	sqlQ += " ORDER BY " + compositeRank + " ASC, COALESCE(NULLIF(o.sync_id, ''), printf('%020d', o.id)) ASC, o.id ASC LIMIT ?"
 	return sqlQ, append(args, limit)
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9297,6 +9297,75 @@ func TestAddObservationNormalizesProject(t *testing.T) {
 	}
 }
 
+func TestMigrateCreatesLowercaseObservationProjectIndex(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.CreateSession("s-project-index", "engram", "/tmp"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	id, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-project-index",
+		Type:      "decision",
+		Title:     "Legacy project index fixture",
+		Content:   "exercise the lowercase project expression",
+		Project:   "engram",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	if _, err := s.DB().Exec(`UPDATE observations SET project = 'EnGrAm' WHERE id = ?`, id); err != nil {
+		t.Fatalf("seed legacy mixed-case project: %v", err)
+	}
+
+	// Drop the new index to model an existing database, then rerun the
+	// idempotent migration that must install it.
+	if _, err := s.DB().Exec(`DROP INDEX IF EXISTS idx_obs_project_lower`); err != nil {
+		t.Fatalf("drop project expression index: %v", err)
+	}
+	if err := s.migrate(); err != nil {
+		t.Fatalf("migrate existing database: %v", err)
+	}
+
+	var definition string
+	if err := s.DB().QueryRow(`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_obs_project_lower'`).Scan(&definition); err != nil {
+		t.Errorf("find project expression index: %v", err)
+	} else if !strings.Contains(definition, "ON observations(LOWER(project))") {
+		t.Errorf("project expression index definition = %q", definition)
+	}
+
+	var count int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM observations o WHERE LOWER(o.project) = ?`, "engram").Scan(&count); err != nil {
+		t.Fatalf("query legacy project predicate: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("legacy project predicate returned %d observations, want 1", count)
+	}
+
+	rows, err := s.DB().Query(`EXPLAIN QUERY PLAN SELECT o.id FROM observations o WHERE LOWER(o.project) = ?`, "engram")
+	if err != nil {
+		t.Fatalf("explain lowercase project predicate: %v", err)
+	}
+	defer rows.Close()
+
+	var plan []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read query plan: %v", err)
+	}
+	t.Logf("lowercase project query plan: %v", plan)
+	if !strings.Contains(strings.Join(plan, "\n"), "idx_obs_project_lower") {
+		t.Fatalf("lowercase project predicate did not use idx_obs_project_lower: %v", plan)
+	}
+}
+
 func TestSearchNormalizesProjectFilter(t *testing.T) {
 	s := newTestStore(t)
 
@@ -13713,6 +13782,107 @@ func TestSearchMatchMode_EmptyQueryAnyReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty query with match_mode=any, got nil")
 	}
+}
+
+func TestSearchCompositeLexicalReranking(t *testing.T) {
+	const (
+		sessionID = "s-composite-rerank"
+		project   = "engram"
+		query     = "compositelexicalsignal"
+	)
+
+	seed := func(t *testing.T, s *Store, syncID, lastSeenAt string, pinned bool, revisions, duplicates int) int64 {
+		t.Helper()
+		result, err := s.db.Exec(`
+			INSERT INTO observations (
+				sync_id, session_id, type, title, content, project, scope,
+				revision_count, duplicate_count, last_seen_at, pinned, created_at, updated_at
+			) VALUES (?, ?, 'decision', ?, 'same lexical content', ?, 'project', ?, ?, ?, ?, ?, ?)
+		`, syncID, sessionID, query, project, revisions, duplicates, lastSeenAt, pinned, lastSeenAt, lastSeenAt)
+		if err != nil {
+			t.Fatalf("seed observation %q: %v", syncID, err)
+		}
+		id, err := result.LastInsertId()
+		if err != nil {
+			t.Fatalf("read seeded observation ID: %v", err)
+		}
+		return id
+	}
+	newStore := func(t *testing.T) *Store {
+		t.Helper()
+		s := newTestStore(t)
+		if err := s.CreateSession(sessionID, project, "/tmp/engram"); err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		return s
+	}
+	search := func(t *testing.T, s *Store) []SearchResult {
+		t.Helper()
+		results, err := s.SearchContext(context.Background(), query, SearchOptions{Project: project, Limit: 10})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		return results
+	}
+
+	t.Run("pinned outranks unpinned without changing raw rank", func(t *testing.T) {
+		s := newStore(t)
+		lastSeenAt := time.Now().UTC().Format("2006-01-02 15:04:05")
+		unpinnedID := seed(t, s, "rerank-pin-a", lastSeenAt, false, 1, 1)
+		pinnedID := seed(t, s, "rerank-pin-z", lastSeenAt, true, 1, 1)
+
+		results := search(t, s)
+		if len(results) != 2 || results[0].ID != pinnedID || results[1].ID != unpinnedID {
+			t.Fatalf("pinned ordering = %+v, want pinned %d before unpinned %d", results, pinnedID, unpinnedID)
+		}
+		if results[0].Rank != results[1].Rank {
+			t.Fatalf("rank projection changed by reranking: pinned=%v unpinned=%v", results[0].Rank, results[1].Rank)
+		}
+	})
+
+	t.Run("fresh outranks stale", func(t *testing.T) {
+		s := newStore(t)
+		staleID := seed(t, s, "rerank-recency-a", "2000-01-01 00:00:00", false, 1, 1)
+		freshID := seed(t, s, "rerank-recency-z", time.Now().UTC().Format("2006-01-02 15:04:05"), false, 1, 1)
+
+		results := search(t, s)
+		if len(results) != 2 || results[0].ID != freshID || results[1].ID != staleID {
+			t.Fatalf("recency ordering = %+v, want fresh %d before stale %d", results, freshID, staleID)
+		}
+	})
+
+	t.Run("stronger revision and duplicate stability outranks weaker stability", func(t *testing.T) {
+		s := newStore(t)
+		lastSeenAt := time.Now().UTC().Format("2006-01-02 15:04:05")
+		weakID := seed(t, s, "rerank-stability-a", lastSeenAt, false, 1, 1)
+		strongID := seed(t, s, "rerank-stability-z", lastSeenAt, false, 9, 9)
+
+		results := search(t, s)
+		if len(results) != 2 || results[0].ID != strongID || results[1].ID != weakID {
+			t.Fatalf("stability ordering = %+v, want strong %d before weak %d", results, strongID, weakID)
+		}
+	})
+
+	t.Run("shared preview path uses stable persisted identity tie-break", func(t *testing.T) {
+		s := newStore(t)
+		lastSeenAt := time.Now().UTC().Format("2006-01-02 15:04:05")
+		seed(t, s, "rerank-tie-b", lastSeenAt, false, 1, 1)
+		firstID := seed(t, s, "rerank-tie-a", lastSeenAt, false, 1, 1)
+
+		first := search(t, s)
+		second := search(t, s)
+		if len(first) != 2 || len(second) != 2 || first[0].ID != firstID || second[0].ID != firstID || first[0].ID != second[0].ID || first[1].ID != second[1].ID {
+			t.Fatalf("stable search ordering = first=%+v second=%+v, want sync_id tie-break order", first, second)
+		}
+
+		previews, err := s.SearchPreviewsContext(context.Background(), query, SearchOptions{Project: project, Limit: 10})
+		if err != nil {
+			t.Fatalf("search previews: %v", err)
+		}
+		if len(previews) != 2 || previews[0].ID != first[0].ID || previews[1].ID != first[1].ID {
+			t.Fatalf("preview ordering = %+v, want search ordering %+v", previews, first)
+		}
+	})
 }
 
 func TestSearch_WeightedBM25Ranking(t *testing.T) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9346,7 +9346,11 @@ func TestMigrateCreatesLowercaseObservationProjectIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("explain lowercase project predicate: %v", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			t.Errorf("close query plan rows: %v", err)
+		}
+	}()
 
 	var plan []string
 	for rows.Next() {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #958

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:question` — Question requiring tracked work
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Rerank observation FTS results with bounded pinned, recency, and stability signals while preserving raw weighted BM25 projection.
- Add deterministic cross-store tie-breaking shared by context search and search preview.
- Make case-insensitive observation project filtering indexable without changing legacy mixed-case behavior.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Adds portable composite FTS ordering and the idempotent `LOWER(project)` expression index. |
| `internal/store/store_test.go` | Covers ranking signals, deterministic ties, preview parity, legacy project matching, migration, and query-plan index use. |

## 🧪 Test Plan

- [x] Focused regressions pass: `go test ./internal/store -run '^(TestSearchCompositeLexicalReranking|TestMigrateCreatesLowercaseObservationProjectIndex)$' -count=1 -timeout=60s`
- [x] Affected package passes: `go test ./internal/store -count=1 -timeout=120s`
- [x] Search benchmark smoke passed before the portability correction: `go test ./internal/store -run '^$' -bench '^BenchmarkSearch_AllMode_Hit$' -benchtime=100ms -count=1 -timeout=120s`
- [x] Whitespace validation passes: `git diff --check`
- [ ] Full unit suite: `go test ./...` — delegated to PR CI
- [ ] E2E suite: `go test -tags e2e ./internal/server/...` — delegated to PR CI
- [ ] Lint: `make lint` — delegated to PR CI
- [ ] Manually tested the affected functionality

---

## 🤖 Automated Checks

These run automatically and all must pass before merge.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #958`)
- [x] I added exactly one `type:*` label to this PR
- [ ] I ran the full unit suite locally: `go test ./...` — CI owns broad verification
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` — CI owns broad verification
- [ ] I ran lint locally: `make lint` — CI owns broad verification
- [x] Docs are not required because no command, API, configuration, or workflow contract changed
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits
- [x] I checked every changed path against the Transient Artifact Policy

---

## 💬 Notes for Reviewers

The reranker keeps lexical relevance dominant: pinned contributes up to 10%, recency up to 6%, and revision/duplicate stability up to 4%. It uses SQLite-core arithmetic only, avoiding optional math extensions. The `Rank` field remains the existing BM25 value; the composite score affects ordering only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Search Improvements**
  * Project searches now work consistently regardless of capitalization.
  * Search results prioritize pinned, recent, and stable observations.
  * Results with similar relevance are ordered consistently across searches.
  * Search previews follow the same ranking and ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->