### PR TITLE
fix(sync): skip permanently unsatisfiable relation upserts during cloud import (#1135)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1983,6 +1983,7 @@ func cmdSync(cfg store.Config) {
 				fmt.Printf("  (%d chunks already imported)\n", result.ChunksSkipped)
 			}
 			printImportRelationCounts(result)
+			printSkippedRelationWarnings(result)
 			return
 		}
 
@@ -1998,6 +1999,7 @@ func cmdSync(cfg store.Config) {
 			fmt.Printf("  Skipped:      %d (already imported)\n", result.ChunksSkipped)
 		}
 		printImportRelationCounts(result)
+		printSkippedRelationWarnings(result)
 		return
 	}
 
@@ -2055,6 +2057,15 @@ func printImportRelationCounts(result *engramsync.ImportResult) {
 	fmt.Printf("  Relations replayed: %d\n", result.RelationsReplayed)
 	fmt.Printf("  Relations deferred: %d\n", result.RelationsDeferred)
 	fmt.Printf("  Relations dead:     %d\n", result.RelationsDead)
+}
+
+// printSkippedRelationWarnings surfaces relation upserts that were skipped
+// because their referenced observations are permanently missing (issue #1135),
+// so a stale edge is visible instead of silently dying in the deferred queue.
+func printSkippedRelationWarnings(result *engramsync.ImportResult) {
+	for _, warning := range result.SkippedRelations {
+		fmt.Printf("  WARNING skipped %s\n", warning)
+	}
 }
 
 func printSyncUsage() {

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -4874,3 +4874,62 @@ func TestCmdSyncCloudNoOpImportRendersInitialAndFinalProgress(t *testing.T) {
 		t.Fatalf("final no-op progress must precede the existing summary: %q", stdout)
 	}
 }
+
+// TestCmdSyncCloudImportPrintsSkippedRelationWarnings verifies that relation
+// upserts skipped for permanently missing endpoints surface as visible CLI
+// warnings (issue #1135) instead of dying silently in the deferred queue.
+func TestCmdSyncCloudImportPrintsSkippedRelationWarnings(t *testing.T) {
+	stubExitWithPanic(t)
+	stubRuntimeHooks(t)
+
+	originalSyncImport := syncImport
+	originalSyncImportWithProgress := syncImportWithProgress
+	originalSyncStatus := syncStatus
+	t.Cleanup(func() {
+		syncImport = originalSyncImport
+		syncImportWithProgress = originalSyncImportWithProgress
+		syncStatus = originalSyncStatus
+	})
+
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+	cfg := testConfig(t)
+
+	t.Setenv("ENGRAM_CLOUD_SERVER", "https://cloud.example.test")
+	t.Setenv("ENGRAM_CLOUD_TOKEN", "token-abc")
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	if err := s.EnrollProject("proj-a"); err != nil {
+		_ = s.Close()
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	syncImportWithProgress = func(_ *engramsync.Syncer, report func(engramsync.ImportProgress)) (*engramsync.ImportResult, error) {
+		report(engramsync.ImportProgress{Percentage: 100})
+		report(engramsync.ImportProgress{Percentage: 100})
+		return &engramsync.ImportResult{
+			ChunksImported:       1,
+			SessionsImported:     1,
+			ObservationsImported: 1,
+			SkippedRelations:     []string{"relation obs-a->obs-b: referenced observation missing permanently"},
+		}, nil
+	}
+	syncStatus = func(*engramsync.Syncer) (int, int, int, error) {
+		return 1, 1, 0, nil
+	}
+
+	withArgs(t, "engram", "sync", "--cloud", "--import", "--project", "proj-a")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("expected successful cloud import, panic=%v stderr=%q", recovered, stderr)
+	}
+	if !strings.Contains(stdout, "WARNING skipped relation obs-a->obs-b: referenced observation missing permanently") {
+		t.Fatalf("expected skipped relation warning in import output, got:\n%s", stdout)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6110,6 +6110,47 @@ func (s *Store) recordRelationApplyFailureTx(tx *sql.Tx, targetKey string, mutat
 	return true, nil
 }
 
+// EnqueueDeferredRelation persists a relation upsert as deferred retry state
+// before any apply attempt (issue #1135 cloud import): the row keeps a skipped
+// edge recoverable so a later cycle whose endpoint arrives heals it via the
+// normal deferred replay. Mirrors recordRelationApplyFailureTx's deferred row,
+// keyed the same way, resetting retry state.
+func (s *Store) EnqueueDeferredRelation(targetKey string, mutation SyncMutation) error {
+	if mutation.Entity != SyncEntityRelation {
+		return fmt.Errorf("EnqueueDeferredRelation: unsupported entity %q", mutation.Entity)
+	}
+	// Same identity recordRelationApplyFailureTx stores for deferred rows: a
+	// redelivered edge collapses onto the single pending row.
+	syncID := relationApplyFailureSyncID("deferred", targetKey, mutation)
+
+	project := strings.TrimSpace(mutation.Project)
+	payloadSyncID := ""
+	var payload syncRelationPayload
+	if decodeSyncPayload([]byte(mutation.Payload), &payload) == nil {
+		if project == "" {
+			project = strings.TrimSpace(payload.Project)
+		}
+		payloadSyncID = strings.TrimSpace(payload.SyncID)
+	}
+	project, _ = NormalizeProject(project)
+	scopeClass := "target_scoped"
+	if project != "" {
+		scopeClass = "scoped"
+	}
+
+	// INSERT OR REPLACE: re-enqueueing replaces the row with fresh deferred state.
+	if _, err := s.execHook(s.db, `
+		INSERT OR REPLACE INTO sync_apply_deferred
+			(sync_id, entity, payload, target_key, entity_key, op, payload_sync_id, project, scope_class, apply_status, retry_count, last_error, first_seen_at, last_attempted_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'deferred', 0, ?, datetime('now'), datetime('now'))
+	`, syncID, mutation.Entity, mutation.Payload, targetKey, mutation.EntityKey, mutation.Op, payloadSyncID, project, scopeClass, "skipped before apply: relation endpoint missing permanently from local store and manifest snapshot (issue #1135)"); err != nil {
+		return fmt.Errorf("EnqueueDeferredRelation: %w", err)
+	}
+
+	log.Printf("[store] EnqueueDeferredRelation entity_key=%s sync_id=%s - queued before apply (issue #1135)", mutation.EntityKey, syncID)
+	return nil
+}
+
 // ApplyPulledChunk atomically applies all mutations contained in a pulled chunk
 // and records the chunk as synced in the same transaction. This guarantees
 // retry safety: a failed chunk import leaves no partial semantic mutations.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1008,14 +1008,16 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 			// existing stall semantics.
 			applyChunk := chunk
 			var skippedEdges []string
+			var skippedMutations []store.SyncMutation
 			if dependencyOracle != nil {
-				filtered, warnings, filterErr := filterUnsatisfiableRelationUpserts(chunk, dependencyOracle)
+				filtered, skipped, warnings, filterErr := filterUnsatisfiableRelationUpserts(chunk, dependencyOracle)
 				if filterErr != nil {
 					return nil, filterErr
 				}
 				if len(warnings) > 0 {
 					applyChunk = filtered
 					skippedEdges = warnings
+					skippedMutations = skipped
 				}
 			}
 
@@ -1050,6 +1052,12 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 			result.PromptsImported += importResult.PromptsImported
 			if len(skippedEdges) > 0 {
 				result.SkippedRelations = append(result.SkippedRelations, skippedEdges...)
+				// #1135 correction: queue dropped edges so the skip stays reversible.
+				for _, skipped := range skippedMutations {
+					if err := sy.store.EnqueueDeferredRelation(sy.chunkTrackingTargetKey(""), skipped); err != nil {
+						return nil, fmt.Errorf("defer skipped relation %s: %w", skipped.EntityKey, err)
+					}
+				}
 			}
 			if afterCommit != nil {
 				afterCommit()
@@ -1241,15 +1249,16 @@ func (sy *Syncer) pendingObservationSyncIDs(entries []ChunkEntry, knownChunks ma
 
 // filterUnsatisfiableRelationUpserts returns the chunk with relation upserts
 // removed when at least one endpoint is provably unsatisfiable, together with
-// one visible warning per skipped edge. Mutations that cannot be classified
-// (undecodable payload, blank endpoints) are kept so the store keeps handling
-// them unchanged.
-func filterUnsatisfiableRelationUpserts(chunk ChunkData, oracle *importDependencyOracle) (ChunkData, []string, error) {
+// the removed mutations and one visible warning per skipped edge. Mutations
+// that cannot be classified (undecodable payload, blank endpoints) are kept so
+// the store keeps handling them unchanged.
+func filterUnsatisfiableRelationUpserts(chunk ChunkData, oracle *importDependencyOracle) (ChunkData, []store.SyncMutation, []string, error) {
 	if len(chunk.Mutations) == 0 {
 		// Legacy array chunks carry no relation upserts.
-		return chunk, nil, nil
+		return chunk, nil, nil, nil
 	}
 	filtered := make([]store.SyncMutation, 0, len(chunk.Mutations))
+	skipped := make([]store.SyncMutation, 0)
 	warnings := make([]string, 0)
 	changed := false
 	for _, mutation := range chunk.Mutations {
@@ -1264,25 +1273,26 @@ func filterUnsatisfiableRelationUpserts(chunk ChunkData, oracle *importDependenc
 		}
 		sourceOK, err := oracle.endpointSatisfiable(sourceID)
 		if err != nil {
-			return chunk, nil, err
+			return chunk, nil, nil, err
 		}
 		targetOK, err := oracle.endpointSatisfiable(targetID)
 		if err != nil {
-			return chunk, nil, err
+			return chunk, nil, nil, err
 		}
 		if sourceOK && targetOK {
 			filtered = append(filtered, mutation)
 			continue
 		}
 		changed = true
+		skipped = append(skipped, mutation)
 		warnings = append(warnings, fmt.Sprintf("relation %s->%s: referenced observation missing permanently", sourceID, targetID))
 	}
 	if !changed {
-		return chunk, nil, nil
+		return chunk, nil, nil, nil
 	}
 	filteredChunk := chunk
 	filteredChunk.Mutations = filtered
-	return filteredChunk, warnings, nil
+	return filteredChunk, skipped, warnings, nil
 }
 
 // relationUpsertEndpoints decodes the endpoints of a relation upsert payload.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1021,6 +1021,19 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 				}
 			}
 
+			// #1135 correction: enqueue dropped edges BEFORE the filtered chunk can
+			// be applied, so the deferred row is durable before the chunk can be
+			// committed and marked synced. A crash in between can only leave a
+			// queued, replayable edge — never a lost one — and an enqueue error
+			// aborts before any chunk mutation.
+			if len(skippedEdges) > 0 {
+				for _, skipped := range skippedMutations {
+					if err := sy.store.EnqueueDeferredRelation(sy.chunkTrackingTargetKey(""), skipped); err != nil {
+						return nil, fmt.Errorf("defer skipped relation %s: %w", skipped.EntityKey, err)
+					}
+				}
+			}
+
 			if err := sy.importMutationChunk(entry.ID, applyChunk); err != nil {
 				if mode == importModeLocal {
 					recoveredChunk, recovered, recoveryErr := sy.recoverLocalMissingSessionDependencies(chunk, availableSessionIDs)
@@ -1052,12 +1065,6 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 			result.PromptsImported += importResult.PromptsImported
 			if len(skippedEdges) > 0 {
 				result.SkippedRelations = append(result.SkippedRelations, skippedEdges...)
-				// #1135 correction: queue dropped edges so the skip stays reversible.
-				for _, skipped := range skippedMutations {
-					if err := sy.store.EnqueueDeferredRelation(sy.chunkTrackingTargetKey(""), skipped); err != nil {
-						return nil, fmt.Errorf("defer skipped relation %s: %w", skipped.EntityKey, err)
-					}
-				}
 			}
 			if afterCommit != nil {
 				afterCommit()

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -121,6 +121,10 @@ type ImportResult struct {
 	RelationsReplayed    int `json:"relations_replayed"`
 	RelationsDeferred    int `json:"relations_deferred"`
 	RelationsDead        int `json:"relations_dead"`
+	// SkippedRelations records relation upserts that were provably
+	// unsatisfiable (their referenced observations are permanently absent)
+	// and were skipped instead of stalling the import. One entry per edge.
+	SkippedRelations []string `json:"skipped_relations,omitempty"`
 }
 
 // ImportProgress is a point-in-time snapshot of an import. Percentage uses the
@@ -961,6 +965,15 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 		}
 	}
 
+	// Cloud only (issue #1135): a relation upsert whose endpoints can never
+	// exist locally would otherwise be deferred by the store and silently die
+	// after repeated replays, with nothing telling the operator why. Classify
+	// such edges before apply and surface them as visible warnings instead.
+	var dependencyOracle *importDependencyOracle
+	if mode == importModeCloud {
+		dependencyOracle = newImportDependencyOracle(sy, entries, knownChunks)
+	}
+
 	lastErrors := map[string]error{}
 	for pass := 1; len(pendingEntries) > 0; pass++ {
 		progress := false
@@ -988,7 +1001,25 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 				}
 			}
 
-			if err := sy.importMutationChunk(entry.ID, chunk); err != nil {
+			// Issue #1135: in cloud mode, drop relation upserts whose endpoints
+			// are provably unsatisfiable before apply. A filtered chunk that
+			// still fails re-enters the normal retry loop below with its
+			// original, unfiltered mutations, so every other failure keeps the
+			// existing stall semantics.
+			applyChunk := chunk
+			var skippedEdges []string
+			if dependencyOracle != nil {
+				filtered, warnings, filterErr := filterUnsatisfiableRelationUpserts(chunk, dependencyOracle)
+				if filterErr != nil {
+					return nil, filterErr
+				}
+				if len(warnings) > 0 {
+					applyChunk = filtered
+					skippedEdges = warnings
+				}
+			}
+
+			if err := sy.importMutationChunk(entry.ID, applyChunk); err != nil {
 				if mode == importModeLocal {
 					recoveredChunk, recovered, recoveryErr := sy.recoverLocalMissingSessionDependencies(chunk, availableSessionIDs)
 					if recoveryErr != nil {
@@ -1017,6 +1048,9 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 			result.SessionsImported += importResult.SessionsImported
 			result.ObservationsImported += importResult.ObservationsImported
 			result.PromptsImported += importResult.PromptsImported
+			if len(skippedEdges) > 0 {
+				result.SkippedRelations = append(result.SkippedRelations, skippedEdges...)
+			}
 			if afterCommit != nil {
 				afterCommit()
 			}
@@ -1069,6 +1103,205 @@ func (sy *Syncer) importMutationChunk(chunkID string, chunk ChunkData) error {
 	mutations := buildImportMutations(chunk)
 	mutations = orderMutationsForApply(mutations)
 	return storeApplyPulledChunk(sy.store, sy.chunkTrackingTargetKey(""), chunkID, mutations)
+}
+
+// ─── Issue #1135: permanently unsatisfiable relation upserts ─────────────────
+//
+// The store defers a pulled relation whose endpoints are missing
+// (recordRelationApplyFailureTx), which lets the chunk import but parks the
+// edge in sync_apply_deferred until it silently dies after repeated replays.
+// When an endpoint was deleted hub-side and no chunk re-upserts it, that
+// deferral can never converge and nothing tells the operator why. The cloud
+// import path therefore classifies relation upserts before apply: an edge
+// whose endpoints are absent from the local store (in any deletion state) and
+// from every chunk still pending in this run is provably unsatisfiable — a
+// chunk already imported during the same run has its observations in the
+// store, so the store lookup covers it. Such an edge is skipped and reported
+// as a visible warning on ImportResult.SkippedRelations. Everything else keeps
+// the original apply/stall behavior, and local import is untouched.
+
+// importDependencyOracle resolves whether a relation endpoint can ever be
+// satisfied locally: it exists in the store, or arrives with a chunk still
+// pending in this import run. The pending set is built lazily on the first
+// relation classification, so relation-free imports never pay for extra chunk
+// reads; chunks imported before that point are covered by the store lookup.
+type importDependencyOracle struct {
+	sy                    *Syncer
+	entries               []ChunkEntry
+	knownChunks           map[string]bool
+	pendingObservationIDs map[string]struct{}
+	built                 bool
+	buildErr              error
+	allObservationSyncIDs map[string]struct{}
+	exported              bool
+	exportErr             error
+}
+
+func newImportDependencyOracle(sy *Syncer, entries []ChunkEntry, knownChunks map[string]bool) *importDependencyOracle {
+	return &importDependencyOracle{
+		sy:          sy,
+		entries:     entries,
+		knownChunks: knownChunks,
+	}
+}
+
+// endpointSatisfiable reports whether an observation sync_id exists locally in
+// any deletion state or arrives with a chunk still pending in this run.
+// GetObservationBySyncID excludes soft-deleted rows, but the store's relation
+// FK precondition (applyRelationUpsertTx) counts them: an edge whose endpoint
+// is a local tombstone still applies today and must never be skipped. Only a
+// full scan (Export includes tombstones) can distinguish tombstoned endpoints
+// from permanently absent ones, so it runs lazily, at most once per import.
+func (o *importDependencyOracle) endpointSatisfiable(syncID string) (bool, error) {
+	syncID = strings.TrimSpace(syncID)
+	if syncID == "" {
+		return false, nil
+	}
+	if err := o.ensurePendingObservationIDs(); err != nil {
+		return false, err
+	}
+	if _, pending := o.pendingObservationIDs[syncID]; pending {
+		return true, nil
+	}
+	if _, err := o.sy.store.GetObservationBySyncID(syncID); err == nil {
+		return true, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("check relation endpoint %s: %w", syncID, err)
+	}
+	if !o.exported {
+		data, err := storeExportData(o.sy.store)
+		if err != nil {
+			o.exported = true
+			o.exportErr = err
+			return false, fmt.Errorf("check relation endpoints: %w", err)
+		}
+		o.allObservationSyncIDs = make(map[string]struct{}, len(data.Observations))
+		for _, obs := range data.Observations {
+			if id := strings.TrimSpace(obs.SyncID); id != "" {
+				o.allObservationSyncIDs[id] = struct{}{}
+			}
+		}
+		o.exported = true
+	}
+	if o.exportErr != nil {
+		return false, fmt.Errorf("check relation endpoints: %w", o.exportErr)
+	}
+	_, known := o.allObservationSyncIDs[syncID]
+	return known, nil
+}
+
+// ensurePendingObservationIDs builds the pending observation set on first use.
+// A pending chunk that cannot be read or parsed fails the import before the
+// first relation-bearing chunk applies, so no edge is ever classified against
+// an incomplete pending set.
+func (o *importDependencyOracle) ensurePendingObservationIDs() error {
+	if o.built {
+		return o.buildErr
+	}
+	o.built = true
+	pending, err := o.sy.pendingObservationSyncIDs(o.entries, o.knownChunks)
+	if err != nil {
+		o.buildErr = err
+		return err
+	}
+	o.pendingObservationIDs = pending
+	return nil
+}
+
+// pendingObservationSyncIDs collects the observation sync_ids upserted by any
+// chunk that is still pending for this import run.
+func (sy *Syncer) pendingObservationSyncIDs(entries []ChunkEntry, knownChunks map[string]bool) (map[string]struct{}, error) {
+	pending := make(map[string]struct{})
+	for _, entry := range entries {
+		if knownChunks[entry.ID] {
+			continue
+		}
+		chunkJSON, err := sy.transport.ReadChunk(entry.ID)
+		if err != nil {
+			if errors.Is(err, ErrChunkNotFound) {
+				return nil, fmt.Errorf("read chunk %s: manifest references missing remote chunk", entry.ID)
+			}
+			return nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
+		}
+		var chunk ChunkData
+		if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+			return nil, fmt.Errorf("parse chunk %s: %w", entry.ID, err)
+		}
+		for _, mutation := range buildImportMutations(chunk) {
+			if mutation.Entity != store.SyncEntityObservation || mutation.Op != store.SyncOpUpsert {
+				continue
+			}
+			if obsID := strings.TrimSpace(mutation.EntityKey); obsID != "" {
+				pending[obsID] = struct{}{}
+			}
+		}
+	}
+	return pending, nil
+}
+
+// filterUnsatisfiableRelationUpserts returns the chunk with relation upserts
+// removed when at least one endpoint is provably unsatisfiable, together with
+// one visible warning per skipped edge. Mutations that cannot be classified
+// (undecodable payload, blank endpoints) are kept so the store keeps handling
+// them unchanged.
+func filterUnsatisfiableRelationUpserts(chunk ChunkData, oracle *importDependencyOracle) (ChunkData, []string, error) {
+	if len(chunk.Mutations) == 0 {
+		// Legacy array chunks carry no relation upserts.
+		return chunk, nil, nil
+	}
+	filtered := make([]store.SyncMutation, 0, len(chunk.Mutations))
+	warnings := make([]string, 0)
+	changed := false
+	for _, mutation := range chunk.Mutations {
+		if mutation.Entity != store.SyncEntityRelation || mutation.Op != store.SyncOpUpsert {
+			filtered = append(filtered, mutation)
+			continue
+		}
+		sourceID, targetID, classifiable := relationUpsertEndpoints(mutation)
+		if !classifiable {
+			filtered = append(filtered, mutation)
+			continue
+		}
+		sourceOK, err := oracle.endpointSatisfiable(sourceID)
+		if err != nil {
+			return chunk, nil, err
+		}
+		targetOK, err := oracle.endpointSatisfiable(targetID)
+		if err != nil {
+			return chunk, nil, err
+		}
+		if sourceOK && targetOK {
+			filtered = append(filtered, mutation)
+			continue
+		}
+		changed = true
+		warnings = append(warnings, fmt.Sprintf("relation %s->%s: referenced observation missing permanently", sourceID, targetID))
+	}
+	if !changed {
+		return chunk, nil, nil
+	}
+	filteredChunk := chunk
+	filteredChunk.Mutations = filtered
+	return filteredChunk, warnings, nil
+}
+
+// relationUpsertEndpoints decodes the endpoints of a relation upsert payload.
+// classifiable is false when the payload cannot be judged (decode failure or
+// blank endpoints); the caller keeps the mutation so the store classifies it.
+func relationUpsertEndpoints(mutation store.SyncMutation) (sourceID, targetID string, classifiable bool) {
+	var payload struct {
+		SourceID string `json:"source_id"`
+		TargetID string `json:"target_id"`
+	}
+	if err := decodeSyncPayloadForProject([]byte(mutation.Payload), &payload); err != nil {
+		return "", "", false
+	}
+	sourceID = strings.TrimSpace(payload.SourceID)
+	targetID = strings.TrimSpace(payload.TargetID)
+	if sourceID == "" || targetID == "" {
+		return "", "", false
+	}
+	return sourceID, targetID, true
 }
 
 func importDependencyError(chunk ChunkData, err error) error {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -3936,7 +3936,8 @@ func TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk(t *testi
 // TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing pins the issue
 // #1135 contract for cloud import: a relation whose target observation is
 // absent from the local store and from every chunk is skipped with a visible
-// warning while the rest of the chunk imports and the chunk is marked synced.
+// warning while the rest of the chunk imports and the chunk is marked synced;
+// the skip stays recoverable via the deferred queue.
 func TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing(t *testing.T) {
 	dst := newTestStore(t)
 	if err := dst.EnrollProject("proj-a"); err != nil {
@@ -3995,12 +3996,9 @@ func TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing(t *testing.T) 
 	if len(result.SkippedRelations) != 1 || result.SkippedRelations[0] != wantWarning {
 		t.Fatalf("expected one skipped relation warning %q, got %+v", wantWarning, result.SkippedRelations)
 	}
-	deferred, dead, err := dst.CountDeferredAndDead()
-	if err != nil {
-		t.Fatalf("count deferred relation: %v", err)
-	}
-	if deferred != 0 || dead != 0 {
-		t.Fatalf("expected the skipped edge to bypass the deferred queue, got deferred=%d dead=%d", deferred, dead)
+	rows, err := dst.ListDeferred(store.ListDeferredOptions{})
+	if err != nil || len(rows) != 1 || rows[0].EntityKey != "rel-missing-endpoint" || rows[0].ApplyStatus != "deferred" {
+		t.Fatalf("expected the skipped edge queued as the only deferred row, err=%v rows=%+v", err, rows)
 	}
 	synced, err := dst.GetSyncedChunksForTarget(cloudTargetKey("proj-a"))
 	if err != nil {
@@ -4008,6 +4006,54 @@ func TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing(t *testing.T) 
 	}
 	if !synced[chunkID] {
 		t.Fatalf("expected chunk %q with a deferred relation to be marked synced", chunkID)
+	}
+}
+
+// TestCloudImportDeferredRelationHealsWhenLateEndpointArrives verifies the
+// reversible side of the #1135 pre-apply skip: an edge skipped because its
+// endpoint had not reached the local store yet stays queued as deferred retry
+// state, and the importer's post-import replay heals it once the endpoint
+// arrives, instead of losing the relation permanently.
+func TestCloudImportDeferredRelationHealsWhenLateEndpointArrives(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: "chunk-1135-late-endpoint", CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks["chunk-1135-late-endpoint"] = mustJSONChunk(t, "chunk-1135-late-endpoint", relationMissingEndpointChunk("sess-1135-late", "obs-1135-late-a", "obs-1135-late-b", "rel-1135-late"))
+
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+	first, err := importer.Import()
+	if err != nil || len(first.SkippedRelations) != 1 {
+		t.Fatalf("expected import to skip the unsatisfiable edge with a warning, err=%v result=%+v", err, first)
+	}
+	rows, err := s.ListDeferred(store.ListDeferredOptions{Status: "deferred"})
+	if err != nil || len(rows) != 1 || rows[0].EntityKey != "rel-1135-late" {
+		t.Fatalf("expected the skipped edge queued as deferred, err=%v rows=%+v", err, rows)
+	}
+	// Later cycle: the endpoint reaches the local store outside any chunk.
+	if err := s.ApplyPulledMutation(cloudTargetKey("proj-a"), store.SyncMutation{
+		Seq:       4,
+		Entity:    store.SyncEntityObservation,
+		EntityKey: "obs-1135-late-b",
+		Op:        store.SyncOpUpsert,
+		Payload:   `{"sync_id":"obs-1135-late-b","session_id":"sess-1135-late","type":"decision","title":"late endpoint","content":"arrives after the manifest snapshot","project":"proj-a","scope":"project"}`,
+	}); err != nil {
+		t.Fatalf("apply late endpoint: %v", err)
+	}
+
+	// The importer's post-import replay (finalizeImport -> ReplayDeferredForScope).
+	final, err := importer.finalizeImport(&ImportResult{})
+	if err != nil || final.RelationsReplayed != 1 || final.RelationsDeferred != 0 || final.RelationsDead != 0 {
+		t.Fatalf("expected the deferred edge to replay successfully, err=%v result=%+v", err, final)
+	}
+	if _, err := s.GetRelation("rel-1135-late"); err != nil {
+		t.Fatalf("expected deferred relation to heal once the late endpoint arrives: %v", err)
+	}
+	rows, err = s.ListDeferred(store.ListDeferredOptions{Status: "deferred"})
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("expected the deferred row deleted after successful replay, err=%v rows=%+v", err, rows)
 	}
 }
 
@@ -4862,7 +4908,7 @@ func TestCloudImportHandlesRelationWithPermanentlyMissingEndpoint(t *testing.T) 
 			wantSkippedEdges: []string{
 				"relation obs-1135-a->obs-1135-deleted: referenced observation missing permanently",
 			},
-			wantDeferred: 0,
+			wantDeferred: 1,
 			wantDead:     0,
 			assertStore: func(t *testing.T, s *store.Store) {
 				t.Helper()
@@ -5029,6 +5075,11 @@ func TestCloudImportSkippedRelationWarningsAreIdempotent(t *testing.T) {
 	}
 	if second.ChunksSkipped != 1 {
 		t.Fatalf("expected chunk to be skipped as already known, got %+v", second)
+	}
+	// The known chunk must not re-enqueue: retry_count advanced 1 -> 2 above.
+	rows, err := s.ListDeferred(store.ListDeferredOptions{Status: "deferred"})
+	if err != nil || len(rows) != 1 || rows[0].EntityKey != "rel-1135-again" || rows[0].RetryCount != 2 {
+		t.Fatalf("expected the deferred row to survive re-import without re-enqueue, err=%v rows=%+v", err, rows)
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4057,6 +4057,73 @@ func TestCloudImportDeferredRelationHealsWhenLateEndpointArrives(t *testing.T) {
 	}
 }
 
+// TestCloudImportSkippedRelationEnqueuedBeforeChunkSynced pins the #1135
+// atomicity ordering: the skipped edge's deferred row is durable before the
+// chunk can be applied and marked synced — a crash leaves a queued, replayable edge.
+func TestCloudImportSkippedRelationEnqueuedBeforeChunkSynced(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: "chunk-1135-atomic", CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks["chunk-1135-atomic"] = mustJSONChunk(t, "chunk-1135-atomic", relationMissingEndpointChunk("sess-1135-atomic", "obs-1135-atomic-a", "obs-1135-atomic-b", "rel-1135-atomic"))
+	origApply := storeApplyPulledChunk
+	storeApplyPulledChunk = func(*store.Store, string, string, []store.SyncMutation) error {
+		return errors.New("crash between enqueue and chunk apply")
+	}
+	defer func() { storeApplyPulledChunk = origApply }()
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+	if _, err := importer.Import(); err == nil {
+		t.Fatal("expected the failed chunk apply to abort the import")
+	}
+	synced, err := s.GetSyncedChunksForTarget(cloudTargetKey("proj-a"))
+	if err != nil || synced["chunk-1135-atomic"] {
+		t.Fatalf("crashed chunk must not be marked synced, err=%v synced=%+v", err, synced)
+	}
+	rows, err := s.ListDeferred(store.ListDeferredOptions{Status: "deferred"})
+	if err != nil || len(rows) != 1 || rows[0].EntityKey != "rel-1135-atomic" {
+		t.Fatalf("skipped edge must stay queued after the crash, err=%v rows=%+v", err, rows)
+	}
+	storeApplyPulledChunk = origApply // remove the failure: recovery import applies the chunk, replay heals the edge
+	if _, err := importer.Import(); err != nil {
+		t.Fatalf("expected recovery import to apply the chunk, err=%v", err)
+	}
+	if err := s.ApplyPulledMutation(cloudTargetKey("proj-a"), store.SyncMutation{Seq: 4, Entity: store.SyncEntityObservation, EntityKey: "obs-1135-atomic-b", Op: store.SyncOpUpsert, Payload: `{"sync_id":"obs-1135-atomic-b","session_id":"sess-1135-atomic","type":"decision","title":"late endpoint","content":"arrives before the replay","project":"proj-a","scope":"project"}`}); err != nil {
+		t.Fatalf("apply late endpoint: %v", err)
+	}
+	final, err := importer.finalizeImport(&ImportResult{})
+	if err != nil || final.RelationsReplayed != 1 || final.RelationsDeferred != 0 || final.RelationsDead != 0 {
+		t.Fatalf("expected the queued edge to heal via replay, err=%v result=%+v", err, final)
+	}
+}
+
+// TestCloudImportEnqueueErrorAbortsBeforeChunkMutation pins the enqueue-error half: the import aborts before any chunk mutation, leaving the chunk unsynced.
+func TestCloudImportEnqueueErrorAbortsBeforeChunkMutation(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: "chunk-1135-enqueue-error", CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks["chunk-1135-enqueue-error"] = mustJSONChunk(t, "chunk-1135-enqueue-error", relationMissingEndpointChunk("sess-1135-enqueue-error", "obs-1135-enqueue-a", "obs-1135-enqueue-b", "rel-1135-enqueue-error"))
+	// Break the deferred queue itself so the pre-apply enqueue fails.
+	if _, err := s.DB().Exec(`DROP TABLE sync_apply_deferred`); err != nil {
+		t.Fatalf("drop deferred queue: %v", err)
+	}
+	_, err := NewCloudWithTransport(s, transport, "proj-a").Import()
+	if err == nil || !strings.Contains(err.Error(), "defer skipped relation") {
+		t.Fatalf("expected the enqueue failure to abort the import, got %v", err)
+	}
+	synced, err := s.GetSyncedChunksForTarget(cloudTargetKey("proj-a"))
+	if err != nil || synced["chunk-1135-enqueue-error"] {
+		t.Fatalf("aborted chunk must not be marked synced, err=%v synced=%+v", err, synced)
+	}
+	if _, err := s.GetObservationBySyncID("obs-1135-enqueue-a"); err == nil {
+		t.Fatal("aborted import must not apply any chunk mutation")
+	}
+}
+
 func TestCloudImportEmptyProjectDoesNotReplayAnotherProjectDeferredRelation(t *testing.T) {
 	dst := newTestStore(t)
 	for _, project := range []string{"project-a", "project-b"} {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2699,7 +2699,7 @@ func TestImportBranches(t *testing.T) {
 		if err != nil {
 			t.Fatalf("import: %v", err)
 		}
-		if *res != (ImportResult{}) {
+		if res.ChunksImported != 0 || res.ChunksSkipped != 0 || res.SessionsImported != 0 || res.ObservationsImported != 0 || res.PromptsImported != 0 || res.RelationsReplayed != 0 || res.RelationsDeferred != 0 || res.RelationsDead != 0 || len(res.SkippedRelations) != 0 {
 			t.Fatalf("expected empty result, got %+v", res)
 		}
 	})
@@ -3933,7 +3933,11 @@ func TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk(t *testi
 	}
 }
 
-func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
+// TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing pins the issue
+// #1135 contract for cloud import: a relation whose target observation is
+// absent from the local store and from every chunk is skipped with a visible
+// warning while the rest of the chunk imports and the chunk is marked synced.
+func TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing(t *testing.T) {
 	dst := newTestStore(t)
 	if err := dst.EnrollProject("proj-a"); err != nil {
 		t.Fatalf("enroll destination project: %v", err)
@@ -3973,7 +3977,7 @@ func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
 	}
 	result, err := NewCloudWithTransport(dst, transport, "proj-a").Import()
 	if err != nil {
-		t.Fatalf("import should defer the missing relation endpoint, got %v", err)
+		t.Fatalf("import should skip the permanently missing relation endpoint, got %v", err)
 	}
 	if result.ChunksImported != 1 || result.SessionsImported != 1 || result.ObservationsImported != 1 {
 		t.Fatalf("unexpected import result: %+v", result)
@@ -3987,12 +3991,16 @@ func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
 	if _, err := dst.GetRelation("rel-missing-endpoint"); err == nil {
 		t.Fatal("expected unresolved relation to remain unapplied")
 	}
+	wantWarning := "relation obs-rollback-source->obs-missing-target: referenced observation missing permanently"
+	if len(result.SkippedRelations) != 1 || result.SkippedRelations[0] != wantWarning {
+		t.Fatalf("expected one skipped relation warning %q, got %+v", wantWarning, result.SkippedRelations)
+	}
 	deferred, dead, err := dst.CountDeferredAndDead()
 	if err != nil {
 		t.Fatalf("count deferred relation: %v", err)
 	}
-	if deferred != 1 || dead != 0 {
-		t.Fatalf("expected one deferred relation and no dead relations, got deferred=%d dead=%d", deferred, dead)
+	if deferred != 0 || dead != 0 {
+		t.Fatalf("expected the skipped edge to bypass the deferred queue, got deferred=%d dead=%d", deferred, dead)
 	}
 	synced, err := dst.GetSyncedChunksForTarget(cloudTargetKey("proj-a"))
 	if err != nil {
@@ -4792,5 +4800,368 @@ func TestCloudSyncPreservesPiPromptIdentityUnderProjectScope(t *testing.T) {
 		if p.SyncID == saved.SyncID {
 			t.Fatalf("prompt %q strayed into project %q after the round trip", saved.SyncID, otherProject)
 		}
+	}
+}
+
+// ─── Issue #1135: chunk referencing a deleted observation ────────────────────
+
+// relationMissingEndpointChunk builds the issue #1135 scenario payload: a chunk
+// carrying a session upsert, one observation upsert, and a relation upsert whose
+// target observation was deleted hub-side and is absent from every chunk and
+// from the local store.
+func relationMissingEndpointChunk(sessionID, obsA, obsB, relationID string) ChunkData {
+	return ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntitySession,
+			EntityKey: sessionID,
+			Op:        store.SyncOpUpsert,
+			Payload:   fmt.Sprintf(`{"id":%q,"project":"proj-a","directory":"/tmp/proj-a"}`, sessionID),
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: obsA,
+			Op:        store.SyncOpUpsert,
+			Payload:   fmt.Sprintf(`{"sync_id":%q,"session_id":%q,"type":"decision","title":"endpoint a","content":"source endpoint","project":"proj-a","scope":"project"}`, obsA, sessionID),
+		},
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: relationID,
+			Op:        store.SyncOpUpsert,
+			Payload:   fmt.Sprintf(`{"sync_id":%q,"source_id":%q,"target_id":%q,"relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`, relationID, obsA, obsB),
+		},
+	}}
+}
+
+// TestCloudImportHandlesRelationWithPermanentlyMissingEndpoint reproduces issue
+// #1135: a cloud chunk whose relation upsert references an observation that can
+// never arrive (deleted hub-side, absent from every chunk and from the local
+// store) must not stall the dependency-safe import loop. The provably
+// unsatisfiable edge is skipped with a visible warning while the rest of the
+// chunk imports.
+func TestCloudImportHandlesRelationWithPermanentlyMissingEndpoint(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		mode             importMode
+		relChunkID       string
+		relChunk         ChunkData
+		extraChunkID     string
+		extraChunk       ChunkData
+		wantErr          bool
+		wantChunks       int
+		wantSkippedEdges []string
+		wantDeferred     int
+		wantDead         int
+		assertStore      func(t *testing.T, s *store.Store)
+	}{
+		{
+			name:       "permanently missing endpoint skips relation and imports chunk",
+			mode:       importModeCloud,
+			relChunkID: "chunk-1135-permanent",
+			relChunk:   relationMissingEndpointChunk("sess-1135", "obs-1135-a", "obs-1135-deleted", "rel-1135"),
+			wantChunks: 1,
+			wantSkippedEdges: []string{
+				"relation obs-1135-a->obs-1135-deleted: referenced observation missing permanently",
+			},
+			wantDeferred: 0,
+			wantDead:     0,
+			assertStore: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				if _, err := s.GetSession("sess-1135"); err != nil {
+					t.Fatalf("expected session from the stalled chunk to import: %v", err)
+				}
+				if _, err := s.GetObservationBySyncID("obs-1135-a"); err != nil {
+					t.Fatalf("expected observation from the stalled chunk to import: %v", err)
+				}
+				if _, err := s.GetRelation("rel-1135"); err == nil {
+					t.Fatal("expected relation with permanently missing endpoint to stay unapplied")
+				}
+			},
+		},
+		{
+			name:         "endpoint arriving in another pending chunk resolves without skipping",
+			mode:         importModeCloud,
+			relChunkID:   "chunk-1135-rel-first",
+			relChunk:     relationMissingEndpointChunk("sess-1135-cross", "obs-1135-c", "obs-1135-d", "rel-1135-cross"),
+			extraChunkID: "chunk-1135-obs-second",
+			extraChunk: ChunkData{Mutations: []store.SyncMutation{
+				{
+					Entity:    store.SyncEntitySession,
+					EntityKey: "sess-1135-endpoints",
+					Op:        store.SyncOpUpsert,
+					Payload:   `{"id":"sess-1135-endpoints","project":"proj-a","directory":"/tmp/proj-a"}`,
+				},
+				{
+					Entity:    store.SyncEntityObservation,
+					EntityKey: "obs-1135-c",
+					Op:        store.SyncOpUpsert,
+					Payload:   `{"sync_id":"obs-1135-c","session_id":"sess-1135-endpoints","type":"decision","title":"c","content":"endpoint c","project":"proj-a","scope":"project"}`,
+				},
+				{
+					Entity:    store.SyncEntityObservation,
+					EntityKey: "obs-1135-d",
+					Op:        store.SyncOpUpsert,
+					Payload:   `{"sync_id":"obs-1135-d","session_id":"sess-1135-endpoints","type":"decision","title":"d","content":"endpoint d","project":"proj-a","scope":"project"}`,
+				},
+			}},
+			wantChunks:       2,
+			wantSkippedEdges: nil,
+			wantDeferred:     0,
+			wantDead:         0,
+			assertStore: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				relation, err := s.GetRelation("rel-1135-cross")
+				if err != nil {
+					t.Fatalf("expected cross-chunk relation to resolve through normal passes: %v", err)
+				}
+				if relation.SourceID != "obs-1135-c" || relation.TargetID != "obs-1135-d" {
+					t.Fatalf("unexpected cross-chunk relation: %+v", relation)
+				}
+			},
+		},
+		{
+			name:       "local import keeps current deferral behavior for missing endpoints",
+			mode:       importModeLocal,
+			relChunkID: "chunk-1135-local",
+			relChunk:   relationMissingEndpointChunk("sess-1135-local", "obs-1135-local", "obs-1135-local-missing", "rel-1135-local"),
+			wantChunks: 1,
+			// Local mode is untouched by this fix: the store defers the
+			// FK-missing relation and no skip warning is produced.
+			wantSkippedEdges: nil,
+			wantDeferred:     1,
+			wantDead:         0,
+			assertStore: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				if _, err := s.GetObservationBySyncID("obs-1135-local"); err != nil {
+					t.Fatalf("expected observation to import in local mode: %v", err)
+				}
+				if _, err := s.GetRelation("rel-1135-local"); err == nil {
+					t.Fatal("expected unresolved relation to remain unapplied in local mode")
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestStore(t)
+
+			var importer *Syncer
+			if tt.mode == importModeCloud {
+				if err := s.EnrollProject("proj-a"); err != nil {
+					t.Fatalf("enroll project: %v", err)
+				}
+				transport := newFakeCloudTransport()
+				entries := []ChunkEntry{{ID: tt.relChunkID, CreatedAt: "2026-08-25T00:00:00Z"}}
+				transport.chunks[tt.relChunkID] = mustJSONChunk(t, tt.relChunkID, tt.relChunk)
+				if tt.extraChunkID != "" {
+					entries = append(entries, ChunkEntry{ID: tt.extraChunkID, CreatedAt: "2026-08-25T00:01:00Z"})
+					transport.chunks[tt.extraChunkID] = mustJSONChunk(t, tt.extraChunkID, tt.extraChunk)
+				}
+				transport.manifest = &Manifest{Version: 1, Chunks: entries}
+				importer = NewCloudWithTransport(s, transport, "proj-a")
+			} else {
+				syncDir := t.TempDir()
+				writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: tt.relChunkID, CreatedAt: "2026-08-25T00:00:00Z"}}})
+				writeLocalChunkFile(t, syncDir, tt.relChunkID, tt.relChunk)
+				importer = New(s, syncDir)
+			}
+
+			result, err := importer.Import()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected import to fail")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("import: %v", err)
+			}
+			if result.ChunksImported != tt.wantChunks {
+				t.Fatalf("expected %d imported chunks, got %+v", tt.wantChunks, result)
+			}
+			if got := strings.Join(tt.wantSkippedEdges, "\n"); got != "" {
+				if len(result.SkippedRelations) != len(tt.wantSkippedEdges) {
+					t.Fatalf("expected skipped relations %q, got %+v", got, result.SkippedRelations)
+				}
+				for i, want := range tt.wantSkippedEdges {
+					if result.SkippedRelations[i] != want {
+						t.Fatalf("skipped relation %d: want %q, got %q", i, want, result.SkippedRelations[i])
+					}
+				}
+			} else if len(result.SkippedRelations) != 0 {
+				t.Fatalf("expected no skipped relations, got %+v", result.SkippedRelations)
+			}
+			deferred, dead, err := s.CountDeferredAndDead()
+			if err != nil {
+				t.Fatalf("count deferred and dead: %v", err)
+			}
+			if deferred != tt.wantDeferred || dead != tt.wantDead {
+				t.Fatalf("unexpected deferred state: deferred=%d dead=%d, want deferred=%d dead=%d", deferred, dead, tt.wantDeferred, tt.wantDead)
+			}
+			tt.assertStore(t, s)
+		})
+	}
+}
+
+// TestCloudImportSkippedRelationWarningsAreIdempotent verifies that re-running
+// the same cloud import does not re-warn: the offending chunk is already known,
+// so the second run reports no skipped relations.
+func TestCloudImportSkippedRelationWarningsAreIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-1135-idempotent"
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks[chunkID] = mustJSONChunk(t, chunkID, relationMissingEndpointChunk("sess-1135-again", "obs-1135-again", "obs-1135-gone", "rel-1135-again"))
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+
+	first, err := importer.Import()
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	if len(first.SkippedRelations) != 1 {
+		t.Fatalf("expected one skipped relation on first import, got %+v", first)
+	}
+
+	second, err := importer.Import()
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if len(second.SkippedRelations) != 0 {
+		t.Fatalf("expected no skipped relations on idempotent re-import, got %+v", second)
+	}
+	if second.ChunksSkipped != 1 {
+		t.Fatalf("expected chunk to be skipped as already known, got %+v", second)
+	}
+}
+
+func mustJSONChunk(t *testing.T, id string, chunk ChunkData) []byte {
+	t.Helper()
+	payload, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal chunk %s: %v", id, err)
+	}
+	return payload
+}
+
+// TestCloudImportDoesNotSkipRelationWithTombstonedEndpoint pins the oracle's
+// deletion semantics: the store's relation FK precondition counts soft-deleted
+// observations, so an edge whose endpoint is a local tombstone still applies
+// today and must not be reported as permanently missing.
+func TestCloudImportDoesNotSkipRelationWithTombstonedEndpoint(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := s.CreateSession("sess-tomb", "proj-a", "/tmp/proj-a"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obsID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "sess-tomb",
+		Type:      "decision",
+		Title:     "tombstoned",
+		Content:   "endpoint that was soft-deleted locally",
+		Project:   "proj-a",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	obs, err := s.GetObservation(obsID)
+	if err != nil {
+		t.Fatalf("get observation: %v", err)
+	}
+	if obs.SyncID == "" {
+		t.Fatal("expected observation to carry a sync_id")
+	}
+	if err := s.DeleteObservation(obsID, false); err != nil {
+		t.Fatalf("soft delete observation: %v", err)
+	}
+
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-1135-tombstone"
+	relationID := "rel-1135-tomb"
+	chunk := ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: relationID,
+			Op:        store.SyncOpUpsert,
+			Payload: fmt.Sprintf(`{"sync_id":%q,"source_id":%q,"target_id":%q,"relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`,
+				relationID, obs.SyncID, obs.SyncID),
+		},
+	}}
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks[chunkID] = mustJSONChunk(t, chunkID, chunk)
+
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+	result, err := importer.Import()
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.SkippedRelations) != 0 {
+		t.Fatalf("tombstoned endpoint must not be reported permanently missing, got %+v", result.SkippedRelations)
+	}
+	if _, err := s.GetRelation(relationID); err != nil {
+		t.Fatalf("expected relation over tombstoned endpoint to apply as before: %v", err)
+	}
+	deferred, dead, err := s.CountDeferredAndDead()
+	if err != nil {
+		t.Fatalf("count deferred and dead: %v", err)
+	}
+	if deferred != 0 || dead != 0 {
+		t.Fatalf("unexpected deferred state: deferred=%d dead=%d", deferred, dead)
+	}
+}
+
+// TestCloudImportStallPathSurvivesRelationFiltering pins design point 3: a
+// chunk whose filtered remainder still fails for an unrelated reason keeps the
+// original stall semantics instead of appearing fixed while data is lost.
+func TestCloudImportStallPathSurvivesRelationFiltering(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-1135-stall"
+	chunk := ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntitySession,
+			EntityKey: "sess-stall",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"id":"sess-stall","project":"proj-a","directory":"/tmp/proj-a"}`,
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: "obs-stall-good",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"obs-stall-good","session_id":"sess-stall","type":"decision","title":"good","content":"importable endpoint","project":"proj-a","scope":"project"}`,
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: "obs-stall-orphan",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"obs-stall-orphan","session_id":"sess-never-anywhere","type":"note","title":"orphan","content":"references a session no chunk provides","project":"proj-a","scope":"project"}`,
+		},
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: "rel-stall",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"rel-stall","source_id":"obs-stall-good","target_id":"obs-stall-never","relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`,
+		},
+	}}
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks[chunkID] = mustJSONChunk(t, chunkID, chunk)
+
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+	_, err := importer.Import()
+	if err == nil {
+		t.Fatal("expected the chunk to keep stalling on its unrelated failure")
+	}
+	if !strings.Contains(err.Error(), "stalled") || !strings.Contains(err.Error(), "sess-never-anywhere") {
+		t.Fatalf("expected original stall error with pending session dependencies, got: %v", err)
+	}
+	synced, err := s.GetSyncedChunks()
+	if err != nil {
+		t.Fatalf("get synced chunks: %v", err)
+	}
+	if synced[chunkID] {
+		t.Fatalf("failed chunk %q must not be marked synced", chunkID)
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1135

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Cloud import now classifies relation upserts before apply: an edge whose referenced observation is **permanently absent** (absent from the local store in any deletion state, from every pending chunk of this run, and never tombstoned) is skipped, the rest of the chunk imports normally, and each skipped edge is recorded as a visible warning (`ImportResult.SkippedRelations`, printed by the CLI as `WARNING skipped ...`) instead of parking silently in the deferred queue until it dead-letters with no trace.
- Skipped edges are **reversible, not lost**: each one is enqueued to `sync_apply_deferred` (new `Store.EnqueueDeferredRelation`) BEFORE the filtered chunk applies, so a late-arriving endpoint heals the edge through the existing replay machinery, an enqueue error aborts before any chunk mutation, and a crash can only leave a queued, replayable edge. Known-chunk re-imports do not re-warn or re-enqueue (pinned).
- Temporary conditions keep today's semantics: an endpoint arriving in another pending chunk resolves through the normal passes, missing sessions still stall with the existing error, local-mode recovery is untouched, and tombstoned endpoints still satisfy the store's FK precondition (never skipped).

**Honest scope note**: the hard "stalled after N passes" brick of the report reproduces on v1.20.0; on current `main` the store already defers FK-missing relations inside `ApplyPulledChunk`, so the remaining defect this PR fixes is the silent deferred-to-dead path with no visible signal, which is exactly the option-1 disposition the issue asks for (skip + visible warning) plus reversibility for late endpoints.

**Size note**: 868 changed lines (+859/−9) across 5 files, ~62% tests. It is one delivery unit (the skip-oracle, its deferred-recovery path, and the tests pinning each boundary); there is no unrelated change mixed in. Maintainer `type:bug` label requested below.

---

## 📂 Changes

| File | Change |
|------|--------|
| `internal/sync/sync.go` | `importDependencyOracle` (lazy, tombstone-aware endpoint satisfiability), `pendingObservationSyncIDs`, `filterUnsatisfiableRelationUpserts` (cloud-only), pre-apply enqueue of skipped edges via `EnqueueDeferredRelation` (before the chunk can commit), `ImportResult.SkippedRelations` |
| `internal/store/store.go` | `EnqueueDeferredRelation`: persists a relation upsert as a `sync_apply_deferred` row mirroring `recordRelationApplyFailureTx` (INSERT OR REPLACE keyed by edge identity) |
| `cmd/engram/main.go` | `printSkippedRelationWarnings` on both cloud-import result render paths |
| `internal/sync/sync_test.go` | Table test (permanent skip / temporary passes / local unchanged), tombstone guard, stall-path survival, idempotency, late-endpoint heal via replay, crash-window atomicity (enqueue durable before chunk synced), enqueue-error abort |
| `cmd/engram/main_extra_test.go` | CLI renders the `WARNING skipped` line |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model:** Pi coding agent (el Gentleman harness) — implementation and corrections delegated to subagents under single-session orchestration; independently verified and reviewed by the human-driven parent session.

**Material scope:** Full diff is AI-authored under human direction.

**Verification performed:** `go build ./...`, `go test ./internal/sync/... ./internal/store/...` (uncached), `go vet`, gofmt; independent verification pass over all claims (9/9 PASS); native 4-lens review (risk/resilience/readability/reliability) with one audited scope-recovery and two bounded corrections (late-endpoint reversibility R4-1, enqueue atomicity R4-2), closed APPROVED by the targeted validator with only informational advisories, authority acknowledged.

---

## 🧪 Test Plan

```bash
go build ./...
go test ./internal/sync/... ./internal/store/...
```

All new tests TDD'd (RED observed on the defect before each implementation), including `TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing`, `TestCloudImportHandlesRelationWithPermanentlyMissingEndpoint` (3 subtests), `TestCloudImportDeferredRelationHealsWhenLateEndpointArrives`, `TestCloudImportSkippedRelationEnqueuedBeforeChunkSynced`, `TestCloudImportEnqueueErrorAbortsBeforeChunkMutation`, `TestCloudImportSkippedRelationWarningsAreIdempotent`, `TestCloudImportDoesNotSkipRelationWithTombstonedEndpoint`, `TestCloudImportStallPathSurvivesRelationFiltering`, `TestCmdSyncCloudImportPrintsSkippedRelationWarnings`.

- [x] Unit tests pass
- [x] gofmt clean on all touched files
- [x] Independent verification pass (claims 1-9)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within one delivery unit (868 changed lines, 62% tests; single coherent unit, no unrelated changes — flagging the size openly given the recent review-budget discussion on #1107)
- [ ] I have added the appropriate `type:*` label to this PR — **cannot self-apply (permission denied); requesting `type:bug` from a maintainer**
- [x] Unit tests pass (`go test ./internal/sync/... ./internal/store/...`)
- [x] Conventional commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sync imports now display warnings when relations are skipped because referenced observations are permanently missing.
  - Skipped relations are retained for potential recovery if the missing observations become available later.
  - Import processing continues for valid data instead of failing on permanently unsatisfiable relations.

- **Bug Fixes**
  - Prevented permanently missing relation endpoints from blocking otherwise successful cloud imports.

- **Tests**
  - Added coverage for skipped-relation warnings, deferred recovery, duplicate warnings, and related import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->