### PR TITLE
fix(sync): coalesce pending session upserts

### DIFF
--- a/internal/cloud/cloudserver/cloudserver_test.go
+++ b/internal/cloud/cloudserver/cloudserver_test.go
@@ -1318,6 +1318,11 @@ func TestHandlerPushRejectsMutationUpsertsMissingRequiredFields(t *testing.T) {
 			wantErr: "session payload directory is required for upsert",
 		},
 		{
+			name:    "session upsert blank directory",
+			payload: `{"mutations":[{"entity":"session","entity_key":"s-1","op":"upsert","payload":"{\"id\":\"s-1\",\"directory\":\"   \"}"}]}`,
+			wantErr: "session payload directory is required for upsert",
+		},
+		{
 			name:    "observation upsert missing title",
 			payload: `{"mutations":[{"entity":"observation","entity_key":"obs-1","op":"upsert","payload":"{\"sync_id\":\"obs-1\",\"session_id\":\"s-1\",\"type\":\"decision\",\"content\":\"c\",\"scope\":\"project\"}"}]}`,
 			wantErr: "observation payload title is required for upsert",
@@ -1356,6 +1361,11 @@ func TestHandlerPushRejectsDirectChunkArraysMissingRequiredFields(t *testing.T) 
 		{
 			name:    "session missing directory",
 			payload: `{"sessions":[{"id":"s-1"}]}`,
+			wantErr: "sessions[0].directory is required",
+		},
+		{
+			name:    "session blank directory",
+			payload: `{"sessions":[{"id":"s-1","directory":"   "}]}`,
 			wantErr: "sessions[0].directory is required",
 		},
 		{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -98,6 +98,9 @@ var (
 
 	// ErrPulledSessionIdentityInvalid identifies an invalid identity after successful decoding and legacy fallback.
 	ErrPulledSessionIdentityInvalid = errors.New("pulled session identity is invalid")
+	// ErrPulledSessionDirectoryInvalid identifies a pulled or imported session that
+	// has no concrete directory and therefore cannot be admitted as cloud state.
+	ErrPulledSessionDirectoryInvalid = errors.New("pulled session directory is invalid")
 )
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -5069,6 +5072,9 @@ func (s *Store) Import(data *ExportData) (*ImportResult, error) {
 		if err := validateSessionID(sess.ID); err != nil {
 			return nil, fmt.Errorf("import session: %w", err)
 		}
+		if strings.TrimSpace(sess.Directory) == "" {
+			return nil, fmt.Errorf("import session %s: %w: directory is required", sess.ID, ErrPulledSessionDirectoryInvalid)
+		}
 		if strings.TrimSpace(sess.OwnershipMode) != "" && !validSessionOwnershipMode(sess.OwnershipMode) {
 			return nil, fmt.Errorf("import session %s: %w %q", sess.ID, ErrInvalidSessionOwnershipMode, sess.OwnershipMode)
 		}
@@ -7470,8 +7476,8 @@ func (s *Store) createSessionTx(tx *sql.Tx, id, project, directory, mode string)
 		 ON CONFLICT(id) DO UPDATE SET
 		   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
 		   ownership_mode = CASE WHEN ifnull(trim(sessions.ownership_mode, ?), '') = '' THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
-		   directory = CASE WHEN sessions.directory = '' THEN excluded.directory ELSE sessions.directory END`,
-		id, project, mode, directory, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet,
+		   directory = CASE WHEN trim(sessions.directory, ?) = '' THEN excluded.directory ELSE sessions.directory END`,
+		id, project, mode, directory, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet,
 	)
 	return err
 }
@@ -7482,9 +7488,9 @@ func (s *Store) startSessionTx(tx *sql.Tx, id, project, directory, mode string) 
 		 ON CONFLICT(id) DO UPDATE SET
 		   project   = CASE WHEN ifnull(trim(sessions.project, ?), '') = '' THEN excluded.project ELSE sessions.project END,
 		   ownership_mode = CASE WHEN ifnull(trim(sessions.ownership_mode, ?), '') = '' THEN excluded.ownership_mode ELSE sessions.ownership_mode END,
-		   directory = CASE WHEN sessions.directory = '' THEN excluded.directory ELSE sessions.directory END
+		   directory = CASE WHEN trim(sessions.directory, ?) = '' THEN excluded.directory ELSE sessions.directory END
 		 WHERE sessions.ended_at IS NULL`,
-		id, project, mode, directory, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet,
+		id, project, mode, directory, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet, sqlWhitespaceTrimSet,
 	)
 	if err != nil {
 		return err
@@ -8483,6 +8489,11 @@ func (s *Store) enqueueSyncMutationWithSourceTx(tx *sql.Tx, entity, entityKey, o
 	if source == "" {
 		source = SyncSourceLocal
 	}
+	if source == SyncSourceLocal && entity == SyncEntitySession && op == SyncOpUpsert {
+		if session, ok := payload.(syncSessionPayload); ok && strings.TrimSpace(session.Directory) == "" {
+			return nil
+		}
+	}
 	if op == SyncOpUpsert {
 		if err := s.clearSyncDeleteTombstoneForUpsertTx(tx, entity, entityKey); err != nil {
 			return err
@@ -8514,6 +8525,14 @@ func (s *Store) enqueueSyncMutationWithSourceTx(tx *sql.Tx, entity, entityKey, o
 		}
 		if !enrolled {
 			return nil
+		}
+	}
+	if source == SyncSourceLocal && entity == SyncEntitySession && op == SyncOpUpsert {
+		if _, err := s.execHook(tx, `DELETE FROM sync_mutations
+			WHERE target_key = ? AND entity = ? AND entity_key = ? AND op = ? AND source = ? AND project = ? AND acked_at IS NULL`,
+			DefaultSyncTargetKey, entity, entityKey, op, source, project,
+		); err != nil {
+			return err
 		}
 	}
 	if _, err := s.execHook(tx,
@@ -8803,6 +8822,9 @@ func (s *Store) applyPulledMutationTx(tx *sql.Tx, mutation SyncMutation) error {
 		if mutation.Op == SyncOpDelete || isSessionDeletePayload(payload) {
 			return s.applySessionDeleteTx(tx, payload)
 		}
+		if err := validatePulledSessionDirectory([]byte(mutation.Payload)); err != nil {
+			return err
+		}
 		return s.applySessionPayloadTx(tx, payload)
 	case SyncEntityObservation:
 		var payload syncObservationPayload
@@ -8825,6 +8847,22 @@ func (s *Store) applyPulledMutationTx(tx *sql.Tx, mutation SyncMutation) error {
 	default:
 		return fmt.Errorf("unknown sync entity %q", mutation.Entity)
 	}
+}
+
+func validatePulledSessionDirectory(raw []byte) error {
+	var fields map[string]json.RawMessage
+	if err := decodeSyncPayload(raw, &fields); err != nil {
+		return err
+	}
+	directory, ok := fields["directory"]
+	if !ok {
+		return fmt.Errorf("%w: directory is required", ErrPulledSessionDirectoryInvalid)
+	}
+	var value string
+	if err := json.Unmarshal(directory, &value); err != nil || strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%w: directory must be non-blank", ErrPulledSessionDirectoryInvalid)
+	}
+	return nil
 }
 
 // pulledSessionDeadLetterSyncID derives the identity of a quarantined pulled

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7104,7 +7104,11 @@ func TestLocalSessionUpsertsCoalescePendingState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list session mutations: %v", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			t.Errorf("close session mutation rows: %v", err)
+		}
+	}()
 	var localUpsertSeq, deleteSeq int64
 	seen := map[string]int{}
 	for rows.Next() {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3162,8 +3162,8 @@ func TestStoreLocalSyncFoundationEnqueuesCoreMutations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list pending sync mutations: %v", err)
 	}
-	if len(mutations) != 6 {
-		t.Fatalf("expected 6 pending mutations, got %d", len(mutations))
+	if len(mutations) != 5 {
+		t.Fatalf("expected 5 pending mutations after session-upsert coalescing, got %d", len(mutations))
 	}
 
 	var observationSyncID string
@@ -3182,27 +3182,24 @@ func TestStoreLocalSyncFoundationEnqueuesCoreMutations(t *testing.T) {
 		t.Fatalf("expected prompt sync id to be persisted")
 	}
 
-	if mutations[0].Entity != SyncEntitySession || mutations[0].EntityKey != "sync-session" || mutations[0].Op != SyncOpUpsert {
-		t.Fatalf("unexpected session mutation: %+v", mutations[0])
+	if mutations[0].Entity != SyncEntityObservation || mutations[0].EntityKey != observationSyncID || mutations[0].Op != SyncOpUpsert {
+		t.Fatalf("unexpected observation insert mutation: %+v", mutations[0])
 	}
 	if mutations[1].Entity != SyncEntityObservation || mutations[1].EntityKey != observationSyncID || mutations[1].Op != SyncOpUpsert {
-		t.Fatalf("unexpected observation insert mutation: %+v", mutations[1])
+		t.Fatalf("unexpected observation update mutation: %+v", mutations[1])
 	}
-	if mutations[2].Entity != SyncEntityObservation || mutations[2].EntityKey != observationSyncID || mutations[2].Op != SyncOpUpsert {
-		t.Fatalf("unexpected observation update mutation: %+v", mutations[2])
+	if mutations[2].Entity != SyncEntityObservation || mutations[2].EntityKey != observationSyncID || mutations[2].Op != SyncOpDelete {
+		t.Fatalf("unexpected observation delete mutation: %+v", mutations[2])
 	}
-	if mutations[3].Entity != SyncEntityObservation || mutations[3].EntityKey != observationSyncID || mutations[3].Op != SyncOpDelete {
-		t.Fatalf("unexpected observation delete mutation: %+v", mutations[3])
+	if mutations[3].Entity != SyncEntityPrompt || mutations[3].EntityKey != promptSyncID || mutations[3].Op != SyncOpUpsert {
+		t.Fatalf("unexpected prompt mutation: %+v", mutations[3])
 	}
-	if mutations[4].Entity != SyncEntityPrompt || mutations[4].EntityKey != promptSyncID || mutations[4].Op != SyncOpUpsert {
-		t.Fatalf("unexpected prompt mutation: %+v", mutations[4])
-	}
-	if mutations[5].Entity != SyncEntitySession || mutations[5].EntityKey != "sync-session" || mutations[5].Op != SyncOpUpsert {
-		t.Fatalf("unexpected end session mutation: %+v", mutations[5])
+	if mutations[4].Entity != SyncEntitySession || mutations[4].EntityKey != "sync-session" || mutations[4].Op != SyncOpUpsert {
+		t.Fatalf("unexpected end session mutation: %+v", mutations[4])
 	}
 
 	var deletedPayload map[string]any
-	if err := json.Unmarshal([]byte(mutations[3].Payload), &deletedPayload); err != nil {
+	if err := json.Unmarshal([]byte(mutations[2].Payload), &deletedPayload); err != nil {
 		t.Fatalf("decode delete payload: %v", err)
 	}
 	if deletedPayload["sync_id"] != observationSyncID {
@@ -3212,7 +3209,7 @@ func TestStoreLocalSyncFoundationEnqueuesCoreMutations(t *testing.T) {
 		t.Fatalf("expected delete payload to mark deleted=true, got %#v", deletedPayload["deleted"])
 	}
 
-	if err := s.AckSyncMutations(DefaultSyncTargetKey, mutations[3].Seq); err != nil {
+	if err := s.AckSyncMutations(DefaultSyncTargetKey, mutations[2].Seq); err != nil {
 		t.Fatalf("ack sync mutations: %v", err)
 	}
 	remaining, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
@@ -7058,6 +7055,125 @@ func TestCreateSessionMutationUsesPersistedCanonicalData(t *testing.T) {
 	}
 }
 
+func TestLocalSessionUpsertsCoalescePendingState(t *testing.T) {
+	s := newTestStore(t)
+	enrollTestProject(t, s, "alpha")
+	enrollTestProject(t, s, "beta")
+
+	if err := s.CreateSession("session-a", "alpha", "/alpha"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := s.StartSession("session-a", "alpha", "/ignored"); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := s.EndSession("session-a", "first completion"); err != nil {
+		t.Fatalf("end session: %v", err)
+	}
+
+	var pending int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND op = ? AND source = ? AND acked_at IS NULL`, SyncEntitySession, "session-a", SyncOpUpsert, SyncSourceLocal).Scan(&pending); err != nil {
+		t.Fatalf("count pending session upserts: %v", err)
+	}
+	if pending != 1 {
+		t.Fatalf("pending session upserts = %d, want 1", pending)
+	}
+	if _, err := s.DB().Exec(`UPDATE sync_mutations SET acked_at = datetime('now') WHERE entity = ? AND entity_key = ? AND op = ? AND source = ?`, SyncEntitySession, "session-a", SyncOpUpsert, SyncSourceLocal); err != nil {
+		t.Fatalf("acknowledge session history: %v", err)
+	}
+
+	if err := s.CreateSession("session-a", "alpha", "/alpha"); err != nil {
+		t.Fatalf("refresh ended session: %v", err)
+	}
+	if err := s.DeleteSession("session-a"); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+	if err := s.CreateSession("session-a", "alpha", "/replacement"); err != nil {
+		t.Fatalf("recreate session: %v", err)
+	}
+	if err := s.CreateSession("session-b", "alpha", "/other"); err != nil {
+		t.Fatalf("create unrelated session: %v", err)
+	}
+	if err := s.CreateSession("session-c", "beta", "/beta"); err != nil {
+		t.Fatalf("create other-project session: %v", err)
+	}
+	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`, DefaultSyncTargetKey, SyncEntitySession, "session-a", SyncOpUpsert, `{"id":"session-a","project":"alpha","directory":"/remote"}`, SyncSourceRemote, "alpha"); err != nil {
+		t.Fatalf("seed remote upsert: %v", err)
+	}
+
+	rows, err := s.DB().Query(`SELECT seq, entity_key, op, source, acked_at FROM sync_mutations WHERE entity = ? ORDER BY seq`, SyncEntitySession)
+	if err != nil {
+		t.Fatalf("list session mutations: %v", err)
+	}
+	defer rows.Close()
+	var localUpsertSeq, deleteSeq int64
+	seen := map[string]int{}
+	for rows.Next() {
+		var seq int64
+		var entityKey, op, source string
+		var ackedAt sql.NullString
+		if err := rows.Scan(&seq, &entityKey, &op, &source, &ackedAt); err != nil {
+			t.Fatalf("scan session mutation: %v", err)
+		}
+		seen[entityKey+":"+op+":"+source]++
+		if entityKey == "session-a" && op == SyncOpUpsert && source == SyncSourceLocal && !ackedAt.Valid {
+			localUpsertSeq = seq
+		}
+		if entityKey == "session-a" && op == SyncOpDelete && source == SyncSourceLocal {
+			deleteSeq = seq
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate session mutations: %v", err)
+	}
+	if localUpsertSeq == 0 || deleteSeq == 0 || deleteSeq >= localUpsertSeq {
+		t.Fatalf("delete seq=%d and replacement upsert seq=%d, want delete before upsert", deleteSeq, localUpsertSeq)
+	}
+	if seen["session-a:upsert:local"] != 2 || seen["session-a:delete:local"] != 1 || seen["session-a:upsert:remote"] != 1 || seen["session-b:upsert:local"] != 1 || seen["session-c:upsert:local"] != 1 {
+		t.Fatalf("session mutation coverage = %#v", seen)
+	}
+}
+
+func TestPartialLocalSessionWaitsForDirectoryBeforeJournal(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("partial-session", "engram", " \t "); err != nil {
+		t.Fatalf("create partial session: %v", err)
+	}
+	partial, err := s.GetSession("partial-session")
+	if err != nil || strings.TrimSpace(partial.Directory) != "" {
+		t.Fatalf("partial session = %+v, %v; want persisted blank directory", partial, err)
+	}
+	enrollTestProject(t, s, "engram")
+	var mutations int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ?`, SyncEntitySession, "partial-session").Scan(&mutations); err != nil {
+		t.Fatalf("count partial mutations: %v", err)
+	}
+	if mutations != 0 {
+		t.Fatalf("partial session mutations = %d, want 0", mutations)
+	}
+
+	if err := s.CreateSession("partial-session", "engram", "/ready"); err != nil {
+		t.Fatalf("complete partial session: %v", err)
+	}
+	if err := s.StartSession("partial-session", "engram", "/ignored"); err != nil {
+		t.Fatalf("refresh completed session: %v", err)
+	}
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND op = ? AND source = ? AND acked_at IS NULL`, SyncEntitySession, "partial-session", SyncOpUpsert, SyncSourceLocal).Scan(&mutations); err != nil {
+		t.Fatalf("count completed mutations: %v", err)
+	}
+	if mutations != 1 {
+		t.Fatalf("completed session mutations = %d, want 1", mutations)
+	}
+	var payload syncSessionPayload
+	var raw string
+	if err := s.DB().QueryRow(`SELECT payload FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`, SyncEntitySession, "partial-session", SyncSourceLocal).Scan(&raw); err != nil {
+		t.Fatalf("load completed payload: %v", err)
+	}
+	if err := decodeSyncPayload([]byte(raw), &payload); err != nil || payload.Directory != "/ready" {
+		t.Fatalf("completed payload = %+v, %v; want /ready", payload, err)
+	}
+}
+
 func TestStartSessionCreatesAndIdempotentlyStartsActiveSession(t *testing.T) {
 	s := newTestStore(t)
 	enrollTestProject(t, s, "engram")
@@ -7080,8 +7196,8 @@ func TestStartSessionCreatesAndIdempotentlyStartsActiveSession(t *testing.T) {
 	if err := s.DB().QueryRow(`SELECT count(*) FROM sync_mutations WHERE entity = ? AND entity_key = ?`, SyncEntitySession, "strict-active").Scan(&mutations); err != nil {
 		t.Fatalf("count session mutations: %v", err)
 	}
-	if mutations != 2 {
-		t.Fatalf("session mutations = %d, want 2 for two valid starts", mutations)
+	if mutations != 1 {
+		t.Fatalf("session mutations = %d, want one newest pending upsert", mutations)
 	}
 }
 
@@ -7227,6 +7343,33 @@ func TestEnqueueSessionMutationRejectsBlankKeyAndRollsBack(t *testing.T) {
 	if err := s.DB().QueryRow(`SELECT count(*) FROM sync_mutations WHERE entity = ? AND `+sqlSessionIDBlank("entity_key"), SyncEntitySession, sqlWhitespaceTrimSet).Scan(&mutations); err != nil || sessions != 0 || mutations != 0 {
 		t.Fatalf("sessions=%d blank mutations=%d err=%v", sessions, mutations, err)
 	}
+}
+
+func TestInboundSessionDirectoryAdmissionRejectsBlankValues(t *testing.T) {
+	t.Run("pulled mutation", func(t *testing.T) {
+		s := newTestStore(t)
+		err := s.ApplyPulledMutation(DefaultSyncTargetKey, SyncMutation{
+			Seq: 1, Entity: SyncEntitySession, EntityKey: "blank-directory", Op: SyncOpUpsert,
+			Payload: `{"id":"blank-directory","project":"engram","directory":" \t "}`,
+		})
+		if !errors.Is(err, ErrPulledSessionDirectoryInvalid) {
+			t.Fatalf("ApplyPulledMutation error = %v, want ErrPulledSessionDirectoryInvalid", err)
+		}
+		if _, err := s.GetSession("blank-directory"); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("blank pulled session persisted: %v", err)
+		}
+	})
+
+	t.Run("direct import", func(t *testing.T) {
+		s := newTestStore(t)
+		_, err := s.Import(&ExportData{Sessions: []Session{{ID: "blank-import", Project: "engram", Directory: " "}}})
+		if !errors.Is(err, ErrPulledSessionDirectoryInvalid) {
+			t.Fatalf("Import error = %v, want ErrPulledSessionDirectoryInvalid", err)
+		}
+		if _, err := s.GetSession("blank-import"); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("blank imported session persisted: %v", err)
+		}
+	})
 }
 
 func TestApplyPulledSessionMutationSkipsInvalidIdentityWithEvidence(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1104

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:question` — Question requiring tracked work
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Coalesce superseded pending local session upserts while preserving acknowledged history, deletes, sources, projects, and ordering boundaries.
- Keep partial sessions local until they have a concrete directory, and reject explicitly blank inbound session directories while preserving legacy missing-field compatibility.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Coalesce pending session upserts and enforce outbound/inbound directory admission. |
| `internal/store/store_test.go` | Cover coalescing scope, ordering, deletes, partial sessions, and pull/import validation. |
| `internal/cloud/cloudserver/cloudserver_test.go` | Cover explicit blank-directory rejection for direct and mutation pushes. |

## 🧪 Test Plan

- [x] Focused store regressions pass:
  - `go test ./internal/store -run '^(TestLocalSessionUpsertsCoalescePendingState|TestPartialLocalSessionWaitsForDirectoryBeforeJournal|TestStartSessionCreatesAndIdempotentlyStartsActiveSession|TestStoreLocalSyncFoundationEnqueuesCoreMutations|TestDeleteSession_EnrolledProjectEnqueuesSyncDeleteMutation)$' -count=1`
  - `go test ./internal/store -run '^(TestInboundSessionDirectoryAdmissionRejectsBlankValues|TestApplyPulledMutationAcceptsStringifiedSessionPayload)$' -count=1`
- [x] Focused cloud regressions pass:
  - `go test ./internal/cloud/cloudserver -run '^(TestHandlerPushRejectsMutationUpsertsMissingRequiredFields|TestHandlerPushRejectsDirectChunkArraysMissingRequiredFields|TestMutationPushAcceptsSparseLegacyPayloads)$' -count=1`
- [x] Affected packages pass: `go test ./internal/store -count=1` and `go test ./internal/cloud/cloudserver -count=1`
- [x] Independent verification passed with no candidate-caused severe or major findings.
- [x] Native four-lens review approved and acknowledged.
- [ ] Full unit suite locally: CI is the designated broad-suite owner for this unchanged candidate.
- [ ] E2E suite locally: CI is the designated broad-suite owner for this unchanged candidate.
- [ ] Lint locally: CI will run the repository-pinned lint job.
- [ ] Manual testing: not applicable; behavior is exercised at deterministic store and cloud boundaries.

---

## 🤖 Automated Checks

These run automatically and all must pass before merge.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1104`).
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran the full unit suite locally; CI owns broad validation for this candidate.
- [ ] I ran the E2E suite locally; CI owns broad validation for this candidate.
- [ ] I ran lint locally; CI owns repository-pinned lint validation.
- [x] Docs assessed; no public API, CLI, configuration, or workflow documentation changed.
- [x] Commits follow conventional commit format.
- [x] No `Co-Authored-By` trailers are present.
- [x] Every changed path complies with the Transient Artifact Policy.

---

## 💬 Notes for Reviewers

The local store remains the source of truth. A session without a concrete directory is retained locally but does not enter cloud mutation traffic until completed. Coalescing is limited to unacknowledged local `session/upsert` rows for the same project and session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Session imports and synchronized updates now reject records with missing or whitespace-only directory values.
  - Incomplete local sessions are held until a valid directory is provided, preventing invalid data from being recorded.
  - Session updates are consolidated more reliably, reducing duplicate pending synchronization changes.
  - Existing sessions with blank directories are corrected when a valid directory is supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->