### PR TITLE
fix(opencode): close sub-agent and misregistered sessions at every lifecycle signal (#1131)

### DIFF
--- a/internal/setup/plugins/opencode/engram.ts
+++ b/internal/setup/plugins/opencode/engram.ts
@@ -329,12 +329,11 @@ export const Engram: Plugin = async (ctx) => {
     return knownSessions.has(sessionId) && parentSessions.get(sessionId) === null
   }
 
-  async function closeDeletedRootSession(sessionId: string): Promise<boolean> {
+  // Best-effort end of one Engram session. One POST per session lifetime:
+  // closedSessions dedups confirmed closures, closingSessions dedups calls
+  // that are still in flight.
+  async function endSessionInEngram(sessionId: string): Promise<boolean> {
     if (closedSessions.has(sessionId)) return true
-    if (!deletedRootSessions.has(sessionId)) {
-      if (!isKnownAuthoritativeRootSession(sessionId)) return false
-      deletedRootSessions.add(sessionId)
-    }
 
     const inFlight = closingSessions.get(sessionId)
     if (inFlight) return inFlight
@@ -350,6 +349,29 @@ export const Engram: Plugin = async (ctx) => {
     })
     closingSessions.set(sessionId, close)
     return close
+  }
+
+  async function closeDeletedRootSession(sessionId: string): Promise<boolean> {
+    if (closedSessions.has(sessionId)) return true
+    if (!deletedRootSessions.has(sessionId)) {
+      if (!isKnownAuthoritativeRootSession(sessionId)) return false
+      deletedRootSessions.add(sessionId)
+    }
+
+    return endSessionInEngram(sessionId)
+  }
+
+  // End any session this plugin registered in Engram. Confirmed roots keep
+  // the deletedRootSessions retry discipline; every other known
+  // registration (late-reclassified children, legacy misregistrations)
+  // ends exactly once. Unregistered sessions have nothing to close.
+  async function closeKnownSession(sessionId: string): Promise<boolean> {
+    if (closedSessions.has(sessionId)) return true
+    if (!knownSessions.has(sessionId) && !deletedRootSessions.has(sessionId)) return false
+    if (isKnownAuthoritativeRootSession(sessionId) || deletedRootSessions.has(sessionId)) {
+      return closeDeletedRootSession(sessionId)
+    }
+    return endSessionInEngram(sessionId)
   }
 
   function cacheSessionInfo(info: { id?: unknown; parentID?: unknown; projectID?: unknown } | undefined): boolean {
@@ -528,8 +550,10 @@ export const Engram: Plugin = async (ctx) => {
   return {
 		dispose: async () => {
 			if (!localReady) return
-      const rootSessionIDs = [...knownSessions].filter(isKnownAuthoritativeRootSession)
-      await Promise.all(rootSessionIDs.map(closeDeletedRootSession))
+      // Every known registration owns an Engram lifecycle (#1131) —
+      // including children misregistered before their parentID was known.
+      // Children that were never registered remain untouched.
+      await Promise.all([...knownSessions].map(closeKnownSession))
     },
 
     // ─── Event Listeners ───────────────────────────────────────────
@@ -552,6 +576,16 @@ export const Engram: Plugin = async (ctx) => {
         if (isSubAgent) subAgentSessions.add(sessionId)
         else subAgentSessions.delete(sessionId)
 
+        // Issue #1131: a session registered as a root that now reveals a
+        // parentID was misregistered. End its Engram session so no open row
+        // blocks directory-based session resolution, and drop it from
+        // knownSessions so nothing re-registers it. It stays tracked in
+        // subAgentSessions; sessions never registered have nothing to close.
+        if (isSubAgent && knownSessions.has(sessionId)) {
+          await closeKnownSession(sessionId)
+          knownSessions.delete(sessionId)
+        }
+
         if (event.type === "session.created" && sessionId && !isSubAgent) {
           await ensureSession(sessionId)
         }
@@ -563,9 +597,10 @@ export const Engram: Plugin = async (ctx) => {
         const info = (event.properties as any)?.info
         const sessionId = info?.id
         if (sessionId) {
-          // Only a registered, event-validated root owns an Engram lifecycle.
+          // Any known registration owns an Engram lifecycle (#1131):
+          // confirmed roots keep the deletedRootSessions retry discipline.
           // Await the best-effort endpoint before invalidating local ownership.
-          await closeDeletedRootSession(sessionId)
+          await closeKnownSession(sessionId)
           invalidateSessionTree(sessionId)
         }
       }

--- a/plugin/opencode/engram.test.mts
+++ b/plugin/opencode/engram.test.mts
@@ -31,3 +31,177 @@ test("preserves UTC parsing and the 15-minute observation age threshold", () => 
   assert.equal(shouldNudgeForObservations(true, [{ created_at: naiveUTC(900) }], nowSecs, null), true)
   assert.equal(shouldNudgeForObservations(true, [{ created_at: naiveUTCTimeSeparator(900) }], nowSecs, null), true)
 })
+
+// ─── Plugin lifecycle (issue #1131) ──────────────────────────────────────────
+
+interface RecordedRequest {
+  path: string
+  method?: string
+  body?: any
+}
+
+const PROJECT_ID = "project-1"
+let runtimeImport = 0
+
+function sessionInfo(id: string, parentID?: string, projectID = PROJECT_ID) {
+  return { id, ...(parentID === undefined ? {} : { parentID }), projectID }
+}
+
+function httpResponse(data: any = { status: "created" }, ok = true) {
+  return {
+    ok,
+    async json() {
+      return data
+    },
+  }
+}
+
+function endRequests(requests: RecordedRequest[], sessionID: string) {
+  return requests.filter(({ path, method }) => method === "POST" && path === `/sessions/${sessionID}/end`)
+}
+
+async function createRuntime(t: any, { sessionGet }: { sessionGet?: (request: { path: { id: string } }) => any } = {}) {
+  const originalFetch = globalThis.fetch
+  const originalBun = (globalThis as any).Bun
+  const originalEngramURL = process.env.ENGRAM_URL
+  delete process.env.ENGRAM_URL
+  const requests: RecordedRequest[] = []
+  const registeredIDs: string[] = []
+  const bun = globalThis as any
+  bun.Bun = {
+    spawnSync(args: string[]) {
+      if (args[1] === "instance-id")
+        return { exitCode: 0, stdout: Buffer.from("00000000000000000000000000000000\n") }
+      return { exitCode: 0, stdout: Buffer.from("/work/engram\n") }
+    },
+    spawn() {},
+    file() {
+      return {
+        async exists() {
+          return false
+        },
+      }
+    },
+  }
+  globalThis.fetch = (async (url: any, init?: any) => {
+    const path = new URL(url).pathname
+    if (path === "/health")
+      return httpResponse({ status: "ok", instance_id: "00000000000000000000000000000000" })
+    const body = init?.body ? JSON.parse(init.body) : undefined
+    requests.push({ path, method: init?.method, body })
+    if (path === "/project/current")
+      return httpResponse({ project: "engram", project_source: "git_remote" })
+    if (path === "/sessions") {
+      registeredIDs.push(body.id)
+      return httpResponse()
+    }
+    return httpResponse({})
+  }) as typeof fetch
+
+  t.after(() => {
+    globalThis.fetch = originalFetch
+    bun.Bun = originalBun
+    if (originalEngramURL === undefined) delete process.env.ENGRAM_URL
+    else process.env.ENGRAM_URL = originalEngramURL
+  })
+
+  runtimeImport += 1
+  const moduleURL = new URL(`./engram.ts?lifecycle=${runtimeImport}`, import.meta.url)
+  const { Engram } = await import(moduleURL.href)
+  const plugin: any = await Engram({
+    directory: "/work/engram",
+    project: { id: PROJECT_ID },
+    client: {
+      session: {
+        async get(request: { path: { id: string } }) {
+          if (!sessionGet) throw new Error(`unexpected SDK session.get for ${request.path.id}`)
+          return sessionGet(request)
+        },
+      },
+    },
+  } as any)
+  return {
+    dispose: () => plugin.dispose(),
+    event: (type: string, info: any) => plugin.event({ event: { type, properties: { info } } }),
+    after: plugin["tool.execute.after"],
+    requests,
+    registeredIDs,
+  }
+}
+
+test("#1131 ends a root registration in Engram when a later event reveals a parentID", async (t) => {
+  const runtime = await createRuntime(t)
+  await runtime.event("session.created", sessionInfo("sess-root"))
+  await runtime.event("session.created", sessionInfo("sess-child"))
+  assert.deepEqual(runtime.registeredIDs, ["sess-root", "sess-child"])
+
+  await runtime.event("session.updated", sessionInfo("sess-child", "sess-root"))
+
+  assert.equal(endRequests(runtime.requests, "sess-child").length, 1)
+
+  // The session must stay de-registered: a later root-path flow must not
+  // register it again and duplicate events must not end it twice.
+  await runtime.event("session.updated", sessionInfo("sess-child", "sess-root"))
+  await runtime.after({ tool: "Bash", sessionID: "sess-child" }, { args: {} })
+  assert.deepEqual(runtime.registeredIDs, ["sess-root", "sess-child"])
+  assert.equal(endRequests(runtime.requests, "sess-child").length, 1)
+})
+
+// A registered root whose ownership confirmation was invalidated by a
+// later malformed event stays in knownSessions but is no longer an
+// authoritative root: the legacy misregistration that must still be ended.
+async function registerMisregisteredChild(runtime: Awaited<ReturnType<typeof createRuntime>>) {
+  await runtime.event("session.created", sessionInfo("sess-child"))
+  await runtime.event("session.updated", { id: "sess-child", projectID: "other-project" })
+}
+
+test("#1131 ends a known child registration when session.deleted fires", async (t) => {
+  const runtime = await createRuntime(t)
+  await runtime.event("session.created", sessionInfo("sess-root"))
+  await registerMisregisteredChild(runtime)
+
+  await runtime.event("session.deleted", { id: "sess-child" })
+
+  assert.equal(endRequests(runtime.requests, "sess-child").length, 1)
+  assert.equal(endRequests(runtime.requests, "sess-root").length, 0)
+})
+
+test("#1131 disposal ends every known session including misregistered children", async (t) => {
+  const runtime = await createRuntime(t)
+  await runtime.event("session.created", sessionInfo("sess-root"))
+  await registerMisregisteredChild(runtime)
+
+  await runtime.dispose()
+
+  assert.equal(endRequests(runtime.requests, "sess-root").length, 1)
+  assert.equal(endRequests(runtime.requests, "sess-child").length, 1)
+})
+
+test("#1131 keeps deleted-root semantics: exactly one end across deletion and disposal", async (t) => {
+  const runtime = await createRuntime(t)
+  await runtime.event("session.created", sessionInfo("sess-root"))
+  await runtime.event("session.deleted", { id: "sess-root" })
+  await runtime.dispose()
+
+  assert.equal(endRequests(runtime.requests, "sess-root").length, 1)
+})
+
+test("#1131 never ends sessions that were never registered", async (t) => {
+  const runtime = await createRuntime(t)
+  await runtime.event("session.created", sessionInfo("sess-root"))
+  await runtime.event("session.updated", sessionInfo("sess-unknown", "sess-root"))
+  await runtime.event("session.deleted", { id: "sess-unknown" })
+
+  assert.equal(endRequests(runtime.requests, "sess-unknown").length, 0)
+  assert.deepEqual(runtime.registeredIDs, ["sess-root"])
+})
+
+test("#1131 duplicate reclassification events fire exactly one end POST", async (t) => {
+  const runtime = await createRuntime(t)
+  await runtime.event("session.created", sessionInfo("sess-child"))
+  await runtime.event("session.updated", sessionInfo("sess-child", "sess-root"))
+  await runtime.event("session.updated", sessionInfo("sess-child", "sess-root"))
+  await runtime.dispose()
+
+  assert.equal(endRequests(runtime.requests, "sess-child").length, 1)
+})

--- a/plugin/opencode/engram.ts
+++ b/plugin/opencode/engram.ts
@@ -329,12 +329,11 @@ export const Engram: Plugin = async (ctx) => {
     return knownSessions.has(sessionId) && parentSessions.get(sessionId) === null
   }
 
-  async function closeDeletedRootSession(sessionId: string): Promise<boolean> {
+  // Best-effort end of one Engram session. One POST per session lifetime:
+  // closedSessions dedups confirmed closures, closingSessions dedups calls
+  // that are still in flight.
+  async function endSessionInEngram(sessionId: string): Promise<boolean> {
     if (closedSessions.has(sessionId)) return true
-    if (!deletedRootSessions.has(sessionId)) {
-      if (!isKnownAuthoritativeRootSession(sessionId)) return false
-      deletedRootSessions.add(sessionId)
-    }
 
     const inFlight = closingSessions.get(sessionId)
     if (inFlight) return inFlight
@@ -350,6 +349,29 @@ export const Engram: Plugin = async (ctx) => {
     })
     closingSessions.set(sessionId, close)
     return close
+  }
+
+  async function closeDeletedRootSession(sessionId: string): Promise<boolean> {
+    if (closedSessions.has(sessionId)) return true
+    if (!deletedRootSessions.has(sessionId)) {
+      if (!isKnownAuthoritativeRootSession(sessionId)) return false
+      deletedRootSessions.add(sessionId)
+    }
+
+    return endSessionInEngram(sessionId)
+  }
+
+  // End any session this plugin registered in Engram. Confirmed roots keep
+  // the deletedRootSessions retry discipline; every other known
+  // registration (late-reclassified children, legacy misregistrations)
+  // ends exactly once. Unregistered sessions have nothing to close.
+  async function closeKnownSession(sessionId: string): Promise<boolean> {
+    if (closedSessions.has(sessionId)) return true
+    if (!knownSessions.has(sessionId) && !deletedRootSessions.has(sessionId)) return false
+    if (isKnownAuthoritativeRootSession(sessionId) || deletedRootSessions.has(sessionId)) {
+      return closeDeletedRootSession(sessionId)
+    }
+    return endSessionInEngram(sessionId)
   }
 
   function cacheSessionInfo(info: { id?: unknown; parentID?: unknown; projectID?: unknown } | undefined): boolean {
@@ -528,8 +550,10 @@ export const Engram: Plugin = async (ctx) => {
   return {
 		dispose: async () => {
 			if (!localReady) return
-      const rootSessionIDs = [...knownSessions].filter(isKnownAuthoritativeRootSession)
-      await Promise.all(rootSessionIDs.map(closeDeletedRootSession))
+      // Every known registration owns an Engram lifecycle (#1131) —
+      // including children misregistered before their parentID was known.
+      // Children that were never registered remain untouched.
+      await Promise.all([...knownSessions].map(closeKnownSession))
     },
 
     // ─── Event Listeners ───────────────────────────────────────────
@@ -552,6 +576,16 @@ export const Engram: Plugin = async (ctx) => {
         if (isSubAgent) subAgentSessions.add(sessionId)
         else subAgentSessions.delete(sessionId)
 
+        // Issue #1131: a session registered as a root that now reveals a
+        // parentID was misregistered. End its Engram session so no open row
+        // blocks directory-based session resolution, and drop it from
+        // knownSessions so nothing re-registers it. It stays tracked in
+        // subAgentSessions; sessions never registered have nothing to close.
+        if (isSubAgent && knownSessions.has(sessionId)) {
+          await closeKnownSession(sessionId)
+          knownSessions.delete(sessionId)
+        }
+
         if (event.type === "session.created" && sessionId && !isSubAgent) {
           await ensureSession(sessionId)
         }
@@ -563,9 +597,10 @@ export const Engram: Plugin = async (ctx) => {
         const info = (event.properties as any)?.info
         const sessionId = info?.id
         if (sessionId) {
-          // Only a registered, event-validated root owns an Engram lifecycle.
+          // Any known registration owns an Engram lifecycle (#1131):
+          // confirmed roots keep the deletedRootSessions retry discipline.
           // Await the best-effort endpoint before invalidating local ownership.
-          await closeDeletedRootSession(sessionId)
+          await closeKnownSession(sessionId)
           invalidateSessionTree(sessionId)
         }
       }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1131

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Sub-agent task sessions accumulated with `ended_at` NULL because the plugin classifies children from event shapes that can miss the `parentID` (#116 family): a task first seen without its parentID is registered as a root, and roots only ever closed on `session.deleted` or plugin `dispose` — so completed task sessions stayed active-resolution candidates until the #1102 activity window aged them out, and until then two of them blocked directory-based `mem_save` with the multiple-active-sessions error.
- The plugin now closes every registration it owns at each termination signal: a `session.updated` that reveals a `parentID` for an already-registered root ends it in Engram (one end POST per lifetime, existing dedup discipline preserved) and drops it from the known set; `session.deleted` ends any known registration; `dispose` ends every known session.
- Completed task sessions stop being candidates immediately; the existing 7-day activity window handles the remainder. The `engram doctor` orphaned/ambiguous-candidate warning from expected behavior 2 of the issue is intentionally out of this plugin-scoped unit and will be filed as its own follow-up issue.

---

## 📂 Changes

| File | Change |
|------|--------|
| `plugin/opencode/engram.ts` | `endSessionInEngram` primitive (closedSessions/closingSessions dedup preserved); `closeKnownSession` routing (authoritative roots keep the deleted-root retry discipline); late-reclassification close in the created/updated listener; `session.deleted` covers any known registration; `dispose` covers all knownSessions |
| `internal/setup/plugins/opencode/engram.ts` | Byte-identical mirror (repo identity-test convention) |
| `plugin/opencode/engram.test.mts` | Fake Bun/fetch harness + 6 lifecycle tests: late reclassification ends the misregistered root exactly once and prevents re-registration; deleted known child ends; dispose ends every known session; deleted-root dedup across deletion+dispose; never-registered sessions never end; duplicate reclassification events fire one end |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model:** Pi coding agent (el Gentleman harness) — implementation delegated to subagents under single-session orchestration; independently verified and reviewed by the human-driven parent session.

**Material scope:** Full diff is AI-authored under human direction.

**Verification performed:** `node --test --experimental-strip-types engram.test.mts` (9/9 incl. the 3 pre-existing tests byte-untouched), `node --test engram.test.mjs` (68/68 incl. the embedded-identity test), `cmp` byte-identity of both plugin copies (re-verified after test runs); independent verification pass with a full-hunk diff audit (no-bypass, no double-end, no re-registration ordering hunts); native review (reliability lens, medium tier) closed **approved** with 3 informational advisories, authority acknowledged.

---

## 🧪 Test Plan

```bash
cd plugin/opencode
node --test --experimental-strip-types engram.test.mts
node --test engram.test.mjs
```

- [x] Unit tests pass
- [x] Byte-identity of the plugin mirror verified (cmp)
- [x] Independent verification pass with diff audit

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (280 changed lines)
- [ ] I have added the appropriate `type:*` label to this PR — **cannot self-apply (permission denied); requesting `type:bug` from a maintainer**
- [x] Unit tests pass
- [x] Conventional commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session cleanup during shutdown, deletion, and plugin disposal.
  - Ensured registered and attempted sessions are properly closed, including sessions later identified as child or legacy sessions.
  - Prevented duplicate closure requests while preserving retry handling for eligible sessions.
  - Prevented sessions from being revived while closure is pending.
  - Coordinated cleanup with in-progress registration and prevented post-disposal registrations.

- **Tests**
  - Added coverage for session reclassification, deletion, disposal, duplicate events, and cleanup edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->