### PR TITLE
fix(setup): register Claude MCP at user scope

### DIFF
--- a/cmd/engram/main.go
+++ b/cmd/engram/main.go
@@ -3322,8 +3322,9 @@ func printPostInstall(result *setup.Result) {
 		fmt.Println("  1. Restart Claude Code — the plugin is active immediately")
 		fmt.Println("  2. Verify with: claude plugin list")
 		if result.MCPConfigured {
-			fmt.Printf("  3. MCP config written to %s using absolute binary path\n", setup.ClaudeCodeUserMCPPath())
-			fmt.Println("     (survives plugin auto-updates; re-run 'engram setup claude-code' if you move the binary)")
+			fmt.Printf("  3. Claude CLI registered the user MCP server in %s using an absolute binary path\n", setup.ClaudeCodeUserMCPPath())
+			fmt.Println("     If the binary moves, run: claude mcp remove engram --scope user")
+			fmt.Println("     Then re-run: engram setup claude-code")
 		} else {
 			fmt.Println("  3. MCP configuration was not written. Re-run 'engram setup claude-code' after resolving the reported error.")
 		}

--- a/cmd/engram/setup_protocol_test.go
+++ b/cmd/engram/setup_protocol_test.go
@@ -103,7 +103,7 @@ func TestPrintPostInstallClaudeCodeReportsMCPStatus(t *testing.T) {
 
 	t.Run("configured", func(t *testing.T) {
 		t.Setenv("CLAUDE_CONFIG_DIR", "")
-		expected := "MCP config written to " + setup.ClaudeCodeUserMCPPath()
+		expected := "Claude CLI registered the user MCP server in " + setup.ClaudeCodeUserMCPPath()
 		stdout, stderr := captureOutput(t, func() {
 			printPostInstall(&setup.Result{Agent: "claude-code", MCPConfigured: true})
 		})
@@ -115,7 +115,7 @@ func TestPrintPostInstallClaudeCodeReportsMCPStatus(t *testing.T) {
 	t.Run("configured with CLAUDE_CONFIG_DIR override", func(t *testing.T) {
 		dir := t.TempDir()
 		t.Setenv("CLAUDE_CONFIG_DIR", dir)
-		expected := "MCP config written to " + filepath.Join(dir, "mcp", "engram.json")
+		expected := "Claude CLI registered the user MCP server in " + filepath.Join(dir, ".claude.json")
 		stdout, stderr := captureOutput(t, func() {
 			printPostInstall(&setup.Result{Agent: "claude-code", MCPConfigured: true})
 		})
@@ -126,7 +126,7 @@ func TestPrintPostInstallClaudeCodeReportsMCPStatus(t *testing.T) {
 
 	t.Run("not configured", func(t *testing.T) {
 		t.Setenv("CLAUDE_CONFIG_DIR", "")
-		notExpected := "MCP config written to " + setup.ClaudeCodeUserMCPPath()
+		notExpected := "Claude CLI registered the user MCP server in " + setup.ClaudeCodeUserMCPPath()
 		stdout, stderr := captureOutput(t, func() {
 			printPostInstall(&setup.Result{Agent: "claude-code"})
 		})

--- a/docs/AGENT-SETUP.md
+++ b/docs/AGENT-SETUP.md
@@ -30,11 +30,11 @@ Engram works with **any MCP-compatible agent**. Pick your agent below.
 | Kilo Code       | `engram setup kilocode`                                                                      | [Details](#kilo-code)                              |
 | Any MCP agent   | `engram mcp` (stdio)                                                                         | [Details](#any-other-mcp-agent)                    |
 
-> **Native setup for all agents above.** `engram setup <agent>` writes the right
-> MCP registration (handling each client's config format — `mcpServers`,
-> `servers`, or OpenCode's `mcp` object) plus the Memory Protocol into that
-> agent's instruction surface, idempotently. The per-agent sections below describe
-> the exact files each command touches and the manual equivalent.
+> **Native setup for all agents above.** `engram setup <agent>` configures the
+> supported MCP registration and Memory Protocol idempotently. Claude Code is the
+> exception to direct config writes: its CLI owns user-scope MCP registration. The
+> per-agent sections below describe each integration's authoritative owner and
+> manual equivalent.
 
 ### Protocol verbosity
 
@@ -306,24 +306,19 @@ Marketplace installation provides plugin assets only; it does not register the M
 engram setup claude-code
 ```
 
-`engram setup claude-code` is the sole MCP registration owner. It writes the durable user-level config at `~/.claude/mcp/engram.json` with the absolute `engram` binary path. It refreshes an existing regular file, but refuses to replace a symlink or other non-regular path; inspect it and manually replace it with a regular file before rerunning setup. If that write is not possible, setup warns and completes the plugin installation; resolve the error and rerun setup before using plugin MCP tools. You'll be asked whether to add engram's agent-profile MCP tools to `~/.claude/settings.json` `permissions.allow`. The setup writes entries for both the durable user-level MCP server id (`mcp__engram__...`) and the plugin-scoped server id used by older Claude Code plugin installs, so re-running setup repairs stale or incomplete allowlists without adding startup delay. Existing marketplace plugin copies receive hooks, scripts, and skills updates through normal Claude Code plugin updates; do not edit the plugin cache manually. If `CLAUDE_CONFIG_DIR` is set, Engram writes the MCP registration and permissions allowlist under that directory instead (`$CLAUDE_CONFIG_DIR/mcp/engram.json`, `$CLAUDE_CONFIG_DIR/settings.json`), matching Claude Code's own config-directory override.
+`engram setup claude-code` delegates MCP registration to Claude CLI. Claude writes the user-scope top-level `mcpServers.engram` entry in `~/.claude.json` (Windows: `%USERPROFILE%\\.claude.json`); when `CLAUDE_CONFIG_DIR` is set, Claude uses `$CLAUDE_CONFIG_DIR/.claude.json`. Engram reads only that documented entry: an exact stdio command and arguments (`<absolute-engram-path> mcp --tools=agent`) is a no-op, while a missing entry is added with `claude mcp add --transport stdio --scope user engram -- <absolute-engram-path> mcp --tools=agent` and then verified. A mismatched or unreadable entry is reported as a conflict and is never overwritten. If verification fails after a proven-absent add, setup asks Claude to remove that user-scope entry and reports both errors if rollback fails. You'll be asked whether to add Engram's agent-profile MCP tools to `~/.claude/settings.json` `permissions.allow`. Existing marketplace plugin copies receive hooks, scripts, and skills updates through normal Claude Code plugin updates; do not edit the plugin cache manually.
 
 `engram setup claude-code --protocol=slim` requires Engram plugin version 0.1.1 or later. Setup checks `claude plugin list --json` after a successful install and warns, without failing or changing the selected slim mode, when it cannot verify the installed enabled marketplace plugin. Update through your normal Claude Code plugin update path and restart Claude Code. Session-only `claude --plugin-dir ...` plugins cannot be detected by this check.
 
 **Option C: Bare MCP** — all 23 tools by default, no session management:
 
-Add to your `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
+Use Claude CLI to register the user-scope server (replace the placeholder with the absolute Engram executable path):
 
-```json
-{
-  "mcpServers": {
-    "engram": {
-      "command": "engram",
-      "args": ["mcp"]
-    }
-  }
-}
+```bash
+claude mcp add --transport stdio --scope user engram -- <absolute-engram-path> mcp --tools=agent
 ```
+
+Claude rejects an existing user-scope server with the same name rather than overwriting it. To remove the registration later, run `claude mcp remove engram --scope user`.
 
 With bare MCP, add a [Surviving Compaction](#surviving-compaction-recommended) prompt to your `CLAUDE.md` so the agent remembers to use Engram after context resets.
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -92,7 +92,7 @@ engram setup claude-code
 claude --plugin-dir ./plugin/claude-code
 ```
 
-Existing marketplace-only copies create their durable MCP registration at the next SessionStart and require one more Claude Code restart before MCP tools return. If `~/.claude/mcp/engram.json` is a symlink or another non-regular path, SessionStart and direct setup refuse to replace it; inspect it and manually replace it with a regular file before rerunning `engram setup claude-code`. Do not edit the plugin cache manually. When `CLAUDE_CONFIG_DIR` is set, Engram writes the MCP registration under that directory instead (`$CLAUDE_CONFIG_DIR/mcp/engram.json`, `$CLAUDE_CONFIG_DIR/settings.json`), the same directory Claude Code itself uses.
+Each SessionStart delegates MCP registration to `engram setup claude-code --mcp-only`; the hook does not inspect, write, or delete Claude configuration. Claude CLI owns the user-scope `mcpServers.engram` entry in `~/.claude.json` (Windows: `%USERPROFILE%\\.claude.json`) or `$CLAUDE_CONFIG_DIR/.claude.json` when that override is set. Setup accepts only the exact expected stdio command and arguments as configured; mismatched or unreadable entries are visible conflicts and are never overwritten. Do not edit the plugin cache manually.
 
 The `--protocol=slim` setup option requires Engram plugin 0.1.1 or later. After successful Claude Code setup, Engram checks `claude plugin list --json`; an unverifiable, disabled, or older plugin produces a warning but does not fail setup or replace the selected slim mode. Use your normal Claude Code plugin update path, then restart Claude Code. Plugins loaded with session-only `claude --plugin-dir ...` cannot be detected.
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -6,8 +6,8 @@
 //     resolved absolute binary path so child processes never require PATH
 //     resolution in headless/systemd environments.
 //   - Claude Code: runs `claude plugin marketplace add` + `claude plugin install`,
-//     then writes a durable MCP config to ~/.claude/mcp/engram.json using the
-//     absolute binary path so the subprocess never needs PATH resolution.
+//     then asks Claude CLI to register a durable user-scope stdio MCP server using
+//     the resolved absolute binary path.
 //   - Gemini CLI: injects MCP registration in ~/.gemini/settings.json
 //   - Codex: injects MCP registration in ~/.codex/config.toml
 //   - Pi: installs gentle-engram/pi-mcp-adapter packages and writes Pi MCP config
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1042,25 +1043,22 @@ func installClaudeCode() (*Result, error) {
 		}
 	}
 
-	// Step 3: Write the sole durable user-level MCP registration at ~/.claude/mcp/engram.json
-	// with the absolute binary path. This survives plugin cache auto-updates and
-	// works on Windows where MCP subprocesses may not inherit PATH.
-	files := 0
+	// Step 3: Claude CLI owns user-scope MCP writes. Engram only reads the
+	// documented config structure to make this idempotent and verify the result.
 	mcpConfigured := false
 	if err := writeClaudeCodeUserMCPFn(); err != nil {
 		// Non-fatal: the plugin installs, but MCP tools remain unavailable until
-		// setup can write the user-level registration.
-		fmt.Fprintf(os.Stderr, "warning: could not write user MCP config (%s): %v\n", ClaudeCodeUserMCPPath(), err)
+		// Claude can register the user-scope server.
+		fmt.Fprintf(os.Stderr, "warning: could not register Claude Code user MCP server (%s): %v\n", ClaudeCodeUserMCPPath(), err)
 		fmt.Fprintf(os.Stderr, "  The plugin is installed, but rerun `engram setup claude-code` after resolving this error to register MCP tools.\n")
 	} else {
-		files = 1
 		mcpConfigured = true
 	}
 
+	home, _ := userHomeDir()
 	return &Result{
 		Agent:         "claude-code",
-		Destination:   claudeCodeMCPDir(),
-		Files:         files,
+		Destination:   claudeCodeConfigRoot(home),
 		MCPConfigured: mcpConfigured,
 	}, nil
 }
@@ -1082,56 +1080,27 @@ func claudeCodeConfigRoot(home string) string {
 	return abs
 }
 
-// claudeCodeMCPDir returns the directory for user-level Claude Code MCP configs.
-// Files placed here are NOT managed by the plugin system and survive plugin updates.
+// claudeCodeMCPDir is retained for legacy path compatibility only. Claude user
+// MCP registration is authoritative only in ClaudeCodeUserMCPPath.
 func claudeCodeMCPDir() string {
 	home, _ := userHomeDir()
 	return filepath.Join(claudeCodeConfigRoot(home), "mcp")
 }
 
-// ClaudeCodeUserMCPPath returns the path for the engram MCP config in the
-// user-level MCP directory (see claudeCodeConfigRoot).
+// ClaudeCodeUserMCPPath returns the Claude Code user configuration file that
+// contains the top-level mcpServers object. Claude CLI owns all writes to it.
 func ClaudeCodeUserMCPPath() string {
-	return filepath.Join(claudeCodeMCPDir(), "engram.json")
+	home, _ := userHomeDir()
+	if strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")) == "" {
+		return filepath.Join(home, ".claude.json")
+	}
+	return filepath.Join(claudeCodeConfigRoot(home), ".claude.json")
 }
 
-// writeClaudeCodeUserMCP writes ~/.claude/mcp/engram.json with the canonical
-// absolute path to the engram binary. This is idempotent — it always writes
-// (overwrites) so that if the binary moves (e.g. brew upgrade), running setup
-// again fixes it. The command is resolved via canonicalEngramCommand() so a
-// versioned Homebrew/Linuxbrew Cellar path maps to the stable
-// <brew-prefix>/bin/engram symlink that survives `brew upgrade`.
-//
-// os.Executable() is called exactly once and its result is passed to the
-// canonicalization helper, so the written path is always derived from the same
-// executable result that was checked for an error. The error contract preserves
-// the original "resolve binary path" failure — the Claude Code user MCP config
-// must not be written with a PATH-dependent command when the binary cannot be
-// resolved absolutely.
+// writeClaudeCodeUserMCP is retained as the normal setup seam. It delegates all
+// registration writes to Claude CLI through EnsureClaudeCodeUserMCP.
 func writeClaudeCodeUserMCP() error {
-	path := ClaudeCodeUserMCPPath()
-	data, err := claudeCodeUserMCPData()
-	if err != nil {
-		return err
-	}
-
-	dir := claudeCodeMCPDir()
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create mcp dir: %w", err)
-	}
-	if info, err := lstatFn(path); err == nil {
-		if err := validateClaudeCodeUserMCP(path, info); err != nil {
-			return err
-		}
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat user MCP config: %w", err)
-	}
-
-	if err := writeFileFn(path, data, 0644); err != nil {
-		return fmt.Errorf("write mcp config: %w", err)
-	}
-
-	return nil
+	return EnsureClaudeCodeUserMCP()
 }
 
 func claudeCodeUserMCPData() ([]byte, error) {
@@ -1154,52 +1123,130 @@ func claudeCodeUserMCPData() ([]byte, error) {
 	return data, nil
 }
 
-func createClaudeCodeUserMCP(path string, data []byte, perm os.FileMode) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
-	if err != nil {
-		return err
-	}
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		return err
-	}
-	return file.Close()
+func createClaudeCodeUserMCP(string, []byte, os.FileMode) error {
+	return fmt.Errorf("Claude CLI owns user MCP configuration writes")
 }
 
-// EnsureClaudeCodeUserMCP creates the user-owned registration only when absent.
-func EnsureClaudeCodeUserMCP() error {
+type claudeCodeMCPState uint8
+
+const (
+	claudeCodeMCPAbsent claudeCodeMCPState = iota
+	claudeCodeMCPExact
+	claudeCodeMCPConflict
+)
+
+type claudeCodeMCPServer struct {
+	Type    string   `json:"type"`
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+// inspectClaudeCodeUserMCP reads only the documented user-scope top-level
+// mcpServers.engram entry. Unknown or malformed data is fail-closed.
+func inspectClaudeCodeUserMCP(command string) (claudeCodeMCPState, error) {
 	path := ClaudeCodeUserMCPPath()
-	if info, err := lstatFn(path); err == nil {
-		return validateClaudeCodeUserMCP(path, info)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat user MCP config: %w", err)
+	data, err := readFileFn(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return claudeCodeMCPAbsent, nil
+		}
+		return claudeCodeMCPConflict, fmt.Errorf("read Claude Code user config %s: %w", path, err)
 	}
 
-	data, err := claudeCodeUserMCPData()
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(data, &config); err != nil || config == nil {
+		if err == nil {
+			err = fmt.Errorf("must contain a JSON object")
+		}
+		return claudeCodeMCPConflict, fmt.Errorf("parse Claude Code user config %s: %w", path, err)
+	}
+	rawServers, ok := config["mcpServers"]
+	if !ok {
+		return claudeCodeMCPAbsent, nil
+	}
+	var servers map[string]json.RawMessage
+	if err := json.Unmarshal(rawServers, &servers); err != nil || servers == nil {
+		if err == nil {
+			err = fmt.Errorf("mcpServers must be a JSON object")
+		}
+		return claudeCodeMCPConflict, fmt.Errorf("parse Claude Code mcpServers in %s: %w", path, err)
+	}
+	rawServer, ok := servers["engram"]
+	if !ok {
+		return claudeCodeMCPAbsent, nil
+	}
+	var server claudeCodeMCPServer
+	if err := json.Unmarshal(rawServer, &server); err != nil {
+		return claudeCodeMCPConflict, fmt.Errorf("parse Claude Code mcpServers.engram in %s: %w", path, err)
+	}
+	if server.Type == "stdio" && server.Command == command && slices.Equal(server.Args, []string{"mcp", "--tools=agent"}) {
+		return claudeCodeMCPExact, nil
+	}
+	return claudeCodeMCPConflict, nil
+}
+
+func claudeCodeExpectedEngramCommand() (string, error) {
+	exe, err := osExecutable()
+	if err != nil {
+		return "", fmt.Errorf("resolve binary path: %w", err)
+	}
+	return claudeCodeEngramCommand(exe)
+}
+
+// EnsureClaudeCodeUserMCP registers an absent user-scope server through Claude
+// CLI, verifies it by re-reading Claude's config, and never overwrites a
+// pre-existing registration.
+func EnsureClaudeCodeUserMCP() error {
+	command, err := claudeCodeExpectedEngramCommand()
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(claudeCodeMCPDir(), 0755); err != nil {
-		return fmt.Errorf("create mcp dir: %w", err)
-	}
-	if err := createClaudeCodeUserMCPFn(path, data, 0644); err == nil {
-		return nil
-	} else if !os.IsExist(err) {
-		return fmt.Errorf("create user MCP config: %w", err)
-	}
-
-	info, err := lstatFn(path)
+	state, err := inspectClaudeCodeUserMCP(command)
 	if err != nil {
-		return fmt.Errorf("stat user MCP config: %w", err)
+		return err
 	}
-	return validateClaudeCodeUserMCP(path, info)
-}
+	switch state {
+	case claudeCodeMCPExact:
+		return nil
+	case claudeCodeMCPConflict:
+		return fmt.Errorf("Claude Code MCP conflict at %s: mcpServers.engram differs from Engram's expected stdio command; resolve it manually", ClaudeCodeUserMCPPath())
+	}
 
-func validateClaudeCodeUserMCP(path string, info os.FileInfo) error {
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("user MCP config must be a regular file; replace it manually before retrying: %s", path)
+	claudeBin, err := lookPathFn("claude")
+	if err != nil {
+		return fmt.Errorf("locate claude CLI: %w", err)
 	}
-	return nil
+	addArgs := []string{"mcp", "add", "--transport", "stdio", "--scope", "user", "engram", "--", command, "mcp", "--tools=agent"}
+	if _, addErr := runCommand(claudeBin, addArgs...); addErr != nil {
+		state, inspectErr := inspectClaudeCodeUserMCP(command)
+		if inspectErr != nil {
+			return fmt.Errorf("Claude MCP add failed: %w; recheck failed: %v", addErr, inspectErr)
+		}
+		if state == claudeCodeMCPExact {
+			return nil
+		}
+		if state == claudeCodeMCPConflict {
+			return fmt.Errorf("Claude Code MCP conflict after add error: %w", addErr)
+		}
+		return fmt.Errorf("Claude MCP add: %w", addErr)
+	}
+
+	state, verifyErr := inspectClaudeCodeUserMCP(command)
+	if verifyErr == nil && state == claudeCodeMCPExact {
+		return nil
+	}
+	verification := fmt.Errorf("verify Claude Code MCP registration")
+	if verifyErr != nil {
+		verification = fmt.Errorf("verify Claude Code MCP registration: %w", verifyErr)
+	} else if state == claudeCodeMCPConflict {
+		verification = fmt.Errorf("verify Claude Code MCP registration: registered entry conflicts with expected stdio command")
+	} else {
+		verification = fmt.Errorf("verify Claude Code MCP registration: mcpServers.engram is absent")
+	}
+	if _, rollbackErr := runCommand(claudeBin, "mcp", "remove", "engram", "--scope", "user"); rollbackErr != nil {
+		return fmt.Errorf("%v; rollback Claude MCP registration: %w", verification, rollbackErr)
+	}
+	return verification
 }
 
 // ClaudeCodeSettingsPath returns the path to Claude Code's user-level

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1435,15 +1435,15 @@ func TestInstallClaudeCodeBranches(t *testing.T) {
 		if result.Agent != "claude-code" {
 			t.Fatalf("unexpected agent: %q", result.Agent)
 		}
-		// When writeClaudeCodeUserMCP succeeds, files == 1
-		if result.Files != 1 {
-			t.Fatalf("expected 1 file when user MCP write succeeds, got %d", result.Files)
+		// Claude CLI owns the registration write, so setup reports no local files.
+		if result.Files != 0 {
+			t.Fatalf("expected 0 local files when Claude registration succeeds, got %d", result.Files)
 		}
 		if !result.MCPConfigured {
 			t.Fatal("expected successful user MCP write to report MCP configuration")
 		}
-		// Destination should point to the .claude/mcp dir, not be empty
-		expectedDir := filepath.Join(home, ".claude", "mcp")
+		// Destination should point to Claude's configuration directory, not be empty.
+		expectedDir := filepath.Join(home, ".claude")
 		if result.Destination != expectedDir {
 			t.Fatalf("expected destination %q, got %q", expectedDir, result.Destination)
 		}
@@ -1609,420 +1609,6 @@ func TestParseClaudeCodePluginVersion(t *testing.T) {
 }
 
 // ─── Issue #100: Windows PATH fix ────────────────────────────────────────────
-
-func TestWriteClaudeCodeUserMCP(t *testing.T) {
-	t.Run("writes json with absolute binary path", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		if err := writeClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("writeClaudeCodeUserMCP failed: %v", err)
-		}
-
-		mcpPath := filepath.Join(home, ".claude", "mcp", "engram.json")
-		raw, err := os.ReadFile(mcpPath)
-		if err != nil {
-			t.Fatalf("read mcp config: %v", err)
-		}
-
-		var cfg map[string]any
-		if err := json.Unmarshal(raw, &cfg); err != nil {
-			t.Fatalf("parse mcp config: %v", err)
-		}
-
-		if cfg["command"] != executable {
-			t.Fatalf("expected absolute path command, got %#v", cfg["command"])
-		}
-		args, ok := cfg["args"].([]any)
-		if !ok || len(args) != 2 || args[0] != "mcp" || args[1] != "--tools=agent" {
-			t.Fatalf("expected args [mcp --tools=agent], got %#v", cfg["args"])
-		}
-	})
-
-	t.Run("overwrites existing (idempotent — always refreshes path)", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		mcpDir := filepath.Join(home, ".claude", "mcp")
-		if err := os.MkdirAll(mcpDir, 0755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(mcpDir, "engram.json"), []byte(`{"command":"old"}`), 0644); err != nil {
-			t.Fatalf("write old config: %v", err)
-		}
-
-		if err := writeClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("writeClaudeCodeUserMCP failed: %v", err)
-		}
-
-		raw, err := os.ReadFile(filepath.Join(mcpDir, "engram.json"))
-		if err != nil {
-			t.Fatalf("read updated config: %v", err)
-		}
-		var cfg map[string]any
-		if err := json.Unmarshal(raw, &cfg); err != nil {
-			t.Fatalf("parse config: %v", err)
-		}
-		if cfg["command"] != executable {
-			t.Fatalf("expected updated command, got %#v", cfg["command"])
-		}
-	})
-
-	t.Run("rejects symlink without changing its target", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		target := filepath.Join(t.TempDir(), "user-owned.json")
-		const original = `{"command":"user-owned"}`
-		if err := os.WriteFile(target, []byte(original), 0644); err != nil {
-			t.Fatalf("write symlink target: %v", err)
-		}
-		path := filepath.Join(home, ".claude", "mcp", "engram.json")
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			t.Fatalf("create MCP directory: %v", err)
-		}
-		if err := os.Symlink(target, path); err != nil {
-			t.Skipf("symlinks unavailable: %v", err)
-		}
-
-		err := writeClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "regular file") {
-			t.Fatalf("expected symlink rejection, got %v", err)
-		}
-		info, err := os.Lstat(path)
-		if err != nil {
-			t.Fatalf("lstat MCP config: %v", err)
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			t.Fatalf("MCP config is no longer a symlink: mode %v", info.Mode())
-		}
-		raw, err := os.ReadFile(target)
-		if err != nil {
-			t.Fatalf("read symlink target: %v", err)
-		}
-		if string(raw) != original {
-			t.Fatalf("symlink target was changed: got %q want %q", raw, original)
-		}
-	})
-
-	t.Run("rejects dangling symlink", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		path := filepath.Join(home, ".claude", "mcp", "engram.json")
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			t.Fatalf("create MCP directory: %v", err)
-		}
-		if err := os.Symlink(filepath.Join(t.TempDir(), "missing.json"), path); err != nil {
-			t.Skipf("symlinks unavailable: %v", err)
-		}
-
-		err := writeClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "regular file") {
-			t.Fatalf("expected dangling symlink rejection, got %v", err)
-		}
-		info, err := os.Lstat(path)
-		if err != nil {
-			t.Fatalf("lstat MCP config: %v", err)
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			t.Fatalf("MCP config is no longer a symlink: mode %v", info.Mode())
-		}
-	})
-
-	t.Run("homebrew cellar path maps to stable bin symlink", func(t *testing.T) {
-		// Regression for issue #461: a versioned Cellar executable (the real
-		// target of <brew-prefix>/bin/engram) must be rewritten to the stable
-		// symlink so the written command survives `brew upgrade`. Previously
-		// writeClaudeCodeUserMCP called EvalSymlinks directly and baked in the
-		// versioned Cellar path, which broke once brew removed the old version.
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		brewPrefix := t.TempDir()
-		cellarExe := filepath.Join(brewPrefix, "Cellar", "engram", "1.20.0", "bin", "engram")
-		stableSymlink := filepath.Join(brewPrefix, "bin", "engram")
-		osExecutable = func() (string, error) { return cellarExe, nil }
-		statFn = func(name string) (os.FileInfo, error) {
-			if filepath.ToSlash(name) == filepath.ToSlash(stableSymlink) {
-				return nil, nil // stable symlink exists on disk
-			}
-			return nil, os.ErrNotExist
-		}
-
-		if err := writeClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("writeClaudeCodeUserMCP failed: %v", err)
-		}
-
-		mcpPath := filepath.Join(home, ".claude", "mcp", "engram.json")
-		raw, err := os.ReadFile(mcpPath)
-		if err != nil {
-			t.Fatalf("read mcp config: %v", err)
-		}
-		var cfg map[string]any
-		if err := json.Unmarshal(raw, &cfg); err != nil {
-			t.Fatalf("parse mcp config: %v", err)
-		}
-		got, ok := cfg["command"].(string)
-		if !ok {
-			t.Fatalf("expected string command, got %#v", cfg["command"])
-		}
-		if filepath.ToSlash(got) != filepath.ToSlash(stableSymlink) {
-			t.Fatalf("expected stable symlink %q, got %q", stableSymlink, got)
-		}
-		if strings.Contains(got, "Cellar") {
-			t.Fatalf("command must not contain a versioned Cellar path, got %q", got)
-		}
-	})
-
-	t.Run("homebrew cellar with missing stable symlink preserves absolute exe (issue #461 pr713)", func(t *testing.T) {
-		// Regression for PR #713 CodeRabbit Major: a Cellar exe with the stable
-		// symlink absent must not persist bare "engram"; writeClaudeCodeUserMCP
-		// must preserve the already-obtained absolute exe, or error.
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		cellarExe := filepath.Join(t.TempDir(), "Cellar", "engram", "1.20.0", "bin", "engram")
-		osExecutable = func() (string, error) { return cellarExe, nil }
-		statFn = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
-
-		if err := writeClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("writeClaudeCodeUserMCP failed: %v", err)
-		}
-
-		mcpPath := filepath.Join(home, ".claude", "mcp", "engram.json")
-		raw, err := os.ReadFile(mcpPath)
-		if err != nil {
-			t.Fatalf("read mcp config: %v", err)
-		}
-		var cfg map[string]any
-		if err := json.Unmarshal(raw, &cfg); err != nil {
-			t.Fatalf("parse mcp config: %v", err)
-		}
-		got, ok := cfg["command"].(string)
-		if !ok {
-			t.Fatalf("expected string command, got %#v", cfg["command"])
-		}
-		if got == "engram" {
-			t.Fatalf("must not persist bare 'engram' when absolute exe is available, got %q", got)
-		}
-		if !filepath.IsAbs(got) {
-			t.Fatalf("expected absolute command, got %q", got)
-		}
-		if filepath.ToSlash(got) != filepath.ToSlash(cellarExe) {
-			t.Fatalf("expected absolute exe %q preserved, got %q", cellarExe, got)
-		}
-	})
-
-	t.Run("non-absolute executable returns error instead of writing bare command", func(t *testing.T) {
-		// Defensive guard: non-absolute exe + non-absolute canonical fallback
-		// must refuse to write rather than persist a PATH-dependent command.
-		resetSetupSeams(t)
-		useTestHome(t)
-		osExecutable = func() (string, error) { return "engram", nil }
-
-		err := writeClaudeCodeUserMCP()
-		if err == nil {
-			t.Fatalf("expected error for non-absolute executable, got nil")
-		}
-		if !strings.Contains(err.Error(), "absolute") {
-			t.Fatalf("expected absolute-path error, got %v", err)
-		}
-	})
-
-	t.Run("os.Executable failure returns error", func(t *testing.T) {
-		resetSetupSeams(t)
-		useTestHome(t)
-		osExecutable = func() (string, error) { return "", errors.New("exec not found") }
-
-		err := writeClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "resolve binary path") {
-			t.Fatalf("expected resolve binary path error, got %v", err)
-		}
-	})
-
-	t.Run("marshal error returns error", func(t *testing.T) {
-		resetSetupSeams(t)
-		useTestHome(t)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-		jsonMarshalIndentFn = func(any, string, string) ([]byte, error) {
-			return nil, errors.New("marshal boom")
-		}
-
-		err := writeClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "marshal mcp config") {
-			t.Fatalf("expected marshal mcp config error, got %v", err)
-		}
-	})
-
-	t.Run("non-regular path is rejected", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-		// Make ~/.claude/mcp/engram.json a directory so write fails
-		mcpDir := filepath.Join(home, ".claude", "mcp")
-		if err := os.MkdirAll(mcpDir, 0755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		if err := os.MkdirAll(filepath.Join(mcpDir, "engram.json"), 0755); err != nil {
-			t.Fatalf("create dir as file: %v", err)
-		}
-
-		err := writeClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "regular file") {
-			t.Fatalf("expected non-regular path error, got %v", err)
-		}
-	})
-
-	t.Run("create dir error returns error", func(t *testing.T) {
-		resetSetupSeams(t)
-		// Block ~/.claude/mcp creation by making .claude a file
-		blocked := t.TempDir()
-		if err := os.WriteFile(filepath.Join(blocked, ".claude"), []byte("x"), 0644); err != nil {
-			t.Fatalf("write blocking file: %v", err)
-		}
-		userHomeDir = func() (string, error) { return blocked, nil }
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		err := writeClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "create mcp dir") {
-			t.Fatalf("expected create mcp dir error, got %v", err)
-		}
-	})
-}
-
-func TestEnsureClaudeCodeUserMCP(t *testing.T) {
-	t.Run("existing regular file is left untouched", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		path := filepath.Join(home, ".claude", "mcp", "engram.json")
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			t.Fatalf("create MCP directory: %v", err)
-		}
-		const existing = `{"command":"user-owned"}`
-		if err := os.WriteFile(path, []byte(existing), 0644); err != nil {
-			t.Fatalf("write existing MCP config: %v", err)
-		}
-
-		if err := EnsureClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("EnsureClaudeCodeUserMCP: %v", err)
-		}
-		raw, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read existing MCP config: %v", err)
-		}
-		if string(raw) != existing {
-			t.Fatalf("existing MCP config was changed: got %q want %q", raw, existing)
-		}
-	})
-
-	t.Run("missing path is created exclusively", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		if err := EnsureClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("EnsureClaudeCodeUserMCP: %v", err)
-		}
-		info, err := os.Lstat(filepath.Join(home, ".claude", "mcp", "engram.json"))
-		if err != nil {
-			t.Fatalf("lstat created MCP config: %v", err)
-		}
-		if !info.Mode().IsRegular() {
-			t.Fatalf("created MCP config mode = %v, want regular file", info.Mode())
-		}
-	})
-
-	t.Run("lstat error is returned", func(t *testing.T) {
-		resetSetupSeams(t)
-		useTestHome(t)
-		lstatFn = func(string) (os.FileInfo, error) { return nil, errors.New("lstat boom") }
-
-		err := EnsureClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "stat user MCP config") {
-			t.Fatalf("expected stat error, got %v", err)
-		}
-	})
-
-	t.Run("exclusive create error is returned", func(t *testing.T) {
-		resetSetupSeams(t)
-		useTestHome(t)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-		createClaudeCodeUserMCPFn = func(string, []byte, os.FileMode) error {
-			return errors.New("write boom")
-		}
-
-		err := EnsureClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "create user MCP config") {
-			t.Fatalf("expected exclusive create error, got %v", err)
-		}
-	})
-
-	t.Run("concurrent creator wins without clobbering", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		path := filepath.Join(home, ".claude", "mcp", "engram.json")
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		checked := make(chan struct{})
-		continueEnsure := make(chan struct{})
-		lstatCalls := 0
-		lstatFn = func(name string) (os.FileInfo, error) {
-			if name == path && lstatCalls == 0 {
-				lstatCalls++
-				close(checked)
-				<-continueEnsure
-				return nil, os.ErrNotExist
-			}
-			return os.Lstat(name)
-		}
-
-		done := make(chan error, 1)
-		go func() { done <- EnsureClaudeCodeUserMCP() }()
-		<-checked
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			t.Fatalf("create MCP directory: %v", err)
-		}
-		const concurrentConfig = `{"command":"concurrent-owner"}`
-		if err := os.WriteFile(path, []byte(concurrentConfig), 0644); err != nil {
-			t.Fatalf("write concurrent MCP config: %v", err)
-		}
-		close(continueEnsure)
-		if err := <-done; err != nil {
-			t.Fatalf("EnsureClaudeCodeUserMCP: %v", err)
-		}
-		raw, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read concurrent MCP config: %v", err)
-		}
-		if string(raw) != concurrentConfig {
-			t.Fatalf("concurrent MCP config was clobbered: got %q want %q", raw, concurrentConfig)
-		}
-	})
-
-	t.Run("non-regular path is rejected", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		path := filepath.Join(home, ".claude", "mcp", "engram.json")
-		if err := os.MkdirAll(path, 0755); err != nil {
-			t.Fatalf("create directory at MCP config path: %v", err)
-		}
-
-		err := EnsureClaudeCodeUserMCP()
-		if err == nil || !strings.Contains(err.Error(), "regular file") {
-			t.Fatalf("expected non-regular path error, got %v", err)
-		}
-	})
-}
 
 func TestResolveEngramCommand(t *testing.T) {
 	t.Run("unix returns absolute path from os.Executable", func(t *testing.T) {
@@ -2234,24 +1820,6 @@ func TestCanonicalEngramCommand(t *testing.T) {
 	}
 }
 
-// TestClaudeCodeMCPDirPaths verifies claudeCodeMCPDir and ClaudeCodeUserMCPPath
-// derive their paths from the stubbed home directory under the default (no
-// CLAUDE_CONFIG_DIR) resolution.
-func TestClaudeCodeMCPDirPaths(t *testing.T) {
-	resetSetupSeams(t)
-	userHomeDir = func() (string, error) { return "/home/tester", nil }
-
-	expectedDir := filepath.Join("/home/tester", ".claude", "mcp")
-	if got := claudeCodeMCPDir(); got != expectedDir {
-		t.Fatalf("expected %s, got %s", expectedDir, got)
-	}
-
-	expectedPath := filepath.Join("/home/tester", ".claude", "mcp", "engram.json")
-	if got := ClaudeCodeUserMCPPath(); got != expectedPath {
-		t.Fatalf("expected %s, got %s", expectedPath, got)
-	}
-}
-
 // TestClaudeCodeConfigRootHonorsClaudeConfigDir verifies claudeCodeConfigRoot's CLAUDE_CONFIG_DIR override (issue #1081).
 func TestClaudeCodeConfigRootHonorsClaudeConfigDir(t *testing.T) {
 	const fakeHome = "/home/tester"
@@ -2337,65 +1905,6 @@ func assertClaudeCodeWritesUnderRoot(t *testing.T, root, executable string) {
 			t.Fatalf("expected tool %q at index %d, got %q", tool, i, allow[i])
 		}
 	}
-}
-
-// TestClaudeCodeWritesHonorClaudeConfigDir executes writeClaudeCodeUserMCP,
-// EnsureClaudeCodeUserMCP, and AddClaudeCodeAllowlist under an absolute and a
-// relative CLAUDE_CONFIG_DIR override, and verifies nothing is written under
-// the stubbed HOME's default ~/.claude (issue #1081).
-func TestClaudeCodeWritesHonorClaudeConfigDir(t *testing.T) {
-	t.Run("absolute", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		root := filepath.Join(t.TempDir(), "custom-config")
-		t.Setenv("CLAUDE_CONFIG_DIR", root)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		if err := writeClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("writeClaudeCodeUserMCP failed: %v", err)
-		}
-		if err := EnsureClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("EnsureClaudeCodeUserMCP failed: %v", err)
-		}
-		if err := AddClaudeCodeAllowlist(); err != nil {
-			t.Fatalf("AddClaudeCodeAllowlist failed: %v", err)
-		}
-
-		assertClaudeCodeWritesUnderRoot(t, root, executable)
-
-		if _, err := os.Stat(filepath.Join(home, ".claude")); !os.IsNotExist(err) {
-			t.Fatalf("expected %s/.claude to not exist, stat err=%v", home, err)
-		}
-	})
-
-	t.Run("relative", func(t *testing.T) {
-		resetSetupSeams(t)
-		home := useTestHome(t)
-		cwd := t.TempDir()
-		t.Chdir(cwd)
-		rel := filepath.Join("relative", "claude-config")
-		t.Setenv("CLAUDE_CONFIG_DIR", rel)
-		executable := filepath.Join(t.TempDir(), "engram")
-		osExecutable = func() (string, error) { return executable, nil }
-
-		if err := writeClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("writeClaudeCodeUserMCP failed: %v", err)
-		}
-		if err := EnsureClaudeCodeUserMCP(); err != nil {
-			t.Fatalf("EnsureClaudeCodeUserMCP failed: %v", err)
-		}
-		if err := AddClaudeCodeAllowlist(); err != nil {
-			t.Fatalf("AddClaudeCodeAllowlist failed: %v", err)
-		}
-
-		root := filepath.Join(cwd, rel)
-		assertClaudeCodeWritesUnderRoot(t, root, executable)
-
-		if _, err := os.Stat(filepath.Join(home, ".claude")); !os.IsNotExist(err) {
-			t.Fatalf("expected %s/.claude to not exist, stat err=%v", home, err)
-		}
-	})
 }
 
 // TestGeminiInjectUsesAbsolutePath verifies that injectGeminiMCP writes the
@@ -4800,6 +4309,182 @@ func TestInstallOpenCodeBakesENGRAMBIN(t *testing.T) {
 //	a) read session data from event.properties.info (not event.properties)
 //	b) suppress child sessions only when authoritative parentID is present
 //	c) track sub-agent IDs in subAgentSessions for cross-hook suppression
+func TestEnsureClaudeCodeUserMCPUsesClaudeManagedUserConfig(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	path := filepath.Join(home, ".claude.json")
+	command := filepath.Join(t.TempDir(), "engram")
+	claude := filepath.Join(t.TempDir(), "claude")
+	osExecutable = func() (string, error) { return command, nil }
+	lookPathFn = func(string) (string, error) { return claude, nil }
+	var calls [][]string
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		if err := os.WriteFile(path, []byte(fmt.Sprintf(`{"mcpServers":{"engram":{"type":"stdio","command":%q,"args":["mcp","--tools=agent"]}}}`, command)), 0644); err != nil {
+			t.Fatalf("simulate Claude config write: %v", err)
+		}
+		return nil, nil
+	}
+	if err := EnsureClaudeCodeUserMCP(); err != nil {
+		t.Fatalf("ensure absent registration: %v", err)
+	}
+	want := [][]string{{claude, "mcp", "add", "--transport", "stdio", "--scope", "user", "engram", "--", command, "mcp", "--tools=agent"}}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("commands = %#v, want %#v (Claude must own the config write)", calls, want)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected simulated Claude config write at %s: %v", path, err)
+	}
+}
+
+func TestEnsureClaudeCodeUserMCPConflictAndRecovery(t *testing.T) {
+	command := filepath.Join(t.TempDir(), "engram")
+	claude := filepath.Join(t.TempDir(), "claude")
+	config := func(command string) string {
+		return fmt.Sprintf(`{"mcpServers":{"engram":{"type":"stdio","command":%q,"args":["mcp","--tools=agent"]}}}`, command)
+	}
+	prepare := func(t *testing.T, contents string) (string, *[][]string) {
+		t.Helper()
+		resetSetupSeams(t)
+		home := useTestHome(t)
+		path := filepath.Join(home, ".claude.json")
+		if contents != "" {
+			if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+				t.Fatalf("seed Claude config: %v", err)
+			}
+		}
+		osExecutable = func() (string, error) { return command, nil }
+		lookPathFn = func(string) (string, error) { return claude, nil }
+		calls := [][]string{}
+		runCommand = func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, append([]string{name}, args...))
+			return nil, nil
+		}
+		return path, &calls
+	}
+
+	t.Run("exact match is a no-op", func(t *testing.T) {
+		_, calls := prepare(t, config(command))
+		if err := EnsureClaudeCodeUserMCP(); err != nil {
+			t.Fatalf("ensure exact entry: %v", err)
+		}
+		if len(*calls) != 0 {
+			t.Fatalf("commands = %#v, want none", *calls)
+		}
+	})
+
+	t.Run("mismatch is not clobbered", func(t *testing.T) {
+		path, calls := prepare(t, config(`C:\Custom\engram.exe`))
+		before, _ := os.ReadFile(path)
+		err := EnsureClaudeCodeUserMCP()
+		after, _ := os.ReadFile(path)
+		if err == nil || !strings.Contains(err.Error(), "conflict") || len(*calls) != 0 || string(before) != string(after) {
+			t.Fatalf("error=%v calls=%#v config changed=%t", err, *calls, string(before) != string(after))
+		}
+	})
+
+	t.Run("malformed config fails closed", func(t *testing.T) {
+		_, calls := prepare(t, "{")
+		err := EnsureClaudeCodeUserMCP()
+		if err == nil || !strings.Contains(err.Error(), "parse") || len(*calls) != 0 {
+			t.Fatalf("error=%v calls=%#v", err, *calls)
+		}
+	})
+
+	t.Run("postcheck failure rolls back", func(t *testing.T) {
+		_, calls := prepare(t, "")
+		err := EnsureClaudeCodeUserMCP()
+		if err == nil || !strings.Contains(err.Error(), "verify") {
+			t.Fatalf("error = %v", err)
+		}
+		want := [][]string{
+			{claude, "mcp", "add", "--transport", "stdio", "--scope", "user", "engram", "--", command, "mcp", "--tools=agent"},
+			{claude, "mcp", "remove", "engram", "--scope", "user"},
+		}
+		if !reflect.DeepEqual(*calls, want) {
+			t.Fatalf("commands=%#v want=%#v", *calls, want)
+		}
+	})
+
+	t.Run("rollback failure retains verification failure", func(t *testing.T) {
+		_, calls := prepare(t, "")
+		runCommand = func(name string, args ...string) ([]byte, error) {
+			*calls = append(*calls, append([]string{name}, args...))
+			if args[1] == "remove" {
+				return nil, errors.New("rollback denied")
+			}
+			return nil, nil
+		}
+		err := EnsureClaudeCodeUserMCP()
+		if err == nil || !strings.Contains(err.Error(), "verify") || !strings.Contains(err.Error(), "rollback denied") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("add error recheck handles races", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			contents string
+			want     string
+		}{
+			{name: "exact succeeds", contents: config(command)},
+			{name: "mismatch conflicts", contents: config(`C:\Custom\engram.exe`), want: "conflict"},
+			{name: "absent returns add error", want: "already exists"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				path, calls := prepare(t, "")
+				runCommand = func(name string, args ...string) ([]byte, error) {
+					*calls = append(*calls, append([]string{name}, args...))
+					if tc.contents != "" {
+						if err := os.WriteFile(path, []byte(tc.contents), 0644); err != nil {
+							t.Fatalf("simulate racing config: %v", err)
+						}
+					}
+					return nil, errors.New("already exists")
+				}
+				err := EnsureClaudeCodeUserMCP()
+				if tc.want == "" && err != nil {
+					t.Fatalf("error = %v, want nil", err)
+				}
+				if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+					t.Fatalf("error = %v, want %q", err, tc.want)
+				}
+			})
+		}
+	})
+}
+
+func TestClaudeCodeUserMCPPathUsesClaudeJSONLocations(t *testing.T) {
+	resetSetupSeams(t)
+	home := useTestHome(t)
+	if got, want := ClaudeCodeUserMCPPath(), filepath.Join(home, ".claude.json"); got != want {
+		t.Fatalf("default path = %q, want %q", got, want)
+	}
+	root := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", root)
+	if got, want := ClaudeCodeUserMCPPath(), filepath.Join(root, ".claude.json"); got != want {
+		t.Fatalf("override path = %q, want %q", got, want)
+	}
+
+	t.Run("override config is inspected without invoking Claude", func(t *testing.T) {
+		resetSetupSeams(t)
+		useTestHome(t)
+		override := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", override)
+		osExecutable = func() (string, error) { return `C:\Engram\engram.exe`, nil }
+		if err := os.WriteFile(ClaudeCodeUserMCPPath(), []byte(`{"mcpServers":{"engram":{"type":"stdio","command":"C:\\Engram\\engram.exe","args":["mcp","--tools=agent"]}}}`), 0644); err != nil {
+			t.Fatalf("write overridden Claude config: %v", err)
+		}
+		lookPathFn = func(string) (string, error) {
+			t.Fatal("exact overridden config must not locate Claude")
+			return "", nil
+		}
+		if err := EnsureClaudeCodeUserMCP(); err != nil {
+			t.Fatalf("ensure overridden exact config: %v", err)
+		}
+	})
+}
+
 func TestPluginSubAgentFiltering(t *testing.T) {
 	resetSetupSeams(t)
 	home := useTestHome(t)

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -19,13 +19,10 @@ INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
-MCP_CONFIG="$(claude_config_root)/mcp/engram.json"
-if [ ! -f "$MCP_CONFIG" ] || [ -L "$MCP_CONFIG" ]; then
-  if engram setup claude-code --mcp-only; then
-    printf '%s\n' "Engram MCP registration migrated. Restart Claude Code to enable MCP tools."
-  else
-    printf "warning: Engram MCP registration migration failed; manually replace %s with a regular file, then run 'engram setup claude-code'.\n" "$MCP_CONFIG" >&2
-  fi
+# Claude CLI owns user-scope MCP configuration. Keep this hook as a thin
+# delegator: setup performs conflict detection and postcondition verification.
+if ! engram setup claude-code --mcp-only; then
+  printf '%s\n' "warning: Engram MCP registration failed; run 'engram setup claude-code --mcp-only' after resolving the reported error." >&2
 fi
 # An explicit URL is an external-server opt-in. Only the default local endpoint
 # is owned by this data directory, so reachability alone is never sufficient.

--- a/plugin/claude_code_hook_behavior_test.go
+++ b/plugin/claude_code_hook_behavior_test.go
@@ -863,209 +863,56 @@ func healthyServer(t *testing.T) *httptest.Server {
 }
 
 // TestSessionStartHonorsClaudeConfigDirForMCPMigrationGuard verifies session-start.sh's MCP-migration guard honors CLAUDE_CONFIG_DIR (issue #1081).
-func TestSessionStartHonorsClaudeConfigDirForMCPMigrationGuard(t *testing.T) {
+// TestSessionStartAlwaysDelegatesClaudeMCPRegistration confirms the hook has no
+// config-file authority: setup owns inspection, conflict detection, and writes.
+func TestSessionStartAlwaysDelegatesClaudeMCPRegistration(t *testing.T) {
 	requireHookBinaries(t)
 
-	runWithEngramStub := func(t *testing.T, configDir string) []string {
+	run := func(t *testing.T, setupFails bool) ([]string, string) {
 		t.Helper()
 		srv := healthyServer(t)
-		stubDir := writeRecordingEngramStub(t)
+		stubDir := t.TempDir()
 		logPath := filepath.Join(t.TempDir(), "engram-invocations.log")
-		// bash's PATH is always colon-separated, even under Git Bash on Windows.
+		stub := filepath.Join(stubDir, "engram")
+		script := "#!/bin/bash\nprintf '%s\\n' \"$*\" >> \"$ENGRAM_TEST_ENGRAM_LOG\"\nif [ \"$*\" = \"instance-id\" ]; then printf '00000000000000000000000000000000\\n'; fi\n"
+		if setupFails {
+			script += "if [ \"$*\" = \"setup claude-code --mcp-only\" ]; then exit 1; fi\n"
+		}
+		script += "exit 0\n"
+		if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+			t.Fatalf("write engram stub: %v", err)
+		}
+
+		configDir := t.TempDir()
+		legacyPath := filepath.Join(configDir, "mcp", "engram.json")
+		if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+			t.Fatalf("create stale MCP directory: %v", err)
+		}
+		if err := os.WriteFile(legacyPath, []byte(`{"command":"stale"}`), 0o644); err != nil {
+			t.Fatalf("write stale MCP config: %v", err)
+		}
 		env := map[string]string{
 			"ENGRAM_PORT":            serverPort(t, srv),
+			"ENGRAM_MANAGED_LOCAL":   "0",
 			"CLAUDE_CONFIG_DIR":      configDir,
 			"PATH":                   stubDir + ":" + os.Getenv("PATH"),
 			"ENGRAM_TEST_ENGRAM_LOG": logPath,
 		}
 		stdin := fmt.Sprintf(`{"session_id":%q,"cwd":%q}`, newSessionID(t), t.TempDir())
-		runHook(t, "session-start.sh", stdin, env)
-		return readEngramInvocations(t, logPath)
+		_, stderr := runHookWithStderr(t, "session-start.sh", stdin, env)
+		return readEngramInvocations(t, logPath), stderr
 	}
 
-	t.Run("existing regular file under CLAUDE_CONFIG_DIR skips migration", func(t *testing.T) {
-		configDir := t.TempDir()
-		mcpDir := filepath.Join(configDir, "mcp")
-		if err := os.MkdirAll(mcpDir, 0o755); err != nil {
-			t.Fatalf("create mcp dir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(mcpDir, "engram.json"), []byte("{}"), 0o644); err != nil {
-			t.Fatalf("write existing mcp config: %v", err)
-		}
-
-		for _, args := range runWithEngramStub(t, configDir) {
-			if args == "setup claude-code --mcp-only" {
-				t.Fatalf("migration invoked even though a regular MCP config already exists under CLAUDE_CONFIG_DIR")
-			}
-		}
-	})
-
-	t.Run("missing config under CLAUDE_CONFIG_DIR triggers migration", func(t *testing.T) {
-		configDir := t.TempDir() // mcp/engram.json intentionally absent
-
-		invocations := runWithEngramStub(t, configDir)
-		found := false
-		for _, args := range invocations {
-			if args == "setup claude-code --mcp-only" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("migration was not invoked for a missing MCP config under CLAUDE_CONFIG_DIR; invocations: %v", invocations)
-		}
-	})
-
-	t.Run("symlink under CLAUDE_CONFIG_DIR triggers migration once", func(t *testing.T) {
-		configDir := t.TempDir()
-		mcpDir := filepath.Join(configDir, "mcp")
-		if err := os.MkdirAll(mcpDir, 0o755); err != nil {
-			t.Fatalf("create mcp dir: %v", err)
-		}
-		target := filepath.Join(t.TempDir(), "existing-engram.json")
-		if err := os.WriteFile(target, []byte("{}"), 0o644); err != nil {
-			t.Fatalf("write symlink target: %v", err)
-		}
-		if err := os.Symlink(target, filepath.Join(mcpDir, "engram.json")); err != nil {
-			t.Skipf("symlink creation is unavailable: %v", err)
-		}
-
-		count := 0
-		for _, args := range runWithEngramStub(t, configDir) {
-			if args == "setup claude-code --mcp-only" {
-				count++
-			}
-		}
-		if count != 1 {
-			t.Fatalf("migration invocations for symlink MCP config = %d, want 1", count)
-		}
-	})
-
-	t.Run("migration creates the resolved config and runs once", func(t *testing.T) {
-		configDir := t.TempDir()
-		mcpConfig := filepath.Join(configDir, "mcp", "engram.json")
-		srv := healthyServer(t)
-		stubDir := writeMigratingEngramStub(t)
-		logPath := filepath.Join(t.TempDir(), "engram-invocations.log")
-		env := map[string]string{
-			"ENGRAM_PORT":            serverPort(t, srv),
-			"CLAUDE_CONFIG_DIR":      configDir,
-			"PATH":                   stubDir + ":" + os.Getenv("PATH"),
-			"ENGRAM_TEST_ENGRAM_LOG": logPath,
-			"ENGRAM_TEST_MCP_CONFIG": mcpConfig,
-		}
-		stdin := fmt.Sprintf(`{"session_id":%q,"cwd":%q}`, newSessionID(t), t.TempDir())
-		runHook(t, "session-start.sh", stdin, env)
-		info, err := os.Stat(mcpConfig)
-		if err != nil || !info.Mode().IsRegular() {
-			t.Fatalf("first migration must create regular MCP config at %q: info=%v, err=%v", mcpConfig, info, err)
-		}
-		runHook(t, "session-start.sh", stdin, env)
-		if got := strings.Count(strings.Join(readEngramInvocations(t, logPath), "\n"), "setup claude-code --mcp-only"); got != 1 {
-			t.Fatalf("migration invocations across two SessionStart runs = %d, want 1", got)
-		}
-	})
-
-	// migrationWasInvoked reports whether "setup claude-code --mcp-only"
-	// appears among the recorded engram invocations.
-	migrationWasInvoked := func(invocations []string) bool {
-		for _, args := range invocations {
-			if args == "setup claude-code --mcp-only" {
-				return true
-			}
-		}
-		return false
+	invocations, stderr := run(t, false)
+	if stderr != "" {
+		t.Fatalf("successful setup stderr = %q", stderr)
+	}
+	if got := strings.Count(strings.Join(invocations, "\n"), "setup claude-code --mcp-only"); got != 1 {
+		t.Fatalf("setup invocations = %d, want one despite stale legacy config: %v", got, invocations)
 	}
 
-	t.Run("unset or blank CLAUDE_CONFIG_DIR falls back to $HOME/.claude", func(t *testing.T) {
-		cases := []struct {
-			name          string
-			setConfig     bool
-			configDir     string
-			createConfig  bool
-			wantMigration bool
-		}{
-			{name: "unset/config present", createConfig: true},
-			{name: "unset/config absent", wantMigration: true},
-			{name: "empty/config present", setConfig: true, createConfig: true},
-			{name: "empty/config absent", setConfig: true, wantMigration: true},
-			{name: "whitespace-only/config present", setConfig: true, configDir: "   \t  ", createConfig: true},
-			{name: "whitespace-only/config absent", setConfig: true, configDir: "   \t  ", wantMigration: true},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				home := t.TempDir()
-				if tc.createConfig {
-					mcpDir := filepath.Join(home, ".claude", "mcp")
-					if err := os.MkdirAll(mcpDir, 0o755); err != nil {
-						t.Fatalf("create mcp dir: %v", err)
-					}
-					if err := os.WriteFile(filepath.Join(mcpDir, "engram.json"), []byte("{}"), 0o644); err != nil {
-						t.Fatalf("write existing mcp config: %v", err)
-					}
-				}
-
-				srv := healthyServer(t)
-				stubDir := writeRecordingEngramStub(t)
-				logPath := filepath.Join(t.TempDir(), "engram-invocations.log")
-				env := map[string]string{
-					"ENGRAM_PORT":            serverPort(t, srv),
-					"HOME":                   home,
-					"PATH":                   stubDir + ":" + os.Getenv("PATH"),
-					"ENGRAM_TEST_ENGRAM_LOG": logPath,
-				}
-				if tc.setConfig {
-					env["CLAUDE_CONFIG_DIR"] = tc.configDir
-				}
-				stdin := fmt.Sprintf(`{"session_id":%q,"cwd":%q}`, newSessionID(t), t.TempDir())
-				runHook(t, "session-start.sh", stdin, env)
-
-				if got := migrationWasInvoked(readEngramInvocations(t, logPath)); got != tc.wantMigration {
-					t.Fatalf("migration invoked=%v, want %v", got, tc.wantMigration)
-				}
-			})
-		}
-	})
-
-	t.Run("relative CLAUDE_CONFIG_DIR resolved against hook's working directory", func(t *testing.T) {
-		const rel = "relative-claude-config"
-		cases := []struct {
-			name          string
-			createConfig  bool
-			wantMigration bool
-		}{
-			{name: "config present", createConfig: true, wantMigration: false},
-			{name: "config absent", createConfig: false, wantMigration: true},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				workDir := t.TempDir()
-				if tc.createConfig {
-					mcpDir := filepath.Join(workDir, rel, "mcp")
-					if err := os.MkdirAll(mcpDir, 0o755); err != nil {
-						t.Fatalf("create mcp dir: %v", err)
-					}
-					if err := os.WriteFile(filepath.Join(mcpDir, "engram.json"), []byte("{}"), 0o644); err != nil {
-						t.Fatalf("write existing mcp config: %v", err)
-					}
-				}
-
-				srv := healthyServer(t)
-				stubDir := writeRecordingEngramStub(t)
-				logPath := filepath.Join(t.TempDir(), "engram-invocations.log")
-				env := map[string]string{
-					"ENGRAM_PORT":            serverPort(t, srv),
-					"CLAUDE_CONFIG_DIR":      rel,
-					"PATH":                   stubDir + ":" + os.Getenv("PATH"),
-					"ENGRAM_TEST_ENGRAM_LOG": logPath,
-				}
-				stdin := fmt.Sprintf(`{"session_id":%q,"cwd":%q}`, newSessionID(t), t.TempDir())
-				runHookInDir(t, "session-start.sh", stdin, env, workDir)
-
-				if got := migrationWasInvoked(readEngramInvocations(t, logPath)); got != tc.wantMigration {
-					t.Fatalf("migration invoked=%v, want %v", got, tc.wantMigration)
-				}
-			})
-		}
-	})
+	_, stderr = run(t, true)
+	if !strings.Contains(stderr, "warning: Engram MCP registration failed") {
+		t.Fatalf("failed setup stderr = %q, want actionable warning", stderr)
+	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1153

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:question` — Question requiring tracked work
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no behavior change)
- [ ] `type:chore` — Maintenance, dependencies, tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Register Engram through Claude Code's supported user-scoped MCP CLI contract instead of writing an ignored file.
- Preserve user-owned registrations with exact-match idempotency, conflict detection, postcondition verification, and scoped rollback.
- Keep SessionStart thin and align setup output, regression tests, and documentation.

## 📂 Changes

| File | Change |
|------|--------|
| `internal/setup/setup.go` | Inspect documented user MCP state and delegate add/remove writes to the Claude CLI. |
| `internal/setup/setup_test.go` | Cover idempotency, conflicts, malformed state, races, rollback, config paths, and cross-platform commands. |
| `cmd/engram/*` | Align `--mcp-only` behavior and binary-relocation guidance. |
| `plugin/claude-code/*` | Always delegate SessionStart registration to the Go setup owner and replace obsolete guard tests. |
| `docs/AGENT-SETUP.md`, `docs/PLUGINS.md` | Document Claude-managed user-scope registration and recovery. |

## 🧪 Test Plan

- [x] Focused setup registration tests pass.
- [x] Focused `cmd/engram` MCP/setup tests pass.
- [x] Focused Claude SessionStart behavior test passes.
- [x] `bash -n plugin/claude-code/scripts/session-start.sh`
- [x] `gofmt -d` reports no changes.
- [x] `git diff --check`
- [ ] Unit tests pass locally: `go test ./...` — assigned to CI; local affected suites had pre-existing environment failures/timeouts.
- [ ] E2E tests pass locally: `go test -tags e2e ./internal/server/...` — not run; unaffected and assigned to CI.
- [ ] Lint passes locally: `make lint` — assigned to CI. Local ShellCheck could not resolve the existing dynamic `_helpers.sh` source.
- [ ] Manually tested against a real Claude user profile — intentionally not run to avoid mutating user configuration.

---

## 🤖 Automated Checks

| Check | What it verifies | Status |
|-------|-----------------|--------|
| **Check Issue Reference** | PR body contains `Closes #1153` | ✅ |
| **Check Issue Has status:approved** | Linked issue is approved | ✅ |
| **Check PR Has type:* Label** | Exactly one canonical type label | ✅ |
| **Check PR Has No Transient Artifacts** | Changed paths comply with policy | ✅ |
| **Unit Tests** | `go test ./...` | ✅ |
| **E2E Tests** | Server integration tests | ✅ |
| **Plugin Tests** | Plugin behavior | ✅ |
| **Lint** | No new Go lint findings | ✅ |

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above (`Closes #1153`).
- [x] I added exactly one `type:*` label to this PR.
- [ ] I ran unit tests locally: `go test ./...` — CI owns the broad suite.
- [ ] I ran e2e tests locally: `go test -tags e2e ./internal/server/...` — CI owns this suite.
- [ ] I ran lint locally: `make lint` — CI owns lint.
- [x] Docs updated because behavior changed.
- [x] Commits follow conventional commits format.
- [x] No `Co-Authored-By` trailers in commits.
- [x] I checked every changed path against the Transient Artifact Policy.

---

## 💬 Notes for Reviewers

- All required CI checks pass on head `29dce70`.

- Official Claude Code documentation places user-scoped MCP servers under top-level `mcpServers` in `~/.claude.json` and recommends `claude mcp add --scope user`.
- Engram reads that documented entry only for deterministic comparison; Claude CLI remains the sole writer.
- Native high-risk review completed successfully for the implementation and both CI follow-up corrections.
- This cohesive fix carries an explicitly approved `size:exception`: 348 additions and 804 deletions, largely from removing obsolete ignored-path and shell-gate tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code MCP registration is now managed through the Claude CLI at user scope.
  * Setup verifies registrations, preserves conflicting entries, and rolls back failed changes when possible.
  * Claude Code session startup automatically rechecks MCP registration and reports actionable setup errors.

* **Documentation**
  * Updated setup guidance for Claude CLI-managed registration, manual registration, configuration locations, and conflict handling.
  * Added recovery guidance for relocating existing registrations and rerunning setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
