### PR TITLE
fix(sync): skip permanently unsatisfiable relation upserts during cloud import (#1135)

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -1988,6 +1988,7 @@ func cmdSync(cfg store.Config) {
 				fmt.Printf("  (%d chunks already imported)\n", result.ChunksSkipped)
 			}
 			printImportRelationCounts(result)
+			printSkippedRelationWarnings(result)
 			return
 		}
 
@@ -2003,6 +2004,7 @@ func cmdSync(cfg store.Config) {
 			fmt.Printf("  Skipped:      %d (already imported)\n", result.ChunksSkipped)
 		}
 		printImportRelationCounts(result)
+		printSkippedRelationWarnings(result)
 		return
 	}
 
@@ -2060,6 +2062,15 @@ func printImportRelationCounts(result *engramsync.ImportResult) {
 	fmt.Printf("  Relations replayed: %d\n", result.RelationsReplayed)
 	fmt.Printf("  Relations deferred: %d\n", result.RelationsDeferred)
 	fmt.Printf("  Relations dead:     %d\n", result.RelationsDead)
+}
+
+// printSkippedRelationWarnings surfaces relation upserts that were skipped
+// because their referenced observations are permanently missing (issue #1135),
+// so a stale edge is visible instead of silently dying in the deferred queue.
+func printSkippedRelationWarnings(result *engramsync.ImportResult) {
+	for _, warning := range result.SkippedRelations {
+		fmt.Printf("  WARNING skipped %s\n", warning)
+	}
 }
 
 func printSyncUsage() {

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -4877,7 +4877,8 @@ func TestCmdSyncCloudNoOpImportRendersInitialAndFinalProgress(t *testing.T) {
 
 // TestCmdSyncCloudImportPrintsSkippedRelationWarnings verifies that relation
 // upserts skipped for permanently missing endpoints surface as visible CLI
-// warnings (issue #1135) instead of dying silently in the deferred queue.
+// warnings (issue #1135) instead of dying silently in the deferred queue, on
+// both the imported-chunks path and the no-new-chunks path.
 func TestCmdSyncCloudImportPrintsSkippedRelationWarnings(t *testing.T) {
 	stubExitWithPanic(t)
 	stubRuntimeHooks(t)
@@ -4910,26 +4911,47 @@ func TestCmdSyncCloudImportPrintsSkippedRelationWarnings(t *testing.T) {
 		t.Fatalf("close store: %v", err)
 	}
 
-	syncImportWithProgress = func(_ *engramsync.Syncer, report func(engramsync.ImportProgress)) (*engramsync.ImportResult, error) {
-		report(engramsync.ImportProgress{Percentage: 100})
-		report(engramsync.ImportProgress{Percentage: 100})
-		return &engramsync.ImportResult{
-			ChunksImported:       1,
-			SessionsImported:     1,
-			ObservationsImported: 1,
-			SkippedRelations:     []string{"relation obs-a->obs-b: referenced observation missing permanently"},
-		}, nil
+	cases := []struct {
+		name   string
+		result *engramsync.ImportResult
+	}{
+		{
+			name: "imported chunks",
+			result: &engramsync.ImportResult{
+				ChunksImported:       1,
+				SessionsImported:     1,
+				ObservationsImported: 1,
+				SkippedRelations:     []string{"relation obs-a->obs-b: referenced observation missing permanently"},
+			},
+		},
+		{
+			name: "no new chunks",
+			result: &engramsync.ImportResult{
+				ChunksSkipped:    1,
+				SkippedRelations: []string{"relation obs-a->obs-b: referenced observation missing permanently"},
+			},
+		},
 	}
-	syncStatus = func(*engramsync.Syncer) (int, int, int, error) {
-		return 1, 1, 0, nil
-	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			syncImportWithProgress = func(_ *engramsync.Syncer, report func(engramsync.ImportProgress)) (*engramsync.ImportResult, error) {
+				report(engramsync.ImportProgress{Percentage: 100})
+				report(engramsync.ImportProgress{Percentage: 100})
+				return tc.result, nil
+			}
+			syncStatus = func(*engramsync.Syncer) (int, int, int, error) {
+				return 1, 1, 0, nil
+			}
 
-	withArgs(t, "engram", "sync", "--cloud", "--import", "--project", "proj-a")
-	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
-	if recovered != nil || stderr != "" {
-		t.Fatalf("expected successful cloud import, panic=%v stderr=%q", recovered, stderr)
-	}
-	if !strings.Contains(stdout, "WARNING skipped relation obs-a->obs-b: referenced observation missing permanently") {
-		t.Fatalf("expected skipped relation warning in import output, got:\n%s", stdout)
+			withArgs(t, "engram", "sync", "--cloud", "--import", "--project", "proj-a")
+			stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+			if recovered != nil || stderr != "" {
+				t.Fatalf("expected successful cloud import, panic=%v stderr=%q", recovered, stderr)
+			}
+			if !strings.Contains(stdout, "WARNING skipped relation obs-a->obs-b: referenced observation missing permanently") {
+				t.Fatalf("expected skipped relation warning in import output, got:\n%s", stdout)
+			}
+		})
 	}
 }

--- a/cmd/engram/main_extra_test.go
+++ b/cmd/engram/main_extra_test.go
@@ -4874,3 +4874,62 @@ func TestCmdSyncCloudNoOpImportRendersInitialAndFinalProgress(t *testing.T) {
 		t.Fatalf("final no-op progress must precede the existing summary: %q", stdout)
 	}
 }
+
+// TestCmdSyncCloudImportPrintsSkippedRelationWarnings verifies that relation
+// upserts skipped for permanently missing endpoints surface as visible CLI
+// warnings (issue #1135) instead of dying silently in the deferred queue.
+func TestCmdSyncCloudImportPrintsSkippedRelationWarnings(t *testing.T) {
+	stubExitWithPanic(t)
+	stubRuntimeHooks(t)
+
+	originalSyncImport := syncImport
+	originalSyncImportWithProgress := syncImportWithProgress
+	originalSyncStatus := syncStatus
+	t.Cleanup(func() {
+		syncImport = originalSyncImport
+		syncImportWithProgress = originalSyncImportWithProgress
+		syncStatus = originalSyncStatus
+	})
+
+	workDir := t.TempDir()
+	withCwd(t, workDir)
+	cfg := testConfig(t)
+
+	t.Setenv("ENGRAM_CLOUD_SERVER", "https://cloud.example.test")
+	t.Setenv("ENGRAM_CLOUD_TOKEN", "token-abc")
+
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	if err := s.EnrollProject("proj-a"); err != nil {
+		_ = s.Close()
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	syncImportWithProgress = func(_ *engramsync.Syncer, report func(engramsync.ImportProgress)) (*engramsync.ImportResult, error) {
+		report(engramsync.ImportProgress{Percentage: 100})
+		report(engramsync.ImportProgress{Percentage: 100})
+		return &engramsync.ImportResult{
+			ChunksImported:       1,
+			SessionsImported:     1,
+			ObservationsImported: 1,
+			SkippedRelations:     []string{"relation obs-a->obs-b: referenced observation missing permanently"},
+		}, nil
+	}
+	syncStatus = func(*engramsync.Syncer) (int, int, int, error) {
+		return 1, 1, 0, nil
+	}
+
+	withArgs(t, "engram", "sync", "--cloud", "--import", "--project", "proj-a")
+	stdout, stderr, recovered := captureOutputAndRecover(t, func() { cmdSync(cfg) })
+	if recovered != nil || stderr != "" {
+		t.Fatalf("expected successful cloud import, panic=%v stderr=%q", recovered, stderr)
+	}
+	if !strings.Contains(stdout, "WARNING skipped relation obs-a->obs-b: referenced observation missing permanently") {
+		t.Fatalf("expected skipped relation warning in import output, got:\n%s", stdout)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6251,7 +6251,7 @@ func (s *Store) ApplyPulledChunk(targetKey, chunkID string, mutations []SyncMuta
 func (s *Store) GetObservationBySyncID(syncID string) (*Observation, error) {
 	row := s.db.QueryRow(
 		`SELECT `+observationSelectColumns+`
-		 FROM observations WHERE sync_id = ? AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`,
+			 FROM observations WHERE sync_id = ? AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`,
 		syncID,
 	)
 	var o Observation
@@ -6259,6 +6259,23 @@ func (s *Store) GetObservationBySyncID(syncID string) (*Observation, error) {
 		return nil, err
 	}
 	return &o, nil
+}
+
+// HasObservationBySyncIDAnyState reports whether an observation with the given
+// sync_id exists locally in any deletion state, tombstones included. It mirrors
+// the tombstone-inclusive relation FK precondition (getObservationBySyncIDTx
+// with includeDeleted) for callers outside Store transactions and answers
+// through the idx_obs_sync_id index without materializing an export.
+func (s *Store) HasObservationBySyncIDAnyState(syncID string) (bool, error) {
+	var one int
+	err := s.db.QueryRow(`SELECT 1 FROM observations WHERE sync_id = ? LIMIT 1`, syncID).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check observation sync_id %s: %w", syncID, err)
+	}
+	return true, nil
 }
 
 // ─── Project Enrollment for Cloud Sync ───────────────────────────────────────

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4433,6 +4433,77 @@ func TestApplyRemoteMutationIdempotent(t *testing.T) {
 	}
 }
 
+// TestStoreHasObservationBySyncIDAnyState pins the tombstone-inclusive
+// existence contract that relation imports rely on: HasObservationBySyncIDAnyState
+// must see live and soft-deleted (tombstoned) rows alike, while
+// GetObservationBySyncID keeps excluding deleted ones.
+func TestStoreHasObservationBySyncIDAnyState(t *testing.T) {
+	s := newTestStore(t)
+
+	create := SyncMutation{
+		Seq:       41,
+		TargetKey: DefaultSyncTargetKey,
+		Entity:    SyncEntitySession,
+		EntityKey: "remote-session",
+		Op:        SyncOpUpsert,
+		Payload:   `{"id":"remote-session","project":"engram","directory":"/remote"}`,
+	}
+	if err := s.ApplyPulledMutation(DefaultSyncTargetKey, create); err != nil {
+		t.Fatalf("apply session mutation: %v", err)
+	}
+
+	obsMutation := SyncMutation{
+		Seq:       42,
+		TargetKey: DefaultSyncTargetKey,
+		Entity:    SyncEntityObservation,
+		EntityKey: "obs-remote-1",
+		Op:        SyncOpUpsert,
+		Payload:   `{"sync_id":"obs-remote-1","session_id":"remote-session","type":"decision","title":"Remote","content":"Pulled from cloud","project":"engram","scope":"project"}`,
+	}
+	if err := s.ApplyPulledMutation(DefaultSyncTargetKey, obsMutation); err != nil {
+		t.Fatalf("apply observation mutation: %v", err)
+	}
+
+	known, err := s.HasObservationBySyncIDAnyState("obs-remote-1")
+	if err != nil {
+		t.Fatalf("check live observation: %v", err)
+	}
+	if !known {
+		t.Fatalf("expected live observation to be visible in any state")
+	}
+
+	absent, err := s.HasObservationBySyncIDAnyState("obs-never-pulled")
+	if err != nil {
+		t.Fatalf("check absent observation: %v", err)
+	}
+	if absent {
+		t.Fatalf("expected absent observation to be invisible in any state")
+	}
+
+	deleteMutation := SyncMutation{
+		Seq:       43,
+		TargetKey: DefaultSyncTargetKey,
+		Entity:    SyncEntityObservation,
+		EntityKey: "obs-remote-1",
+		Op:        SyncOpDelete,
+		Payload:   `{"sync_id":"obs-remote-1","deleted":true}`,
+	}
+	if err := s.ApplyPulledMutation(DefaultSyncTargetKey, deleteMutation); err != nil {
+		t.Fatalf("apply delete mutation: %v", err)
+	}
+	if _, err := s.GetObservationBySyncID("obs-remote-1"); err == nil {
+		t.Fatalf("expected pulled delete to hide observation from GetObservationBySyncID")
+	}
+
+	tombstoned, err := s.HasObservationBySyncIDAnyState("obs-remote-1")
+	if err != nil {
+		t.Fatalf("check tombstoned observation: %v", err)
+	}
+	if !tombstoned {
+		t.Fatalf("expected tombstoned observation to stay visible in any state")
+	}
+}
+
 func TestApplyPulledMutationClearsDegradedReasonFields(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.MarkSyncBlocked(DefaultSyncTargetKey, "blocked_unenrolled", "project not enrolled"); err != nil {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1132,9 +1132,6 @@ type importDependencyOracle struct {
 	pendingObservationIDs map[string]struct{}
 	built                 bool
 	buildErr              error
-	allObservationSyncIDs map[string]struct{}
-	exported              bool
-	exportErr             error
 }
 
 func newImportDependencyOracle(sy *Syncer, entries []ChunkEntry, knownChunks map[string]bool) *importDependencyOracle {
@@ -1149,9 +1146,9 @@ func newImportDependencyOracle(sy *Syncer, entries []ChunkEntry, knownChunks map
 // any deletion state or arrives with a chunk still pending in this run.
 // GetObservationBySyncID excludes soft-deleted rows, but the store's relation
 // FK precondition (applyRelationUpsertTx) counts them: an edge whose endpoint
-// is a local tombstone still applies today and must never be skipped. Only a
-// full scan (Export includes tombstones) can distinguish tombstoned endpoints
-// from permanently absent ones, so it runs lazily, at most once per import.
+// is a local tombstone still applies today and must never be skipped.
+// HasObservationBySyncIDAnyState answers tombstone-inclusively through the
+// idx_obs_sync_id index, so classification never materializes an export.
 func (o *importDependencyOracle) endpointSatisfiable(syncID string) (bool, error) {
 	syncID = strings.TrimSpace(syncID)
 	if syncID == "" {
@@ -1163,30 +1160,10 @@ func (o *importDependencyOracle) endpointSatisfiable(syncID string) (bool, error
 	if _, pending := o.pendingObservationIDs[syncID]; pending {
 		return true, nil
 	}
-	if _, err := o.sy.store.GetObservationBySyncID(syncID); err == nil {
-		return true, nil
-	} else if !errors.Is(err, sql.ErrNoRows) {
+	known, err := o.sy.store.HasObservationBySyncIDAnyState(syncID)
+	if err != nil {
 		return false, fmt.Errorf("check relation endpoint %s: %w", syncID, err)
 	}
-	if !o.exported {
-		data, err := storeExportData(o.sy.store)
-		if err != nil {
-			o.exported = true
-			o.exportErr = err
-			return false, fmt.Errorf("check relation endpoints: %w", err)
-		}
-		o.allObservationSyncIDs = make(map[string]struct{}, len(data.Observations))
-		for _, obs := range data.Observations {
-			if id := strings.TrimSpace(obs.SyncID); id != "" {
-				o.allObservationSyncIDs[id] = struct{}{}
-			}
-		}
-		o.exported = true
-	}
-	if o.exportErr != nil {
-		return false, fmt.Errorf("check relation endpoints: %w", o.exportErr)
-	}
-	_, known := o.allObservationSyncIDs[syncID]
 	return known, nil
 }
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -121,6 +121,10 @@ type ImportResult struct {
 	RelationsReplayed    int `json:"relations_replayed"`
 	RelationsDeferred    int `json:"relations_deferred"`
 	RelationsDead        int `json:"relations_dead"`
+	// SkippedRelations records relation upserts that were provably
+	// unsatisfiable (their referenced observations are permanently absent)
+	// and were skipped instead of stalling the import. One entry per edge.
+	SkippedRelations []string `json:"skipped_relations,omitempty"`
 }
 
 // ImportProgress is a point-in-time snapshot of an import. Percentage uses the
@@ -961,6 +965,15 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 		}
 	}
 
+	// Cloud only (issue #1135): a relation upsert whose endpoints can never
+	// exist locally would otherwise be deferred by the store and silently die
+	// after repeated replays, with nothing telling the operator why. Classify
+	// such edges before apply and surface them as visible warnings instead.
+	var dependencyOracle *importDependencyOracle
+	if mode == importModeCloud {
+		dependencyOracle = newImportDependencyOracle(sy, entries, knownChunks)
+	}
+
 	lastErrors := map[string]error{}
 	for pass := 1; len(pendingEntries) > 0; pass++ {
 		progress := false
@@ -988,7 +1001,25 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 				}
 			}
 
-			if err := sy.importMutationChunk(entry.ID, chunk); err != nil {
+			// Issue #1135: in cloud mode, drop relation upserts whose endpoints
+			// are provably unsatisfiable before apply. A filtered chunk that
+			// still fails re-enters the normal retry loop below with its
+			// original, unfiltered mutations, so every other failure keeps the
+			// existing stall semantics.
+			applyChunk := chunk
+			var skippedEdges []string
+			if dependencyOracle != nil {
+				filtered, warnings, filterErr := filterUnsatisfiableRelationUpserts(chunk, dependencyOracle)
+				if filterErr != nil {
+					return nil, filterErr
+				}
+				if len(warnings) > 0 {
+					applyChunk = filtered
+					skippedEdges = warnings
+				}
+			}
+
+			if err := sy.importMutationChunk(entry.ID, applyChunk); err != nil {
 				if mode == importModeLocal {
 					recoveredChunk, recovered, recoveryErr := sy.recoverLocalMissingSessionDependencies(chunk, availableSessionIDs)
 					if recoveryErr != nil {
@@ -1017,6 +1048,9 @@ func (sy *Syncer) importEntriesDependencySafeWithProgress(entries []ChunkEntry, 
 			result.SessionsImported += importResult.SessionsImported
 			result.ObservationsImported += importResult.ObservationsImported
 			result.PromptsImported += importResult.PromptsImported
+			if len(skippedEdges) > 0 {
+				result.SkippedRelations = append(result.SkippedRelations, skippedEdges...)
+			}
 			if afterCommit != nil {
 				afterCommit()
 			}
@@ -1069,6 +1103,205 @@ func (sy *Syncer) importMutationChunk(chunkID string, chunk ChunkData) error {
 	mutations := buildImportMutations(chunk)
 	mutations = orderMutationsForApply(mutations)
 	return storeApplyPulledChunk(sy.store, sy.chunkTrackingTargetKey(""), chunkID, mutations)
+}
+
+// ─── Issue #1135: permanently unsatisfiable relation upserts ─────────────────
+//
+// The store defers a pulled relation whose endpoints are missing
+// (recordRelationApplyFailureTx), which lets the chunk import but parks the
+// edge in sync_apply_deferred until it silently dies after repeated replays.
+// When an endpoint was deleted hub-side and no chunk re-upserts it, that
+// deferral can never converge and nothing tells the operator why. The cloud
+// import path therefore classifies relation upserts before apply: an edge
+// whose endpoints are absent from the local store (in any deletion state) and
+// from every chunk still pending in this run is provably unsatisfiable — a
+// chunk already imported during the same run has its observations in the
+// store, so the store lookup covers it. Such an edge is skipped and reported
+// as a visible warning on ImportResult.SkippedRelations. Everything else keeps
+// the original apply/stall behavior, and local import is untouched.
+
+// importDependencyOracle resolves whether a relation endpoint can ever be
+// satisfied locally: it exists in the store, or arrives with a chunk still
+// pending in this import run. The pending set is built lazily on the first
+// relation classification, so relation-free imports never pay for extra chunk
+// reads; chunks imported before that point are covered by the store lookup.
+type importDependencyOracle struct {
+	sy                    *Syncer
+	entries               []ChunkEntry
+	knownChunks           map[string]bool
+	pendingObservationIDs map[string]struct{}
+	built                 bool
+	buildErr              error
+	allObservationSyncIDs map[string]struct{}
+	exported              bool
+	exportErr             error
+}
+
+func newImportDependencyOracle(sy *Syncer, entries []ChunkEntry, knownChunks map[string]bool) *importDependencyOracle {
+	return &importDependencyOracle{
+		sy:          sy,
+		entries:     entries,
+		knownChunks: knownChunks,
+	}
+}
+
+// endpointSatisfiable reports whether an observation sync_id exists locally in
+// any deletion state or arrives with a chunk still pending in this run.
+// GetObservationBySyncID excludes soft-deleted rows, but the store's relation
+// FK precondition (applyRelationUpsertTx) counts them: an edge whose endpoint
+// is a local tombstone still applies today and must never be skipped. Only a
+// full scan (Export includes tombstones) can distinguish tombstoned endpoints
+// from permanently absent ones, so it runs lazily, at most once per import.
+func (o *importDependencyOracle) endpointSatisfiable(syncID string) (bool, error) {
+	syncID = strings.TrimSpace(syncID)
+	if syncID == "" {
+		return false, nil
+	}
+	if err := o.ensurePendingObservationIDs(); err != nil {
+		return false, err
+	}
+	if _, pending := o.pendingObservationIDs[syncID]; pending {
+		return true, nil
+	}
+	if _, err := o.sy.store.GetObservationBySyncID(syncID); err == nil {
+		return true, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("check relation endpoint %s: %w", syncID, err)
+	}
+	if !o.exported {
+		data, err := storeExportData(o.sy.store)
+		if err != nil {
+			o.exported = true
+			o.exportErr = err
+			return false, fmt.Errorf("check relation endpoints: %w", err)
+		}
+		o.allObservationSyncIDs = make(map[string]struct{}, len(data.Observations))
+		for _, obs := range data.Observations {
+			if id := strings.TrimSpace(obs.SyncID); id != "" {
+				o.allObservationSyncIDs[id] = struct{}{}
+			}
+		}
+		o.exported = true
+	}
+	if o.exportErr != nil {
+		return false, fmt.Errorf("check relation endpoints: %w", o.exportErr)
+	}
+	_, known := o.allObservationSyncIDs[syncID]
+	return known, nil
+}
+
+// ensurePendingObservationIDs builds the pending observation set on first use.
+// A pending chunk that cannot be read or parsed fails the import before the
+// first relation-bearing chunk applies, so no edge is ever classified against
+// an incomplete pending set.
+func (o *importDependencyOracle) ensurePendingObservationIDs() error {
+	if o.built {
+		return o.buildErr
+	}
+	o.built = true
+	pending, err := o.sy.pendingObservationSyncIDs(o.entries, o.knownChunks)
+	if err != nil {
+		o.buildErr = err
+		return err
+	}
+	o.pendingObservationIDs = pending
+	return nil
+}
+
+// pendingObservationSyncIDs collects the observation sync_ids upserted by any
+// chunk that is still pending for this import run.
+func (sy *Syncer) pendingObservationSyncIDs(entries []ChunkEntry, knownChunks map[string]bool) (map[string]struct{}, error) {
+	pending := make(map[string]struct{})
+	for _, entry := range entries {
+		if knownChunks[entry.ID] {
+			continue
+		}
+		chunkJSON, err := sy.transport.ReadChunk(entry.ID)
+		if err != nil {
+			if errors.Is(err, ErrChunkNotFound) {
+				return nil, fmt.Errorf("read chunk %s: manifest references missing remote chunk", entry.ID)
+			}
+			return nil, fmt.Errorf("read chunk %s: %w", entry.ID, err)
+		}
+		var chunk ChunkData
+		if err := json.Unmarshal(chunkJSON, &chunk); err != nil {
+			return nil, fmt.Errorf("parse chunk %s: %w", entry.ID, err)
+		}
+		for _, mutation := range buildImportMutations(chunk) {
+			if mutation.Entity != store.SyncEntityObservation || mutation.Op != store.SyncOpUpsert {
+				continue
+			}
+			if obsID := strings.TrimSpace(mutation.EntityKey); obsID != "" {
+				pending[obsID] = struct{}{}
+			}
+		}
+	}
+	return pending, nil
+}
+
+// filterUnsatisfiableRelationUpserts returns the chunk with relation upserts
+// removed when at least one endpoint is provably unsatisfiable, together with
+// one visible warning per skipped edge. Mutations that cannot be classified
+// (undecodable payload, blank endpoints) are kept so the store keeps handling
+// them unchanged.
+func filterUnsatisfiableRelationUpserts(chunk ChunkData, oracle *importDependencyOracle) (ChunkData, []string, error) {
+	if len(chunk.Mutations) == 0 {
+		// Legacy array chunks carry no relation upserts.
+		return chunk, nil, nil
+	}
+	filtered := make([]store.SyncMutation, 0, len(chunk.Mutations))
+	warnings := make([]string, 0)
+	changed := false
+	for _, mutation := range chunk.Mutations {
+		if mutation.Entity != store.SyncEntityRelation || mutation.Op != store.SyncOpUpsert {
+			filtered = append(filtered, mutation)
+			continue
+		}
+		sourceID, targetID, classifiable := relationUpsertEndpoints(mutation)
+		if !classifiable {
+			filtered = append(filtered, mutation)
+			continue
+		}
+		sourceOK, err := oracle.endpointSatisfiable(sourceID)
+		if err != nil {
+			return chunk, nil, err
+		}
+		targetOK, err := oracle.endpointSatisfiable(targetID)
+		if err != nil {
+			return chunk, nil, err
+		}
+		if sourceOK && targetOK {
+			filtered = append(filtered, mutation)
+			continue
+		}
+		changed = true
+		warnings = append(warnings, fmt.Sprintf("relation %s->%s: referenced observation missing permanently", sourceID, targetID))
+	}
+	if !changed {
+		return chunk, nil, nil
+	}
+	filteredChunk := chunk
+	filteredChunk.Mutations = filtered
+	return filteredChunk, warnings, nil
+}
+
+// relationUpsertEndpoints decodes the endpoints of a relation upsert payload.
+// classifiable is false when the payload cannot be judged (decode failure or
+// blank endpoints); the caller keeps the mutation so the store classifies it.
+func relationUpsertEndpoints(mutation store.SyncMutation) (sourceID, targetID string, classifiable bool) {
+	var payload struct {
+		SourceID string `json:"source_id"`
+		TargetID string `json:"target_id"`
+	}
+	if err := decodeSyncPayloadForProject([]byte(mutation.Payload), &payload); err != nil {
+		return "", "", false
+	}
+	sourceID = strings.TrimSpace(payload.SourceID)
+	targetID = strings.TrimSpace(payload.TargetID)
+	if sourceID == "" || targetID == "" {
+		return "", "", false
+	}
+	return sourceID, targetID, true
 }
 
 func importDependencyError(chunk ChunkData, err error) error {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2699,7 +2699,7 @@ func TestImportBranches(t *testing.T) {
 		if err != nil {
 			t.Fatalf("import: %v", err)
 		}
-		if *res != (ImportResult{}) {
+		if res.ChunksImported != 0 || res.ChunksSkipped != 0 || res.SessionsImported != 0 || res.ObservationsImported != 0 || res.PromptsImported != 0 || res.RelationsReplayed != 0 || res.RelationsDeferred != 0 || res.RelationsDead != 0 || len(res.SkippedRelations) != 0 {
 			t.Fatalf("expected empty result, got %+v", res)
 		}
 	})
@@ -3933,7 +3933,11 @@ func TestCloudImportAppliesObservationsBeforeEarlierRelationInSameChunk(t *testi
 	}
 }
 
-func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
+// TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing pins the issue
+// #1135 contract for cloud import: a relation whose target observation is
+// absent from the local store and from every chunk is skipped with a visible
+// warning while the rest of the chunk imports and the chunk is marked synced.
+func TestCloudImportSkipsRelationWhenEndpointIsPermanentlyMissing(t *testing.T) {
 	dst := newTestStore(t)
 	if err := dst.EnrollProject("proj-a"); err != nil {
 		t.Fatalf("enroll destination project: %v", err)
@@ -3973,7 +3977,7 @@ func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
 	}
 	result, err := NewCloudWithTransport(dst, transport, "proj-a").Import()
 	if err != nil {
-		t.Fatalf("import should defer the missing relation endpoint, got %v", err)
+		t.Fatalf("import should skip the permanently missing relation endpoint, got %v", err)
 	}
 	if result.ChunksImported != 1 || result.SessionsImported != 1 || result.ObservationsImported != 1 {
 		t.Fatalf("unexpected import result: %+v", result)
@@ -3987,12 +3991,16 @@ func TestCloudImportDefersRelationWhenEndpointIsMissing(t *testing.T) {
 	if _, err := dst.GetRelation("rel-missing-endpoint"); err == nil {
 		t.Fatal("expected unresolved relation to remain unapplied")
 	}
+	wantWarning := "relation obs-rollback-source->obs-missing-target: referenced observation missing permanently"
+	if len(result.SkippedRelations) != 1 || result.SkippedRelations[0] != wantWarning {
+		t.Fatalf("expected one skipped relation warning %q, got %+v", wantWarning, result.SkippedRelations)
+	}
 	deferred, dead, err := dst.CountDeferredAndDead()
 	if err != nil {
 		t.Fatalf("count deferred relation: %v", err)
 	}
-	if deferred != 1 || dead != 0 {
-		t.Fatalf("expected one deferred relation and no dead relations, got deferred=%d dead=%d", deferred, dead)
+	if deferred != 0 || dead != 0 {
+		t.Fatalf("expected the skipped edge to bypass the deferred queue, got deferred=%d dead=%d", deferred, dead)
 	}
 	synced, err := dst.GetSyncedChunksForTarget(cloudTargetKey("proj-a"))
 	if err != nil {
@@ -4792,5 +4800,368 @@ func TestCloudSyncPreservesPiPromptIdentityUnderProjectScope(t *testing.T) {
 		if p.SyncID == saved.SyncID {
 			t.Fatalf("prompt %q strayed into project %q after the round trip", saved.SyncID, otherProject)
 		}
+	}
+}
+
+// ─── Issue #1135: chunk referencing a deleted observation ────────────────────
+
+// relationMissingEndpointChunk builds the issue #1135 scenario payload: a chunk
+// carrying a session upsert, one observation upsert, and a relation upsert whose
+// target observation was deleted hub-side and is absent from every chunk and
+// from the local store.
+func relationMissingEndpointChunk(sessionID, obsA, obsB, relationID string) ChunkData {
+	return ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntitySession,
+			EntityKey: sessionID,
+			Op:        store.SyncOpUpsert,
+			Payload:   fmt.Sprintf(`{"id":%q,"project":"proj-a","directory":"/tmp/proj-a"}`, sessionID),
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: obsA,
+			Op:        store.SyncOpUpsert,
+			Payload:   fmt.Sprintf(`{"sync_id":%q,"session_id":%q,"type":"decision","title":"endpoint a","content":"source endpoint","project":"proj-a","scope":"project"}`, obsA, sessionID),
+		},
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: relationID,
+			Op:        store.SyncOpUpsert,
+			Payload:   fmt.Sprintf(`{"sync_id":%q,"source_id":%q,"target_id":%q,"relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`, relationID, obsA, obsB),
+		},
+	}}
+}
+
+// TestCloudImportHandlesRelationWithPermanentlyMissingEndpoint reproduces issue
+// #1135: a cloud chunk whose relation upsert references an observation that can
+// never arrive (deleted hub-side, absent from every chunk and from the local
+// store) must not stall the dependency-safe import loop. The provably
+// unsatisfiable edge is skipped with a visible warning while the rest of the
+// chunk imports.
+func TestCloudImportHandlesRelationWithPermanentlyMissingEndpoint(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		mode             importMode
+		relChunkID       string
+		relChunk         ChunkData
+		extraChunkID     string
+		extraChunk       ChunkData
+		wantErr          bool
+		wantChunks       int
+		wantSkippedEdges []string
+		wantDeferred     int
+		wantDead         int
+		assertStore      func(t *testing.T, s *store.Store)
+	}{
+		{
+			name:       "permanently missing endpoint skips relation and imports chunk",
+			mode:       importModeCloud,
+			relChunkID: "chunk-1135-permanent",
+			relChunk:   relationMissingEndpointChunk("sess-1135", "obs-1135-a", "obs-1135-deleted", "rel-1135"),
+			wantChunks: 1,
+			wantSkippedEdges: []string{
+				"relation obs-1135-a->obs-1135-deleted: referenced observation missing permanently",
+			},
+			wantDeferred: 0,
+			wantDead:     0,
+			assertStore: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				if _, err := s.GetSession("sess-1135"); err != nil {
+					t.Fatalf("expected session from the stalled chunk to import: %v", err)
+				}
+				if _, err := s.GetObservationBySyncID("obs-1135-a"); err != nil {
+					t.Fatalf("expected observation from the stalled chunk to import: %v", err)
+				}
+				if _, err := s.GetRelation("rel-1135"); err == nil {
+					t.Fatal("expected relation with permanently missing endpoint to stay unapplied")
+				}
+			},
+		},
+		{
+			name:         "endpoint arriving in another pending chunk resolves without skipping",
+			mode:         importModeCloud,
+			relChunkID:   "chunk-1135-rel-first",
+			relChunk:     relationMissingEndpointChunk("sess-1135-cross", "obs-1135-c", "obs-1135-d", "rel-1135-cross"),
+			extraChunkID: "chunk-1135-obs-second",
+			extraChunk: ChunkData{Mutations: []store.SyncMutation{
+				{
+					Entity:    store.SyncEntitySession,
+					EntityKey: "sess-1135-endpoints",
+					Op:        store.SyncOpUpsert,
+					Payload:   `{"id":"sess-1135-endpoints","project":"proj-a","directory":"/tmp/proj-a"}`,
+				},
+				{
+					Entity:    store.SyncEntityObservation,
+					EntityKey: "obs-1135-c",
+					Op:        store.SyncOpUpsert,
+					Payload:   `{"sync_id":"obs-1135-c","session_id":"sess-1135-endpoints","type":"decision","title":"c","content":"endpoint c","project":"proj-a","scope":"project"}`,
+				},
+				{
+					Entity:    store.SyncEntityObservation,
+					EntityKey: "obs-1135-d",
+					Op:        store.SyncOpUpsert,
+					Payload:   `{"sync_id":"obs-1135-d","session_id":"sess-1135-endpoints","type":"decision","title":"d","content":"endpoint d","project":"proj-a","scope":"project"}`,
+				},
+			}},
+			wantChunks:       2,
+			wantSkippedEdges: nil,
+			wantDeferred:     0,
+			wantDead:         0,
+			assertStore: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				relation, err := s.GetRelation("rel-1135-cross")
+				if err != nil {
+					t.Fatalf("expected cross-chunk relation to resolve through normal passes: %v", err)
+				}
+				if relation.SourceID != "obs-1135-c" || relation.TargetID != "obs-1135-d" {
+					t.Fatalf("unexpected cross-chunk relation: %+v", relation)
+				}
+			},
+		},
+		{
+			name:       "local import keeps current deferral behavior for missing endpoints",
+			mode:       importModeLocal,
+			relChunkID: "chunk-1135-local",
+			relChunk:   relationMissingEndpointChunk("sess-1135-local", "obs-1135-local", "obs-1135-local-missing", "rel-1135-local"),
+			wantChunks: 1,
+			// Local mode is untouched by this fix: the store defers the
+			// FK-missing relation and no skip warning is produced.
+			wantSkippedEdges: nil,
+			wantDeferred:     1,
+			wantDead:         0,
+			assertStore: func(t *testing.T, s *store.Store) {
+				t.Helper()
+				if _, err := s.GetObservationBySyncID("obs-1135-local"); err != nil {
+					t.Fatalf("expected observation to import in local mode: %v", err)
+				}
+				if _, err := s.GetRelation("rel-1135-local"); err == nil {
+					t.Fatal("expected unresolved relation to remain unapplied in local mode")
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestStore(t)
+
+			var importer *Syncer
+			if tt.mode == importModeCloud {
+				if err := s.EnrollProject("proj-a"); err != nil {
+					t.Fatalf("enroll project: %v", err)
+				}
+				transport := newFakeCloudTransport()
+				entries := []ChunkEntry{{ID: tt.relChunkID, CreatedAt: "2026-08-25T00:00:00Z"}}
+				transport.chunks[tt.relChunkID] = mustJSONChunk(t, tt.relChunkID, tt.relChunk)
+				if tt.extraChunkID != "" {
+					entries = append(entries, ChunkEntry{ID: tt.extraChunkID, CreatedAt: "2026-08-25T00:01:00Z"})
+					transport.chunks[tt.extraChunkID] = mustJSONChunk(t, tt.extraChunkID, tt.extraChunk)
+				}
+				transport.manifest = &Manifest{Version: 1, Chunks: entries}
+				importer = NewCloudWithTransport(s, transport, "proj-a")
+			} else {
+				syncDir := t.TempDir()
+				writeManifestFile(t, syncDir, &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: tt.relChunkID, CreatedAt: "2026-08-25T00:00:00Z"}}})
+				writeLocalChunkFile(t, syncDir, tt.relChunkID, tt.relChunk)
+				importer = New(s, syncDir)
+			}
+
+			result, err := importer.Import()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected import to fail")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("import: %v", err)
+			}
+			if result.ChunksImported != tt.wantChunks {
+				t.Fatalf("expected %d imported chunks, got %+v", tt.wantChunks, result)
+			}
+			if got := strings.Join(tt.wantSkippedEdges, "\n"); got != "" {
+				if len(result.SkippedRelations) != len(tt.wantSkippedEdges) {
+					t.Fatalf("expected skipped relations %q, got %+v", got, result.SkippedRelations)
+				}
+				for i, want := range tt.wantSkippedEdges {
+					if result.SkippedRelations[i] != want {
+						t.Fatalf("skipped relation %d: want %q, got %q", i, want, result.SkippedRelations[i])
+					}
+				}
+			} else if len(result.SkippedRelations) != 0 {
+				t.Fatalf("expected no skipped relations, got %+v", result.SkippedRelations)
+			}
+			deferred, dead, err := s.CountDeferredAndDead()
+			if err != nil {
+				t.Fatalf("count deferred and dead: %v", err)
+			}
+			if deferred != tt.wantDeferred || dead != tt.wantDead {
+				t.Fatalf("unexpected deferred state: deferred=%d dead=%d, want deferred=%d dead=%d", deferred, dead, tt.wantDeferred, tt.wantDead)
+			}
+			tt.assertStore(t, s)
+		})
+	}
+}
+
+// TestCloudImportSkippedRelationWarningsAreIdempotent verifies that re-running
+// the same cloud import does not re-warn: the offending chunk is already known,
+// so the second run reports no skipped relations.
+func TestCloudImportSkippedRelationWarningsAreIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-1135-idempotent"
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks[chunkID] = mustJSONChunk(t, chunkID, relationMissingEndpointChunk("sess-1135-again", "obs-1135-again", "obs-1135-gone", "rel-1135-again"))
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+
+	first, err := importer.Import()
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	if len(first.SkippedRelations) != 1 {
+		t.Fatalf("expected one skipped relation on first import, got %+v", first)
+	}
+
+	second, err := importer.Import()
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if len(second.SkippedRelations) != 0 {
+		t.Fatalf("expected no skipped relations on idempotent re-import, got %+v", second)
+	}
+	if second.ChunksSkipped != 1 {
+		t.Fatalf("expected chunk to be skipped as already known, got %+v", second)
+	}
+}
+
+func mustJSONChunk(t *testing.T, id string, chunk ChunkData) []byte {
+	t.Helper()
+	payload, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal chunk %s: %v", id, err)
+	}
+	return payload
+}
+
+// TestCloudImportDoesNotSkipRelationWithTombstonedEndpoint pins the oracle's
+// deletion semantics: the store's relation FK precondition counts soft-deleted
+// observations, so an edge whose endpoint is a local tombstone still applies
+// today and must not be reported as permanently missing.
+func TestCloudImportDoesNotSkipRelationWithTombstonedEndpoint(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if err := s.CreateSession("sess-tomb", "proj-a", "/tmp/proj-a"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	obsID, err := s.AddObservation(store.AddObservationParams{
+		SessionID: "sess-tomb",
+		Type:      "decision",
+		Title:     "tombstoned",
+		Content:   "endpoint that was soft-deleted locally",
+		Project:   "proj-a",
+		Scope:     "project",
+	})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	obs, err := s.GetObservation(obsID)
+	if err != nil {
+		t.Fatalf("get observation: %v", err)
+	}
+	if obs.SyncID == "" {
+		t.Fatal("expected observation to carry a sync_id")
+	}
+	if err := s.DeleteObservation(obsID, false); err != nil {
+		t.Fatalf("soft delete observation: %v", err)
+	}
+
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-1135-tombstone"
+	relationID := "rel-1135-tomb"
+	chunk := ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: relationID,
+			Op:        store.SyncOpUpsert,
+			Payload: fmt.Sprintf(`{"sync_id":%q,"source_id":%q,"target_id":%q,"relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`,
+				relationID, obs.SyncID, obs.SyncID),
+		},
+	}}
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks[chunkID] = mustJSONChunk(t, chunkID, chunk)
+
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+	result, err := importer.Import()
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.SkippedRelations) != 0 {
+		t.Fatalf("tombstoned endpoint must not be reported permanently missing, got %+v", result.SkippedRelations)
+	}
+	if _, err := s.GetRelation(relationID); err != nil {
+		t.Fatalf("expected relation over tombstoned endpoint to apply as before: %v", err)
+	}
+	deferred, dead, err := s.CountDeferredAndDead()
+	if err != nil {
+		t.Fatalf("count deferred and dead: %v", err)
+	}
+	if deferred != 0 || dead != 0 {
+		t.Fatalf("unexpected deferred state: deferred=%d dead=%d", deferred, dead)
+	}
+}
+
+// TestCloudImportStallPathSurvivesRelationFiltering pins design point 3: a
+// chunk whose filtered remainder still fails for an unrelated reason keeps the
+// original stall semantics instead of appearing fixed while data is lost.
+func TestCloudImportStallPathSurvivesRelationFiltering(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("proj-a"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	transport := newFakeCloudTransport()
+	chunkID := "chunk-1135-stall"
+	chunk := ChunkData{Mutations: []store.SyncMutation{
+		{
+			Entity:    store.SyncEntitySession,
+			EntityKey: "sess-stall",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"id":"sess-stall","project":"proj-a","directory":"/tmp/proj-a"}`,
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: "obs-stall-good",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"obs-stall-good","session_id":"sess-stall","type":"decision","title":"good","content":"importable endpoint","project":"proj-a","scope":"project"}`,
+		},
+		{
+			Entity:    store.SyncEntityObservation,
+			EntityKey: "obs-stall-orphan",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"obs-stall-orphan","session_id":"sess-never-anywhere","type":"note","title":"orphan","content":"references a session no chunk provides","project":"proj-a","scope":"project"}`,
+		},
+		{
+			Entity:    store.SyncEntityRelation,
+			EntityKey: "rel-stall",
+			Op:        store.SyncOpUpsert,
+			Payload:   `{"sync_id":"rel-stall","source_id":"obs-stall-good","target_id":"obs-stall-never","relation":"related","judgment_status":"judged","marked_by_actor":"test-actor","marked_by_kind":"test","project":"proj-a"}`,
+		},
+	}}
+	transport.manifest = &Manifest{Version: 1, Chunks: []ChunkEntry{{ID: chunkID, CreatedAt: "2026-08-25T00:00:00Z"}}}
+	transport.chunks[chunkID] = mustJSONChunk(t, chunkID, chunk)
+
+	importer := NewCloudWithTransport(s, transport, "proj-a")
+	_, err := importer.Import()
+	if err == nil {
+		t.Fatal("expected the chunk to keep stalling on its unrelated failure")
+	}
+	if !strings.Contains(err.Error(), "stalled") || !strings.Contains(err.Error(), "sess-never-anywhere") {
+		t.Fatalf("expected original stall error with pending session dependencies, got: %v", err)
+	}
+	synced, err := s.GetSyncedChunks()
+	if err != nil {
+		t.Fatalf("get synced chunks: %v", err)
+	}
+	if synced[chunkID] {
+		t.Fatalf("failed chunk %q must not be marked synced", chunkID)
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1135

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Cloud import skips a relation only when the current manifest carries durable observation-delete evidence for an endpoint that is absent locally and from all pending upserts. Mere absence remains retryable and follows the existing deferred path.
- Every skipped relation is persisted in `sync_apply_deferred` before the filtered chunk can apply or be marked synced. Existing replay heals the edge if the endpoint later reappears, and enqueue failure aborts without partial semantic writes.
- Pending observation classification now falls back to the upsert payload's `sync_id` when `EntityKey` is blank and reuses parsed chunks, avoiding false skips and duplicate transport reads while retaining legacy ownership validation.
- Retry-capped skipped relations are re-armed only when a fresh pre-apply enqueue sees the same dead row and its decoded payload identity matches the deferred identity, resetting the bounded retry window without resurrecting mismatched, ordinary, or hash-keyed dead evidence.

**Honest scope note:** the original slice treated absence from the local store and pending upserts as proof of permanent deletion. Review found that this could drop a valid late relation. The correction therefore absorbs the previously planned deferred-replay slice and the chunk decode-sharing work tracked in #1163 because both are required to close the three review actionables safely.

**Size note (`size:exception`):** 1,847 changed lines (+1,778/−69) across 7 files. The PR grew through review corrections: `5db3c7c` added durable delete evidence, chunk reuse, and replay persistence; `93efd36` added bounded dead-row re-arm; `2971086` binds that re-arm to matching payload identity and strengthens deterministic store/error diagnostics. The tests stay with the behavior they verify rather than being split or compressed.

---

## 📂 Changes

| File | Change |
|------|--------|
| `internal/sync/sync.go` | Durable delete-evidence oracle, payload-owned observation identity, parsed-chunk reuse, and enqueue-before-apply ordering |
| `internal/sync/sync_test.go` | Cloud import coverage for false-skip prevention, cache reuse, ownership checks, durable enqueue, retry preservation, and replay healing |
| `internal/store/store.go` | Tombstone-inclusive observation lookup plus shared deferred-row writer and `EnqueueDeferredRelation` |
| `internal/store/store_test.go` | Tombstone-inclusive lookup contract |
| `internal/store/sync_apply_test.go` | Deferred-row identity, scope, collapse, retry-state, and entity-guard coverage |
| `cmd/engram/main.go` | Visible skipped-relation warnings |
| `cmd/engram/main_extra_test.go` | Warning output on imported-chunk and no-new-chunk paths |

---

## Review Correction Context

The correction resolves all three CodeRabbit actionables:

1. Observation upserts with blank `EntityKey` use payload `sync_id` during classification.
2. Parsed pending chunks are shared with the apply loop instead of being fetched and decoded twice.
3. Permanent skip requires durable delete evidence, and skipped edges are persisted before chunk commit for bounded replay/dead-letter handling.
4. A fresh pre-apply enqueue re-arms a retry-capped skipped edge only when its payload identity matches the deferred identity; ordinary, mismatched, and non-retryable dead rows remain dead.

Native review receipts: the first correction is approved and burned as `review-d0056b28172d1512`; the committed retry-cap range `5db3c7c..93efd36` is approved and burned as `review-0d91dcd05a696d00`; the final payload-identity guard candidate is approved and burned as `review-659b2e6b8f7d66e9` before delivery in `2971086`.

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used**

**Tool/model:** Pi coding agent (el Gentleman harness), with a delegated implementation writer, independent verifier, and native four-lens review.

**Material scope:** Full implementation and review correction are AI-authored under human direction.

**Verification performed:** strict RED→GREEN tests for each reviewed behavior, independent verification, `go build ./...`, focused `go vet`, focused tests, and uncached `internal/store` + `internal/sync` suites. The repository-wide suite passed except two unchanged `internal/server` Unix-socket tests rejected by this host's group-writable parent directory; no server files changed.

---

## 🧪 Test Plan

```bash
go build ./...
go vet ./internal/store/ ./internal/sync/
go test ./internal/store/ ./internal/sync/ -count=1
```

- [x] Focused sync correction tests pass
- [x] Focused deferred-store tests pass
- [x] `internal/store` and `internal/sync` pass uncached
- [x] `gofmt` clean on all changed files
- [x] Native four-lens review approved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud sync imports now warn when relations reference permanently missing observations.
  * Remaining data continues importing while skipped relations are preserved for replay and can recover if observations return.
  * Relations that may resolve later or reference deleted observations continue to be handled normally.
  * Deferred relations can recover after referenced observations become available, including after repeated retry failures.
  * Repeated warnings are avoided, and deferred processing remains reliable when imports encounter errors.

* **Tests**
  * Added coverage for warning output, replay recovery, cross-chunk resolution, deleted observations, deduplication, and import failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->