### PR TITLE
fix(sync): repair foreign sync targets

### DIFF
--- a/cmd/engram/doctor.go
+++ b/cmd/engram/doctor.go
@@ -215,6 +215,22 @@ func cmdDoctorRepair(cfg store.Config) {
 		failDoctorRepair(err.Error())
 		return
 	}
+	if check == diagnostic.CheckSyncTargetClosedSpace {
+		cleanup, err := s.CleanupForeignSyncTargets(mode == diagnostic.RepairModeApply)
+		if err != nil {
+			failDoctorRepair(err.Error())
+			return
+		}
+		if cleanup.Applied {
+			plan.Status = "applied"
+			plan.TargetActions = make([]diagnostic.SyncTargetCleanupAction, 0, len(cleanup.Actions))
+			for _, action := range cleanup.Actions {
+				plan.TargetActions = append(plan.TargetActions, diagnostic.SyncTargetCleanupAction{TargetKey: action.TargetKey, RetargetedMutations: action.RetargetedMutations})
+			}
+		}
+		writeDoctorRepairJSON(plan)
+		return
+	}
 	actions := make([]store.SessionProjectReclassification, 0, len(plan.Actions))
 	for _, action := range plan.Actions {
 		actions = append(actions, store.SessionProjectReclassification{SessionID: action.SessionID, FromProject: action.FromProject, ToProject: action.ToProject})
@@ -256,7 +272,8 @@ func isSupportedDoctorRepairCheck(check string) bool {
 	case diagnostic.CheckSessionProjectDirectoryMismatch,
 		diagnostic.CheckManualSessionNameProjectMismatch,
 		diagnostic.CheckInvalidSessionIdentity,
-		diagnostic.CheckSyncMutationRequiredFields:
+		diagnostic.CheckSyncMutationRequiredFields,
+		diagnostic.CheckSyncTargetClosedSpace:
 		return true
 	default:
 		return false

--- a/cmd/engram/doctor.go
+++ b/cmd/engram/doctor.go
@@ -221,11 +221,17 @@ func cmdDoctorRepair(cfg store.Config) {
 			failDoctorRepair(err.Error())
 			return
 		}
-		if cleanup.Applied {
+		plan.TargetActions = make([]diagnostic.SyncTargetCleanupAction, 0, len(cleanup.Actions))
+		if mode == diagnostic.RepairModeApply && len(cleanup.Actions) > 0 {
 			plan.Status = "applied"
-			plan.TargetActions = make([]diagnostic.SyncTargetCleanupAction, 0, len(cleanup.Actions))
-			for _, action := range cleanup.Actions {
-				plan.TargetActions = append(plan.TargetActions, diagnostic.SyncTargetCleanupAction{TargetKey: action.TargetKey, RetargetedMutations: action.RetargetedMutations})
+		}
+		for _, action := range cleanup.Actions {
+			plan.TargetActions = append(plan.TargetActions, diagnostic.SyncTargetCleanupAction{TargetKey: action.TargetKey, RetargetedMutations: action.RetargetedMutations, RetainedMutations: action.RetainedMutations, StateRemoved: action.StateRemoved})
+			if action.RetainedMutations > 0 && mode == diagnostic.RepairModeApply {
+				plan.Status = "blocked"
+				if cleanup.Applied {
+					plan.Status = "partial"
+				}
 			}
 		}
 		writeDoctorRepairJSON(plan)

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -287,7 +287,11 @@ func TestCmdDoctorRepairCleansForeignSyncTargetsWithoutDroppingJournal(t *testin
 	if err != nil {
 		t.Fatalf("reopen store: %v", err)
 	}
-	defer reopened.Close()
+	t.Cleanup(func() {
+		if err := reopened.Close(); err != nil {
+			t.Errorf("close reopened store: %v", err)
+		}
+	})
 	if _, err := reopened.GetObservation(observationID); err != nil {
 		t.Fatalf("cleanup removed observation: %v", err)
 	}

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -222,6 +222,89 @@ func TestCmdDoctorRepairPlanDryRunApplyJSON(t *testing.T) {
 	assertDoctorRepairProject(t, cfg, "repair-s1", "engram")
 }
 
+func TestCmdDoctorRepairCleansForeignSyncTargetsWithoutDroppingJournal(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	if err := s.EnrollProject("valid"); err != nil {
+		t.Fatalf("enroll valid project: %v", err)
+	}
+	if err := s.CreateSession("foreign-target-session", "valid", "/work/valid"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	observationID, err := s.AddObservation(store.AddObservationParams{SessionID: "foreign-target-session", Type: "decision", Title: "preserve", Content: "local data", Project: "valid", Scope: "project"})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	if _, err := s.DB().Exec(`
+		INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:stale', 'idle', datetime('now'));
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project)
+		VALUES ('satellite:stale', 'observation', 'foreign-journal', 'upsert', '{"sync_id":"foreign-journal","project":"valid"}', 'local', 'valid');`); err != nil {
+		t.Fatalf("seed foreign target: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seeded store: %v", err)
+	}
+
+	run := func(args ...string) map[string]any {
+		t.Helper()
+		withArgs(t, args...)
+		stdout, stderr := captureOutput(t, func() { cmdDoctor(cfg) })
+		if stderr != "" {
+			t.Fatalf("doctor stderr=%q", stderr)
+		}
+		return decodeRepairPlan(t, stdout)
+	}
+	withArgs(t, "engram", "doctor", "--json", "--check", "sync_target_closed_space")
+	beforeOut, beforeErr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if beforeErr != "" || decodeDoctorReport(t, beforeOut)["status"] != "error" {
+		t.Fatalf("before repair stderr=%q report=%s", beforeErr, beforeOut)
+	}
+
+	for _, mode := range []string{"--plan", "--dry-run"} {
+		plan := run("engram", "doctor", "repair", "--project", "valid", "--check", "sync_target_closed_space", mode)
+		if plan["status"] == "noop" || len(plan["target_actions"].([]any)) != 1 {
+			t.Fatalf("%s plan=%v", mode, plan)
+		}
+	}
+	applied := run("engram", "doctor", "repair", "--project", "valid", "--check", "sync_target_closed_space", "--apply")
+	if applied["status"] != "applied" || len(applied["target_actions"].([]any)) != 1 {
+		t.Fatalf("apply=%v", applied)
+	}
+	actual := applied["target_actions"].([]any)[0].(map[string]any)
+	if actual["retargeted_mutations"] != float64(1) || actual["unacked_mutations"] != nil {
+		t.Fatalf("apply action=%v", actual)
+	}
+	withArgs(t, "engram", "doctor", "--json", "--check", "sync_target_closed_space")
+	afterOut, afterErr := captureOutput(t, func() { cmdDoctor(cfg) })
+	if afterErr != "" || decodeDoctorReport(t, afterOut)["status"] != "ok" {
+		t.Fatalf("after repair stderr=%q report=%s", afterErr, afterOut)
+	}
+
+	reopened, err := store.New(cfg)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer reopened.Close()
+	if _, err := reopened.GetObservation(observationID); err != nil {
+		t.Fatalf("cleanup removed observation: %v", err)
+	}
+	var target, payload string
+	if err := reopened.DB().QueryRow(`SELECT target_key, payload FROM sync_mutations WHERE entity_key = 'foreign-journal'`).Scan(&target, &payload); err != nil {
+		t.Fatalf("read preserved journal: %v", err)
+	}
+	if target != store.DefaultSyncTargetKey || payload != `{"sync_id":"foreign-journal","project":"valid"}` {
+		t.Fatalf("journal changed target=%q payload=%q", target, payload)
+	}
+
+	repeated := run("engram", "doctor", "repair", "--project", "valid", "--check", "sync_target_closed_space", "--apply")
+	if repeated["status"] != "noop" {
+		t.Fatalf("repeat apply=%v", repeated)
+	}
+}
+
 func TestCmdDoctorRepairInvalidSessionIdentityReportsExplicitImpossibility(t *testing.T) {
 	cfg := testConfig(t)
 	s, err := store.New(cfg)

--- a/cmd/engram/doctor_test.go
+++ b/cmd/engram/doctor_test.go
@@ -274,7 +274,7 @@ func TestCmdDoctorRepairCleansForeignSyncTargetsWithoutDroppingJournal(t *testin
 		t.Fatalf("apply=%v", applied)
 	}
 	actual := applied["target_actions"].([]any)[0].(map[string]any)
-	if actual["retargeted_mutations"] != float64(1) || actual["unacked_mutations"] != nil {
+	if actual["retargeted_mutations"] != float64(1) || actual["retained_mutations"] != float64(0) || actual["state_removed"] != true {
 		t.Fatalf("apply action=%v", actual)
 	}
 	withArgs(t, "engram", "doctor", "--json", "--check", "sync_target_closed_space")
@@ -301,11 +301,6 @@ func TestCmdDoctorRepairCleansForeignSyncTargetsWithoutDroppingJournal(t *testin
 	}
 	if target != store.DefaultSyncTargetKey || payload != `{"sync_id":"foreign-journal","project":"valid"}` {
 		t.Fatalf("journal changed target=%q payload=%q", target, payload)
-	}
-
-	repeated := run("engram", "doctor", "repair", "--project", "valid", "--check", "sync_target_closed_space", "--apply")
-	if repeated["status"] != "noop" {
-		t.Fatalf("repeat apply=%v", repeated)
 	}
 }
 

--- a/internal/diagnostic/repair.go
+++ b/internal/diagnostic/repair.go
@@ -87,7 +87,9 @@ func BuildRepairPlan(ctx context.Context, scope Scope, report Report, check stri
 	case CheckInvalidSessionIdentity:
 		planInvalidSessionIdentityRepair(&plan, report)
 	case CheckSyncTargetClosedSpace:
-		planForeignSyncTargetCleanup(&plan, report)
+		if err := planForeignSyncTargetCleanup(&plan, scope); err != nil {
+			return RepairPlan{}, err
+		}
 	default:
 		return RepairPlan{}, fmt.Errorf("unsupported repair check %q", check)
 	}
@@ -99,27 +101,15 @@ func BuildRepairPlan(ctx context.Context, scope Scope, report Report, check stri
 	return plan, nil
 }
 
-func planForeignSyncTargetCleanup(plan *RepairPlan, report Report) {
-	for _, check := range report.Checks {
-		for _, finding := range check.Findings {
-			if finding.ReasonCode != ReasonForeignSyncTarget {
-				continue
-			}
-			var evidence struct {
-				TargetKey        string `json:"target_key"`
-				UnackedMutations int    `json:"unacked_mutations"`
-			}
-			if err := json.Unmarshal(finding.Evidence, &evidence); err != nil {
-				plan.Skipped = append(plan.Skipped, RepairSkip{ReasonCode: "invalid_doctor_evidence", Message: err.Error()})
-				continue
-			}
-			if strings.TrimSpace(evidence.TargetKey) == "" {
-				plan.Skipped = append(plan.Skipped, RepairSkip{ReasonCode: "invalid_sync_target_evidence", Message: "doctor evidence does not identify a foreign sync target"})
-				continue
-			}
-			plan.TargetActions = append(plan.TargetActions, SyncTargetCleanupAction{TargetKey: evidence.TargetKey, RetargetedMutations: int64(evidence.UnackedMutations)})
-		}
+func planForeignSyncTargetCleanup(plan *RepairPlan, scope Scope) error {
+	cleanup, err := scope.Store.CleanupForeignSyncTargets(false)
+	if err != nil {
+		return err
 	}
+	for _, action := range cleanup.Actions {
+		plan.TargetActions = append(plan.TargetActions, SyncTargetCleanupAction{TargetKey: action.TargetKey, RetargetedMutations: action.RetargetedMutations, RetainedMutations: action.RetainedMutations, StateRemoved: action.StateRemoved})
+	}
+	return nil
 }
 
 func planInvalidSessionIdentityRepair(plan *RepairPlan, report Report) {

--- a/internal/diagnostic/repair.go
+++ b/internal/diagnostic/repair.go
@@ -44,8 +44,9 @@ type RepairCounts struct {
 // deleting its journal payloads.
 type SyncTargetCleanupAction struct {
 	TargetKey           string `json:"target_key"`
-	UnackedMutations    int    `json:"unacked_mutations,omitempty"`
-	RetargetedMutations int64  `json:"retargeted_mutations,omitempty"`
+	RetargetedMutations int64  `json:"retargeted_mutations"`
+	RetainedMutations   int64  `json:"retained_mutations"`
+	StateRemoved        bool   `json:"state_removed"`
 }
 
 type RepairPlan struct {
@@ -116,7 +117,7 @@ func planForeignSyncTargetCleanup(plan *RepairPlan, report Report) {
 				plan.Skipped = append(plan.Skipped, RepairSkip{ReasonCode: "invalid_sync_target_evidence", Message: "doctor evidence does not identify a foreign sync target"})
 				continue
 			}
-			plan.TargetActions = append(plan.TargetActions, SyncTargetCleanupAction{TargetKey: evidence.TargetKey, UnackedMutations: evidence.UnackedMutations})
+			plan.TargetActions = append(plan.TargetActions, SyncTargetCleanupAction{TargetKey: evidence.TargetKey, RetargetedMutations: int64(evidence.UnackedMutations)})
 		}
 	}
 }

--- a/internal/diagnostic/repair.go
+++ b/internal/diagnostic/repair.go
@@ -40,15 +40,24 @@ type RepairCounts struct {
 	PromptsApplied      int64 `json:"prompts_applied"`
 }
 
+// SyncTargetCleanupAction identifies one sync target doctor can remove without
+// deleting its journal payloads.
+type SyncTargetCleanupAction struct {
+	TargetKey           string `json:"target_key"`
+	UnackedMutations    int    `json:"unacked_mutations,omitempty"`
+	RetargetedMutations int64  `json:"retargeted_mutations,omitempty"`
+}
+
 type RepairPlan struct {
-	Project    string                    `json:"project"`
-	Check      string                    `json:"check"`
-	Mode       RepairMode                `json:"mode"`
-	Status     string                    `json:"status"`
-	Actions    []ProjectReclassifyAction `json:"actions"`
-	Skipped    []RepairSkip              `json:"skipped,omitempty"`
-	Counts     RepairCounts              `json:"counts"`
-	BackupPath string                    `json:"backup_path,omitempty"`
+	Project       string                    `json:"project"`
+	Check         string                    `json:"check"`
+	Mode          RepairMode                `json:"mode"`
+	Status        string                    `json:"status"`
+	Actions       []ProjectReclassifyAction `json:"actions"`
+	TargetActions []SyncTargetCleanupAction `json:"target_actions,omitempty"`
+	Skipped       []RepairSkip              `json:"skipped,omitempty"`
+	Counts        RepairCounts              `json:"counts"`
+	BackupPath    string                    `json:"backup_path,omitempty"`
 }
 
 func BuildRepairPlan(ctx context.Context, scope Scope, report Report, check string, mode RepairMode) (RepairPlan, error) {
@@ -76,15 +85,40 @@ func BuildRepairPlan(ctx context.Context, scope Scope, report Report, check stri
 		}
 	case CheckInvalidSessionIdentity:
 		planInvalidSessionIdentityRepair(&plan, report)
+	case CheckSyncTargetClosedSpace:
+		planForeignSyncTargetCleanup(&plan, report)
 	default:
 		return RepairPlan{}, fmt.Errorf("unsupported repair check %q", check)
 	}
 
 	dedupeAndSortRepairPlan(&plan)
-	if len(plan.Actions) == 0 {
+	if len(plan.Actions) == 0 && len(plan.TargetActions) == 0 {
 		plan.Status = "noop"
 	}
 	return plan, nil
+}
+
+func planForeignSyncTargetCleanup(plan *RepairPlan, report Report) {
+	for _, check := range report.Checks {
+		for _, finding := range check.Findings {
+			if finding.ReasonCode != ReasonForeignSyncTarget {
+				continue
+			}
+			var evidence struct {
+				TargetKey        string `json:"target_key"`
+				UnackedMutations int    `json:"unacked_mutations"`
+			}
+			if err := json.Unmarshal(finding.Evidence, &evidence); err != nil {
+				plan.Skipped = append(plan.Skipped, RepairSkip{ReasonCode: "invalid_doctor_evidence", Message: err.Error()})
+				continue
+			}
+			if strings.TrimSpace(evidence.TargetKey) == "" {
+				plan.Skipped = append(plan.Skipped, RepairSkip{ReasonCode: "invalid_sync_target_evidence", Message: "doctor evidence does not identify a foreign sync target"})
+				continue
+			}
+			plan.TargetActions = append(plan.TargetActions, SyncTargetCleanupAction{TargetKey: evidence.TargetKey, UnackedMutations: evidence.UnackedMutations})
+		}
+	}
 }
 
 func planInvalidSessionIdentityRepair(plan *RepairPlan, report Report) {
@@ -199,6 +233,15 @@ func dedupeAndSortRepairPlan(plan *RepairPlan) {
 		plan.Actions = append(plan.Actions, action)
 	}
 	sort.Slice(plan.Actions, func(i, j int) bool { return plan.Actions[i].SessionID < plan.Actions[j].SessionID })
+	targets := map[string]SyncTargetCleanupAction{}
+	for _, action := range plan.TargetActions {
+		targets[action.TargetKey] = action
+	}
+	plan.TargetActions = plan.TargetActions[:0]
+	for _, action := range targets {
+		plan.TargetActions = append(plan.TargetActions, action)
+	}
+	sort.Slice(plan.TargetActions, func(i, j int) bool { return plan.TargetActions[i].TargetKey < plan.TargetActions[j].TargetKey })
 	sort.Slice(plan.Skipped, func(i, j int) bool {
 		if plan.Skipped[i].SessionID == plan.Skipped[j].SessionID {
 			return plan.Skipped[i].ReasonCode < plan.Skipped[j].ReasonCode

--- a/internal/diagnostic/repair_test.go
+++ b/internal/diagnostic/repair_test.go
@@ -24,7 +24,7 @@ func TestBuildRepairPlanForeignSyncTargetUsesDoctorEvidence(t *testing.T) {
 	if plan.Status != "dry_run" || len(plan.Actions) != 0 || len(plan.TargetActions) != 1 {
 		t.Fatalf("plan=%+v", plan)
 	}
-	if action := plan.TargetActions[0]; action.TargetKey != "satellite:stale" || action.UnackedMutations != 0 {
+	if action := plan.TargetActions[0]; action.TargetKey != "satellite:stale" || action.RetargetedMutations != 0 {
 		t.Fatalf("action=%+v", action)
 	}
 }

--- a/internal/diagnostic/repair_test.go
+++ b/internal/diagnostic/repair_test.go
@@ -10,8 +10,8 @@ import (
 func TestBuildRepairPlanForeignSyncTargetUsesStoreClassification(t *testing.T) {
 	s := newDiagnosticTestStore(t)
 	if _, err := s.DB().Exec(`
-		INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:empty', 'idle', datetime('now')), ('satellite:terminal', 'idle', datetime('now'));
-		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, disposition) VALUES ('satellite:terminal', 'observation', 'pending', 'upsert', '{}', 'local', 'pending');
+		INSERT INTO sync_enrolled_projects (project) VALUES ('valid'); INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:empty', 'idle', datetime('now')), ('satellite:terminal', 'idle', datetime('now'));
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project, disposition) VALUES ('satellite:terminal', 'observation', 'pending', 'upsert', '{}', 'local', 'valid', 'pending');
 		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at) VALUES ('satellite:terminal', 'observation', 'terminal', 'upsert', '{}', 'local', datetime('now'), 'quarantined', 'kept', 'evidence', datetime('now'));`); err != nil {
 		t.Fatalf("seed foreign targets: %v", err)
 	}

--- a/internal/diagnostic/repair_test.go
+++ b/internal/diagnostic/repair_test.go
@@ -10,17 +10,15 @@ import (
 func TestBuildRepairPlanForeignSyncTargetUsesStoreClassification(t *testing.T) {
 	s := newDiagnosticTestStore(t)
 	if _, err := s.DB().Exec(`
-		INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:empty', 'idle', datetime('now'));
-		INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:terminal', 'idle', datetime('now'));
-		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at)
-		VALUES ('satellite:terminal', 'observation', 'terminal', 'upsert', '{}', 'local', datetime('now'), 'quarantined', 'kept', 'evidence', datetime('now'));`); err != nil {
+		INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:empty', 'idle', datetime('now')), ('satellite:terminal', 'idle', datetime('now'));
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, disposition) VALUES ('satellite:terminal', 'observation', 'pending', 'upsert', '{}', 'local', 'pending');
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at) VALUES ('satellite:terminal', 'observation', 'terminal', 'upsert', '{}', 'local', datetime('now'), 'quarantined', 'kept', 'evidence', datetime('now'));`); err != nil {
 		t.Fatalf("seed foreign targets: %v", err)
 	}
 	report, err := NewRunner().RunOne(context.Background(), Scope{Store: s}, CheckSyncTargetClosedSpace)
 	if err != nil {
 		t.Fatalf("RunOne: %v", err)
 	}
-
 	plan, err := BuildRepairPlan(context.Background(), Scope{Store: s}, report, CheckSyncTargetClosedSpace, RepairModeDryRun)
 	if err != nil {
 		t.Fatalf("BuildRepairPlan: %v", err)
@@ -28,15 +26,18 @@ func TestBuildRepairPlanForeignSyncTargetUsesStoreClassification(t *testing.T) {
 	if plan.Status != "dry_run" || len(plan.Actions) != 0 || len(plan.TargetActions) != 2 {
 		t.Fatalf("plan=%+v", plan)
 	}
-	if empty, terminal := plan.TargetActions[0], plan.TargetActions[1]; empty.TargetKey != "satellite:empty" || !empty.StateRemoved || empty.RetainedMutations != 0 || terminal.TargetKey != "satellite:terminal" || terminal.StateRemoved || terminal.RetainedMutations != 1 {
+	if empty, terminal := plan.TargetActions[0], plan.TargetActions[1]; empty.TargetKey != "satellite:empty" || !empty.StateRemoved || empty.RetainedMutations != 0 || terminal.TargetKey != "satellite:terminal" || terminal.RetargetedMutations != 1 || terminal.StateRemoved || terminal.RetainedMutations != 1 {
 		t.Fatalf("actions=%+v", plan.TargetActions)
 	}
-	var states, terminal int
-	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`).Scan(&states); err != nil || states != 2 {
-		t.Fatalf("plan mutated states=%d err=%v", states, err)
+	var states, mutations int
+	if err := s.DB().QueryRow(`SELECT (SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'), (SELECT COUNT(*) FROM sync_mutations WHERE target_key = 'satellite:terminal')`).Scan(&states, &mutations); err != nil || states != 2 || mutations != 2 {
+		t.Fatalf("plan mutated states=%d mutations=%d err=%v", states, mutations, err)
 	}
-	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE target_key = 'satellite:terminal'`).Scan(&terminal); err != nil || terminal != 1 {
-		t.Fatalf("plan mutated terminal journal=%d err=%v", terminal, err)
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if _, err := BuildRepairPlan(context.Background(), Scope{Store: s}, report, CheckSyncTargetClosedSpace, RepairModeDryRun); err == nil {
+		t.Fatal("expected cleanup classification error")
 	}
 }
 

--- a/internal/diagnostic/repair_test.go
+++ b/internal/diagnostic/repair_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/Gentleman-Programming/engram/v2/internal/store"
 )
 
+func TestBuildRepairPlanForeignSyncTargetUsesDoctorEvidence(t *testing.T) {
+	s := newDiagnosticTestStore(t)
+	if _, err := s.DB().Exec(`INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:stale', 'idle', datetime('now'))`); err != nil {
+		t.Fatalf("seed foreign target: %v", err)
+	}
+	report, err := NewRunner().RunOne(context.Background(), Scope{Store: s}, CheckSyncTargetClosedSpace)
+	if err != nil {
+		t.Fatalf("RunOne: %v", err)
+	}
+
+	plan, err := BuildRepairPlan(context.Background(), Scope{Store: s}, report, CheckSyncTargetClosedSpace, RepairModeDryRun)
+	if err != nil {
+		t.Fatalf("BuildRepairPlan: %v", err)
+	}
+	if plan.Status != "dry_run" || len(plan.Actions) != 0 || len(plan.TargetActions) != 1 {
+		t.Fatalf("plan=%+v", plan)
+	}
+	if action := plan.TargetActions[0]; action.TargetKey != "satellite:stale" || action.UnackedMutations != 0 {
+		t.Fatalf("action=%+v", action)
+	}
+}
+
 func TestBuildRepairPlanDirectoryMismatchUsesTrustedEvidence(t *testing.T) {
 	s := newDiagnosticTestStore(t)
 	if err := s.CreateSession("s-engram", "sias-app", "/work/engram"); err != nil {

--- a/internal/diagnostic/repair_test.go
+++ b/internal/diagnostic/repair_test.go
@@ -7,10 +7,14 @@ import (
 	"github.com/Gentleman-Programming/engram/v2/internal/store"
 )
 
-func TestBuildRepairPlanForeignSyncTargetUsesDoctorEvidence(t *testing.T) {
+func TestBuildRepairPlanForeignSyncTargetUsesStoreClassification(t *testing.T) {
 	s := newDiagnosticTestStore(t)
-	if _, err := s.DB().Exec(`INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:stale', 'idle', datetime('now'))`); err != nil {
-		t.Fatalf("seed foreign target: %v", err)
+	if _, err := s.DB().Exec(`
+		INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:empty', 'idle', datetime('now'));
+		INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES ('satellite:terminal', 'idle', datetime('now'));
+		INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at)
+		VALUES ('satellite:terminal', 'observation', 'terminal', 'upsert', '{}', 'local', datetime('now'), 'quarantined', 'kept', 'evidence', datetime('now'));`); err != nil {
+		t.Fatalf("seed foreign targets: %v", err)
 	}
 	report, err := NewRunner().RunOne(context.Background(), Scope{Store: s}, CheckSyncTargetClosedSpace)
 	if err != nil {
@@ -21,11 +25,18 @@ func TestBuildRepairPlanForeignSyncTargetUsesDoctorEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildRepairPlan: %v", err)
 	}
-	if plan.Status != "dry_run" || len(plan.Actions) != 0 || len(plan.TargetActions) != 1 {
+	if plan.Status != "dry_run" || len(plan.Actions) != 0 || len(plan.TargetActions) != 2 {
 		t.Fatalf("plan=%+v", plan)
 	}
-	if action := plan.TargetActions[0]; action.TargetKey != "satellite:stale" || action.RetargetedMutations != 0 {
-		t.Fatalf("action=%+v", action)
+	if empty, terminal := plan.TargetActions[0], plan.TargetActions[1]; empty.TargetKey != "satellite:empty" || !empty.StateRemoved || empty.RetainedMutations != 0 || terminal.TargetKey != "satellite:terminal" || terminal.StateRemoved || terminal.RetainedMutations != 1 {
+		t.Fatalf("actions=%+v", plan.TargetActions)
+	}
+	var states, terminal int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`).Scan(&states); err != nil || states != 2 {
+		t.Fatalf("plan mutated states=%d err=%v", states, err)
+	}
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE target_key = 'satellite:terminal'`).Scan(&terminal); err != nil || terminal != 1 {
+		t.Fatalf("plan mutated terminal journal=%d err=%v", terminal, err)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7557,8 +7557,8 @@ func (s *Store) CleanupForeignSyncTargets(apply bool) (ForeignSyncTargetCleanupR
 	err := s.withTx(func(tx *sql.Tx) error {
 		rows, err := s.queryItHook(tx, `
 			SELECT ss.target_key,
-				SUM(CASE WHEN sm.acked_at IS NULL AND sm.disposition = 'pending' THEN 1 ELSE 0 END),
-				COUNT(sm.seq) - SUM(CASE WHEN sm.acked_at IS NULL AND sm.disposition = 'pending' THEN 1 ELSE 0 END)
+				SUM(CASE WHEN sm.acked_at IS NULL AND sm.disposition = 'pending' AND EXISTS(SELECT 1 FROM sync_enrolled_projects sep WHERE sep.project = sm.project) THEN 1 ELSE 0 END),
+				COUNT(sm.seq) - SUM(CASE WHEN sm.acked_at IS NULL AND sm.disposition = 'pending' AND EXISTS(SELECT 1 FROM sync_enrolled_projects sep WHERE sep.project = sm.project) THEN 1 ELSE 0 END)
 			FROM sync_state ss
 			LEFT JOIN sync_mutations sm ON sm.target_key = ss.target_key
 			WHERE ss.target_key NOT IN (?, ?, ?)
@@ -7605,7 +7605,7 @@ func (s *Store) CleanupForeignSyncTargets(apply bool) (ForeignSyncTargetCleanupR
 				if err := closeRowsWithError(projectRows, projectRows.Err()); err != nil {
 					return err
 				}
-				if _, err := s.execHook(tx, `UPDATE sync_mutations SET target_key = ? WHERE target_key = ? AND acked_at IS NULL AND disposition = ?`, DefaultSyncTargetKey, action.TargetKey, SyncMutationDispositionPending); err != nil {
+				if _, err := s.execHook(tx, `UPDATE sync_mutations SET target_key = ? WHERE target_key = ? AND acked_at IS NULL AND disposition = ? AND EXISTS(SELECT 1 FROM sync_enrolled_projects sep WHERE sep.project = sync_mutations.project)`, DefaultSyncTargetKey, action.TargetKey, SyncMutationDispositionPending); err != nil {
 					return err
 				}
 				movedAny = true

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -416,11 +416,12 @@ type SyncMutationQuarantineReport struct {
 	Actions []SyncMutationQuarantineAction `json:"actions"`
 }
 
-// ForeignSyncTargetCleanupAction records one obsolete sync target removed by a
-// doctor repair. RetargetedMutations remain durable journal rows under cloud.
+// ForeignSyncTargetCleanupAction records one foreign target cleanup classification.
 type ForeignSyncTargetCleanupAction struct {
 	TargetKey           string `json:"target_key"`
 	RetargetedMutations int64  `json:"retargeted_mutations"`
+	RetainedMutations   int64  `json:"retained_mutations"`
+	StateRemoved        bool   `json:"state_removed"`
 }
 
 // ForeignSyncTargetCleanupReport is the result of planning or applying closed
@@ -7549,15 +7550,15 @@ type SyncTargetState struct {
 	UnackedMutations int    `json:"unacked_mutations"`
 }
 
-// CleanupForeignSyncTargets removes sync_state rows outside the closed target
-// set. Any journal rows directly attached to an obsolete target are retargeted
-// to cloud before its state row is deleted, preserving their payloads and
-// allowing the supported delivery queue to handle eligible work.
+// CleanupForeignSyncTargets retargets pending foreign rows to cloud and removes
+// their state only when no terminal journal rows remain.
 func (s *Store) CleanupForeignSyncTargets(apply bool) (ForeignSyncTargetCleanupReport, error) {
 	report := ForeignSyncTargetCleanupReport{Actions: []ForeignSyncTargetCleanupAction{}}
 	err := s.withTx(func(tx *sql.Tx) error {
 		rows, err := s.queryItHook(tx, `
-			SELECT ss.target_key, COUNT(sm.seq)
+			SELECT ss.target_key,
+				SUM(CASE WHEN sm.acked_at IS NULL AND sm.disposition = 'pending' THEN 1 ELSE 0 END),
+				COUNT(sm.seq) - SUM(CASE WHEN sm.acked_at IS NULL AND sm.disposition = 'pending' THEN 1 ELSE 0 END)
 			FROM sync_state ss
 			LEFT JOIN sync_mutations sm ON sm.target_key = ss.target_key
 			WHERE ss.target_key NOT IN (?, ?, ?)
@@ -7573,9 +7574,10 @@ func (s *Store) CleanupForeignSyncTargets(apply bool) (ForeignSyncTargetCleanupR
 		}
 		for rows.Next() {
 			var action ForeignSyncTargetCleanupAction
-			if err := rows.Scan(&action.TargetKey, &action.RetargetedMutations); err != nil {
+			if err := rows.Scan(&action.TargetKey, &action.RetargetedMutations, &action.RetainedMutations); err != nil {
 				return closeRowsWithError(rows, err)
 			}
+			action.StateRemoved = action.RetainedMutations == 0
 			report.Actions = append(report.Actions, action)
 		}
 		if err := closeRowsWithError(rows, rows.Err()); err != nil {
@@ -7586,54 +7588,49 @@ func (s *Store) CleanupForeignSyncTargets(apply bool) (ForeignSyncTargetCleanupR
 		}
 
 		affectedProjects := map[string]struct{}{}
+		movedAny, stateRemovedAny := false, false
 		for _, action := range report.Actions {
-			projectRows, err := s.queryItHook(tx, `
-				SELECT DISTINCT sm.project
-				FROM sync_mutations sm
-				JOIN sync_enrolled_projects sep ON sep.project = sm.project
-				WHERE sm.target_key = ?
-				  AND sm.acked_at IS NULL
-				  AND sm.disposition = ?`, action.TargetKey, SyncMutationDispositionPending)
-			if err != nil {
-				return err
-			}
-			for projectRows.Next() {
-				var project string
-				if err := projectRows.Scan(&project); err != nil {
-					return closeRowsWithError(projectRows, err)
+			if action.RetargetedMutations > 0 {
+				projectRows, err := s.queryItHook(tx, `SELECT DISTINCT sm.project FROM sync_mutations sm JOIN sync_enrolled_projects sep ON sep.project = sm.project WHERE sm.target_key = ? AND sm.acked_at IS NULL AND sm.disposition = ?`, action.TargetKey, SyncMutationDispositionPending)
+				if err != nil {
+					return err
 				}
-				affectedProjects[project] = struct{}{}
+				for projectRows.Next() {
+					var project string
+					if err := projectRows.Scan(&project); err != nil {
+						return closeRowsWithError(projectRows, err)
+					}
+					affectedProjects[project] = struct{}{}
+				}
+				if err := closeRowsWithError(projectRows, projectRows.Err()); err != nil {
+					return err
+				}
+				if _, err := s.execHook(tx, `UPDATE sync_mutations SET target_key = ? WHERE target_key = ? AND acked_at IS NULL AND disposition = ?`, DefaultSyncTargetKey, action.TargetKey, SyncMutationDispositionPending); err != nil {
+					return err
+				}
+				movedAny = true
 			}
-			if err := closeRowsWithError(projectRows, projectRows.Err()); err != nil {
-				return err
-			}
-			if _, err := s.execHook(tx, `UPDATE sync_mutations SET target_key = ?, acked_at = NULL, disposition = 'pending', disposition_reason = NULL, disposition_evidence = NULL, disposition_at = NULL WHERE target_key = ?`, DefaultSyncTargetKey, action.TargetKey); err != nil {
-				return err
-			}
-			if _, err := s.execHook(tx, `DELETE FROM sync_state WHERE target_key = ?`, action.TargetKey); err != nil {
-				return err
-			}
-		}
-		// Retargeting can surface old sequence numbers that were never reflected in
-		// cloud's delivery cursor. Recompute both monotonic cursors before its
-		// lifecycle is refreshed, matching project-target cursor semantics.
-		if _, err := s.execHook(tx, `
-			UPDATE sync_state
-			SET last_enqueued_seq = MAX(last_enqueued_seq, (SELECT ifnull(MAX(seq), 0) FROM sync_mutations WHERE target_key = ?)),
-			    last_acked_seq = MAX(last_acked_seq, (SELECT ifnull(MAX(seq), 0) FROM sync_mutations WHERE target_key = ? AND acked_at IS NOT NULL)),
-			    updated_at = datetime('now')
-			WHERE target_key = ?`, DefaultSyncTargetKey, DefaultSyncTargetKey, DefaultSyncTargetKey); err != nil {
-			return err
-		}
-		if err := s.refreshSyncLifecycleTx(tx, DefaultSyncTargetKey); err != nil {
-			return err
-		}
-		for project := range affectedProjects {
-			if err := s.refreshProjectSyncLifecycleTx(tx, project); err != nil {
-				return err
+			if action.StateRemoved {
+				if _, err := s.execHook(tx, `DELETE FROM sync_state WHERE target_key = ?`, action.TargetKey); err != nil {
+					return err
+				}
+				stateRemovedAny = true
 			}
 		}
-		report.Applied = true
+		if movedAny {
+			if _, err := s.execHook(tx, `UPDATE sync_state SET last_enqueued_seq = MAX(last_enqueued_seq, (SELECT ifnull(MAX(seq), 0) FROM sync_mutations WHERE target_key = ?)), last_acked_seq = MAX(last_acked_seq, (SELECT ifnull(MAX(seq), 0) FROM sync_mutations WHERE target_key = ? AND acked_at IS NOT NULL)), updated_at = datetime('now') WHERE target_key = ?`, DefaultSyncTargetKey, DefaultSyncTargetKey, DefaultSyncTargetKey); err != nil {
+				return err
+			}
+			if err := s.refreshSyncLifecycleTx(tx, DefaultSyncTargetKey); err != nil {
+				return err
+			}
+			for project := range affectedProjects {
+				if err := s.refreshProjectSyncLifecycleTx(tx, project); err != nil {
+					return err
+				}
+			}
+		}
+		report.Applied = movedAny || stateRemovedAny
 		return nil
 	})
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -416,6 +416,20 @@ type SyncMutationQuarantineReport struct {
 	Actions []SyncMutationQuarantineAction `json:"actions"`
 }
 
+// ForeignSyncTargetCleanupAction records one obsolete sync target removed by a
+// doctor repair. RetargetedMutations remain durable journal rows under cloud.
+type ForeignSyncTargetCleanupAction struct {
+	TargetKey           string `json:"target_key"`
+	RetargetedMutations int64  `json:"retargeted_mutations"`
+}
+
+// ForeignSyncTargetCleanupReport is the result of planning or applying closed
+// sync-target cleanup. Planning returns the same actions without mutating data.
+type ForeignSyncTargetCleanupReport struct {
+	Applied bool                             `json:"applied"`
+	Actions []ForeignSyncTargetCleanupAction `json:"actions"`
+}
+
 type PendingSyncMutationProjectCount struct {
 	Project string `json:"project"`
 	Count   int64  `json:"count"`
@@ -7533,6 +7547,99 @@ type SyncTargetState struct {
 	TargetKey        string `json:"target_key"`
 	Lifecycle        string `json:"lifecycle"`
 	UnackedMutations int    `json:"unacked_mutations"`
+}
+
+// CleanupForeignSyncTargets removes sync_state rows outside the closed target
+// set. Any journal rows directly attached to an obsolete target are retargeted
+// to cloud before its state row is deleted, preserving their payloads and
+// allowing the supported delivery queue to handle eligible work.
+func (s *Store) CleanupForeignSyncTargets(apply bool) (ForeignSyncTargetCleanupReport, error) {
+	report := ForeignSyncTargetCleanupReport{Actions: []ForeignSyncTargetCleanupAction{}}
+	err := s.withTx(func(tx *sql.Tx) error {
+		rows, err := s.queryItHook(tx, `
+			SELECT ss.target_key, COUNT(sm.seq)
+			FROM sync_state ss
+			LEFT JOIN sync_mutations sm ON sm.target_key = ss.target_key
+			WHERE ss.target_key NOT IN (?, ?, ?)
+			  AND NOT EXISTS (
+				SELECT 1 FROM sync_enrolled_projects sep
+				WHERE ss.target_key = ? || sep.project
+			  )
+			GROUP BY ss.target_key
+			ORDER BY ss.target_key ASC`,
+			DefaultSyncTargetKey, SyncInboxTargetKey, LocalChunkTargetKey, DefaultSyncTargetKey+":")
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			var action ForeignSyncTargetCleanupAction
+			if err := rows.Scan(&action.TargetKey, &action.RetargetedMutations); err != nil {
+				return closeRowsWithError(rows, err)
+			}
+			report.Actions = append(report.Actions, action)
+		}
+		if err := closeRowsWithError(rows, rows.Err()); err != nil {
+			return err
+		}
+		if !apply || len(report.Actions) == 0 {
+			return nil
+		}
+
+		affectedProjects := map[string]struct{}{}
+		for _, action := range report.Actions {
+			projectRows, err := s.queryItHook(tx, `
+				SELECT DISTINCT sm.project
+				FROM sync_mutations sm
+				JOIN sync_enrolled_projects sep ON sep.project = sm.project
+				WHERE sm.target_key = ?
+				  AND sm.acked_at IS NULL
+				  AND sm.disposition = ?`, action.TargetKey, SyncMutationDispositionPending)
+			if err != nil {
+				return err
+			}
+			for projectRows.Next() {
+				var project string
+				if err := projectRows.Scan(&project); err != nil {
+					return closeRowsWithError(projectRows, err)
+				}
+				affectedProjects[project] = struct{}{}
+			}
+			if err := closeRowsWithError(projectRows, projectRows.Err()); err != nil {
+				return err
+			}
+			if _, err := s.execHook(tx, `UPDATE sync_mutations SET target_key = ?, acked_at = NULL, disposition = 'pending', disposition_reason = NULL, disposition_evidence = NULL, disposition_at = NULL WHERE target_key = ?`, DefaultSyncTargetKey, action.TargetKey); err != nil {
+				return err
+			}
+			if _, err := s.execHook(tx, `DELETE FROM sync_state WHERE target_key = ?`, action.TargetKey); err != nil {
+				return err
+			}
+		}
+		// Retargeting can surface old sequence numbers that were never reflected in
+		// cloud's delivery cursor. Recompute both monotonic cursors before its
+		// lifecycle is refreshed, matching project-target cursor semantics.
+		if _, err := s.execHook(tx, `
+			UPDATE sync_state
+			SET last_enqueued_seq = MAX(last_enqueued_seq, (SELECT ifnull(MAX(seq), 0) FROM sync_mutations WHERE target_key = ?)),
+			    last_acked_seq = MAX(last_acked_seq, (SELECT ifnull(MAX(seq), 0) FROM sync_mutations WHERE target_key = ? AND acked_at IS NOT NULL)),
+			    updated_at = datetime('now')
+			WHERE target_key = ?`, DefaultSyncTargetKey, DefaultSyncTargetKey, DefaultSyncTargetKey); err != nil {
+			return err
+		}
+		if err := s.refreshSyncLifecycleTx(tx, DefaultSyncTargetKey); err != nil {
+			return err
+		}
+		for project := range affectedProjects {
+			if err := s.refreshProjectSyncLifecycleTx(tx, project); err != nil {
+				return err
+			}
+		}
+		report.Applied = true
+		return nil
+	})
+	if err != nil {
+		return ForeignSyncTargetCleanupReport{}, fmt.Errorf("cleanup foreign sync targets: %w", err)
+	}
+	return report, nil
 }
 
 // ListSyncStates returns every sync_state row with its pending mutation count,

--- a/internal/store/sync_state_test.go
+++ b/internal/store/sync_state_test.go
@@ -29,19 +29,19 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 			t.Fatalf("seed foreign target %q: %v", target, err)
 		}
 	}
-	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		"satellite:pending", SyncEntityObservation, "preserved-mutation", SyncOpUpsert, `{"sync_id":"preserved-mutation","project":"valid"}`, SyncSourceLocal, "valid"); err != nil {
+	pendingResult, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"satellite:pending", SyncEntityObservation, "preserved-mutation", SyncOpUpsert, `{"sync_id":"preserved-mutation","project":"valid"}`, SyncSourceLocal, "valid")
+	if err != nil {
 		t.Fatalf("seed pending mutation: %v", err)
 	}
-	metadataResult, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), 'quarantined', 'kept_reason', 'kept_evidence', datetime('now'))`, "satellite:pending", SyncEntityObservation, "preserved-metadata", SyncOpUpsert, `{}`, SyncSourceLocal, "valid")
-	if err != nil {
+	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), 'quarantined', 'kept_reason', 'kept_evidence', datetime('now'))`, "satellite:pending", SyncEntityObservation, "preserved-metadata", SyncOpUpsert, `{}`, SyncSourceLocal, "valid"); err != nil {
 		t.Fatalf("seed metadata mutation: %v", err)
 	}
-	metadataSeq, err := metadataResult.LastInsertId()
+	pendingSeq, err := pendingResult.LastInsertId()
 	if err != nil {
-		t.Fatalf("metadata sequence: %v", err)
+		t.Fatalf("pending sequence: %v", err)
 	}
-	if _, err := s.DB().Exec(`CREATE TRIGGER abort_foreign_cleanup BEFORE DELETE ON sync_state WHEN OLD.target_key = 'satellite:pending' BEGIN SELECT RAISE(ABORT, 'forced cleanup failure'); END`); err != nil {
+	if _, err := s.DB().Exec(`CREATE TRIGGER abort_foreign_cleanup BEFORE UPDATE ON sync_mutations WHEN NEW.target_key = 'cloud' BEGIN SELECT RAISE(ABORT, 'forced cleanup failure'); END`); err != nil {
 		t.Fatalf("create rollback trigger: %v", err)
 	}
 	if _, err := s.CleanupForeignSyncTargets(true); err == nil || scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`) != 2 || scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE target_key = 'satellite:pending'`) != 2 {
@@ -66,11 +66,11 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 	if err != nil {
 		t.Fatalf("apply cleanup: %v", err)
 	}
-	if !applied.Applied || len(applied.Actions) != 2 || applied.Actions[1].RetargetedMutations != 2 {
+	if !applied.Applied || len(applied.Actions) != 2 || applied.Actions[1].RetargetedMutations != 1 || applied.Actions[1].RetainedMutations != 1 || applied.Actions[1].StateRemoved {
 		t.Fatalf("applied=%+v", applied)
 	}
-	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`); got != 0 {
-		t.Fatalf("foreign targets remain after cleanup: %d", got)
+	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`); got != 1 {
+		t.Fatalf("foreign targets after mixed cleanup: %d", got)
 	}
 	var target, payload string
 	if err := s.DB().QueryRow(`SELECT target_key, payload FROM sync_mutations WHERE entity_key = 'preserved-mutation'`).Scan(&target, &payload); err != nil {
@@ -80,17 +80,17 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 		t.Fatalf("preserved mutation target=%q payload=%q", target, payload)
 	}
 	pending, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
-	if err != nil || len(pending) == 0 || pending[len(pending)-1].Seq != metadataSeq {
+	if err != nil || len(pending) == 0 || pending[len(pending)-1].Seq != pendingSeq {
 		t.Fatalf("retargeted mutation is not queued: %+v, %v", pending, err)
 	}
 	cloud, err := s.GetSyncState(DefaultSyncTargetKey)
-	if err != nil || cloud.LastEnqueuedSeq != metadataSeq || cloud.LastAckedSeq != 0 {
-		t.Fatalf("cloud cursor=%+v, want enqueued=%d and acknowledged=0: %v", cloud, metadataSeq, err)
+	if err != nil || cloud.LastEnqueuedSeq != pendingSeq || cloud.LastAckedSeq != 0 {
+		t.Fatalf("cloud cursor=%+v, want enqueued=%d and acknowledged=0: %v", cloud, pendingSeq, err)
 	}
-	var metadataTarget, disposition string
-	var ackedAt, reason, evidence, dispositionAt sql.NullString
-	if err := s.DB().QueryRow(`SELECT target_key, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at FROM sync_mutations WHERE entity_key = 'preserved-metadata'`).Scan(&metadataTarget, &ackedAt, &disposition, &reason, &evidence, &dispositionAt); err != nil || metadataTarget != DefaultSyncTargetKey || ackedAt.Valid || disposition != SyncMutationDispositionPending || reason.Valid || evidence.Valid || dispositionAt.Valid {
-		t.Fatalf("metadata reset target=%q ack=%v disposition=%q reason=%v evidence=%v at=%v err=%v", metadataTarget, ackedAt, disposition, reason, evidence, dispositionAt, err)
+	var metadataTarget, disposition, reason, evidence string
+	var ackedAt, dispositionAt sql.NullString
+	if err := s.DB().QueryRow(`SELECT target_key, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at FROM sync_mutations WHERE entity_key = 'preserved-metadata'`).Scan(&metadataTarget, &ackedAt, &disposition, &reason, &evidence, &dispositionAt); err != nil || metadataTarget != "satellite:pending" || !ackedAt.Valid || disposition != SyncMutationDispositionQuarantined || reason != "kept_reason" || evidence != "kept_evidence" || !dispositionAt.Valid {
+		t.Fatalf("metadata changed target=%q ack=%v disposition=%q reason=%q evidence=%q at=%v err=%v", metadataTarget, ackedAt, disposition, reason, evidence, dispositionAt, err)
 	}
 	if _, err := s.GetObservation(observationID); err != nil {
 		t.Fatalf("cleanup removed local observation: %v", err)
@@ -104,7 +104,7 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 	if err != nil {
 		t.Fatalf("repeat cleanup: %v", err)
 	}
-	if repeated.Applied || len(repeated.Actions) != 0 {
+	if repeated.Applied || len(repeated.Actions) != 1 || repeated.Actions[0].RetargetedMutations != 0 || repeated.Actions[0].RetainedMutations != 1 || repeated.Actions[0].StateRemoved {
 		t.Fatalf("repeat cleanup=%+v", repeated)
 	}
 }

--- a/internal/store/sync_state_test.go
+++ b/internal/store/sync_state_test.go
@@ -6,6 +6,109 @@ import (
 	"time"
 )
 
+func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnrollProject("valid"); err != nil {
+		t.Fatalf("enroll valid project: %v", err)
+	}
+	if err := s.EnrollProject("isolate"); err != nil {
+		t.Fatalf("enroll isolated project: %v", err)
+	}
+	if _, err := s.DB().Exec(`INSERT INTO sync_state (target_key, lifecycle, last_enqueued_seq, reason_code, updated_at) VALUES (?, 'degraded', 77, 'isolated', datetime('now'))`, syncTargetKeyForProject("isolate")); err != nil {
+		t.Fatalf("seed isolated target: %v", err)
+	}
+	if err := s.CreateSession("cleanup-session", "valid", "/work/valid"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	observationID, err := s.AddObservation(AddObservationParams{SessionID: "cleanup-session", Type: "decision", Title: "preserve", Content: "local observation", Project: "valid", Scope: "project"})
+	if err != nil {
+		t.Fatalf("add observation: %v", err)
+	}
+	for _, target := range []string{"satellite:inert", "satellite:pending"} {
+		if _, err := s.DB().Exec(`INSERT INTO sync_state (target_key, lifecycle, updated_at) VALUES (?, 'idle', datetime('now'))`, target); err != nil {
+			t.Fatalf("seed foreign target %q: %v", target, err)
+		}
+	}
+	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"satellite:pending", SyncEntityObservation, "preserved-mutation", SyncOpUpsert, `{"sync_id":"preserved-mutation","project":"valid"}`, SyncSourceLocal, "valid"); err != nil {
+		t.Fatalf("seed pending mutation: %v", err)
+	}
+	metadataResult, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), 'quarantined', 'kept_reason', 'kept_evidence', datetime('now'))`, "satellite:pending", SyncEntityObservation, "preserved-metadata", SyncOpUpsert, `{}`, SyncSourceLocal, "valid")
+	if err != nil {
+		t.Fatalf("seed metadata mutation: %v", err)
+	}
+	metadataSeq, err := metadataResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("metadata sequence: %v", err)
+	}
+	if _, err := s.DB().Exec(`CREATE TRIGGER abort_foreign_cleanup BEFORE DELETE ON sync_state WHEN OLD.target_key = 'satellite:pending' BEGIN SELECT RAISE(ABORT, 'forced cleanup failure'); END`); err != nil {
+		t.Fatalf("create rollback trigger: %v", err)
+	}
+	if _, err := s.CleanupForeignSyncTargets(true); err == nil || scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`) != 2 || scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE target_key = 'satellite:pending'`) != 2 {
+		t.Fatal("failed cleanup persisted a partial change")
+	}
+	if _, err := s.DB().Exec(`DROP TRIGGER abort_foreign_cleanup`); err != nil {
+		t.Fatalf("drop rollback trigger: %v", err)
+	}
+
+	planned, err := s.CleanupForeignSyncTargets(false)
+	if err != nil {
+		t.Fatalf("plan cleanup: %v", err)
+	}
+	if planned.Applied || len(planned.Actions) != 2 {
+		t.Fatalf("plan=%+v", planned)
+	}
+	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`); got != 2 {
+		t.Fatalf("plan changed foreign targets: %d", got)
+	}
+
+	applied, err := s.CleanupForeignSyncTargets(true)
+	if err != nil {
+		t.Fatalf("apply cleanup: %v", err)
+	}
+	if !applied.Applied || len(applied.Actions) != 2 || applied.Actions[1].RetargetedMutations != 2 {
+		t.Fatalf("applied=%+v", applied)
+	}
+	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`); got != 0 {
+		t.Fatalf("foreign targets remain after cleanup: %d", got)
+	}
+	var target, payload string
+	if err := s.DB().QueryRow(`SELECT target_key, payload FROM sync_mutations WHERE entity_key = 'preserved-mutation'`).Scan(&target, &payload); err != nil {
+		t.Fatalf("read preserved mutation: %v", err)
+	}
+	if target != DefaultSyncTargetKey || payload != `{"sync_id":"preserved-mutation","project":"valid"}` {
+		t.Fatalf("preserved mutation target=%q payload=%q", target, payload)
+	}
+	pending, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
+	if err != nil || len(pending) == 0 || pending[len(pending)-1].Seq != metadataSeq {
+		t.Fatalf("retargeted mutation is not queued: %+v, %v", pending, err)
+	}
+	cloud, err := s.GetSyncState(DefaultSyncTargetKey)
+	if err != nil || cloud.LastEnqueuedSeq != metadataSeq || cloud.LastAckedSeq != 0 {
+		t.Fatalf("cloud cursor=%+v, want enqueued=%d and acknowledged=0: %v", cloud, metadataSeq, err)
+	}
+	var metadataTarget, disposition string
+	var ackedAt, reason, evidence, dispositionAt sql.NullString
+	if err := s.DB().QueryRow(`SELECT target_key, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at FROM sync_mutations WHERE entity_key = 'preserved-metadata'`).Scan(&metadataTarget, &ackedAt, &disposition, &reason, &evidence, &dispositionAt); err != nil || metadataTarget != DefaultSyncTargetKey || ackedAt.Valid || disposition != SyncMutationDispositionPending || reason.Valid || evidence.Valid || dispositionAt.Valid {
+		t.Fatalf("metadata reset target=%q ack=%v disposition=%q reason=%v evidence=%v at=%v err=%v", metadataTarget, ackedAt, disposition, reason, evidence, dispositionAt, err)
+	}
+	if _, err := s.GetObservation(observationID); err != nil {
+		t.Fatalf("cleanup removed local observation: %v", err)
+	}
+	isolated, err := s.GetSyncState(syncTargetKeyForProject("isolate"))
+	if err != nil || isolated.Lifecycle != SyncLifecycleDegraded || isolated.LastEnqueuedSeq != 77 || derefString(isolated.ReasonCode) != "isolated" {
+		t.Fatalf("cleanup changed isolated target: %+v, %v", isolated, err)
+	}
+
+	repeated, err := s.CleanupForeignSyncTargets(true)
+	if err != nil {
+		t.Fatalf("repeat cleanup: %v", err)
+	}
+	if repeated.Applied || len(repeated.Actions) != 0 {
+		t.Fatalf("repeat cleanup=%+v", repeated)
+	}
+}
+
 func TestPolicyFailureReasonAndCloudSummaryUseProjectState(t *testing.T) {
 	s := newTestStore(t)
 	message := "policy denial guidance"

--- a/internal/store/sync_state_test.go
+++ b/internal/store/sync_state_test.go
@@ -34,7 +34,7 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 	if err != nil {
 		t.Fatalf("seed pending mutation: %v", err)
 	}
-	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), 'quarantined', 'kept_reason', 'kept_evidence', datetime('now'))`, "satellite:pending", SyncEntityObservation, "preserved-metadata", SyncOpUpsert, `{}`, SyncSourceLocal, "valid"); err != nil {
+	if _, err := s.DB().Exec(`INSERT INTO sync_mutations (target_key, entity, entity_key, op, payload, source, project, acked_at, disposition, disposition_reason, disposition_evidence, disposition_at) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), 'quarantined', 'kept_reason', 'kept_evidence', datetime('now')), (?, ?, ?, ?, ?, ?, ?, NULL, 'pending', NULL, NULL, NULL)`, "satellite:pending", SyncEntityObservation, "preserved-metadata", SyncOpUpsert, `{}`, SyncSourceLocal, "valid", "satellite:pending", SyncEntityObservation, "local-only", SyncOpUpsert, `{"sync_id":"local-only","project":"local-only"}`, SyncSourceLocal, "local-only"); err != nil {
 		t.Fatalf("seed metadata mutation: %v", err)
 	}
 	pendingSeq, err := pendingResult.LastInsertId()
@@ -44,7 +44,7 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 	if _, err := s.DB().Exec(`CREATE TRIGGER abort_foreign_cleanup BEFORE UPDATE ON sync_mutations WHEN NEW.target_key = 'cloud' BEGIN SELECT RAISE(ABORT, 'forced cleanup failure'); END`); err != nil {
 		t.Fatalf("create rollback trigger: %v", err)
 	}
-	if _, err := s.CleanupForeignSyncTargets(true); err == nil || scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`) != 2 || scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE target_key = 'satellite:pending'`) != 2 {
+	if _, err := s.CleanupForeignSyncTargets(true); err == nil || scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`) != 2 || scalarInt(t, s, `SELECT COUNT(*) FROM sync_mutations WHERE target_key = 'satellite:pending'`) != 3 {
 		t.Fatal("failed cleanup persisted a partial change")
 	}
 	if _, err := s.DB().Exec(`DROP TRIGGER abort_foreign_cleanup`); err != nil {
@@ -55,7 +55,7 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 	if err != nil {
 		t.Fatalf("plan cleanup: %v", err)
 	}
-	if planned.Applied || len(planned.Actions) != 2 {
+	if planned.Applied || len(planned.Actions) != 2 || planned.Actions[1].RetargetedMutations != 1 || planned.Actions[1].RetainedMutations != 2 {
 		t.Fatalf("plan=%+v", planned)
 	}
 	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`); got != 2 {
@@ -66,21 +66,21 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 	if err != nil {
 		t.Fatalf("apply cleanup: %v", err)
 	}
-	if !applied.Applied || len(applied.Actions) != 2 || applied.Actions[1].RetargetedMutations != 1 || applied.Actions[1].RetainedMutations != 1 || applied.Actions[1].StateRemoved {
+	if !applied.Applied || len(applied.Actions) != 2 || applied.Actions[1].RetargetedMutations != 1 || applied.Actions[1].RetainedMutations != 2 || applied.Actions[1].StateRemoved {
 		t.Fatalf("applied=%+v", applied)
 	}
 	if got := scalarInt(t, s, `SELECT COUNT(*) FROM sync_state WHERE target_key LIKE 'satellite:%'`); got != 1 {
 		t.Fatalf("foreign targets after mixed cleanup: %d", got)
 	}
-	var target, payload string
-	if err := s.DB().QueryRow(`SELECT target_key, payload FROM sync_mutations WHERE entity_key = 'preserved-mutation'`).Scan(&target, &payload); err != nil {
+	var target, payload, localTarget string
+	if err := s.DB().QueryRow(`SELECT target_key, payload, (SELECT target_key FROM sync_mutations WHERE entity_key = 'local-only') FROM sync_mutations WHERE entity_key = 'preserved-mutation'`).Scan(&target, &payload, &localTarget); err != nil {
 		t.Fatalf("read preserved mutation: %v", err)
 	}
-	if target != DefaultSyncTargetKey || payload != `{"sync_id":"preserved-mutation","project":"valid"}` {
-		t.Fatalf("preserved mutation target=%q payload=%q", target, payload)
+	if target != DefaultSyncTargetKey || payload != `{"sync_id":"preserved-mutation","project":"valid"}` || localTarget != "satellite:pending" {
+		t.Fatalf("mutation targets=%q,%q payload=%q", target, localTarget, payload)
 	}
 	pending, err := s.ListPendingSyncMutations(DefaultSyncTargetKey, 10)
-	if err != nil || len(pending) == 0 || pending[len(pending)-1].Seq != pendingSeq {
+	if err != nil || len(pending) != 3 || pending[len(pending)-1].Seq != pendingSeq {
 		t.Fatalf("retargeted mutation is not queued: %+v, %v", pending, err)
 	}
 	cloud, err := s.GetSyncState(DefaultSyncTargetKey)
@@ -104,7 +104,7 @@ func TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets(t *testing.T) 
 	if err != nil {
 		t.Fatalf("repeat cleanup: %v", err)
 	}
-	if repeated.Applied || len(repeated.Actions) != 1 || repeated.Actions[0].RetargetedMutations != 0 || repeated.Actions[0].RetainedMutations != 1 || repeated.Actions[0].StateRemoved {
+	if repeated.Applied || len(repeated.Actions) != 1 || repeated.Actions[0].RetargetedMutations != 0 || repeated.Actions[0].RetainedMutations != 2 || repeated.Actions[0].StateRemoved {
 		t.Fatalf("repeat cleanup=%+v", repeated)
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1158

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:question` — Question requiring tracked work
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- add a supported Doctor repair for legacy foreign sync targets
- move only enrolled pending rows to `cloud`, preserving local-only and terminal evidence
- expose one authoritative cleanup classification to direct repair-plan and CLI consumers

## 📂 Changes

| File | Change |
|------|--------|
| `internal/store/store.go` | Transactionally retarget eligible enrolled pending rows, retain local-only/terminal evidence, remove empty stale state, and refresh cloud cursors. |
| `internal/store/sync_state_test.go` | Cover enrollment filtering, queue visibility, payload/evidence preservation, mixed targets, isolation, idempotence, and rollback. |
| `internal/diagnostic/repair.go` | Build repair actions from the store's authoritative empty/pending/retained classification. |
| `internal/diagnostic/repair_test.go` | Verify empty, enrolled-pending, and terminal-retained classification, no-mutation dry runs, and error propagation. |
| `cmd/engram/doctor.go` | Allow dry-run/apply and report actual `applied`, `partial`, or `blocked` outcomes. |
| `cmd/engram/doctor_test.go` | Verify planning, application, post-repair behavior, and checked resource cleanup. |

## 🧪 Test Plan

- [x] `go test ./internal/store -run '^TestCleanupForeignSyncTargetsPreservesJournalAndValidTargets$' -count=1 -timeout 120s`
- [x] `go test ./internal/diagnostic -run '^TestBuildRepairPlanForeignSyncTargetUsesStoreClassification$' -count=1 -timeout 120s`
- [x] `go test ./cmd/engram -run '^TestCmdDoctorRepairCleansForeignSyncTargetsWithoutDroppingJournal$' -count=1 -timeout 120s`
- [x] `go test ./internal/store -count=1 -timeout 180s`
- [x] `go test ./internal/diagnostic -count=1 -timeout 180s`
- [x] `golangci-lint run --new-from-rev origin/main`
- [ ] `go test ./cmd/engram -count=1 -timeout 180s` — the unchanged, unrelated `TestCmdSyncDefaultProjectNoData` fails locally because the environment resolves project `blackie`; the focused Doctor regression passes.
- [ ] Full unit, E2E, plugin, and remaining platform suites — CI is the broad-suite owner for this candidate.

---

## 🤖 Automated Checks

Required checks are delegated to CI and must pass before merge.

---

## ✅ Contributor Checklist

- [x] Linked approved issue #1158
- [x] Added exactly one `type:*` label
- [x] Ran focused and affected local tests proportionally
- [x] New-issue lint passes locally
- [x] Documentation reviewed; no existing command example required an update
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers
- [x] All six changed paths comply with the Transient Artifact Policy

---

## 💬 Notes for Reviewers

The branch was rebased onto current `main` after #1162 changed `internal/store/store.go`, then fully reverified. Mixed legacy targets are repaired conservatively: only pending rows belonging to currently enrolled projects move to the supported cloud queue. Unenrolled/local-only, acknowledged, quarantined, and unknown terminal rows remain attached to the legacy target with their audit evidence intact. The command reports retained state explicitly instead of reactivating excluded data or falsely claiming complete cleanup.

The final range is exactly 400 changed lines. Direct repair-plan consumers receive the same store classification as the CLI, including the pending mapping and cleanup-error path requested by CodeRabbit. Native four-lens review approved and acknowledged this committed range after targeted validation of enrollment safety.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Doctor repairs now clean up obsolete or foreign synchronization targets.
  - Repair plans report cleanup actions, including retargeted mutations and removed synchronization state.
  - Plan, dry-run, and apply results are available in JSON format.

- **Bug Fixes**
  - Journal entries and observations are preserved while mutations move to the default synchronization target.
  - Valid synchronization targets are retained, and synchronization state is refreshed after cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->