### PR TITLE
fix(store): prevent unenrolled cloud journal backlog

### DIFF
--- a/cmd/engram/doctor.go
+++ b/cmd/engram/doctor.go
@@ -192,6 +192,9 @@ func cmdDoctorRepair(cfg store.Config) {
 			failDoctorRepair(err.Error())
 			return
 		}
+		if mode == diagnostic.RepairModeApply {
+			report.Applied = len(repairs.Actions) > 0 || len(report.Actions) > 0 || len(sourceRepairs.Actions) > 0
+		}
 		writeDoctorRepairJSON(struct {
 			store.SyncMutationQuarantineReport
 			Repairs                []store.SyncMutationTitleRepairAction      `json:"repairs"`

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -588,6 +588,22 @@ func TestCmdDoctorRepairDefaultsSourceObservationRepairToDryRun(t *testing.T) {
 	}
 }
 
+func TestCmdDoctorRepairApplyNoOpReportsNoAction(t *testing.T) {
+	cfg := testConfig(t)
+	withArgs(t, "engram", "doctor", "repair", "--check", "sync_mutation_required_fields", "--apply")
+	stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if stderr != "" {
+		t.Fatalf("stderr=%q", stderr)
+	}
+	report := decodeRepairPlan(t, stdout)
+	if report["applied"] != false || len(report["actions"].([]any)) != 0 || len(report["repairs"].([]any)) != 0 || len(report["source_repairs"].([]any)) != 0 {
+		t.Fatalf("no-op apply report=%v", report)
+	}
+	if _, ok := report["source_repair_backup_path"]; ok {
+		t.Fatalf("no-op apply created source repair backup: %v", report)
+	}
+}
+
 func TestCmdDoctorRepairQuarantinesInvalidEmptyProjectMutations(t *testing.T) {
 	cfg := testConfig(t)
 	s, err := store.New(cfg)
@@ -641,6 +657,10 @@ func TestCmdDoctorRepairRepairsTitleOnlyObservationMutation(t *testing.T) {
 	s, err := store.New(cfg)
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
+	}
+	if err := s.EnrollProject("engram"); err != nil {
+		s.Close()
+		t.Fatalf("enroll project: %v", err)
 	}
 	if err := s.CreateSession("title-repair", "engram", "/work/engram"); err != nil {
 		t.Fatalf("create session: %v", err)

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -659,7 +659,9 @@ func TestCmdDoctorRepairRepairsTitleOnlyObservationMutation(t *testing.T) {
 		t.Fatalf("store.New: %v", err)
 	}
 	if err := s.EnrollProject("engram"); err != nil {
-		s.Close()
+		if closeErr := s.Close(); closeErr != nil {
+			t.Fatalf("close store after failed enrollment: %v", closeErr)
+		}
 		t.Fatalf("enroll project: %v", err)
 	}
 	if err := s.CreateSession("title-repair", "engram", "/work/engram"); err != nil {

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -657,6 +657,17 @@ func TestCmdSaveResolvesConfiguredProjectWithoutFlag(t *testing.T) {
 		t.Fatalf("write project config: %v", err)
 	}
 	withCwd(t, cwd)
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("open store to enroll project: %v", err)
+	}
+	if err := s.EnrollProject("configured-project"); err != nil {
+		s.Close()
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close enrolled store: %v", err)
+	}
 	withArgs(t, "engram", "save", "resolved-title", "resolved-content")
 
 	stdout, stderr := captureOutput(t, func() { cmdSave(cfg) })
@@ -664,7 +675,7 @@ func TestCmdSaveResolvesConfiguredProjectWithoutFlag(t *testing.T) {
 		t.Fatalf("cmdSave output = stdout %q stderr %q", stdout, stderr)
 	}
 
-	s, err := store.New(cfg)
+	s, err = store.New(cfg)
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}

--- a/cmd/engram/main_test.go
+++ b/cmd/engram/main_test.go
@@ -662,7 +662,9 @@ func TestCmdSaveResolvesConfiguredProjectWithoutFlag(t *testing.T) {
 		t.Fatalf("open store to enroll project: %v", err)
 	}
 	if err := s.EnrollProject("configured-project"); err != nil {
-		s.Close()
+		if closeErr := s.Close(); closeErr != nil {
+			t.Fatalf("close store after failed enrollment: %v", closeErr)
+		}
 		t.Fatalf("enroll project: %v", err)
 	}
 	if err := s.Close(); err != nil {

--- a/internal/cloud/cloudstore/prompt_delete_propagation_test.go
+++ b/internal/cloud/cloudstore/prompt_delete_propagation_test.go
@@ -152,6 +152,63 @@ func TestPromptDeletePropagatesFromLocalStoreToDashboard(t *testing.T) {
 // TestHardDeletedObservationPropagatesFromLocalStoreToDashboard covers the sibling
 // path flagged in #837: DeleteObservation(id, hardDelete=true) removes the row, so
 // its delete can only travel as a chunk.Mutations entry.
+func TestUnenrolledSessionDeleteReenrollmentRemovesDashboardRows(t *testing.T) {
+	const project = "proj-e2e-unenrolled-session-delete"
+	const sessionID = "sess-e2e-unenrolled-delete"
+	const promptContent = "delete with the session"
+
+	local := newPropagationTestStore(t)
+	transport := newCaptureTransport()
+	syncer := engramsync.NewCloudWithTransport(local, transport, project)
+	if err := local.EnrollProject(project); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := local.CreateSession(sessionID, project, "/tmp/"+project); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := local.AddPrompt(store.AddPromptParams{SessionID: sessionID, Content: promptContent, Project: project}); err != nil {
+		t.Fatalf("add prompt: %v", err)
+	}
+	if _, err := syncer.Export("dev", project); err != nil {
+		t.Fatalf("initial export: %v", err)
+	}
+	if !promptListedOnDashboard(t, transport, project, promptContent) {
+		t.Fatal("expected dashboard to list prompt before deletion")
+	}
+
+	if err := local.UnenrollProject(project); err != nil {
+		t.Fatalf("unenroll project: %v", err)
+	}
+	if err := local.DeleteSession(sessionID); err != nil {
+		t.Fatalf("delete session while unenrolled: %v", err)
+	}
+	if _, err := syncer.Export("dev", project); err == nil {
+		t.Fatal("expected unenrolled export to remain blocked")
+	}
+
+	if err := local.EnrollProject(project); err != nil {
+		t.Fatalf("re-enroll project: %v", err)
+	}
+	if result, err := syncer.Export("dev", project); err != nil {
+		t.Fatalf("re-enrollment export: %v", err)
+	} else if result.IsEmpty {
+		t.Fatal("expected re-enrollment to export delete mutations")
+	}
+	if promptListedOnDashboard(t, transport, project, promptContent) {
+		t.Fatal("re-enrolled session delete left prompt on dashboard")
+	}
+	chunkRows, mutationRows := transport.dashboardRows(t, project)
+	model, err := buildDashboardReadModelFromRows(chunkRows, mutationRows)
+	if err != nil {
+		t.Fatalf("build dashboard model: %v", err)
+	}
+	for _, session := range model.projectDetails[project].Sessions {
+		if session.SessionID == sessionID {
+			t.Fatalf("re-enrolled session delete left session on dashboard: %+v", session)
+		}
+	}
+}
+
 func TestHardDeletedObservationPropagatesFromLocalStoreToDashboard(t *testing.T) {
 	const project = "proj-e2e-obs-hard-delete"
 

--- a/internal/diagnostic/diagnostic_test.go
+++ b/internal/diagnostic/diagnostic_test.go
@@ -292,15 +292,15 @@ func TestSyncMutationRequiredFieldsSurfacesNonEnrolledCountFailure(t *testing.T)
 }
 
 // TestSyncMutationRequiredFieldsIgnoresBacklogWithoutCloudEnrollment proves a
-// local-only install is never reported as blocked for a non-enrolled backlog.
-// The store journals sync mutations unconditionally, so on a device that never
-// opted into cloud sync every pending mutation belongs to a non-enrolled
-// project: that is the normal steady state, not a fault.
+// local-only install is never reported as blocked for a legacy non-enrolled
+// backlog. Normal writes no longer create those rows, so the fixture seeds the
+// historical pending mutation directly.
 func TestSyncMutationRequiredFieldsIgnoresBacklogWithoutCloudEnrollment(t *testing.T) {
-	s := newDiagnosticTestStore(t)
+	s, cfg := newDiagnosticTestStoreWithConfig(t)
 	if err := s.CreateSession("manual-save-engram", "engram", "/work/engram"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
+	seedDiagnosticPendingMutation(t, cfg.DataDir, "engram", store.SyncEntitySession, "manual-save-engram", store.SyncOpUpsert, `{"id":"manual-save-engram","project":"engram","directory":"/work/engram"}`)
 	pending, err := s.CountPendingNonEnrolledSyncMutations(store.DefaultSyncTargetKey)
 	if err != nil {
 		t.Fatalf("CountPendingNonEnrolledSyncMutations: %v", err)
@@ -363,7 +363,7 @@ func TestSyncMutationRequiredFieldsReportsCorruptSourceObservations(t *testing.T
 // project whose pending mutations cannot be delivered is reported as blocked
 // with the enrollment guidance, while the enrolled project stays silent.
 func TestSyncMutationRequiredFieldsBlocksNonEnrolledBacklogWhenCloudSyncInUse(t *testing.T) {
-	s := newDiagnosticTestStore(t)
+	s, cfg := newDiagnosticTestStoreWithConfig(t)
 	if err := s.CreateSession("manual-save-enrolled", "enrolled", "/work/enrolled"); err != nil {
 		t.Fatalf("CreateSession enrolled: %v", err)
 	}
@@ -373,6 +373,7 @@ func TestSyncMutationRequiredFieldsBlocksNonEnrolledBacklogWhenCloudSyncInUse(t 
 	if err := s.CreateSession("manual-save-local", "local", "/work/local"); err != nil {
 		t.Fatalf("CreateSession local: %v", err)
 	}
+	seedDiagnosticPendingMutation(t, cfg.DataDir, "local", store.SyncEntitySession, "manual-save-local", store.SyncOpUpsert, `{"id":"manual-save-local","project":"local","directory":"/work/local"}`)
 
 	report, err := NewRunner().RunOne(context.Background(), Scope{Store: s}, CheckSyncMutationRequiredFields)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -723,6 +723,9 @@ func TestHandleRescueProjectOwnershipRescuesNullOwnershipAndReportsLocalJournal(
 	const token = "rescue-token"
 	t.Setenv("ENGRAM_HTTP_TOKEN", token)
 	st := newServerTestStore(t)
+	if err := st.EnrollProject("target"); err != nil {
+		t.Fatalf("enroll target project: %v", err)
+	}
 	if err := st.CreateSession("legacy-session", "legacy", "/tmp"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -859,6 +862,9 @@ func TestHandleRescueProjectOwnershipNotifiesForMissingJournalWithoutRescue(t *t
 	const token = "rescue-token"
 	t.Setenv("ENGRAM_HTTP_TOKEN", token)
 	st := newServerTestStore(t)
+	if err := st.EnrollProject("target"); err != nil {
+		t.Fatalf("enroll target project: %v", err)
+	}
 	if err := st.CreateSession("owned-session", "target", "/tmp"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}

--- a/internal/store/cloud_inbox_test.go
+++ b/internal/store/cloud_inbox_test.go
@@ -152,6 +152,9 @@ func TestObservationAndRelationMutationsStillEnqueue(t *testing.T) {
 
 func TestTelemetryStillJournalsWhileProtocolRequiresSessions(t *testing.T) {
 	s := newTestStore(t)
+	if err := s.EnrollProject("protocol-project"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
 	if err := s.CreateSessionWithOwnershipMode("protocol-session", "protocol-project", "/tmp/protocol", SessionOwnershipProjectOwned); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -173,6 +176,41 @@ func TestTelemetryStillJournalsWhileProtocolRequiresSessions(t *testing.T) {
 		}
 		if state.Lifecycle != SyncLifecyclePending {
 			t.Fatalf("%s lifecycle = %q, want pending after telemetry enqueue", targetKey, state.Lifecycle)
+		}
+	}
+}
+
+func TestLocalCloudJournalWritesRequireEnrollmentAndBackfillCurrentState(t *testing.T) {
+	s := newTestStore(t)
+	const project = "enrollment-gated"
+	if err := s.CreateSession("gated-session", project, "/tmp/gated"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{SessionID: "gated-session", Type: "decision", Title: "before enrollment", Content: "local observation", Project: project, Scope: "project"}); err != nil {
+		t.Fatalf("add observation before enrollment: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "gated-session", Content: "local prompt", Project: project}); err != nil {
+		t.Fatalf("add prompt before enrollment: %v", err)
+	}
+	var before int
+	if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations WHERE project = ? AND acked_at IS NULL`, project).Scan(&before); err != nil || before != 0 {
+		t.Fatalf("pending mutations before enrollment = %d (err %v), want 0", before, err)
+	}
+
+	if err := s.EnrollProject(project); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{SessionID: "gated-session", Type: "decision", Title: "after enrollment", Content: "enrolled observation", Project: project, Scope: "project"}); err != nil {
+		t.Fatalf("add observation after enrollment: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "gated-session", Content: "enrolled prompt", Project: project}); err != nil {
+		t.Fatalf("add prompt after enrollment: %v", err)
+	}
+
+	for entity, want := range map[string]int{SyncEntitySession: 1, SyncEntityObservation: 2, SyncEntityPrompt: 2} {
+		var got int
+		if err := s.db.QueryRow(`SELECT count(*) FROM sync_mutations WHERE project = ? AND entity = ? AND acked_at IS NULL`, project, entity).Scan(&got); err != nil || got != want {
+			t.Fatalf("pending %s mutations = %d (err %v), want %d", entity, got, err, want)
 		}
 	}
 }

--- a/internal/store/remirror_test.go
+++ b/internal/store/remirror_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 )
@@ -16,8 +17,8 @@ func TestRemirrorProjectReplaysCurrentStateWithoutRewritingHistory(t *testing.T)
 	}
 	_, sourceID := addTestObsSession(t, s, "remirror-session", "source", "decision", project, "project")
 	_, targetID := addTestObsSession(t, s, "remirror-session", "target", "decision", project, "project")
-	deletedID, _ := addTestObsSession(t, s, "remirror-session", "deleted", "decision", project, "project")
-	if err := s.DeleteObservation(deletedID, false); err != nil {
+	deletedID, deletedSyncID := addTestObsSession(t, s, "remirror-session", "deleted", "decision", project, "project")
+	if err := s.DeleteObservation(deletedID, true); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.AddPrompt(AddPromptParams{SessionID: "remirror-session", Content: "live", Project: project}); err != nil {
@@ -90,6 +91,18 @@ func TestRemirrorProjectReplaysCurrentStateWithoutRewritingHistory(t *testing.T)
 		if count != 0 {
 			t.Fatalf("missing remirror %s mutations: %+v", entity, want)
 		}
+	}
+	runTombstoneBackfill := func(source string) {
+		t.Helper()
+		if err := s.withTx(func(tx *sql.Tx) error { return s.backfillSyncDeleteTombstonesTx(tx, project, source) }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runTombstoneBackfill("remirror:same")
+	runTombstoneBackfill("remirror:same")
+	runTombstoneBackfill("remirror:new")
+	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source LIKE 'remirror:%'`, SyncEntityObservation, deletedSyncID); got != 3 {
+		t.Fatalf("tombstone remirror mutations = %d, want 3", got)
 	}
 	peer := newTestStore(t)
 	if err := peer.ApplyPulledMutation(DefaultSyncTargetKey, sessionMutation); err != nil {

--- a/internal/store/remirror_test.go
+++ b/internal/store/remirror_test.go
@@ -105,6 +105,9 @@ func TestRemirrorProjectReplaysCurrentStateWithoutRewritingHistory(t *testing.T)
 		if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`, SyncEntityObservation, deletedSyncID, source); got != 1 {
 			t.Fatalf("tombstone mutations for %s = %d, want 1", source, got)
 		}
+		if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ? AND op = ? AND COALESCE(json_extract(payload, '$.hard_delete'), 0) = 1`, SyncEntityObservation, deletedSyncID, source, SyncOpDelete); got != 1 {
+			t.Fatalf("hard-delete tombstone mutations for %s = %d, want 1", source, got)
+		}
 	}
 	peer := newTestStore(t)
 	if err := peer.ApplyPulledMutation(DefaultSyncTargetKey, sessionMutation); err != nil {

--- a/internal/store/remirror_test.go
+++ b/internal/store/remirror_test.go
@@ -101,8 +101,10 @@ func TestRemirrorProjectReplaysCurrentStateWithoutRewritingHistory(t *testing.T)
 	runTombstoneBackfill("remirror:same")
 	runTombstoneBackfill("remirror:same")
 	runTombstoneBackfill("remirror:new")
-	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source LIKE 'remirror:%'`, SyncEntityObservation, deletedSyncID); got != 3 {
-		t.Fatalf("tombstone remirror mutations = %d, want 3", got)
+	for _, source := range []string{"remirror:same", "remirror:new"} {
+		if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`, SyncEntityObservation, deletedSyncID, source); got != 1 {
+			t.Fatalf("tombstone mutations for %s = %d, want 1", source, got)
+		}
 	}
 	peer := newTestStore(t)
 	if err := peer.ApplyPulledMutation(DefaultSyncTargetKey, sessionMutation); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6312,6 +6312,14 @@ func (s *Store) ListEnrolledProjects() ([]EnrolledProject, error) {
 }
 
 // IsProjectEnrolled returns true if the given project is enrolled for cloud sync.
+func isProjectEnrolledTx(tx *sql.Tx, project string) (bool, error) {
+	var enrolled bool
+	if err := tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM sync_enrolled_projects WHERE project = ?)`, project).Scan(&enrolled); err != nil {
+		return false, err
+	}
+	return enrolled, nil
+}
+
 func (s *Store) IsProjectEnrolled(project string) (bool, error) {
 	project, _ = NormalizeProject(project)
 	if project == "" {
@@ -7653,6 +7661,13 @@ func (s *Store) enqueueMissingLocalMutationTx(tx *sql.Tx, entity, entityKey stri
 	if canonical {
 		return true, nil
 	}
+	enrolled, err := isProjectEnrolledTx(tx, project)
+	if err != nil {
+		return false, err
+	}
+	if !enrolled {
+		return false, nil
+	}
 	if err := s.enqueueSyncMutationTx(tx, entity, entityKey, op, payload); err != nil {
 		return false, err
 	}
@@ -8280,6 +8295,18 @@ func (s *Store) enqueueSyncMutationWithSourceTx(tx *sql.Tx, entity, entityKey, o
 			} else {
 				project = derived
 			}
+		}
+	}
+	// Cloud journal delivery is opt-in per project. Local writes remain durable in
+	// SQLite while an unenrolled project accumulates no cloud mutation rows; the
+	// enrollment backfill materializes its current local state once it opts in.
+	if source == SyncSourceLocal && project != "" {
+		enrolled, err := isProjectEnrolledTx(tx, project)
+		if err != nil {
+			return err
+		}
+		if !enrolled {
+			return nil
 		}
 	}
 	if _, err := s.execHook(tx,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1038,6 +1038,16 @@ func (s *Store) migrate() error {
 				deleted_at TEXT NOT NULL DEFAULT (datetime('now'))
 			);
 
+			CREATE TABLE IF NOT EXISTS sync_delete_tombstones (
+				entity      TEXT NOT NULL,
+				entity_key  TEXT NOT NULL,
+				session_id  TEXT,
+				project     TEXT NOT NULL DEFAULT '',
+				deleted_at  TEXT NOT NULL DEFAULT (datetime('now')),
+				hard_delete BOOLEAN NOT NULL DEFAULT 1,
+				PRIMARY KEY (entity, entity_key)
+			);
+
 		CREATE INDEX IF NOT EXISTS idx_prompts_session ON user_prompts(session_id);
 		CREATE INDEX IF NOT EXISTS idx_prompts_project ON user_prompts(project);
 		CREATE INDEX IF NOT EXISTS idx_prompts_created ON user_prompts(created_at DESC);
@@ -1162,6 +1172,7 @@ func (s *Store) migrate() error {
 		CREATE INDEX IF NOT EXISTS idx_obs_dedupe ON observations(normalized_hash, project, scope, type, title, created_at DESC);
 		CREATE INDEX IF NOT EXISTS idx_prompts_sync_id ON user_prompts(sync_id);
 		CREATE INDEX IF NOT EXISTS idx_prompt_tombstones_project ON prompt_tombstones(project, deleted_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_sync_delete_tombstones_project ON sync_delete_tombstones(project, deleted_at DESC);
 		CREATE INDEX IF NOT EXISTS idx_sync_mutations_target_seq ON sync_mutations(target_key, seq);
 		CREATE INDEX IF NOT EXISTS idx_sync_mutations_pending ON sync_mutations(target_key, acked_at, seq);
 	`); err != nil {
@@ -2323,8 +2334,20 @@ func (s *Store) projectSyncBackfillRequired(project string) (bool, error) {
 				  AND sm.entity_key = obs.sync_id
 				  AND sm.source = ?
 			  )
+			UNION ALL
+			SELECT 1
+			FROM sync_delete_tombstones tombstone
+			WHERE tombstone.project = ?
+			  AND NOT EXISTS (
+				SELECT 1 FROM sync_mutations sm
+				WHERE sm.target_key = ?
+				  AND sm.entity = tombstone.entity
+				  AND sm.entity_key = tombstone.entity_key
+				  AND sm.op = ?
+				  AND sm.source = ?
+			  )
 		)
-	`, project, DefaultSyncTargetKey, SyncEntitySession, SyncSourceLocal, project, project, DefaultSyncTargetKey, SyncEntityObservation, SyncSourceLocal).Scan(&missing)
+	`, project, DefaultSyncTargetKey, SyncEntitySession, SyncSourceLocal, project, project, DefaultSyncTargetKey, SyncEntityObservation, SyncSourceLocal, project, DefaultSyncTargetKey, SyncOpDelete, SyncSourceLocal).Scan(&missing)
 	if err != nil {
 		return false, fmt.Errorf("detect project sync metadata gaps: %w", err)
 	}
@@ -3633,6 +3656,36 @@ func (s *Store) DeleteSession(id string) error {
 			return fmt.Errorf("%w: session %q has %d observation(s)", ErrSessionHasObservations, id, count)
 		}
 
+		deletedAt := Now()
+		promptRows, err := s.queryItHook(tx, `SELECT sync_id, session_id, ifnull(project, '') FROM user_prompts WHERE session_id = ? ORDER BY id ASC`, id)
+		if err != nil {
+			return fmt.Errorf("delete session: load prompts: %w", err)
+		}
+		var prompts []syncPromptPayload
+		for promptRows.Next() {
+			var prompt syncPromptPayload
+			if err := promptRows.Scan(&prompt.SyncID, &prompt.SessionID, &prompt.Project); err != nil {
+				return closeRowsWithError(promptRows, fmt.Errorf("delete session: load prompts: %w", err))
+			}
+			if strings.TrimSpace(derefString(prompt.Project)) == "" {
+				prompt.Project = nullableString(project)
+			}
+			prompts = append(prompts, prompt)
+		}
+		if err := promptRows.Close(); err != nil {
+			return err
+		}
+		if err := promptRows.Err(); err != nil {
+			return err
+		}
+		for _, prompt := range prompts {
+			if err := s.recordPromptTombstoneTx(tx, prompt.SyncID, prompt.SessionID, prompt.Project, deletedAt); err != nil {
+				return fmt.Errorf("delete session: record prompt tombstone: %w", err)
+			}
+		}
+		if err := s.recordSyncDeleteTombstoneTx(tx, SyncEntitySession, id, "", project, deletedAt); err != nil {
+			return fmt.Errorf("delete session: record tombstone: %w", err)
+		}
 		if _, err := s.execHook(tx, `DELETE FROM user_prompts WHERE session_id = ?`, id); err != nil {
 			return fmt.Errorf("delete session: remove prompts: %w", err)
 		}
@@ -3654,11 +3707,20 @@ func (s *Store) DeleteSession(id string) error {
 		}
 
 		if enrolled == 1 {
-			now := Now()
+			for _, prompt := range prompts {
+				prompt.Deleted = true
+				prompt.HardDelete = true
+				prompt.DeletedAt = &deletedAt
+				if err := s.enqueueSyncMutationTx(tx, SyncEntityPrompt, prompt.SyncID, SyncOpDelete, prompt); err != nil {
+					return fmt.Errorf("delete session: enqueue prompt mutation: %w", err)
+				}
+			}
 			if err := s.enqueueSyncMutationTx(tx, SyncEntitySession, id, SyncOpDelete, syncSessionPayload{
-				ID:        id,
-				Project:   project,
-				DeletedAt: &now,
+				ID:         id,
+				Project:    project,
+				Deleted:    true,
+				HardDelete: true,
+				DeletedAt:  &deletedAt,
 			}); err != nil {
 				return fmt.Errorf("delete session: enqueue mutation: %w", err)
 			}
@@ -3699,12 +3761,7 @@ func (s *Store) DeletePrompt(id int64) error {
 		if n == 0 {
 			return fmt.Errorf("%w: prompt #%d", ErrPromptNotFound, id)
 		}
-		if _, err := s.execHook(tx,
-			`INSERT INTO prompt_tombstones (sync_id, session_id, project, deleted_at)
-			 VALUES (?, ?, ?, ?)
-			 ON CONFLICT(sync_id) DO UPDATE SET session_id = excluded.session_id, project = excluded.project, deleted_at = excluded.deleted_at`,
-			payload.SyncID, payload.SessionID, payload.Project, now,
-		); err != nil {
+		if err := s.recordPromptTombstoneTx(tx, payload.SyncID, payload.SessionID, payload.Project, now); err != nil {
 			return fmt.Errorf("delete prompt: upsert tombstone: %w", err)
 		}
 		if err := s.enqueueSyncMutationTx(tx, SyncEntityPrompt, payload.SyncID, SyncOpDelete, payload); err != nil {
@@ -3828,6 +3885,18 @@ func (s *Store) DeleteObservation(id int64, hardDelete bool) error {
 
 		deletedAt := Now()
 		if hardDelete {
+			project := derefString(obs.Project)
+			if project == "" {
+				project, err = s.resolveSessionProjectTx(tx, obs.SessionID)
+				if err != nil {
+					return err
+				}
+			}
+			project, _ = NormalizeProject(project)
+			if err := s.recordSyncDeleteTombstoneTx(tx, SyncEntityObservation, obs.SyncID, obs.SessionID, project, deletedAt); err != nil {
+				return fmt.Errorf("record hard observation tombstone: %w", err)
+			}
+			obs.Project = nullableString(project)
 			if _, err := s.execHook(tx, `DELETE FROM observations WHERE id = ?`, id); err != nil {
 				return err
 			}
@@ -7544,6 +7613,9 @@ func (s *Store) backfillProjectSyncMutationsTx(tx *sql.Tx, project string, sourc
 	if err := s.backfillPromptSyncMutationsTx(tx, project, source...); err != nil {
 		return err
 	}
+	if err := s.backfillSyncDeleteTombstonesTx(tx, project, source...); err != nil {
+		return err
+	}
 	return s.backfillRelationSyncMutationsTx(tx, project, source...)
 }
 
@@ -7552,6 +7624,53 @@ func backfillMutationSource(source []string) string {
 		return SyncSourceLocal
 	}
 	return strings.TrimSpace(source[0])
+}
+
+// recordSyncDeleteTombstoneTx preserves delete intent for entities whose local
+// row is physically removed. Prompt tombstones predate this table and retain
+// their own identity and stale-upsert semantics.
+func (s *Store) recordSyncDeleteTombstoneTx(tx *sql.Tx, entity, entityKey, sessionID, project, deletedAt string) error {
+	if entity != SyncEntitySession && entity != SyncEntityObservation {
+		return fmt.Errorf("unsupported sync delete tombstone entity %q", entity)
+	}
+	entityKey = strings.TrimSpace(entityKey)
+	if entityKey == "" {
+		return fmt.Errorf("sync delete tombstone entity key is required")
+	}
+	project, _ = NormalizeProject(strings.TrimSpace(project))
+	_, err := s.execHook(tx, `
+		INSERT INTO sync_delete_tombstones (entity, entity_key, session_id, project, deleted_at, hard_delete)
+		VALUES (?, ?, ?, ?, ?, 1)
+		ON CONFLICT(entity, entity_key) DO UPDATE SET
+			session_id = excluded.session_id,
+			project = excluded.project,
+			deleted_at = excluded.deleted_at,
+			hard_delete = excluded.hard_delete`,
+		entity, entityKey, nullableString(sessionID), project, deletedAt,
+	)
+	return err
+}
+
+func (s *Store) clearSyncDeleteTombstoneForUpsertTx(tx *sql.Tx, entity, entityKey string) error {
+	if entity != SyncEntitySession && entity != SyncEntityObservation {
+		return nil
+	}
+	_, err := s.execHook(tx, `DELETE FROM sync_delete_tombstones WHERE entity = ? AND entity_key = ?`, entity, entityKey)
+	return err
+}
+
+func (s *Store) recordPromptTombstoneTx(tx *sql.Tx, syncID, sessionID string, project *string, deletedAt string) error {
+	if project != nil {
+		normalized, _ := NormalizeProject(strings.TrimSpace(*project))
+		project = nullableString(normalized)
+	}
+	_, err := s.execHook(tx,
+		`INSERT INTO prompt_tombstones (sync_id, session_id, project, deleted_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(sync_id) DO UPDATE SET session_id = excluded.session_id, project = excluded.project, deleted_at = excluded.deleted_at`,
+		syncID, sessionID, project, deletedAt,
+	)
+	return err
 }
 
 // enqueueRescuedProjectMutationsTx journals the rescued rows. sessionIDs covers
@@ -7723,6 +7842,15 @@ func (s *Store) projectNeedsBackfill(project string) (bool, error) {
 			args: []any{project, project, DefaultSyncTargetKey, SyncEntityObservation, SyncOpDelete, SyncSourceLocal},
 		},
 		{
+			q: `SELECT COUNT(*) FROM sync_delete_tombstones tombstone
+			    WHERE tombstone.project = ?
+			      AND NOT EXISTS (
+			        SELECT 1 FROM sync_mutations sm
+			        WHERE sm.target_key = ? AND sm.entity = tombstone.entity AND sm.entity_key = tombstone.entity_key AND sm.op = ? AND sm.source = ?
+			      )`,
+			args: []any{project, DefaultSyncTargetKey, SyncOpDelete, SyncSourceLocal},
+		},
+		{
 			q: `SELECT COUNT(*) FROM user_prompts p
 			    LEFT JOIN sessions s ON s.id = p.session_id
 			    WHERE (ifnull(p.project,'') = ? OR (ifnull(p.project,'') = '' AND ifnull(s.project,'') = ?))
@@ -7811,6 +7939,10 @@ func (s *Store) enrolledProjectsNeedingBackfill() ([]string, error) {
 			FROM prompt_tombstones x LEFT JOIN sessions xs ON xs.id = x.session_id
 			WHERE NOT EXISTS (SELECT 1 FROM sync_mutations sm WHERE sm.target_key = ? AND sm.entity = ? AND sm.entity_key = x.sync_id AND sm.source = ? AND sm.op = ?)
 			UNION
+			SELECT x.project
+			FROM sync_delete_tombstones x
+			WHERE NOT EXISTS (SELECT 1 FROM sync_mutations sm WHERE sm.target_key = ? AND sm.entity = x.entity AND sm.entity_key = x.entity_key AND sm.source = ? AND sm.op = ?)
+			UNION
 			SELECT coalesce(nullif(src.project, ''), src_s.project, '')
 			FROM memory_relations r
 			JOIN observations src ON src.sync_id = r.source_id AND src.deleted_at IS NULL
@@ -7827,6 +7959,7 @@ func (s *Store) enrolledProjectsNeedingBackfill() ([]string, error) {
 		DefaultSyncTargetKey, SyncEntityObservation, SyncOpDelete, SyncSourceLocal,
 		DefaultSyncTargetKey, SyncEntityPrompt, SyncSourceLocal,
 		DefaultSyncTargetKey, SyncEntityPrompt, SyncSourceLocal, SyncOpDelete,
+		DefaultSyncTargetKey, SyncSourceLocal, SyncOpDelete,
 		JudgmentStatusOrphaned, JudgmentStatusPending, DefaultSyncTargetKey, SyncEntityRelation, SyncSourceLocal,
 	)
 	if err != nil {
@@ -8086,6 +8219,76 @@ func (s *Store) backfillObservationSyncMutationsTx(tx *sql.Tx, project string, s
 	return nil
 }
 
+func (s *Store) backfillSyncDeleteTombstonesTx(tx *sql.Tx, project string, source ...string) error {
+	mutationSource := backfillMutationSource(source)
+	rows, err := s.queryItHook(tx, `
+		SELECT entity, entity_key, ifnull(session_id, ''), project, deleted_at, hard_delete
+		FROM sync_delete_tombstones tombstone
+		WHERE project = ?
+		  AND NOT EXISTS (
+			SELECT 1 FROM sync_mutations sm
+			WHERE sm.target_key = ?
+			  AND sm.entity = tombstone.entity
+			  AND sm.entity_key = tombstone.entity_key
+			  AND sm.op = ?
+			  AND sm.source = ?
+		  )
+		ORDER BY CASE entity WHEN 'observation' THEN 0 WHEN 'session' THEN 1 ELSE 2 END, deleted_at ASC, entity_key ASC`,
+		project, DefaultSyncTargetKey, SyncOpDelete, mutationSource,
+	)
+	if err != nil {
+		return err
+	}
+	type tombstone struct {
+		entity, entityKey, sessionID, project, deletedAt string
+		hardDelete                                       bool
+	}
+	var pending []tombstone
+	for rows.Next() {
+		var item tombstone
+		if err := rows.Scan(&item.entity, &item.entityKey, &item.sessionID, &item.project, &item.deletedAt, &item.hardDelete); err != nil {
+			return closeRowsWithError(rows, err)
+		}
+		pending = append(pending, item)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, item := range pending {
+		switch item.entity {
+		case SyncEntityObservation:
+			payload := syncObservationPayload{
+				SyncID:     item.entityKey,
+				SessionID:  item.sessionID,
+				Project:    nullableString(item.project),
+				Deleted:    true,
+				DeletedAt:  &item.deletedAt,
+				HardDelete: item.hardDelete,
+			}
+			if err := s.enqueueSyncMutationWithSourceTx(tx, item.entity, item.entityKey, SyncOpDelete, payload, mutationSource); err != nil {
+				return err
+			}
+		case SyncEntitySession:
+			payload := syncSessionPayload{
+				ID:         item.entityKey,
+				Project:    item.project,
+				Deleted:    true,
+				DeletedAt:  &item.deletedAt,
+				HardDelete: item.hardDelete,
+			}
+			if err := s.enqueueSyncMutationWithSourceTx(tx, item.entity, item.entityKey, SyncOpDelete, payload, mutationSource); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported sync delete tombstone entity %q", item.entity)
+		}
+	}
+	return nil
+}
+
 func (s *Store) backfillPromptSyncMutationsTx(tx *sql.Tx, project string, source ...string) error {
 	mutationSource := backfillMutationSource(source)
 	// ── Live prompts ──────────────────────────────────────────────────────────
@@ -8280,6 +8483,11 @@ func (s *Store) enqueueSyncMutationWithSourceTx(tx *sql.Tx, entity, entityKey, o
 	source = strings.TrimSpace(source)
 	if source == "" {
 		source = SyncSourceLocal
+	}
+	if op == SyncOpUpsert {
+		if err := s.clearSyncDeleteTombstoneForUpsertTx(tx, entity, entityKey); err != nil {
+			return err
+		}
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
@@ -8971,7 +9179,10 @@ func (s *Store) applySessionPayloadTx(tx *sql.Tx, payload syncSessionPayload) er
 		   summary = COALESCE(excluded.summary, sessions.summary)`,
 		payload.ID, payload.Project, nullableOwnershipMode(payload.OwnershipMode), payload.Directory, strings.TrimSpace(payload.StartedAt), payload.EndedAt, payload.Summary,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	return s.clearSyncDeleteTombstoneForUpsertTx(tx, SyncEntitySession, payload.ID)
 }
 
 func isSessionDeletePayload(payload syncSessionPayload) bool {
@@ -9095,7 +9306,10 @@ func (s *Store) applyObservationUpsertTx(tx *sql.Tx, payload syncObservationPayl
 			createdAt,
 			updatedAt,
 		)
-		return err
+		if err != nil {
+			return err
+		}
+		return s.clearSyncDeleteTombstoneForUpsertTx(tx, SyncEntityObservation, payload.SyncID)
 	}
 	if err != nil {
 		return err
@@ -9137,7 +9351,10 @@ func (s *Store) applyObservationUpsertTx(tx *sql.Tx, payload syncObservationPayl
 		updatedAt,
 		existing.ID,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	return s.clearSyncDeleteTombstoneForUpsertTx(tx, SyncEntityObservation, payload.SyncID)
 }
 
 func (s *Store) applyObservationDeleteTx(tx *sql.Tx, payload syncObservationPayload) error {
@@ -9229,13 +9446,7 @@ func (s *Store) applyPromptDeleteTx(tx *sql.Tx, payload syncPromptPayload) error
 		now := Now()
 		deletedAt = &now
 	}
-	_, err := s.execHook(tx,
-		`INSERT INTO prompt_tombstones (sync_id, session_id, project, deleted_at)
-		 VALUES (?, ?, ?, ?)
-		 ON CONFLICT(sync_id) DO UPDATE SET session_id = excluded.session_id, project = excluded.project, deleted_at = excluded.deleted_at`,
-		payload.SyncID, payload.SessionID, payload.Project, *deletedAt,
-	)
-	return err
+	return s.recordPromptTombstoneTx(tx, payload.SyncID, payload.SessionID, payload.Project, *deletedAt)
 }
 
 func isStalePromptUpsert(payload syncPromptPayload, tombstoneDeletedAt string) bool {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1116,14 +1116,6 @@ func (s *Store) migrate() error {
 	if _, err := s.execHook(s.db, schema); err != nil {
 		return err
 	}
-	for _, c := range []struct{ name, definition string }{
-		{"active", "BOOLEAN NOT NULL DEFAULT 1"},
-		{"last_mutation_seq", "INTEGER NOT NULL DEFAULT 0"},
-	} {
-		if err := s.addColumnIfNotExists("sync_delete_tombstones", c.name, c.definition); err != nil {
-			return err
-		}
-	}
 	if err := s.redactCloudUpgradeSnapshots(); err != nil {
 		return err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1043,8 +1043,10 @@ func (s *Store) migrate() error {
 				entity_key  TEXT NOT NULL,
 				session_id  TEXT,
 				project     TEXT NOT NULL DEFAULT '',
-				deleted_at  TEXT NOT NULL DEFAULT (datetime('now')),
-				hard_delete BOOLEAN NOT NULL DEFAULT 1,
+				deleted_at        TEXT NOT NULL DEFAULT (datetime('now')),
+				hard_delete       BOOLEAN NOT NULL DEFAULT 1,
+				active            BOOLEAN NOT NULL DEFAULT 1,
+				last_mutation_seq INTEGER NOT NULL DEFAULT 0,
 				PRIMARY KEY (entity, entity_key)
 			);
 
@@ -1113,6 +1115,14 @@ func (s *Store) migrate() error {
 		`
 	if _, err := s.execHook(s.db, schema); err != nil {
 		return err
+	}
+	for _, c := range []struct{ name, definition string }{
+		{"active", "BOOLEAN NOT NULL DEFAULT 1"},
+		{"last_mutation_seq", "INTEGER NOT NULL DEFAULT 0"},
+	} {
+		if err := s.addColumnIfNotExists("sync_delete_tombstones", c.name, c.definition); err != nil {
+			return err
+		}
 	}
 	if err := s.redactCloudUpgradeSnapshots(); err != nil {
 		return err
@@ -2337,15 +2347,7 @@ func (s *Store) projectSyncBackfillRequired(project string) (bool, error) {
 			UNION ALL
 			SELECT 1
 			FROM sync_delete_tombstones tombstone
-			WHERE tombstone.project = ?
-			  AND NOT EXISTS (
-				SELECT 1 FROM sync_mutations sm
-				WHERE sm.target_key = ?
-				  AND sm.entity = tombstone.entity
-				  AND sm.entity_key = tombstone.entity_key
-				  AND sm.op = ?
-				  AND sm.source = ?
-			  )
+			WHERE tombstone.project = ? AND `+syncDeleteTombstoneNeedsBackfill("tombstone")+`
 		)
 	`, project, DefaultSyncTargetKey, SyncEntitySession, SyncSourceLocal, project, project, DefaultSyncTargetKey, SyncEntityObservation, SyncSourceLocal, project, DefaultSyncTargetKey, SyncOpDelete, SyncSourceLocal).Scan(&missing)
 	if err != nil {
@@ -3631,6 +3633,7 @@ func (s *Store) DeleteSession(id string) error {
 			}
 			return fmt.Errorf("delete session: load session: %w", err)
 		}
+		project, _ = NormalizeProject(strings.TrimSpace(project))
 
 		var enrolled int
 		if err := tx.QueryRow(`SELECT 1 FROM sync_enrolled_projects WHERE project = ? LIMIT 1`, project).Scan(&enrolled); err != nil {
@@ -7626,6 +7629,14 @@ func backfillMutationSource(source []string) string {
 	return strings.TrimSpace(source[0])
 }
 
+func syncDeleteTombstoneNeedsBackfill(alias string) string {
+	return fmt.Sprintf(`%[1]s.active = 1 AND NOT EXISTS (
+		SELECT 1 FROM sync_mutations sm WHERE sm.target_key = ? AND sm.entity = %[1]s.entity
+		AND sm.entity_key = %[1]s.entity_key AND sm.op = ? AND sm.source = ?
+		AND sm.seq > %[1]s.last_mutation_seq
+	)`, alias)
+}
+
 // recordSyncDeleteTombstoneTx preserves delete intent for entities whose local
 // row is physically removed. Prompt tombstones predate this table and retain
 // their own identity and stale-upsert semantics.
@@ -7637,16 +7648,24 @@ func (s *Store) recordSyncDeleteTombstoneTx(tx *sql.Tx, entity, entityKey, sessi
 	if entityKey == "" {
 		return fmt.Errorf("sync delete tombstone entity key is required")
 	}
+	var floor, history int64
+	if err := tx.QueryRow(`SELECT COALESCE(last_mutation_seq, 0) FROM sync_delete_tombstones WHERE entity = ? AND entity_key = ?`, entity, entityKey).Scan(&floor); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if err := tx.QueryRow(`SELECT COALESCE(MAX(seq), 0) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND op = ?`, entity, entityKey, SyncOpDelete).Scan(&history); err != nil {
+		return err
+	}
+	if history > floor {
+		floor = history
+	}
 	project, _ = NormalizeProject(strings.TrimSpace(project))
 	_, err := s.execHook(tx, `
-		INSERT INTO sync_delete_tombstones (entity, entity_key, session_id, project, deleted_at, hard_delete)
-		VALUES (?, ?, ?, ?, ?, 1)
+		INSERT INTO sync_delete_tombstones (entity, entity_key, session_id, project, deleted_at, hard_delete, active, last_mutation_seq)
+		VALUES (?, ?, ?, ?, ?, 1, 1, ?)
 		ON CONFLICT(entity, entity_key) DO UPDATE SET
-			session_id = excluded.session_id,
-			project = excluded.project,
-			deleted_at = excluded.deleted_at,
-			hard_delete = excluded.hard_delete`,
-		entity, entityKey, nullableString(sessionID), project, deletedAt,
+			session_id = excluded.session_id, project = excluded.project, deleted_at = excluded.deleted_at,
+			hard_delete = excluded.hard_delete, active = 1, last_mutation_seq = MAX(sync_delete_tombstones.last_mutation_seq, excluded.last_mutation_seq)`,
+		entity, entityKey, nullableString(sessionID), project, deletedAt, floor,
 	)
 	return err
 }
@@ -7655,7 +7674,7 @@ func (s *Store) clearSyncDeleteTombstoneForUpsertTx(tx *sql.Tx, entity, entityKe
 	if entity != SyncEntitySession && entity != SyncEntityObservation {
 		return nil
 	}
-	_, err := s.execHook(tx, `DELETE FROM sync_delete_tombstones WHERE entity = ? AND entity_key = ?`, entity, entityKey)
+	_, err := s.execHook(tx, `UPDATE sync_delete_tombstones SET active = 0 WHERE entity = ? AND entity_key = ?`, entity, entityKey)
 	return err
 }
 
@@ -7843,11 +7862,7 @@ func (s *Store) projectNeedsBackfill(project string) (bool, error) {
 		},
 		{
 			q: `SELECT COUNT(*) FROM sync_delete_tombstones tombstone
-			    WHERE tombstone.project = ?
-			      AND NOT EXISTS (
-			        SELECT 1 FROM sync_mutations sm
-			        WHERE sm.target_key = ? AND sm.entity = tombstone.entity AND sm.entity_key = tombstone.entity_key AND sm.op = ? AND sm.source = ?
-			      )`,
+			    WHERE tombstone.project = ? AND ` + syncDeleteTombstoneNeedsBackfill("tombstone"),
 			args: []any{project, DefaultSyncTargetKey, SyncOpDelete, SyncSourceLocal},
 		},
 		{
@@ -7941,7 +7956,7 @@ func (s *Store) enrolledProjectsNeedingBackfill() ([]string, error) {
 			UNION
 			SELECT x.project
 			FROM sync_delete_tombstones x
-			WHERE NOT EXISTS (SELECT 1 FROM sync_mutations sm WHERE sm.target_key = ? AND sm.entity = x.entity AND sm.entity_key = x.entity_key AND sm.source = ? AND sm.op = ?)
+			WHERE `+syncDeleteTombstoneNeedsBackfill("x")+`
 			UNION
 			SELECT coalesce(nullif(src.project, ''), src_s.project, '')
 			FROM memory_relations r
@@ -7959,7 +7974,7 @@ func (s *Store) enrolledProjectsNeedingBackfill() ([]string, error) {
 		DefaultSyncTargetKey, SyncEntityObservation, SyncOpDelete, SyncSourceLocal,
 		DefaultSyncTargetKey, SyncEntityPrompt, SyncSourceLocal,
 		DefaultSyncTargetKey, SyncEntityPrompt, SyncSourceLocal, SyncOpDelete,
-		DefaultSyncTargetKey, SyncSourceLocal, SyncOpDelete,
+		DefaultSyncTargetKey, SyncOpDelete, SyncSourceLocal,
 		JudgmentStatusOrphaned, JudgmentStatusPending, DefaultSyncTargetKey, SyncEntityRelation, SyncSourceLocal,
 	)
 	if err != nil {
@@ -8224,15 +8239,7 @@ func (s *Store) backfillSyncDeleteTombstonesTx(tx *sql.Tx, project string, sourc
 	rows, err := s.queryItHook(tx, `
 		SELECT entity, entity_key, ifnull(session_id, ''), project, deleted_at, hard_delete
 		FROM sync_delete_tombstones tombstone
-		WHERE project = ?
-		  AND NOT EXISTS (
-			SELECT 1 FROM sync_mutations sm
-			WHERE sm.target_key = ?
-			  AND sm.entity = tombstone.entity
-			  AND sm.entity_key = tombstone.entity_key
-			  AND sm.op = ?
-			  AND sm.source = ?
-		  )
+		WHERE project = ? AND `+syncDeleteTombstoneNeedsBackfill("tombstone")+`
 		ORDER BY CASE entity WHEN 'observation' THEN 0 WHEN 'session' THEN 1 ELSE 2 END, deleted_at ASC, entity_key ASC`,
 		project, DefaultSyncTargetKey, SyncOpDelete, mutationSource,
 	)

--- a/internal/store/store_migration_test.go
+++ b/internal/store/store_migration_test.go
@@ -938,16 +938,6 @@ func TestMigrate_LegacyDeferredRowsRemainAdministrativeOnly(t *testing.T) {
 func TestMigrateSyncDeleteTombstonesRepeatOpenSafe(t *testing.T) {
 	cfg := mustDefaultConfig(t)
 	cfg.DataDir = t.TempDir()
-	raw, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := raw.Exec(`CREATE TABLE sync_delete_tombstones (entity TEXT NOT NULL, entity_key TEXT NOT NULL, session_id TEXT, project TEXT NOT NULL DEFAULT '', deleted_at TEXT NOT NULL DEFAULT (datetime('now')), hard_delete BOOLEAN NOT NULL DEFAULT 1, PRIMARY KEY (entity, entity_key))`); err != nil {
-		t.Fatal(err)
-	}
-	if err := raw.Close(); err != nil {
-		t.Fatal(err)
-	}
 	first, err := New(cfg)
 	if err != nil {
 		t.Fatalf("first open: %v", err)
@@ -965,7 +955,7 @@ func TestMigrateSyncDeleteTombstonesRepeatOpenSafe(t *testing.T) {
 	t.Cleanup(func() { _ = second.Close() })
 	var active, floor int
 	if err := second.db.QueryRow(`SELECT active, last_mutation_seq FROM sync_delete_tombstones WHERE entity_key = ?`, "migration-floor").Scan(&active, &floor); err != nil || active != 1 || floor != 0 {
-		t.Fatalf("tombstone defaults = active=%d floor=%d err=%v", active, floor, err)
+		t.Fatalf("tombstone defaults/data after repeat open = active=%d floor=%d err=%v", active, floor, err)
 	}
 }
 

--- a/internal/store/store_migration_test.go
+++ b/internal/store/store_migration_test.go
@@ -935,6 +935,32 @@ func TestMigrate_LegacyDeferredRowsRemainAdministrativeOnly(t *testing.T) {
 	}
 }
 
+func TestMigrateSyncDeleteTombstonesRepeatOpenSafe(t *testing.T) {
+	cfg := mustDefaultConfig(t)
+	cfg.DataDir = t.TempDir()
+
+	first, err := New(cfg)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first store: %v", err)
+	}
+
+	second, err := New(cfg)
+	if err != nil {
+		t.Fatalf("repeat open: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+	var table string
+	if err := second.db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sync_delete_tombstones'`).Scan(&table); err != nil {
+		t.Fatalf("find sync delete tombstones table: %v", err)
+	}
+	if table != "sync_delete_tombstones" {
+		t.Fatalf("sync delete tombstones table = %q", table)
+	}
+}
+
 func TestMigrate_AddsNullableLastSuccessAtWithoutBackfill(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "engram.db")

--- a/internal/store/store_migration_test.go
+++ b/internal/store/store_migration_test.go
@@ -938,26 +938,34 @@ func TestMigrate_LegacyDeferredRowsRemainAdministrativeOnly(t *testing.T) {
 func TestMigrateSyncDeleteTombstonesRepeatOpenSafe(t *testing.T) {
 	cfg := mustDefaultConfig(t)
 	cfg.DataDir = t.TempDir()
-
+	raw, err := sql.Open("sqlite", filepath.Join(cfg.DataDir, "engram.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE sync_delete_tombstones (entity TEXT NOT NULL, entity_key TEXT NOT NULL, session_id TEXT, project TEXT NOT NULL DEFAULT '', deleted_at TEXT NOT NULL DEFAULT (datetime('now')), hard_delete BOOLEAN NOT NULL DEFAULT 1, PRIMARY KEY (entity, entity_key))`); err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
 	first, err := New(cfg)
 	if err != nil {
 		t.Fatalf("first open: %v", err)
 	}
+	if _, err := first.db.Exec(`INSERT INTO sync_delete_tombstones (entity, entity_key) VALUES (?, ?)`, SyncEntityObservation, "migration-floor"); err != nil {
+		t.Fatal(err)
+	}
 	if err := first.Close(); err != nil {
 		t.Fatalf("close first store: %v", err)
 	}
-
 	second, err := New(cfg)
 	if err != nil {
 		t.Fatalf("repeat open: %v", err)
 	}
 	t.Cleanup(func() { _ = second.Close() })
-	var table string
-	if err := second.db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sync_delete_tombstones'`).Scan(&table); err != nil {
-		t.Fatalf("find sync delete tombstones table: %v", err)
-	}
-	if table != "sync_delete_tombstones" {
-		t.Fatalf("sync delete tombstones table = %q", table)
+	var active, floor int
+	if err := second.db.QueryRow(`SELECT active, last_mutation_seq FROM sync_delete_tombstones WHERE entity_key = ?`, "migration-floor").Scan(&active, &floor); err != nil || active != 1 || floor != 0 {
+		t.Fatalf("tombstone defaults = active=%d floor=%d err=%v", active, floor, err)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7928,6 +7928,123 @@ func TestEnrollAndLookupProjectNormalization(t *testing.T) {
 	}
 }
 
+func TestDeleteSessionNormalizesPromptTombstoneProjectForReenrollment(t *testing.T) {
+	const canonicalProject = "legacy_project"
+	const sessionID = "legacy-padded-session"
+	const promptSyncID = "prompt-legacy-padded"
+
+	s := newTestStore(t)
+	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, ?, ?)`, sessionID, "  LEGACY__PROJECT  ", "/tmp/legacy"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES (?, ?, ?, ?)`, promptSyncID, sessionID, "legacy prompt", " \t "); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteSession(sessionID); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.EnrollProject(canonicalProject); err != nil {
+		t.Fatal(err)
+	}
+
+	var project, op string
+	if err := s.db.QueryRow(`SELECT project, op FROM sync_mutations WHERE entity = ? AND entity_key = ?`, SyncEntityPrompt, promptSyncID).Scan(&project, &op); err != nil {
+		t.Fatalf("find re-enrolled prompt delete: %v", err)
+	}
+	if project != canonicalProject || op != SyncOpDelete {
+		t.Fatalf("re-enrolled prompt mutation = project %q op %q, want project %q op %q", project, op, canonicalProject, SyncOpDelete)
+	}
+}
+
+func TestUnenrolledHardDeletesReplayAfterReenrollment(t *testing.T) {
+	t.Run("observation", func(t *testing.T) {
+		const project = "unenrolled-hard-observation"
+		s := newTestStore(t)
+		if err := s.CreateSession("unenrolled-hard-observation-session", project, "/tmp/unenrolled-hard-observation"); err != nil {
+			t.Fatal(err)
+		}
+		observationID, err := s.AddObservation(AddObservationParams{
+			SessionID: "unenrolled-hard-observation-session",
+			Type:      "decision",
+			Title:     "delete while unenrolled",
+			Content:   "keep delete intent",
+			Project:   project,
+			Scope:     "project",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var syncID string
+		if err := s.db.QueryRow(`SELECT sync_id FROM observations WHERE id = ?`, observationID).Scan(&syncID); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.DeleteObservation(observationID, true); err != nil {
+			t.Fatal(err)
+		}
+		if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations`); got != 0 {
+			t.Fatalf("unenrolled hard delete wrote %d sync mutations, want 0", got)
+		}
+
+		if err := s.EnrollProject(project); err != nil {
+			t.Fatal(err)
+		}
+		mutations, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(mutations) != 2 || mutations[0].Entity != SyncEntitySession || mutations[0].Op != SyncOpUpsert || mutations[1].Entity != SyncEntityObservation || mutations[1].EntityKey != syncID || mutations[1].Op != SyncOpDelete {
+			t.Fatalf("re-enrollment mutations = %+v, want session upsert then observation delete", mutations)
+		}
+		beforeRepeat := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations`)
+		if err := s.UnenrollProject(project); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.EnrollProject(project); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.withTx(func(tx *sql.Tx) error { return s.backfillProjectSyncMutationsTx(tx, project) }); err != nil {
+			t.Fatal(err)
+		}
+		if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations`); got != beforeRepeat {
+			t.Fatalf("re-enrollment/repeated backfill wrote duplicate mutations: got %d, want %d", got, beforeRepeat)
+		}
+	})
+
+	t.Run("session and prompts", func(t *testing.T) {
+		const project = "unenrolled-hard-session"
+		const sessionID = "unenrolled-hard-session-id"
+		s := newTestStore(t)
+		if err := s.CreateSession(sessionID, project, "/tmp/unenrolled-hard-session"); err != nil {
+			t.Fatal(err)
+		}
+		promptID, err := s.AddPrompt(AddPromptParams{SessionID: sessionID, Content: "delete with session", Project: project})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var promptSyncID string
+		if err := s.db.QueryRow(`SELECT sync_id FROM user_prompts WHERE id = ?`, promptID).Scan(&promptSyncID); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.DeleteSession(sessionID); err != nil {
+			t.Fatal(err)
+		}
+		if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations`); got != 0 {
+			t.Fatalf("unenrolled session delete wrote %d sync mutations, want 0", got)
+		}
+
+		if err := s.EnrollProject(project); err != nil {
+			t.Fatal(err)
+		}
+		mutations, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(mutations) != 2 || mutations[0].Entity != SyncEntityPrompt || mutations[0].EntityKey != promptSyncID || mutations[0].Op != SyncOpDelete || mutations[1].Entity != SyncEntitySession || mutations[1].EntityKey != sessionID || mutations[1].Op != SyncOpDelete {
+			t.Fatalf("re-enrollment mutations = %+v, want prompt delete then session delete", mutations)
+		}
+	})
+}
+
 func TestEnrollProjectBackfillsHistoricalMutations(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -44,6 +44,13 @@ func newTestStore(t *testing.T) *Store {
 	return s
 }
 
+func enrollTestProject(t *testing.T, s *Store, project string) {
+	t.Helper()
+	if err := s.EnrollProject(project); err != nil {
+		t.Fatalf("enroll %q: %v", project, err)
+	}
+}
+
 func TestStoreDataDir(t *testing.T) {
 	cfg := mustDefaultConfig(t)
 	cfg.DataDir = t.TempDir()
@@ -254,6 +261,7 @@ func TestTruncateContentPreservesUTF8BytePrefix(t *testing.T) {
 
 func TestProjectIdentityAdmissionAllowsOwnedWritesAndRejectsReassignment(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "project")
 	if err := s.CreateSession("owned-session", "Project", "/tmp"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -397,9 +405,27 @@ func TestRescueNullProjectOwnershipRequiresExplicitScope(t *testing.T) {
 	}
 }
 
+func TestRescueNullProjectOwnershipDoesNotReportSuppressedUnenrolledJournal(t *testing.T) {
+	type legacySession struct{ id, project string }
+	s := newTestStoreWithNullableLegacySessions(t, legacySession{"legacy-session", "<NULL>"})
+
+	result, err := s.RescueNullProjectOwnership(ProjectRescueParams{TargetProject: "target", SessionIDs: []string{"legacy-session"}})
+	if err != nil {
+		t.Fatalf("RescueNullProjectOwnership: %v", err)
+	}
+	if result.Journaled {
+		t.Fatalf("rescue result = %#v, want Journaled false when enrollment suppresses the local mutation", result)
+	}
+	var mutations int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE project = ? AND acked_at IS NULL`, "target").Scan(&mutations); err != nil || mutations != 0 {
+		t.Fatalf("pending target mutations = %d, err=%v, want 0", mutations, err)
+	}
+}
+
 func TestRescueNullProjectOwnershipRescuesLegacyNullableSessionAndJournalsOnce(t *testing.T) {
 	type legacySession struct{ id, project string }
 	s := newTestStoreWithNullableLegacySessions(t, legacySession{"legacy-session", "<NULL>"})
+	enrollTestProject(t, s, "target")
 
 	result, err := s.RescueNullProjectOwnership(ProjectRescueParams{TargetProject: "target", SessionIDs: []string{"legacy-session"}})
 	if err != nil {
@@ -432,6 +458,7 @@ func TestRescueNullProjectOwnershipStampsMissingSameProjectOwnershipMode(t *test
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newTestStore(t)
+			enrollTestProject(t, s, "target")
 			if err := s.CreateSessionWithOwnershipMode(tc.sessionID, "target", "/tmp", SessionOwnershipShared); err != nil {
 				t.Fatalf("CreateSessionWithOwnershipMode: %v", err)
 			}
@@ -617,6 +644,7 @@ func TestAddObservationAdoptsUnownedLegacySessionProject(t *testing.T) {
 				legacySession{"null-session", "<NULL>"},
 				legacySession{"blank-session", " "},
 			)
+			enrollTestProject(t, s, "target")
 
 			id, err := s.AddObservation(AddObservationParams{SessionID: tc.sessionID, Type: "note", Title: "upgraded", Content: "content", Project: "target"})
 			if err != nil {
@@ -812,6 +840,7 @@ func TestRescueNullProjectOwnershipRescuesOnlyNullRecordsAndJournalsOnce(t *test
 		}
 	}
 
+	enrollTestProject(t, s, "target")
 	params := ProjectRescueParams{TargetProject: "target", ObservationIDs: []int64{observationID, ownedID}, PromptIDs: []int64{promptID}}
 	result, err := s.RescueNullProjectOwnership(params)
 	if err != nil {
@@ -876,6 +905,7 @@ func TestRescueNullProjectOwnershipReplacesStaleAcknowledgedJournal(t *testing.T
 	if _, err := s.DB().Exec(`UPDATE sync_mutations SET project = 'stale', payload = '{"project":"stale"}', acked_at = datetime('now') WHERE entity = ? AND entity_key = ?`, SyncEntityObservation, syncID); err != nil {
 		t.Fatalf("seed stale journal: %v", err)
 	}
+	enrollTestProject(t, s, "target")
 	params := ProjectRescueParams{TargetProject: "target", ObservationIDs: []int64{id}}
 	result, err := s.RescueNullProjectOwnership(params)
 	if err != nil || !result.Journaled {
@@ -897,6 +927,7 @@ func TestRescueNullProjectOwnershipReplacesStaleAcknowledgedJournal(t *testing.T
 
 func TestRescueNullProjectOwnershipEnqueuesDeleteDespitePendingOppositeOperation(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "legacy")
 	if err := s.CreateSession("legacy-session", "legacy", "/tmp"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -918,6 +949,7 @@ func TestRescueNullProjectOwnershipEnqueuesDeleteDespitePendingOppositeOperation
 		t.Fatalf("seed pending opposite mutation: %v", err)
 	}
 
+	enrollTestProject(t, s, "target")
 	params := ProjectRescueParams{TargetProject: "target", ObservationIDs: []int64{id}}
 	assertCanonicalDelete := func() {
 		t.Helper()
@@ -941,6 +973,7 @@ func TestRescueNullProjectOwnershipEnqueuesDeleteDespitePendingOppositeOperation
 
 func TestRescueNullProjectOwnershipRollsBackWhenJournalEnqueueFails(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "target")
 	if err := s.CreateSession("legacy-session", "legacy", "/tmp"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -1012,6 +1045,7 @@ func assertNoBlankOwnedMutations(t *testing.T, s *Store) {
 func TestRescueNullProjectOwnershipMovesDependentSessionOwnershipAtomically(t *testing.T) {
 	type legacySession struct{ id, project string }
 	s := newTestStoreWithNullableLegacySessions(t, legacySession{"legacy-session", "<NULL>"})
+	enrollTestProject(t, s, "target")
 	observationID := seedUnownedObservation(t, s, "legacy-session", "obs-legacy", "legacy")
 
 	result, err := s.RescueNullProjectOwnership(ProjectRescueParams{TargetProject: "target", ObservationIDs: []int64{observationID}})
@@ -4531,6 +4565,7 @@ func TestApplyPulledSessionUpsertTombstoneRemovesSessionAndPrompts(t *testing.T)
 
 func TestSessionSyncPayloadPreservesStartedAtOnApply(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 
 	if err := s.CreateSession("local-session", "engram", "/tmp/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
@@ -4766,6 +4801,7 @@ func TestApplyPulledPromptUpsertUpdatesCreatedAtOnExistingPrompt(t *testing.T) {
 
 func TestDeletePromptEnqueuesDeleteMutationAndTombstone(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 	if err := s.CreateSession("s-del-prompt", "engram", "/tmp/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -4801,6 +4837,7 @@ func TestDeletePromptEnqueuesDeleteMutationAndTombstone(t *testing.T) {
 
 func TestDeleteObservationHardDeleteEnqueuesProjectScopedMutationMetadata(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 	if err := s.CreateSession("s-del-obs", "engram", "/tmp/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -4847,6 +4884,7 @@ func TestDeleteObservationHardDeleteEnqueuesProjectScopedMutationMetadata(t *tes
 
 func TestDeleteObservationHardDeleteDerivesProjectFromSessionWhenEntityProjectEmpty(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 	if err := s.CreateSession("s-del-obs-empty", "engram", "/tmp/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -6953,6 +6991,7 @@ func TestSessionIdentityPreservesNonblankWhitespace(t *testing.T) {
 
 	t.Run("creation and journal", func(t *testing.T) {
 		s := newTestStore(t)
+		enrollTestProject(t, s, "engram")
 		if err := s.CreateSession(id, "engram", "/tmp/engram"); err != nil {
 			t.Fatalf("CreateSession: %v", err)
 		}
@@ -6999,6 +7038,7 @@ func TestSessionIdentityPreservesNonblankWhitespace(t *testing.T) {
 
 func TestCreateSessionMutationUsesPersistedCanonicalData(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 	if err := s.CreateSession("canonical-session", "engram", "/canonical"); err != nil {
 		t.Fatalf("initial CreateSession: %v", err)
 	}
@@ -7020,6 +7060,7 @@ func TestCreateSessionMutationUsesPersistedCanonicalData(t *testing.T) {
 
 func TestStartSessionCreatesAndIdempotentlyStartsActiveSession(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 
 	if err := s.StartSession("strict-active", "engram", "/original"); err != nil {
 		t.Fatalf("initial StartSession: %v", err)
@@ -7434,6 +7475,7 @@ func TestApplyPulledSessionMutationDoesNotNormalizeOpaqueIdentity(t *testing.T) 
 
 func TestBackfillSkipsInvalidSourceAndBackfillsValidSession(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 	if _, err := s.db.Exec(`INSERT INTO sessions (id, project, directory) VALUES ('', 'engram', '/tmp/engram')`); err != nil {
 		t.Fatalf("seed invalid session: %v", err)
 	}
@@ -7566,6 +7608,7 @@ func TestBackfillSessionSyncMutationsSkipsBlankSourceRows(t *testing.T) {
 	for _, tc := range blankSessionIDCases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newTestStore(t)
+			enrollTestProject(t, s, "engram")
 			if _, err := s.DB().Exec(`INSERT INTO sessions (id, project, directory) VALUES (?, 'engram', '/tmp/blank')`, tc.id); err != nil {
 				t.Fatalf("seed blank session: %v", err)
 			}
@@ -7620,6 +7663,7 @@ func TestSessionIdentityPreservesWhitespacePaddedIdentities(t *testing.T) {
 	for _, id := range []string{"\tsession", "session\n", " \r session \v ", " session "} {
 		t.Run(fmt.Sprintf("%q", id), func(t *testing.T) {
 			s := newTestStore(t)
+			enrollTestProject(t, s, "engram")
 			if err := s.CreateSession(id, "engram", "/tmp"); err != nil {
 				t.Fatalf("CreateSession: %v", err)
 			}
@@ -8830,6 +8874,7 @@ func TestExtractProjectFromPayloadWithoutProjectField(t *testing.T) {
 
 func TestEnqueueSyncMutationPopulatesProjectFromSessionPayload(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "enqueued-project")
 	if err := s.CreateSession("enq-session", "enqueued-project", "/tmp"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -8850,6 +8895,7 @@ func TestEnqueueSyncMutationPopulatesProjectFromSessionPayload(t *testing.T) {
 
 func TestEnqueueSyncMutationPopulatesProjectFromObservationPayload(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "obs-proj")
 	if err := s.CreateSession("obs-enq", "obs-proj", "/tmp"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -8881,6 +8927,7 @@ func TestEnqueueSyncMutationPopulatesProjectFromObservationPayload(t *testing.T)
 
 func TestEnqueueSyncMutationPopulatesProjectFromPromptPayload(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "prompt-proj")
 	if err := s.CreateSession("prompt-enq", "prompt-proj", "/tmp"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -8909,6 +8956,7 @@ func TestEnqueueSyncMutationPopulatesProjectFromPromptPayload(t *testing.T) {
 
 func TestEnqueueSyncMutationUsesProjectScopedTargetKey(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "target-proj")
 	if err := s.CreateSession("target-session", "target-proj", "/tmp"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -8989,11 +9037,11 @@ func TestListPendingReturnsNoMutationsWhenNoneEnrolled(t *testing.T) {
 func TestSkipAckNonEnrolledMutationsBasic(t *testing.T) {
 	s := newTestStore(t)
 
-	if err := s.CreateSession("skip-session", "skip-proj", "/tmp"); err != nil {
-		t.Fatalf("create session: %v", err)
+	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`, DefaultSyncTargetKey, SyncEntitySession, "skip-session", SyncOpUpsert, `{"id":"skip-session","project":"skip-proj"}`, SyncSourceLocal, "skip-proj"); err != nil {
+		t.Fatalf("seed non-enrolled mutation: %v", err)
 	}
 
-	// Do NOT enroll "skip-proj" → mutations should be skip-acked.
+	// Do NOT enroll "skip-proj" → the legacy pending mutation is skip-acked.
 	skipped, err := s.SkipAckNonEnrolledMutations(DefaultSyncTargetKey)
 	if err != nil {
 		t.Fatalf("skip-ack: %v", err)
@@ -9022,8 +9070,8 @@ func TestSkipAckPreservesEnrolledProjectMutations(t *testing.T) {
 	if err := s.CreateSession("s-enrolled", "enrolled", "/tmp"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	if err := s.CreateSession("s-not-enrolled", "not-enrolled", "/tmp"); err != nil {
-		t.Fatalf("create session: %v", err)
+	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`, DefaultSyncTargetKey, SyncEntitySession, "s-not-enrolled", SyncOpUpsert, `{"id":"s-not-enrolled","project":"not-enrolled"}`, SyncSourceLocal, "not-enrolled"); err != nil {
+		t.Fatalf("seed non-enrolled mutation: %v", err)
 	}
 
 	// Count total pending before skip-ack.
@@ -10937,6 +10985,7 @@ func TestRepairObservationMutationTitles(t *testing.T) {
 	seed := func(t *testing.T, content string, mutate func(map[string]json.RawMessage)) (*Store, Observation, SyncMutation, string) {
 		t.Helper()
 		s := newTestStore(t)
+		enrollTestProject(t, s, "project-a")
 		if err := s.CreateSession("title-repair", "project-a", "/work/project-a"); err != nil {
 			t.Fatalf("create session: %v", err)
 		}
@@ -11619,6 +11668,7 @@ func TestListDiagnosticObservationRequiredFieldsHandlesLegacyNulls(t *testing.T)
 
 func TestDiagnosticObservationRequiredFieldsAndTitleRepair(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "project-a")
 	if err := s.CreateSession("observation-diagnostic", "project-a", "/work/project-a"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -11718,6 +11768,7 @@ func TestDiagnosticObservationRequiredFieldsAndTitleRepair(t *testing.T) {
 
 func TestRepairObservationSourceTitlesRollsBackWhenCanonicalMutationFails(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "project-a")
 	if err := s.CreateSession("source-title-rollback", "project-a", "/work/project-a"); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -11759,6 +11810,7 @@ func TestRepairObservationSourceTitlesReconcilesPendingMutations(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newTestStore(t)
+			enrollTestProject(t, s, "project-a")
 			if err := s.CreateSession("source-title-pending", "project-a", "/work/project-a"); err != nil {
 				t.Fatalf("CreateSession: %v", err)
 			}
@@ -14203,6 +14255,7 @@ func TestAddObservationRejectsEmptyTitle(t *testing.T) {
 // title whose private tags collapse into the redaction marker.
 func TestAddObservationAcceptsValidTitle(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 	if err := s.CreateSession("s-title-ok", "engram", "/tmp/engram"); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -14353,6 +14406,7 @@ func TestUpdateObservationRejectsBlankTitleWithoutSideEffects(t *testing.T) {
 
 func TestUpdateObservationAcceptsPrivateTagOnlyTitle(t *testing.T) {
 	s := newTestStore(t)
+	enrollTestProject(t, s, "engram")
 	if err := s.CreateSession("s-update-redaction", "engram", t.TempDir()); err != nil {
 		t.Fatalf("create session: %v", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7940,10 +7940,10 @@ func TestDeleteSessionNormalizesPromptTombstoneProjectForReenrollment(t *testing
 	if _, err := s.db.Exec(`INSERT INTO user_prompts (sync_id, session_id, content, project) VALUES (?, ?, ?, ?)`, promptSyncID, sessionID, "legacy prompt", " \t "); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.DeleteSession(sessionID); err != nil {
+	if err := s.EnrollProject(canonicalProject); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.EnrollProject(canonicalProject); err != nil {
+	if err := s.DeleteSession(sessionID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -7953,6 +7953,9 @@ func TestDeleteSessionNormalizesPromptTombstoneProjectForReenrollment(t *testing
 	}
 	if project != canonicalProject || op != SyncOpDelete {
 		t.Fatalf("re-enrolled prompt mutation = project %q op %q, want project %q op %q", project, op, canonicalProject, SyncOpDelete)
+	}
+	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND op = ?`, SyncEntitySession, SyncOpDelete); got != 1 {
+		t.Fatalf("direct session deletes = %d, want 1", got)
 	}
 }
 
@@ -7995,18 +7998,33 @@ func TestUnenrolledHardDeletesReplayAfterReenrollment(t *testing.T) {
 		if len(mutations) != 2 || mutations[0].Entity != SyncEntitySession || mutations[0].Op != SyncOpUpsert || mutations[1].Entity != SyncEntityObservation || mutations[1].EntityKey != syncID || mutations[1].Op != SyncOpDelete {
 			t.Fatalf("re-enrollment mutations = %+v, want session upsert then observation delete", mutations)
 		}
-		beforeRepeat := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations`)
+		firstDeleteSeq := mutations[1].Seq
+		if err := s.AckSyncMutations(DefaultSyncTargetKey, firstDeleteSeq); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.ApplyPulledMutation(DefaultSyncTargetKey, SyncMutation{Seq: 1, Entity: SyncEntityObservation, EntityKey: syncID, Op: SyncOpUpsert, Payload: fmt.Sprintf(`{"sync_id":%q,"session_id":"unenrolled-hard-observation-session","type":"decision","title":"recreated","content":"body","project":%q,"scope":"project"}`, syncID, project)}); err != nil {
+			t.Fatal(err)
+		}
 		if err := s.UnenrollProject(project); err != nil {
 			t.Fatal(err)
+		}
+		recreated, err := s.GetObservationBySyncID(syncID)
+		if err != nil || s.DeleteObservation(recreated.ID, true) != nil {
+			t.Fatalf("delete reused observation: %+v, %v", recreated, err)
 		}
 		if err := s.EnrollProject(project); err != nil {
 			t.Fatal(err)
 		}
+		secondDeleteSeq := scalarInt(t, s, `SELECT MAX(seq) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND op = ?`, SyncEntityObservation, syncID, SyncOpDelete)
+		if int64(secondDeleteSeq) <= firstDeleteSeq {
+			t.Fatalf("reused delete seq = %d, want > %d", secondDeleteSeq, firstDeleteSeq)
+		}
+		beforeRepeat := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations`)
 		if err := s.withTx(func(tx *sql.Tx) error { return s.backfillProjectSyncMutationsTx(tx, project) }); err != nil {
 			t.Fatal(err)
 		}
 		if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations`); got != beforeRepeat {
-			t.Fatalf("re-enrollment/repeated backfill wrote duplicate mutations: got %d, want %d", got, beforeRepeat)
+			t.Fatalf("repeated backfill wrote duplicate mutations: got %d, want %d", got, beforeRepeat)
 		}
 	})
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4649,6 +4649,9 @@ func TestCloudSyncPreservesPiPromptIdentityUnderProjectScope(t *testing.T) {
 	otherSession := "manual-save-" + otherProject
 
 	srcStore := newTestStore(t)
+	if err := srcStore.EnrollProject(targetProject); err != nil {
+		t.Fatalf("enroll target project: %v", err)
+	}
 	if err := srcStore.CreateSession(targetSession, targetProject, "/tmp/"+targetProject); err != nil {
 		t.Fatalf("create target session: %v", err)
 	}
@@ -4733,10 +4736,7 @@ func TestCloudSyncPreservesPiPromptIdentityUnderProjectScope(t *testing.T) {
 		}
 	}
 
-	// Push the enrolled project to the cloud and pull it into a clean store.
-	if err := srcStore.EnrollProject(targetProject); err != nil {
-		t.Fatalf("enroll src project: %v", err)
-	}
+	// Push the target project to the cloud and pull it into a clean store.
 	transport := newFakeCloudTransport()
 	exportResult, err := NewCloudWithTransport(srcStore, transport, targetProject).Export("alice", targetProject)
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1026

Related to #1104. This PR addresses the shared cloud-journal/enrollment slice; session coalescing and empty-directory admission remain separate product decisions.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:question` — Question requiring tracked work
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Gate local cloud-journal writes on project enrollment while preserving local data and enrollment backfill.
- Persist session, prompt, and hard-observation delete intent while unenrolled so re-enrollment removes stale cloud data.
- Report no-op doctor repairs and suppressed rescue journaling truthfully.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Gate local project mutation enqueueing, persist durable delete tombstones, replay them through backfill/remirror, and keep rescue reporting truthful. |
| `internal/store/*_test.go` | Cover unenrolled suppression, durable deletes, re-enrollment, idempotence, migration, legacy identities, and explicit enrollment fixtures. |
| `internal/cloud/cloudstore/prompt_delete_propagation_test.go` | Verify re-enrollment deletes stale session and prompt rows from the cloud dashboard model. |
| `cmd/engram/doctor.go` | Report `applied: false` when repair apply mode performs no action. |
| Other affected tests | Align diagnostic, server, sync, and CLI fixtures with enrollment-gated journaling. |

## 🧪 Test Plan

- [ ] Unit tests pass locally: `go test ./...` (CI-owned broad suite)
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` (CI-owned)
- [x] Lint passes locally: `golangci-lint run --new-from-rev=HEAD~`
- [ ] Manually tested the affected functionality
- [x] All 561 `internal/store` tests pass through four bounded shards.
- [x] `internal/cloud/cloudstore`, `internal/diagnostic`, and `internal/sync` package tests pass.
- [x] Focused CLI, enrollment, migration, re-enrollment, remirror, and cloud materialization regressions pass.
- [x] `git diff --check` passes.

---

## 🤖 Automated Checks

These run automatically and **all must pass** before merge:

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #N` / `Fixes #N` / `Resolves #N` | ⏳ |
| **Check Issue Has status:approved** | Linked issue has `status:approved` label | ⏳ |
| **Check PR Has type:* Label** | Canonical labels, applicability, and cardinality | ⏳ |
| **Check PR Has No Transient Artifacts** | Changed files comply with the transient artifact policy | ⏳ |
| **Unit Tests** | `go test ./...` passes | ⏳ |
| **E2E Tests** | Server E2E suite passes | ⏳ |
| **Plugin Tests** | Pi plugin tests pass | ⏳ |
| **Lint** | No new lint findings | ⏳ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1026`)
- [x] I added exactly **one** `type:*` label to this PR
- [ ] I ran unit tests locally: `go test ./...` (CI-owned)
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` (CI-owned)
- [x] I ran lint locally with golangci-lint 2.13.2
- [x] Docs reviewed; no user-facing documentation change is required for this bug fix
- [x] Commits follow conventional commits format
- [x] No `Co-Authored-By` trailers in commits
- [x] I checked every changed path against the Transient Artifact Policy

---

## 💬 Notes for Reviewers

### Review workload exception

The maintainer explicitly accepted `size:exception` for this cohesive 686-line data-integrity fix. The patch contains 282 production lines and 404 test lines. Enrollment gating is unsafe without durable delete intent: splitting the behavior would permit an enroll → sync → unenroll → delete → re-enroll workflow to retain stale remote entities. The schema, enqueue gate, delete recording, backfill/remirror replay, migration, and cloud-boundary regressions therefore form one rollback unit.

`sync_delete_tombstones` is new in this PR and absent from every supported main/release predecessor. The final `CREATE TABLE` is therefore the supported migration path; schemas created by intermediate unmerged development commits are intentionally outside compatibility scope.

Writer self-verification and an independent read-only verifier closed the original CodeRabbit Major finding and the legacy project-normalization edge. The remaining `DeleteProject --hard` remote-cleanup gap is pre-existing, untouched by this patch, and should be tracked separately.

Native RDD START was unavailable and is tracked in `Gentleman-Programming/gentle-pi#857`; no lineage was created. The required unavailable-review fallback completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cloud sync now reliably propagates session, observation, and prompt deletions, including deletions made before a project is enrolled.
  - Records created or deleted before enrollment are correctly included for synchronization after the project is enrolled.
  - Project ownership is consistently preserved during sync and deletion workflows.
  - Doctor repair reports now accurately indicate whether changes were applied, including no-op repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->