### PR TITLE
fix(cloud): preserve denied auth audits after cancellation (#1134)

### DIFF
--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -110,6 +110,11 @@ const (
 	authAuditReasonAuthorizeError         = "authorize_error"
 )
 
+// requestAuthAuditInsertTimeout bounds the best-effort insert after a rejected
+// request auth: the rejection is already decided, so a stalled audit insert
+// must not hold the 401 response hostage while it waits.
+const requestAuthAuditInsertTimeout = 3 * time.Second
+
 // Bearer-extraction failure sentinels. bearerTokenFromRequest's error text is
 // part of the 401 response body, so the messages stay unchanged; wrapping them
 // as sentinels lets the audit reason mapping classify rejections with
@@ -395,9 +400,10 @@ func requestAuthDenyReason(err error) string {
 
 // recordRequestAuthDeniedAudit emits the per-rejection server log line and
 // records a best-effort cloud_auth_audit_log row for a rejected request
-// authentication (engram#1134). The rejection has already happened, so an
-// audit failure never changes the 401: it is logged and dropped, matching the
-// dashboard login best-effort convention (recordDashboardLoginAuditBestEffort).
+// authentication (engram#1134). The rejection has already happened, so the
+// bounded insert budget and any audit failure never change the 401: failures
+// are logged and dropped, matching the dashboard login best-effort convention
+// (recordDashboardLoginAuditBestEffort).
 // Successful request auth is intentionally unaudited per request (volume; the
 // dashboard login flow audits its own successes). The actor principal stays
 // null (no principal was resolved); ActorSource "request" labels the
@@ -409,7 +415,9 @@ func (s *CloudServer) recordRequestAuthDeniedAudit(r *http.Request, reason strin
 		log.Printf("cloudserver: admin identity store is not configured; request auth audit skipped")
 		return
 	}
-	if err := s.adminIdentity.InsertAuthAuditEvent(r.Context(), cloudstore.AuthAuditEvent{
+	insertCtx, cancel := context.WithTimeout(r.Context(), requestAuthAuditInsertTimeout)
+	defer cancel()
+	if err := s.adminIdentity.InsertAuthAuditEvent(insertCtx, cloudstore.AuthAuditEvent{
 		ActorSource: authAuditActorSourceRequest,
 		Action:      authAuditActionRequestAuth,
 		Outcome:     authAuditOutcomeDenied,

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -93,6 +93,33 @@ const dashboardSessionCookieName = "engram_dashboard_token"
 
 var ErrDashboardSessionCodecRequired = errors.New("dashboard session codec is required for dashboard auth")
 
+// Request-auth audit vocabulary (engram#1134): every rejected sync/admin
+// request authentication is audited best-effort into cloud_auth_audit_log via
+// the same AdminIdentityStore sink the dashboard login/bootstrap flows use.
+const (
+	authAuditActionRequestAuth            = "sync.auth"
+	authAuditActorSourceRequest           = "request"
+	authAuditReasonMissingHeader          = "missing_header"
+	authAuditReasonMalformedBearer        = "malformed_bearer"
+	authAuditReasonUnknownToken           = "unknown_token"
+	authAuditReasonTokenRevoked           = "token_revoked"
+	authAuditReasonPrincipalDisabled      = "principal_disabled"
+	authAuditReasonTokenPrincipalMismatch = "token_principal_mismatch"
+	authAuditReasonPepperMissing          = "pepper_missing"
+	authAuditReasonResolverError          = "resolver_error"
+	authAuditReasonAuthorizeError         = "authorize_error"
+)
+
+// Bearer-extraction failure sentinels. bearerTokenFromRequest's error text is
+// part of the 401 response body, so the messages stay unchanged; wrapping them
+// as sentinels lets the audit reason mapping classify rejections with
+// errors.Is instead of string matching.
+var (
+	errMissingAuthorizationHeader = errors.New("missing authorization header")
+	errAuthorizationNotBearer     = errors.New("authorization must use Bearer token")
+	errBearerTokenRequired        = errors.New("bearer token is required")
+)
+
 func WithSyncStatusProvider(provider dashboard.SyncStatusProvider) Option {
 	return func(s *CloudServer) {
 		s.syncStatus = provider
@@ -319,11 +346,13 @@ func (s *CloudServer) authenticateRequest(w http.ResponseWriter, r *http.Request
 	if s.principalAuth != nil {
 		token, err := bearerTokenFromRequest(r)
 		if err != nil {
+			s.recordRequestAuthDeniedAudit(r, requestAuthDenyReason(err))
 			http.Error(w, fmt.Sprintf("unauthorized: %v", err), http.StatusUnauthorized)
 			return r, false
 		}
 		principal, err := s.principalAuth.ResolveBearerToken(r.Context(), token)
 		if err != nil {
+			s.recordRequestAuthDeniedAudit(r, requestAuthDenyReason(err))
 			http.Error(w, fmt.Sprintf("unauthorized: %v", err), http.StatusUnauthorized)
 			return r, false
 		}
@@ -331,6 +360,7 @@ func (s *CloudServer) authenticateRequest(w http.ResponseWriter, r *http.Request
 	}
 	if s.auth != nil {
 		if err := s.auth.Authorize(r); err != nil {
+			s.recordRequestAuthDeniedAudit(r, authAuditReasonAuthorizeError)
 			http.Error(w, fmt.Sprintf("unauthorized: %v", err), http.StatusUnauthorized)
 			return r, false
 		}
@@ -338,18 +368,70 @@ func (s *CloudServer) authenticateRequest(w http.ResponseWriter, r *http.Request
 	return r, true
 }
 
+// requestAuthDenyReason maps a request-auth rejection to its audit
+// reason_code. Resolver errors are classified with errors.Is because
+// ResolveBearerToken wraps the sentinel classes (e.g.
+// fmt.Errorf("%w: token principal mismatch", ErrInvalidPrincipal)).
+func requestAuthDenyReason(err error) string {
+	switch {
+	case errors.Is(err, errMissingAuthorizationHeader), errors.Is(err, errBearerTokenRequired):
+		return authAuditReasonMissingHeader
+	case errors.Is(err, errAuthorizationNotBearer):
+		return authAuditReasonMalformedBearer
+	case errors.Is(err, cloudauth.ErrUnknownToken):
+		return authAuditReasonUnknownToken
+	case errors.Is(err, cloudauth.ErrTokenRevoked):
+		return authAuditReasonTokenRevoked
+	case errors.Is(err, cloudauth.ErrPrincipalDisabled):
+		return authAuditReasonPrincipalDisabled
+	case errors.Is(err, cloudauth.ErrInvalidPrincipal):
+		return authAuditReasonTokenPrincipalMismatch
+	case errors.Is(err, cloudauth.ErrTokenPepperRequired):
+		return authAuditReasonPepperMissing
+	default:
+		return authAuditReasonResolverError
+	}
+}
+
+// recordRequestAuthDeniedAudit emits the per-rejection server log line and
+// records a best-effort cloud_auth_audit_log row for a rejected request
+// authentication (engram#1134). The rejection has already happened, so an
+// audit failure never changes the 401: it is logged and dropped, matching the
+// dashboard login best-effort convention (recordDashboardLoginAuditBestEffort).
+// Successful request auth is intentionally unaudited per request (volume; the
+// dashboard login flow audits its own successes). The actor principal stays
+// null (no principal was resolved); ActorSource "request" labels the
+// non-dashboard actor shape, mirroring the audit-only sentinel convention
+// documented for authAuditActorSourceUnauthenticated.
+func (s *CloudServer) recordRequestAuthDeniedAudit(r *http.Request, reason string) {
+	log.Printf("[engram-cloud] request auth denied: %s (reason=%s)", r.RemoteAddr, reason)
+	if s.adminIdentity == nil {
+		log.Printf("cloudserver: admin identity store is not configured; request auth audit skipped")
+		return
+	}
+	if err := s.adminIdentity.InsertAuthAuditEvent(r.Context(), cloudstore.AuthAuditEvent{
+		ActorSource: authAuditActorSourceRequest,
+		Action:      authAuditActionRequestAuth,
+		Outcome:     authAuditOutcomeDenied,
+		ReasonCode:  reason,
+		Metadata:    map[string]any{"source": authAuditActorSourceRequest},
+	}); err != nil {
+		log.Printf("[engram-cloud] request auth audit insert failed (best-effort): %v", err)
+	}
+}
+
 func bearerTokenFromRequest(r *http.Request) (string, error) {
 	header := strings.TrimSpace(r.Header.Get("Authorization"))
 	if header == "" {
-		return "", fmt.Errorf("missing authorization header")
+		return "", errMissingAuthorizationHeader
 	}
 	parts := strings.Fields(header)
 	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-		return "", fmt.Errorf("authorization must use Bearer token")
+		return "", errAuthorizationNotBearer
 	}
 	token := strings.TrimSpace(parts[1])
 	if token == "" {
-		return "", fmt.Errorf("bearer token is required")
+		return "", errBearerTokenRequired
 	}
 	return token, nil
 }

--- a/internal/cloud/cloudserver/cloudserver.go
+++ b/internal/cloud/cloudserver/cloudserver.go
@@ -403,7 +403,9 @@ func requestAuthDenyReason(err error) string {
 // authentication (engram#1134). The rejection has already happened, so the
 // bounded insert budget and any audit failure never change the 401: failures
 // are logged and dropped, matching the dashboard login best-effort convention
-// (recordDashboardLoginAuditBestEffort).
+// (recordDashboardLoginAuditBestEffort). The insert budget is detached from
+// r.Context() on purpose: a disconnecting client cancels the request context,
+// and that cancellation must not drop the already-decided denied-audit row.
 // Successful request auth is intentionally unaudited per request (volume; the
 // dashboard login flow audits its own successes). The actor principal stays
 // null (no principal was resolved); ActorSource "request" labels the
@@ -415,7 +417,9 @@ func (s *CloudServer) recordRequestAuthDeniedAudit(r *http.Request, reason strin
 		log.Printf("cloudserver: admin identity store is not configured; request auth audit skipped")
 		return
 	}
-	insertCtx, cancel := context.WithTimeout(r.Context(), requestAuthAuditInsertTimeout)
+	// Deliberately not r.Context(): the client may have disconnected, and the
+	// denied-audit row must still be attempted within its own bounded budget.
+	insertCtx, cancel := context.WithTimeout(context.Background(), requestAuthAuditInsertTimeout)
 	defer cancel()
 	if err := s.adminIdentity.InsertAuthAuditEvent(insertCtx, cloudstore.AuthAuditEvent{
 		ActorSource: authAuditActorSourceRequest,

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	cloudauth "github.com/Gentleman-Programming/engram/v2/internal/cloud/auth"
 	"github.com/Gentleman-Programming/engram/v2/internal/cloud/chunkcodec"
@@ -1882,6 +1883,101 @@ func TestInsecureModeLoginRedirects(t *testing.T) {
 }
 
 // --- engram#1134: failed request-auth middleware auditing (cloud_auth_audit_log) ---
+
+// requestAuthAuditContextStore captures the context passed to request-auth audit
+// inserts while promoting the rest of adminTestStore's identity-store interface.
+type requestAuthAuditContextStore struct {
+	*adminTestStore
+	hasDeadline bool
+	deadline    time.Time
+	block       bool
+	done        chan struct{}
+	insertErr   error
+}
+
+func (s *requestAuthAuditContextStore) InsertAuthAuditEvent(ctx context.Context, event cloudstore.AuthAuditEvent) error {
+	s.deadline, s.hasDeadline = ctx.Deadline()
+	if s.block {
+		<-ctx.Done()
+		s.insertErr = ctx.Err()
+		close(s.done)
+		return s.insertErr
+	}
+	return s.adminTestStore.InsertAuthAuditEvent(ctx, event)
+}
+
+func TestRequestAuthDeniedAuditInsertUsesBoundedContext(t *testing.T) {
+	authn := resolvingAuth{errors: map[string]error{"unknown-token": cloudauth.ErrUnknownToken}}
+	store := &requestAuthAuditContextStore{adminTestStore: newAdminTestStore()}
+	srv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(store))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+	req.Header.Set("Authorization", "Bearer unknown-token")
+	requestStarted := time.Now()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if !store.hasDeadline {
+		t.Fatal("request auth audit insert context must have a deadline")
+	}
+	if store.deadline.Before(requestStarted) || store.deadline.After(requestStarted.Add(10*time.Second)) {
+		t.Fatalf("request auth audit insert deadline = %v, want within 10s of request start %v", store.deadline, requestStarted)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if got, want := rec.Body.String(), "unauthorized: unknown token\n"; got != want {
+		t.Fatalf("401 body = %q, want %q", got, want)
+	}
+}
+
+func TestRequestAuthDeniedAuditInsertTimeoutStillRejects(t *testing.T) {
+	authn := resolvingAuth{errors: map[string]error{"unknown-token": cloudauth.ErrUnknownToken}}
+
+	baselineStore := newAdminTestStore()
+	baselineSrv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(baselineStore))
+	baselineRec := httptest.NewRecorder()
+	baselineReq := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+	baselineReq.Header.Set("Authorization", "Bearer unknown-token")
+	baselineSrv.Handler().ServeHTTP(baselineRec, baselineReq)
+
+	store := &requestAuthAuditContextStore{
+		adminTestStore: newAdminTestStore(),
+		block:          true,
+		done:           make(chan struct{}),
+	}
+	srv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(store))
+
+	var logBuf bytes.Buffer
+	origLog := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(origLog)
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil).WithContext(parentCtx)
+	req.Header.Set("Authorization", "Bearer unknown-token")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if got, want := rec.Body.Bytes(), baselineRec.Body.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("401 body = %q, want byte-identical baseline %q", got, want)
+	}
+	select {
+	case <-store.done:
+	default:
+		t.Fatal("request auth audit insert did not terminate after its context was done")
+	}
+	if !errors.Is(store.insertErr, context.DeadlineExceeded) {
+		t.Fatalf("request auth audit insert error = %v, want %v", store.insertErr, context.DeadlineExceeded)
+	}
+	if !strings.Contains(logBuf.String(), "request auth audit insert failed") {
+		t.Fatalf("expected best-effort audit insert failure log line, got %q", logBuf.String())
+	}
+}
 
 // assertRequestAuthDeniedEvent verifies the audit event contract for a
 // rejected sync/auth request: action sync.auth, outcome denied, the mapped

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1877,5 +1878,203 @@ func TestInsecureModeLoginRedirects(t *testing.T) {
 	}
 	if loc := rec.Header().Get("Location"); loc != "/dashboard/" {
 		t.Fatalf("expected redirect to /dashboard/, got %q", loc)
+	}
+}
+
+// --- engram#1134: failed request-auth middleware auditing (cloud_auth_audit_log) ---
+
+// assertRequestAuthDeniedEvent verifies the audit event contract for a
+// rejected sync/auth request: action sync.auth, outcome denied, the mapped
+// reason code, and a null actor principal with the "request" actor source
+// (matching the claim in engram#1134).
+func assertRequestAuthDeniedEvent(t *testing.T, event cloudstore.AuthAuditEvent, wantReason string) {
+	t.Helper()
+	if event.Action != "sync.auth" {
+		t.Fatalf("audit action = %q, want %q", event.Action, "sync.auth")
+	}
+	if event.Outcome != authAuditOutcomeDenied {
+		t.Fatalf("audit outcome = %q, want %q", event.Outcome, authAuditOutcomeDenied)
+	}
+	if event.ReasonCode != wantReason {
+		t.Fatalf("audit reason_code = %q, want %q", event.ReasonCode, wantReason)
+	}
+	if event.ActorPrincipalID != "" {
+		t.Fatalf("rejected request auth must not reference an actor principal, got %q", event.ActorPrincipalID)
+	}
+	if event.ActorSource != "request" {
+		t.Fatalf("audit actor_source = %q, want %q", event.ActorSource, "request")
+	}
+	if event.Project != "" {
+		t.Fatalf("request auth audit must not claim a project, got %q", event.Project)
+	}
+	assertNoSensitiveAuditMetadata(t, event)
+}
+
+// TestRequestAuthDeniedAuditsUnknownToken is the engram#1134 regression test:
+// a sync request rejected by the principal resolver must still produce a
+// cloud_auth_audit_log row (best-effort) alongside the 401.
+func TestRequestAuthDeniedAuditsUnknownToken(t *testing.T) {
+	authn := resolvingAuth{errors: map[string]error{"unknown-token": cloudauth.ErrUnknownToken}}
+	store := newAdminTestStore()
+	srv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(store))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+	req.Header.Set("Authorization", "Bearer unknown-token")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(store.auditEvents) != 1 {
+		t.Fatalf("expected exactly one auth audit event for the rejected request, got %d: %+v", len(store.auditEvents), store.auditEvents)
+	}
+	assertRequestAuthDeniedEvent(t, store.auditEvents[0], "unknown_token")
+}
+
+// TestRequestAuthDeniedAuditReasonMapping pins the error-class-to-reason_code
+// mapping for every rejection path of the request auth middleware.
+func TestRequestAuthDeniedAuditReasonMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		header     string
+		sendHeader bool
+		tokenErr   error
+		wantReason string
+	}{
+		{name: "missing authorization header", sendHeader: false, wantReason: "missing_header"},
+		{name: "malformed bearer prefix", header: "Token abc", sendHeader: true, wantReason: "malformed_bearer"},
+		{name: "unknown token", header: "Bearer rejected-token", sendHeader: true, tokenErr: cloudauth.ErrUnknownToken, wantReason: "unknown_token"},
+		{name: "revoked token", header: "Bearer rejected-token", sendHeader: true, tokenErr: cloudauth.ErrTokenRevoked, wantReason: "token_revoked"},
+		{name: "disabled principal", header: "Bearer rejected-token", sendHeader: true, tokenErr: cloudauth.ErrPrincipalDisabled, wantReason: "principal_disabled"},
+		{name: "token principal mismatch", header: "Bearer rejected-token", sendHeader: true, tokenErr: fmt.Errorf("%w: token principal mismatch", cloudauth.ErrInvalidPrincipal), wantReason: "token_principal_mismatch"},
+		{name: "pepper missing", header: "Bearer rejected-token", sendHeader: true, tokenErr: cloudauth.ErrTokenPepperRequired, wantReason: "pepper_missing"},
+		{name: "resolver failure", header: "Bearer rejected-token", sendHeader: true, tokenErr: errors.New("resolver unavailable"), wantReason: "resolver_error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authn := resolvingAuth{}
+			if tc.tokenErr != nil {
+				authn.errors = map[string]error{"rejected-token": tc.tokenErr}
+			}
+			store := newAdminTestStore()
+			srv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(store))
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+			if tc.sendHeader {
+				req.Header.Set("Authorization", tc.header)
+			}
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d body=%q", rec.Code, rec.Body.String())
+			}
+			if len(store.auditEvents) != 1 {
+				t.Fatalf("expected exactly one auth audit event, got %d: %+v", len(store.auditEvents), store.auditEvents)
+			}
+			assertRequestAuthDeniedEvent(t, store.auditEvents[0], tc.wantReason)
+		})
+	}
+}
+
+// TestRequestAuthDeniedAuditInsertFailureStillRejects proves the audit write
+// is best-effort: a failing audit insert must not turn the rejection into a
+// 500 and must surface both the per-rejection line and the insert failure.
+func TestRequestAuthDeniedAuditInsertFailureStillRejects(t *testing.T) {
+	authn := resolvingAuth{errors: map[string]error{"unknown-token": cloudauth.ErrUnknownToken}}
+	store := newAdminTestStore()
+	store.auditErr = errors.New("audit table unavailable")
+	srv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(store))
+
+	var logBuf bytes.Buffer
+	origLog := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(origLog)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+	req.Header.Set("Authorization", "Bearer unknown-token")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("audit insert failure must not change the rejection status, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(store.auditEvents) != 0 {
+		t.Fatalf("failed audit inserts must not be recorded, got %+v", store.auditEvents)
+	}
+	logged := logBuf.String()
+	if !strings.Contains(logged, "request auth denied") || !strings.Contains(logged, "reason=unknown_token") {
+		t.Fatalf("expected per-rejection log line with mapped reason, got %q", logged)
+	}
+	if !strings.Contains(logged, "request auth audit insert failed") {
+		t.Fatalf("expected best-effort audit insert failure log line, got %q", logged)
+	}
+}
+
+// TestRequestAuthSuccessWritesNoAuditEvent pins the volume rule from the
+// engram#1134 claim: successful request auth stays unaudited per request.
+func TestRequestAuthSuccessWritesNoAuditEvent(t *testing.T) {
+	principal := cloudauth.Principal{ID: "p-managed", Kind: cloudauth.PrincipalKindHuman, Role: cloudauth.RoleMember, Source: cloudauth.PrincipalSourceManagedToken, Enabled: true}
+	authn := resolvingAuth{principals: map[string]cloudauth.Principal{"managed-token": principal}}
+	store := newAdminTestStore()
+	srv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(store))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+	req.Header.Set("Authorization", "Bearer managed-token")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(store.auditEvents) != 0 {
+		t.Fatalf("successful request auth must not write audit events, got %+v", store.auditEvents)
+	}
+}
+
+// TestLegacyAuthorizeDeniedAuditsAuthorizeError pins the legacy (non-principal)
+// auth branch: its failures are audited best-effort with reason authorize_error.
+func TestLegacyAuthorizeDeniedAuditsAuthorizeError(t *testing.T) {
+	authn := fakeAuth{err: errors.New("legacy token rejected")}
+	store := newAdminTestStore()
+	srv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(store))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+	req.Header.Set("Authorization", "Bearer legacy-token")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(store.auditEvents) != 1 {
+		t.Fatalf("expected exactly one auth audit event for the legacy rejection, got %d: %+v", len(store.auditEvents), store.auditEvents)
+	}
+	assertRequestAuthDeniedEvent(t, store.auditEvents[0], "authorize_error")
+}
+
+// TestRequestAuthDeniedWithoutAuditSinkStillRejects proves the middleware
+// keeps its rejection behavior when no admin identity store is configured.
+func TestRequestAuthDeniedWithoutAuditSinkStillRejects(t *testing.T) {
+	authn := resolvingAuth{errors: map[string]error{"unknown-token": cloudauth.ErrUnknownToken}}
+	srv := New(newFakeMutationStore(), authn, 0)
+
+	var logBuf bytes.Buffer
+	origLog := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(origLog)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil)
+	req.Header.Set("Authorization", "Bearer unknown-token")
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without an audit sink, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(logBuf.String(), "request auth denied") {
+		t.Fatalf("expected per-rejection log line even without an audit sink, got %q", logBuf.String())
 	}
 }

--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -1890,13 +1890,17 @@ type requestAuthAuditContextStore struct {
 	*adminTestStore
 	hasDeadline bool
 	deadline    time.Time
-	block       bool
-	done        chan struct{}
-	insertErr   error
+	// ctxErr captures ctx.Err() at insert time: the insert context must be
+	// live when the store is invoked, whatever happened to the request.
+	ctxErr    error
+	block     bool
+	done      chan struct{}
+	insertErr error
 }
 
 func (s *requestAuthAuditContextStore) InsertAuthAuditEvent(ctx context.Context, event cloudstore.AuthAuditEvent) error {
 	s.deadline, s.hasDeadline = ctx.Deadline()
+	s.ctxErr = ctx.Err()
 	if s.block {
 		<-ctx.Done()
 		s.insertErr = ctx.Err()
@@ -1977,6 +1981,41 @@ func TestRequestAuthDeniedAuditInsertTimeoutStillRejects(t *testing.T) {
 	if !strings.Contains(logBuf.String(), "request auth audit insert failed") {
 		t.Fatalf("expected best-effort audit insert failure log line, got %q", logBuf.String())
 	}
+
+	// Canceled-request scenario (PR #1156 CodeRabbit finding): the insert
+	// context used to derive from r.Context(), so a canceled request could
+	// drop the denied-audit persistence even though the 401 was already
+	// decided. Canceling the request must keep the bounded insert budget and
+	// still persist the audit event.
+	cancelStore := &requestAuthAuditContextStore{adminTestStore: newAdminTestStore()}
+	cancelSrv := New(newFakeMutationStore(), authn, 0, WithAdminIdentityStore(cancelStore))
+	canceledCtx, cancelRequest := context.WithCancel(context.Background())
+	cancelRequest()
+	canceledStarted := time.Now()
+	cancelRec := httptest.NewRecorder()
+	cancelReq := httptest.NewRequest(http.MethodGet, "/sync/pull?project=proj-a", nil).WithContext(canceledCtx)
+	cancelReq.Header.Set("Authorization", "Bearer unknown-token")
+	cancelSrv.Handler().ServeHTTP(cancelRec, cancelReq)
+
+	if cancelRec.Code != http.StatusUnauthorized {
+		t.Fatalf("canceled request: expected 401, got %d body=%q", cancelRec.Code, cancelRec.Body.String())
+	}
+	if got, want := cancelRec.Body.Bytes(), baselineRec.Body.Bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("canceled request: 401 body = %q, want byte-identical baseline %q", got, want)
+	}
+	if cancelStore.ctxErr != nil {
+		t.Fatalf("request auth audit insert context was already done at insert time (%v); a canceled request must not take down the denied-audit insert", cancelStore.ctxErr)
+	}
+	if !cancelStore.hasDeadline {
+		t.Fatal("canceled request: audit insert context must keep its bounded deadline")
+	}
+	if cancelStore.deadline.Before(canceledStarted) || cancelStore.deadline.After(canceledStarted.Add(10*time.Second)) {
+		t.Fatalf("canceled request: audit insert deadline = %v, want within 10s of request start %v", cancelStore.deadline, canceledStarted)
+	}
+	if len(cancelStore.auditEvents) != 1 {
+		t.Fatalf("canceled request: expected exactly one persisted denied audit event, got %d", len(cancelStore.auditEvents))
+	}
+	assertRequestAuthDeniedEvent(t, cancelStore.auditEvents[0], "unknown_token")
 }
 
 // assertRequestAuthDeniedEvent verifies the audit event contract for a


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1134

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:question` — Question requiring tracked work
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Preserve an already-decided denied-auth audit insert when the client cancels or disconnects its request.
- Give the audit insert its own three-second timeout instead of inheriting request cancellation.
- Add a regression scenario proving the HTTP 401 contract and persisted audit event survive a pre-canceled request context.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/cloud/cloudserver/cloudserver.go` | Detaches the bounded denied-audit insert context from request cancellation. |
| `internal/cloud/cloudserver/cloudserver_test.go` | Extends the timeout test with a canceled-request persistence scenario. |

## 🧪 Test Plan

- [x] Focused regression: `go test ./internal/cloud/cloudserver/ -run 'TestRequestAuthDeniedAuditInsertTimeoutStillRejects' -count=1`
- [x] Cloudserver package: `go test ./internal/cloud/cloudserver/ -count=1`
- [x] `go vet` passes
- [x] `gofmt` and `git diff --check` are clean
- [x] LSP diagnostics are clean
- [x] Independent verifier approved the patch
- [x] Native reliability review approved and was acknowledged

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Pi coding agent under el Gentleman orchestration; implementation, verification, and review were AI-assisted under human direction.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1134`)
- [ ] I added exactly **one** `type:*` label to this PR — contributor account lacks permission; requesting `type:bug` from a maintainer
- [x] I ran the focused package tests locally
- [x] E2E is not a separate boundary for this handler path; the HTTP flow is exercised with `httptest`
- [x] Lint/static diagnostics are clean for the changed files
- [x] Docs are not required for this internal reliability fix
- [x] Commits follow conventional commits
- [x] No `Co-Authored-By` trailers in commits
- [x] I checked every changed path against the Transient Artifact Policy

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Denied-auth audit observability |
| Tracker PR | Not needed |
| Position | 2 of 2 |
| Base | `main` |
| Depends on | #1161 |
| Follow-up | None |
| Review budget | 53 / 400 changed lines after #1161 merges; current draft comparison includes the 391-line parent slice |
| Starts at | #1161 merged: denied audits exist with a bounded insert context |
| Ends with | Request cancellation cannot suppress the already-decided denied-auth audit insert |

### Chain Overview

```text
main
 └── #1161 Bounded denied-auth audit
      └── 📍 #1156 Cancellation hardening
```

### Scope
- Includes: independent bounded insert context and canceled-request regression coverage.
- Excludes: the underlying audit vocabulary, reason mapping, and initial persistence wiring reviewed in #1161.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back by reverting `ea7998b` without unrelated changes
- [x] Tests cover this unit

## 💬 Notes for Reviewers

Keep this PR in draft until #1161 merges. GitHub currently shows the parent commits because both PRs target `main`; after #1161 lands, this PR automatically contracts to the 53-line cancellation-hardening slice.
