### PR TITLE
feat(cli): add init command for ambiguous workspaces

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -811,6 +811,12 @@ Child scan constraints: depth=1, max 20 entries, 200ms timeout, skips hidden dir
 
 The Git binding is private to each clone and shared by that clone's linked worktrees. Independent clones and forks establish fresh opaque bindings. Cross-clone identity sharing and alias propagation are not currently supported.
 
+### Initialize an explicit project identity
+
+Use `engram init [project_name] [--force]` to write `.engram/config.json` in the current directory. When `project_name` is omitted, Engram uses the current directory basename. `--force` replaces an existing config; without it, init stops and tells you that the config already exists.
+
+This is the explicit resolution path for a non-Git aggregator workspace that contains multiple child repositories. Run `engram init aggregator-name` at the aggregator root so its config resolves the workspace identity before child-repository scanning reports ambiguity.
+
 ### Response envelope
 
 Most successful MCP tool responses use this envelope:

--- a/cmd/engram/init_config.go
+++ b/cmd/engram/init_config.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const initConfigName = "config.json"
+
+// writeInitConfig creates or replaces the cwd-local project configuration.
+func writeInitConfig(cwd string, data []byte, force bool) error {
+	directory := filepath.Join(cwd, ".engram")
+	if err := ensureInitConfigDirectory(directory); err != nil {
+		return err
+	}
+
+	configPath := filepath.Join(directory, initConfigName)
+	if err := rejectInitConfigSymlink(configPath); err != nil {
+		return err
+	}
+	if force {
+		return replaceInitConfig(configPath, data)
+	}
+	return createInitConfig(configPath, data)
+}
+
+func ensureInitConfigDirectory(path string) error {
+	if err := os.Mkdir(path, 0o755); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("create .engram directory: %w", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect .engram directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf(".engram must be a real directory, not a symlink")
+	}
+	if !info.IsDir() {
+		return fmt.Errorf(".engram must be a directory")
+	}
+	return nil
+}
+
+func rejectInitConfigSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect .engram/config.json: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf(".engram/config.json must not be a symlink")
+	}
+	return nil
+}
+
+func createInitConfig(path string, data []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if errors.Is(err, os.ErrExist) {
+		return fmt.Errorf(".engram/config.json already exists (use --force to overwrite)")
+	}
+	if err != nil {
+		return fmt.Errorf("write .engram/config.json: %w", err)
+	}
+	if err := writeAndCloseInitConfig(file, data); err != nil {
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return fmt.Errorf("write .engram/config.json: %w (remove partial config: %v)", err, removeErr)
+		}
+		return fmt.Errorf("write .engram/config.json: %w", err)
+	}
+	return nil
+}
+
+func replaceInitConfig(path string, data []byte) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".config.json-*")
+	if err != nil {
+		return fmt.Errorf("create replacement config: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	published := false
+	defer func() {
+		if !published {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+
+	if err := temporary.Chmod(0o644); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("set replacement config permissions: %w", err)
+	}
+	if err := writeAndCloseInitConfig(temporary, data); err != nil {
+		return fmt.Errorf("write replacement config: %w", err)
+	}
+	if err := replaceInitConfigFile(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish replacement config: %w", err)
+	}
+	published = true
+	return nil
+}
+
+func writeAndCloseInitConfig(file *os.File, data []byte) error {
+	written, writeErr := file.Write(data)
+	if writeErr == nil && written != len(data) {
+		writeErr = fmt.Errorf("short write: wrote %d of %d bytes", written, len(data))
+	}
+	closeErr := file.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
+}

--- a/cmd/engram/init_config_unix.go
+++ b/cmd/engram/init_config_unix.go
@@ -1,0 +1,9 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package main
+
+import "os"
+
+func replaceInitConfigFile(temporaryPath, configPath string) error {
+	return os.Rename(temporaryPath, configPath)
+}

--- a/cmd/engram/init_config_windows.go
+++ b/cmd/engram/init_config_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+func replaceInitConfigFile(temporaryPath, configPath string) error {
+	return windows.MoveFileEx(
+		windows.StringToUTF16Ptr(temporaryPath),
+		windows.StringToUTF16Ptr(configPath),
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/cmd/engram/init_test.go
+++ b/cmd/engram/init_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gentleman-Programming/engram/v2/internal/store"
+	versioncheck "github.com/Gentleman-Programming/engram/v2/internal/version"
+)
+
+func TestCmdInit(t *testing.T) {
+	for _, tt := range []struct {
+		name, directory, existing, want, wantErr string
+		args                                     []string
+	}{
+		{"explicit name", "workspace", "", "{\n  \"project_name\": \"my-project\"\n}\n", "", []string{"engram", "init", "my-project"}},
+		{"directory basename", "workspace-alpha", "", "{\n  \"project_name\": \"workspace-alpha\"\n}\n", "", []string{"engram", "init"}},
+		{"refuses existing", "workspace", `{"project_name":"old"}`, `{"project_name":"old"}`, "already exists", []string{"engram", "init", "new"}},
+		{"force replaces", "workspace", `{"project_name":"old"}`, "{\n  \"project_name\": \"new\"\n}\n", "", []string{"engram", "init", "new", "--force"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := filepath.Join(t.TempDir(), tt.directory)
+			if err := os.Mkdir(workDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(workDir, ".engram", "config.json")
+			if tt.existing != "" {
+				if err := os.Mkdir(filepath.Dir(configPath), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(configPath, []byte(tt.existing), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			withCwd(t, workDir)
+			stubExitWithPanic(t)
+			withArgs(t, tt.args...)
+			_, stderr, recovered := captureOutputAndRecover(t, cmdInit)
+			if tt.wantErr != "" {
+				if _, ok := recovered.(exitCode); !ok || !strings.Contains(stderr, tt.wantErr) {
+					t.Fatalf("expected %q, panic=%v stderr=%q", tt.wantErr, recovered, stderr)
+				}
+			} else if recovered != nil || stderr != "" {
+				t.Fatalf("cmdInit failed: panic=%v stderr=%q", recovered, stderr)
+			}
+			got, err := os.ReadFile(configPath)
+			if err != nil || string(got) != tt.want {
+				t.Fatalf("config = %q, %v; want %q", got, err, tt.want)
+			}
+			if tt.name == "force replaces" {
+				entries, _ := os.ReadDir(filepath.Dir(configPath))
+				if len(entries) != 1 || entries[0].Name() != "config.json" {
+					t.Fatalf("config directory entries = %v", entries)
+				}
+			}
+		})
+	}
+}
+
+func TestCmdInitRejectsInvalidArguments(t *testing.T) {
+	for _, tt := range []struct{ args []string }{
+		{[]string{"engram", "init", "   "}},
+		{[]string{"engram", "init", "invalid/name"}},
+		{[]string{"engram", "init", "bad\nname"}},
+		{[]string{"engram", "init", "--other"}},
+		{[]string{"engram", "init", "one", "two"}},
+	} {
+		t.Run(strings.Join(tt.args[2:], " "), func(t *testing.T) {
+			withCwd(t, t.TempDir())
+			stubExitWithPanic(t)
+			withArgs(t, tt.args...)
+			_, _, recovered := captureOutputAndRecover(t, cmdInit)
+			if _, ok := recovered.(exitCode); !ok {
+				t.Fatalf("expected init failure, panic=%v", recovered)
+			}
+		})
+	}
+}
+
+func TestWriteInitConfigRejectsStaticSymlinks(t *testing.T) {
+	for _, configLink := range []bool{false, true} {
+		t.Run(map[bool]string{false: "directory", true: "config"}[configLink], func(t *testing.T) {
+			workDir := t.TempDir()
+			target := filepath.Join(workDir, "target")
+			if err := os.Mkdir(target, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			targetConfig := filepath.Join(target, "config.json")
+			if err := os.WriteFile(targetConfig, []byte("preserved"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			link := filepath.Join(workDir, ".engram")
+			linkTarget := target
+			if configLink {
+				if err := os.Mkdir(link, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				link = filepath.Join(link, "config.json")
+				linkTarget = targetConfig
+			}
+			if err := os.Symlink(linkTarget, link); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+			if err := writeInitConfig(workDir, []byte("new"), true); err == nil || !strings.Contains(err.Error(), "symlink") {
+				t.Fatalf("symlink error = %v", err)
+			}
+			if got, _ := os.ReadFile(targetConfig); string(got) != "preserved" {
+				t.Fatalf("symlink target changed to %q", got)
+			}
+		})
+	}
+}
+
+func TestMainDispatchInitSkipsStartup(t *testing.T) {
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+	withArgs(t, "engram", "init", "dispatched")
+	oldCheck := checkForUpdates
+	checkForUpdates = func(string) versioncheck.CheckResult {
+		t.Fatal("init must not check for updates")
+		return versioncheck.CheckResult{}
+	}
+	t.Cleanup(func() { checkForUpdates = oldCheck })
+	oldConfig := storeDefaultConfig
+	storeDefaultConfig = func() (store.Config, error) {
+		t.Fatal("init must not resolve store config")
+		return store.Config{}, nil
+	}
+	t.Cleanup(func() { storeDefaultConfig = oldConfig })
+	oldMigrate := migrateOrphanedDatabase
+	migrateOrphanedDatabase = func(string) { t.Fatal("init must not migrate") }
+	t.Cleanup(func() { migrateOrphanedDatabase = oldMigrate })
+
+	_, stderr, recovered := captureOutputAndRecover(t, main)
+	if recovered != nil || stderr != "" {
+		t.Fatalf("main init dispatch failed: panic=%v stderr=%q", recovered, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".engram", "config.json")); err != nil {
+		t.Fatalf("init config missing: %v", err)
+	}
+}

--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -62,9 +62,10 @@ func init() {
 }
 
 var (
-	storeNew      = store.New
-	newHTTPServer = server.New
-	startHTTP     = (*server.Server).Start
+	storeNew           = store.New
+	storeDefaultConfig = store.DefaultConfig
+	newHTTPServer      = server.New
+	startHTTP          = (*server.Server).Start
 
 	newMCPServer           = mcp.NewServer
 	newMCPServerWithTools  = mcp.NewServerWithTools
@@ -81,7 +82,8 @@ var (
 	newTeaProgram = tea.NewProgram
 	runTeaProgram = (*tea.Program).Run
 
-	checkForUpdates = versioncheck.CheckLatest
+	checkForUpdates         = versioncheck.CheckLatest
+	migrateOrphanedDatabase = migrateOrphanedDB
 
 	setupSupportedAgents         = setup.SupportedAgents
 	setupInstallAgent            = setup.Install
@@ -122,7 +124,7 @@ var (
 	syncStatus = func(sy *engramsync.Syncer) (localChunks int, remoteChunks int, pendingImport int, err error) {
 		return sy.Status()
 	}
-	syncImport = func(sy *engramsync.Syncer) (*engramsync.ImportResult, error) { return sy.Import() }
+	syncImport             = func(sy *engramsync.Syncer) (*engramsync.ImportResult, error) { return sy.Import() }
 	syncImportWithProgress = func(sy *engramsync.Syncer, report func(engramsync.ImportProgress)) (*engramsync.ImportResult, error) {
 		return sy.ImportWithProgress(report)
 	}
@@ -666,7 +668,7 @@ func main() {
 		return
 	}
 
-	cfg, cfgErr := store.DefaultConfig()
+	cfg, cfgErr := storeDefaultConfig()
 	if cfgErr != nil {
 		// Fallback: try to resolve home directory from environment variables
 		// that os.UserHomeDir() might have missed (e.g. MCP subprocesses on
@@ -696,7 +698,7 @@ func main() {
 
 	// Migrate orphaned databases that ended up in wrong locations
 	// (e.g. drive root on Windows due to previous bug).
-	migrateOrphanedDB(cfg.DataDir)
+	migrateOrphanedDatabase(cfg.DataDir)
 
 	switch os.Args[1] {
 	case "serve":
@@ -754,7 +756,7 @@ func shouldCheckForUpdates(args []string) bool {
 	}
 	command := strings.ToLower(strings.TrimSpace(args[0]))
 	switch command {
-	case "mcp", "serve", "protocol-mode", "tui", "version", "--version", "-v", "help", "--help", "-h":
+	case "mcp", "serve", "protocol-mode", "tui", "version", "--version", "-v", "help", "--help", "-h", "init":
 		return false
 	case "cloud":
 		return len(args) < 2 || strings.ToLower(strings.TrimSpace(args[1])) != "serve"
@@ -781,6 +783,9 @@ func handleConfigFreeCommand(args []string) bool {
 				return true
 			}
 		}
+	case "init":
+		cmdInit()
+		return true
 	}
 	return false
 }
@@ -2895,6 +2900,80 @@ func cmdProjectsPrune(cfg store.Config) {
 	fmt.Printf("\nPruned %d project(s): %d sessions, %d prompts removed.\n", successful, totalSessions, totalPrompts)
 }
 
+func cmdInit() {
+	var (
+		force       bool
+		projectName string
+	)
+
+	args := os.Args[2:]
+	for i := 0; i < len(args); i++ {
+		token := args[i]
+		switch {
+		case token == "-h" || token == "--help" || token == "help":
+			fmt.Println("usage: engram init [project_name] [--force]")
+			return
+		case token == "-f" || token == "--force":
+			force = true
+		case strings.HasPrefix(token, "-"):
+			fmt.Fprintf(os.Stderr, "engram: unknown flag: %s\n\nusage: engram init [project_name] [--force]\n", token)
+			exitFunc(1)
+			return
+		default:
+			if projectName == "" {
+				projectName = token
+			} else {
+				fmt.Fprintf(os.Stderr, "engram: unexpected argument: %s\n\nusage: engram init [project_name] [--force]\n", token)
+				exitFunc(1)
+				return
+			}
+		}
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fatal(fmt.Errorf("get current directory: %w", err))
+		return
+	}
+
+	if projectName == "" {
+		projectName = filepath.Base(cwd)
+	}
+
+	trimmed := strings.TrimSpace(projectName)
+	if trimmed == "" {
+		fatal(errors.New("project name is required"))
+		return
+	}
+	if strings.ContainsAny(trimmed, `/\\`) {
+		fatal(errors.New("project name must be a name, not a path"))
+		return
+	}
+	for _, r := range trimmed {
+		if r < 0x20 || r == 0x7f {
+			fatal(errors.New("project name contains control characters"))
+			return
+		}
+	}
+
+	data := map[string]string{
+		"project_name": trimmed,
+	}
+	bytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		fatal(fmt.Errorf("marshal config: %w", err))
+		return
+	}
+	bytes = append(bytes, '\n')
+
+	if err := writeInitConfig(cwd, bytes, force); err != nil {
+		fatal(err)
+		return
+	}
+
+	fmt.Printf("Initialized Engram project %q in .engram/config.json\n", trimmed)
+}
+
 func isPathLikeProjectName(name string) bool {
 	return strings.ContainsAny(name, `/\`)
 }
@@ -3314,6 +3393,8 @@ Commands:
   export [file] [--project PROJECT|--all]
                      Export memories to JSON (default: engram-export.json)
   import <file>      Import memories from a JSON export file
+  init [name]        Initialize an Engram project (.engram/config.json) in current directory
+                       --force, -f   Overwrite existing .engram/config.json
   projects list      List all projects with observation, session, and prompt counts
   projects consolidate [--all] [--dry-run]
                      Merge similar project names into one canonical name


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #511

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:question` — Question requiring tracked work
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Adds `engram init [project_name] [--force]` as the explicit recovery path for ambiguous non-Git aggregator workspaces.
- Keeps ordinary project detection automatic while persisting an unambiguous local project identity when inference is unsafe.

## 📂 Changes

| File | Change |
|------|--------|
| `cmd/engram/main.go` | Dispatches `init` before store startup and implements deterministic naming and validation |
| `cmd/engram/init_config*.go` | Creates configs exclusively and replaces them completely with platform-appropriate publication |
| `cmd/engram/init_test.go` | Covers naming, preservation, force replacement, symlinks, and startup-free dispatch |
| `DOCS.md` | Documents the ambiguous-workspace recovery flow |

## 🧪 Test Plan

- [x] Focused init tests pass
- [x] `GIT_CEILING_DIRECTORIES=C:/Users/Blackie go test ./cmd/engram -count=1`
- [x] Focused project-config precedence tests pass
- [x] `git diff --check origin/main --`
- [ ] Full repository unit suite — delegated to CI
- [ ] E2E suite — delegated to CI
- [ ] Lint — delegated to CI

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` | ⏳ |
| **Check PR Has type:* Label** | Canonical labels, applicability, and cardinality | ⏳ |
| **Check PR Has No Transient Artifacts** | Changed files comply with repository policy | ⏳ |
| **Unit Tests** | `go test ./...` and dead-code validation | ⏳ |
| **E2E Tests** | Server integration suite | ⏳ |
| **Plugin Tests** | Pi plugin tests | ⏳ |
| **Lint** | No new Go lint findings | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #511`)
- [x] I added exactly one `type:*` label
- [ ] I ran the full repository unit suite locally
- [ ] I ran the E2E suite locally
- [ ] I ran lint locally
- [x] Docs updated for the behavior change
- [x] Commit follows Conventional Commits
- [x] No `Co-Authored-By` trailers
- [x] Changed paths comply with the Transient Artifact Policy

---

## 💬 Notes for Reviewers

This is a single 385-line work unit, reduced from the closed oversized implementation. It rejects statically observed symlinks and prevents ordinary overwrite/interruption hazards. Defending against a hostile process concurrently replacing the parent directory is intentionally outside this local CLI recovery feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `engram init` command to create a project configuration with an explicit name or the current directory’s name.
  - Added `--force` support to replace an existing configuration.
  - Added validation and clear handling for invalid arguments or existing configuration files.
  - Supports project identity setup for non-Git workspaces containing multiple repositories.

- **Documentation**
  - Documented the new initialization command and its use in multi-repository workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->